### PR TITLE
Add mingle integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "camp": "~13.11.9",
     "semver": "~2.3.0",
     "bower": "~1.3.11",
-    "promise": "~6.1.0"
+    "promise": "~6.1.0",
+    "xml2js": "^0.4.5"
   },
   "devDependencies": {
     "ass": "~0.0.6",

--- a/try.html
+++ b/try.html
@@ -526,6 +526,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/puppetforge/mc/camptocamp.svg' alt=''/></td>
   <td><code>https://img.shields.io/puppetforge/mc/camptocamp.svg</code></td>
   </tr>
+  <tr><th> Mingle: </th>
+  <td><img src='/mingle/company.mingle-api.thoughtworks.com/project-name/1234/property-name.svg' alt=''/></td>
+  <td><code>https://img.shields.io/mingle/company.mingle-api.thoughtworks.com/project-name/card-number/status-property-name.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h2> Your Badge </h2>
@@ -725,6 +729,9 @@ is where the current server got started.
 </a>
 <a class='photo' href='https://github.com/raphink'>
   <img alt='raphink' src='https://avatars.githubusercontent.com/u/650430?s=80'>
+</a>
+<a class='photo' href='https://github.com/craigcav'>
+  <img alt='craigcav' src='https://avatars1.githubusercontent.com/u/109814?s=80'>
 </a>
 <p><small>:wq</small></p>
 </main>


### PR DESCRIPTION
Adds basic [Mingle](http://www.thoughtworks.com/mingle/) integration.

The result is a badge that looks like this:
[![Mingle Card Status](https://img.shields.io/badge/mingle%20%23322-Development%20Complete-blue.svg)](http://www.thoughtworks.com/mingle/#322)

Given the following markdown:

``` md
[![Mingle](http://localhost:9001/mingle/http/company.mingle-api.thoughtworks.com/project-name/card-number/status-property-name.svg)]()
```

Since Mingle isn't typically public facing, basic auth credentials can be supplied in the `/secrets.json` file by providing `mingle_user` and `mingle_password` properties.
