### PR TITLE
CocoaPods version integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -575,6 +575,39 @@ cache(function(data, match, sendBadge) {
   });
 }));
 
+// CocoaPods version integration.
+camp.route(/^\/cocoapods\/v\/(.*)\.(svg|png|gif|jpg)$/,
+cache(function(data, match, sendBadge) {
+  var spec = match[1];
+  var format = match[2];
+  var apiUrl = 'http://search.cocoapods.org/api/v1/pod/' + spec + '.json';
+  var badgeData = getBadgeData('pod', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var version = data.version;
+      version = version.replace(/^v/, "");
+      badgeData.text[1] = version;
+      if (/^\d/.test(badgeData.text[1])) {
+        badgeData.text[1] = 'v' + version;
+      }
+      if (version[0] === '0' || /dev/.test(version)) {
+        badgeData.colorscheme = 'orange';
+      } else {
+        badgeData.colorscheme = 'blue';
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)+)-(([^-]|--)+)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/try.html
+++ b/try.html
@@ -156,6 +156,10 @@ I made the GitHub Badge Service.
   <td><img src='/packagist/v/symfony/symfony.svg' alt=''/></td>
   <td><code>http://img.shields.io/packagist/v/symfony/symfony.svg</code></td>
   </tr>
+  <tr><th> CocoaPods: </th>
+  <td><img src='/cocoapods/v/AFNetworking.svg' alt='' /></td>
+  <td><code>http://img.shields.io/cocoapods/v/AFNetworking.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h2> Like This? </h2>


### PR DESCRIPTION
You may not have heard about it, if you're not so into iOS/OS X development, but [CocoaPods](http://cocoapods.org) is the most polular package manager for Objective-C projects.

This pull request adds version integration with CocoaPods using [their search API](http://blog.cocoapods.org/Search-API-Version-1/).

The example route would be `http://img.shields.io/cocoapods/v/AFNetworking.svg`, where **`AFNetworking`** is a name of a pod (I'm using AFNetworking as an example, because it's one of the most popular networking frameworks in the community).

The code formatting was preserved in imitation of  your coding style. I've added a suitable entry in the `try.html` file as well.

Looks like it's ready to rock! :smile: 
