### PR TITLE
Allow prefixing the build label.

### DIFF
--- a/server.js
+++ b/server.js
@@ -225,7 +225,7 @@ cache(function(data, match, sendBadge) {
     uri: 'https://api.travis-ci.org/repos/' + userRepo + '/builds.json'
   };
   branch = branch || 'master';
-  var badgeData = getBadgeData('build', data);
+  var badgeData = getBadgeData((data.prefix ? data.prefix + ' ' : '') + 'build', data);
   request(options, function(err, res, json) {
     if (err != null || (json.length !== undefined && json.length === 0)) {
       badgeData.text[1] = 'inaccessible';
@@ -263,7 +263,7 @@ cache(function(data, match, sendBadge) {
   var repo = match[1];  // eg, `gruntjs/grunt`.
   var format = match[2];
   var apiUrl = 'https://ci.appveyor.com/api/projects/' + repo;
-  var badgeData = getBadgeData('build', data);
+  var badgeData = getBadgeData((data.prefix ? data.prefix + ' ' : '') + 'build', data);
   request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -288,7 +288,7 @@ cache(function(data, match, sendBadge) {
 
 function teamcity_badge(url, buildId, advanced, format, data, sendBadge) {
   var apiUrl = url + '/app/rest/builds/buildType:(id:' + buildId + ')?guest=1';
-  var badgeData = getBadgeData('build', data);
+  var badgeData = getBadgeData((data.prefix ? data.prefix + ' ' : '') + 'build', data);
   request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1581,7 +1581,7 @@ cache(function(data, match, sendBadge) {
     uri: scheme + '://' + host + '/job/' + job + '/api/json?tree=color'
   };
 
-  var badgeData = getBadgeData('build', data);
+  var badgeData = getBadgeData((data.prefix ? data.prefix + ' ' : '') + 'build', data);
   request(options, function(err, res, json) {
     if (err !== null) {
       badgeData.text[1] = 'inaccessible';
@@ -1673,7 +1673,7 @@ cache(function(data, match, sendBadge) {
     method: 'GET',
     uri: 'https://www.codeship.io/projects/' + projectId + '/status'
   };
-  var badgeData = getBadgeData('build', data);
+  var badgeData = getBadgeData((data.prefix ? data.prefix + ' ' : '') + 'build', data);
   request(options, function(err, res) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';


### PR DESCRIPTION
It would be nice to prefix the build badge to display multiple build status.

Here are some examples:
![stable build](https://cloud.githubusercontent.com/assets/343404/4177072/86fd2390-3624-11e4-827c-99e9476805de.png)
![dev build](https://cloud.githubusercontent.com/assets/343404/4177073/8a87f648-3624-11e4-84b0-2b96af891368.png)
![upstream build](https://cloud.githubusercontent.com/assets/343404/4177077/0224b768-3625-11e4-8967-18a801ce3984.png)
![1x build](https://cloud.githubusercontent.com/assets/343404/4177079/0730ef4c-3625-11e4-910e-4bb54aaa6e38.png)
![2x build](https://cloud.githubusercontent.com/assets/343404/4177080/09b4bc80-3625-11e4-83f6-d6b2b74143c4.png)
