### PR TITLE
Fix invalid version tags

### DIFF
--- a/server.js
+++ b/server.js
@@ -1928,6 +1928,13 @@ function latestVersion(versions) {
   versions = versions.filter(function(version) {
     return (/^v?[0-9]/).test(version);
   });
+  versions = versions.map(function(version) {
+    var matches = /^(v?[0-9]+)(\.[0-9]+)?(-.*)?$/.exec(version);
+    if (matches) {
+        version = matches[1] + (matches[2] ? matches[2] : '.0') + '.0' + (matches[3] ? matches[3] : '');
+    }
+    return version;
+  });
   try {
     version = semver.maxSatisfying(versions, '');
   } catch(e) {


### PR DESCRIPTION
This is a potential fix for #261 
If the version tag does not match the pattern `major.minor.patch[-extensions]` the version tag will now be fixed, so semver does not throw any "Invalid version" errors.
