### PR TITLE
Replaced usage of linearGradient with fill colour and fill-opacity on intended rect

### DIFF
--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -1,14 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="{{=it.widths[0]+it.widths[1]}}" height="20">
-  <linearGradient id="smooth" x2="0" y2="100%">
-    <stop offset="0"  stop-color="#fff" stop-opacity=".1"/>
-    <stop offset=".1" stop-color="#fff" stop-opacity=".1"/>
-    <stop offset=".9" stop-color="#fff" stop-opacity=".1"/>
-    <stop offset="1"  stop-color="#fff" stop-opacity=".1"/>
-  </linearGradient>
   <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="{{=it.colorA||"#555"}}"/>
   <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.colorB||"#4c1"}}"/>
   <rect x="{{=it.widths[0]}}" width="4" height="20" fill="{{=it.colorB||"#4c1"}}"/>
-  <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
+  <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="#fff" fill-opacity=".1"/>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="{{=it.widths[0]/2+1}}" y="14">{{=it.text[0]}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.text[1]}}</text>


### PR DESCRIPTION
Gradient uses identical colour and opacity, so can be replaced with `fill` and `fill-opacity`.
