### PR TITLE
Add "running" status case for Appveyor

### DIFF
--- a/server.js
+++ b/server.js
@@ -236,7 +236,7 @@ cache(function(data, match, sendBadge) {
       badgeData.text[1] = status;
       if (status === 'success') {
         badgeData.colorscheme = 'brightgreen';
-      } else {
+      } else if (status !== 'running') {
         badgeData.colorscheme = 'red';
       }
       sendBadge(format, badgeData);


### PR DESCRIPTION
Currently if a build is currently running then the badge is displayed as red which is quite disingenuous.
