### PR TITLE
Have the website point to badges/shields

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,7 @@ And tell us, we might be able to bring it to you anyway!
 <p>
 <a href='https://github.com/h5bp/lazyweb-requests/issues/150'>This</a>.<br/>
 All the activity and the code sits
-<a href='https://github.com/badges/gh-badges'>here</a>.
+<a href='https://github.com/badges/shields'>here</a>.
 </p>
 
 <h2> Contributors </h2>


### PR DESCRIPTION
Instead of badges/gh-badges.
