### PR TITLE
Consolidate example image URL and JS code

### DIFF
--- a/try.html
+++ b/try.html
@@ -47,7 +47,7 @@ hr.spacing { border: 0; display: block; height: 3mm; }
 <h2> Your Badge Service </h2>
 
 <p>
-<code>http://img.shields.io/badge/&lt;SUBJECT&gt;-&lt;STATUS&gt;-&lt;COLOR&gt;.svg</code>
+<code><span id="imgUrlPrefix">http://img.shields.io/badge/</span>&lt;SUBJECT&gt;-&lt;STATUS&gt;-&lt;COLOR&gt;.svg</code>
 </p><p>
 Dashes <code>--</code> → <code>-</code> Dash <br/>
 Underscores <code>__</code> → <code>_</code> Underscore <br/>
@@ -231,7 +231,7 @@ function escapeField(s) {
   return s.replace(/-/g, '--').replace(/_/g, '__');
 }
 function makeImage() {
-  var url = '/badge/';
+  var url = document.getElementById('imgUrlPrefix').innerText;
   url += escapeField(imageMaker.subject.value);
   url += '-' + escapeField(imageMaker.status.value);
   url += '-' + escapeField(imageMaker.color.value);


### PR DESCRIPTION
Before they had diverged and the link generator lacked the `img.` subdomain.
