### PR TITLE
Fix latestVersion returning a version string not in the given version list

### DIFF
--- a/server.js
+++ b/server.js
@@ -3240,7 +3240,7 @@ function latestVersion(versions) {
   versions = versions.filter(function(version) {
     return (/^v?[0-9]/).test(version);
   });
-  versions = versions.map(function(version) {
+  semver_versions = versions.map(function(version) {
     var matches = /^(v?[0-9]+)(\.[0-9]+)?(-.*)?$/.exec(version);
     if (matches) {
         version = matches[1] + (matches[2] ? matches[2] : '.0') + '.0' + (matches[3] ? matches[3] : '');
@@ -3248,7 +3248,8 @@ function latestVersion(versions) {
     return version;
   });
   try {
-    version = semver.maxSatisfying(versions, '');
+    version = semver.maxSatisfying(semver_versions, '');
+    version = versions[semver_versions.indexOf(version)];
   } catch(e) {
     versions = versions.sort();
     version = versions[versions.length - 1];


### PR DESCRIPTION
Fixes badges/shields#337

The reason my repository does not work with github release badge is because the "latestVersion" call modifies the version strings from "x.x" to "x.x.0" - after comparison it then returns the modified version. However, to check for prerelease flag, it tries to find the modified version in the version list and of course, does not find it, and errors. This results in a "none" release badge.

This PR fixes latestVersion so after it finds the latest version, it always returns the original string, not the modified one.

Will raise another PR to utilise the /latest API in GitHub release badge shortly - this next PR will likely make this irrelevant in the context of #377 - but I expect the issue addressed by this PR may affect other places unknowingly.