### PR TITLE
Adds TeamCity CodeBetter build badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -880,6 +880,35 @@ cache(function(data, match, sendBadge) {
   });
 }));
 
+// TeamCity CodeBetter version integration.
+camp.route(/^\/teamcity\/codebetter\/(.*)\.(svg|png|gif|jpg)$/,
+cache(function(data, match, sendBadge) {
+  var buildType = match[1];  // eg, `localeval`.
+  var format = match[2];
+  var apiUrl = 'http://teamcity.codebetter.com/app/rest/builds/buildType:(id:' + buildType + ')?guest=1';
+  var badgeData = getBadgeData('build', data);
+  request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var status = data.status;
+      badgeData.text[1] = (status || '').toLowerCase();
+      if (status === 'SUCCESS') {
+        badgeData.colorscheme = 'brightgreen'; 
+      } else {
+        badgeData.colorscheme = 'red'; 
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)+)-(([^-]|--)+)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/try.html
+++ b/try.html
@@ -91,10 +91,6 @@ I made the GitHub Badge Service.
 
 <h3> Miscellaneous </h3>
 <table><tbody>
-  <tr><th> Travis: </th>
-  <td><img src='/travis/joyent/node.svg' alt=''/></td>
-  <td><code>http://img.shields.io/travis/joyent/node.svg</code></td>
-  </tr>
   <tr><th> Travis branch: </th>
   <td><img src='/travis/joyent/node/v0.6.svg' alt=''/></td>
   <td><code>http://img.shields.io/travis/joyent/node/v0.6.svg</code></td>
@@ -126,6 +122,17 @@ I made the GitHub Badge Service.
   <tr><th> Packagist: </th>
   <td><img src='/packagist/l/doctrine/orm.svg' alt=''/></td>
   <td><code>http://img.shields.io/packagist/l/doctrine/orm.svg</code></td>
+  </tr>
+</tbody></table>
+<h3> Build </h3>
+<table><tbody>
+  <tr><th> Travis: </th>
+  <td><img src='/travis/joyent/node.svg' alt=''/></td>
+  <td><code>http://img.shields.io/travis/joyent/node.svg</code></td>
+  </tr>
+  <tr><th> TeamCity CodeBetter: </th>
+  <td><img src='/teamcity/codebetter/bt428.svg' alt=''/></td>
+  <td><code>http://img.shields.io/teamcity/codebetter/bt428.svg</code></td>
   </tr>
 </tbody></table>
 <h3> Downloads </h3>


### PR DESCRIPTION
This PR adds TeamCity CodeBetter build badge. For those who aren't familiar:

> TeamCity is the primary build server for the Microsoft development platform including .NET. CodeBetter [hosts TeamCity](http://teamcity.codebetter.com/) for the majority of OSS projects in the Microsoft development platform including .NET.

I've followed the conventions used by the other badges/shields and used npm's as a base for this one.

If there is anything you need changed or added let me know. 
