### PR TITLE
[CocoaPods] Use new Trunk API endpoint to get podspecs

### DIFF
--- a/server.js
+++ b/server.js
@@ -1465,7 +1465,7 @@ cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var spec = match[2];  // eg, AFNetworking
   var format = match[3];
-  var apiUrl = 'http://search.cocoapods.org/api/v1/pod/' + spec + '.json';
+  var apiUrl = 'https://trunk.cocoapods.org/api/v1/pods/' + spec + '/specs/latest';
   var badgeData = getBadgeData('pod', data);
   badgeData.colorscheme = null;
   request(apiUrl, function(err, res, buffer) {


### PR DESCRIPTION
See https://github.com/CocoaPods/search.cocoapods.org/commit/d6ac677b00a3b5b649f64ad6e2d3f30721545bd8#commitcomment-8340174 and https://github.com/CocoaPods/trunk.cocoapods.org/pull/109.

Shields is the last remaining (known) consumer of that search API, which we're looking to remove in order to allow for backend architecture enhancements.
