### PR TITLE
Fix Gemnasium badges

### DIFF
--- a/server.js
+++ b/server.js
@@ -1075,7 +1075,7 @@ cache(function(data, match, sendBadge) {
     }
     try {
       var nameMatch = buffer.match(/(devD|d)ependencies/)[0];
-      var statusMatch = buffer.match(/'12'>(.+)<\/text>\n<\/g>/)[1];
+      var statusMatch = buffer.match(/'13'>(.+)<\/text>\n<\/g>/)[1];
       badgeData.text[0] = nameMatch;
       badgeData.text[1] = statusMatch;
       if (statusMatch === 'up-to-date') {


### PR DESCRIPTION
Gemnasium has changed the 'y' position of the text, so shields
version of the gemnasium badges are currently broken.
This commit fixes them.
