### PR TITLE
Fix fuzzy edges on the flat template

### DIFF
--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -4,11 +4,11 @@
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
 
-  <mask id="test">
-    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" rx="3" fill="#fff" />
+  <mask id="round">
+    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" rx="3" fill="#fff"/>
   </mask>
 
-  <g mask="url(#test)">
+  <g mask="url(#round)">
     <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
     <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
     <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -3,10 +3,17 @@
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
-  <rect rx="3" width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
-  <rect rx="3" x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
-  <rect x="{{=it.widths[0]}}" width="4" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
-  <rect rx="3" width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
+
+  <mask id="test">
+    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" rx="3" fill="#fff" />
+  </mask>
+
+  <g mask="url(#test)">
+    <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
+    <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
+    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
+  </g>
+
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="{{=it.widths[0]/2+1}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=it.widths[0]/2+1}}" y="14">{{=it.escapeXml(it.text[0])}}</text>


### PR DESCRIPTION
Before:
![](https://9k1.us/DW9,/Screenshot_from_2015-01-13_21:00:29.png)

After:
![](https://9k1.us/AzI*/Screenshot_from_2015-01-13_21:01:34.png)

This also increases the file size by five bytes.  I don't see an easy way to
reduce that though.  (Yet.  Still experimenting with SVGs.)