### PR TITLE
Fix "no such file or directory"

### DIFF
--- a/badge.js
+++ b/badge.js
@@ -17,7 +17,7 @@ canvasContext.font = '11px Verdana, "DejaVu Sans"';
 
 // cache templates.
 var templates = {};
-var templateFiles = fs.readdirSync('templates');
+var templateFiles = fs.readdirSync(path.join(__dirname, 'templates'));
 templateFiles.forEach(function(filename) {
   var templateData = fs.readFileSync(
     path.join(__dirname, 'templates', filename)).toString();


### PR DESCRIPTION
``` javascript
// test.js
var badge = require('gh-badges');

badge({ text: [ "build", "passed" ], colorscheme: "green" }, function(svg) {
        console.log(svg);
});
```

```
$ node test.js

fs.js:665
  return binding.readdir(pathModule._makeLong(path));
                 ^
Error: ENOENT, no such file or directory 'templates'
    at Object.fs.readdirSync (fs.js:665:18)
    at Object.<anonymous> (/vagrant/node_modules/gh-badges/badge.js:20:24)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/vagrant/test.js:1:75)
    at Module._compile (module.js:456:26)
```
