### PR TITLE
Coveralls apiUrl use badge subdomain

### DIFF
--- a/server.js
+++ b/server.js
@@ -539,7 +539,7 @@ cache(function(data, match, sendBadge) {
   var userRepo = match[1];  // eg, `jekyll/jekyll`.
   var branch = match[2];
   var format = match[3];
-  var apiUrl = 'https://coveralls.io/repos/' + userRepo + '/badge.png';
+  var apiUrl = 'http://badge.coveralls.io/repos/' + userRepo + '/badge.png';
   if (branch) {
     apiUrl += '?branch=' + branch;
   }


### PR DESCRIPTION
To bypass CloudFlare's threat control.
