### PR TITLE
Refactored a bit the code for showing the badge for a rubygem downloads count

### DIFF
--- a/try.html
+++ b/try.html
@@ -167,7 +167,15 @@ I made the GitHub Badge Service.
 </tbody></table>
 <h3> Downloads </h3>
 <table><tbody>
-  <tr><th> Gem </th>
+   <tr><th> Gem </th>
+  <td><img src='/gem/dv/rails/stable.svg' alt=''/></td>
+  <td><code>http://img.shields.io/gem/dv/rails/stable.svg</code></td>
+  </tr>
+   <tr><th> Gem </th>
+  <td><img src='/gem/dv/rails/4.1.0.svg' alt=''/></td>
+  <td><code>http://img.shields.io/gem/dv/rails/4.1.0.svg</code></td>
+  </tr>
+    <tr><th> Gem </th>
   <td><img src='/gem/dtv/rails.svg' alt=''/></td>
   <td><code>http://img.shields.io/gem/dtv/rails.svg</code></td>
   </tr>


### PR DESCRIPTION
1. added posibility to show the downloads count for the latest stable version 
   - i used this url http://img.shields.io/gem/dv/rails/stable.svg
   - the badge will look like this:  `[downloads | 81k stable version ]`
2. Added posibility to extract this information for a specific version
   - i used this url http://img.shields.io/gem/dv/rails/4.1.0.svg
   - the badge will look like this:  `[downloads | 258k version 4.1.0 ]`

Please let me know what you think. Maybe this will be useful 
