### PR TITLE
Minor fixes to the flat-square template.

### DIFF
--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="{{=it.widths[0]+it.widths[1]}}" height="20">
-  <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
-  <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
-  <rect x="{{=it.widths[0]}}" width="4" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
-  <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill-opacity=".1"/>
+  <g shape-rendering="crispEdges">
+    <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
+    <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
+  </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="{{=it.widths[0]/2+1}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.escapeXml(it.text[1])}}</text>


### PR DESCRIPTION
This solves an issue I've been having where you can't color match due to there
being a transparent rect sitting on top of the background colors.

It also fixes a fuzzy gray line around the edge of the right color due to
antialiasing on squares (shape-rendering="crispEdges")

I'm also trying to figure out why scaling doesn't work properly in IE.  I'll
put that in another PR when I manage to figure that out though.

Before:
![shields-1](https://cloud.githubusercontent.com/assets/630909/5664372/f1bb71dc-971d-11e4-99d7-06ee27845738.png)

After:
![shields-2](https://cloud.githubusercontent.com/assets/630909/5664373/f1bf5270-971d-11e4-8d70-12612ccf0909.png)