### PR TITLE
Added "ruby-gem-downloads-badge" as a project that uses shields

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make your own badges [here][badges]!
 - [badges2svg][]
 - [reposs][]
 - [ruby-gem-downloads-badge][]
-- 
+
 [gem]: https://github.com/badges/badgerbadgerbadger
 [badges2svg]: https://github.com/bfontaine/badges2svg
 [reposs]: https://github.com/rexfinn/reposs


### PR DESCRIPTION
ruby-gem-downloads-badge is a project that shows the downloads count of a gem , but you can also specify a version or just "stable" and will display the download count of the latest stable version , or it can also display the total download count. 
Here's some examples : 

```
  ![](http://ruby-gem-downloads-badge.herokuapp.com/rails)
```

 ![](http://ruby-gem-downloads-badge.herokuapp.com/rails)

```
  ![](http://ruby-gem-downloads-badge.herokuapp.com/rails?type=total)
```

 ![](http://ruby-gem-downloads-badge.herokuapp.com/rails?type=total)

You can find more details on the readme file of the repository : https://github.com/bogdanRada/ruby-gem-downloads-badge
