### PR TITLE
Fix Gemnasium's devDependencies badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -647,7 +647,7 @@ cache(function(data, match, sendBadge) {
       sendBadge(format, badgeData);
     }
     try {
-      var nameMatch = buffer.match(/(dev)?dependencies/)[0];
+      var nameMatch = buffer.match(/(devD|d)ependencies/)[0];
       var statusMatch = buffer.match(/'12'>(.+)<\/text>\n<\/g>/)[1];
       badgeData.text[0] = nameMatch;
       badgeData.text[1] = statusMatch;


### PR DESCRIPTION
Currently, if a gem is showing 'devDependencies', for example: ![](https://gemnasium.com/dorentus/bnet-authenticator.svg) (devDependencies up-to-date), in shields it becomes: ![](http://img.shields.io/gemnasium/dorentus/bnet-authenticator.svg?style=flat) (dependency invalid).

This patch will fix this minor issue.
