### PR TITLE
Add StackExchange integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ var https = require('https');
 var domain = require('domain');
 var request = require('request');
 var fs = require('fs');
+var zlib = require('zlib');
 var LruCache = require('./lru-cache.js');
 var badge = require('./badge.js');
 var svg2img = require('./svg-to-img.js');
@@ -3079,6 +3080,52 @@ cache(function(data, match, sendBadge, request) {
       badgeData.text[1] = 'invalid';
       sendBadge(format, badgeData);
     }
+  })}
+));
+
+// StackExchange integration.
+camp.route(/^\/stackexchange\/([^\/]+)\/([^\/])\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var site = match[1]; // eg, stackoverflow
+  var info = match[2]; // either `r`
+  var user = match[3]; // eg, 232250
+  var format = match[4];
+  var options = {
+    method: 'GET',
+    uri: 'https://api.stackexchange.com/2.2/users/'+user+'?site='+site,
+    encoding: null
+  }
+  var badgeData = getBadgeData(site, data);
+  request(options, function (err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(badgeData, format);
+    }
+    zlib.gunzip(buffer, function (err, body) {
+      try {
+        var data = JSON.parse(body.toString());
+
+        if (info === 'r') {
+          var reputation = data.items[0].reputation;
+          badgeData.text[1] = metric(reputation);
+          if (reputation === 0) {
+            badgeData.colorscheme = 'red';
+          } else if (reputation < 1000) {
+            badgeData.colorscheme = 'yellow';
+          } else if (reputation < 10000) {
+            badgeData.colorscheme = 'yellowgreen';
+          } else if (reputation < 20000) {
+            badgeData.colorscheme = 'green';
+          } else {
+            badgeData.colorscheme = 'brightgreen';
+          }
+          sendBadge(format, badgeData);
+        }
+      } catch (e) {
+        badgeData.text[1] = 'invalid';
+        sendBadge(format, badgeData);
+      }
+    });
   })}
 ));
 

--- a/server.js
+++ b/server.js
@@ -3114,31 +3114,11 @@ cache(function(data, match, sendBadge, request) {
         if (info === 'r') {
           var reputation = data.items[0].reputation;
           badgeData.text[1] = metric(reputation);
-          if (reputation === 0) {
-            badgeData.colorscheme = 'red';
-          } else if (reputation < 1000) {
-            badgeData.colorscheme = 'yellow';
-          } else if (reputation < 10000) {
-            badgeData.colorscheme = 'yellowgreen';
-          } else if (reputation < 20000) {
-            badgeData.colorscheme = 'green';
-          } else {
-            badgeData.colorscheme = 'brightgreen';
-          }
+          badgeData.colorscheme = floorCountColor(1000, 10000, 20000);
         } else if (info === 't') {
           var count = data.items[0].count;
           badgeData.text[1] = metric(count)+' questions';
-          if (count === 0) {
-            badgeData.colorscheme = 'red';
-          } else if (count < 1000) {
-            badgeData.colorscheme = 'yellow';
-          } else if (count < 10000) {
-            badgeData.colorscheme = 'yellowgreen';
-          } else if (count < 20000) {
-            badgeData.colorscheme = 'green';
-          } else {
-            badgeData.colorscheme = 'brightgreen';
-          }
+          badgeData.colorscheme = floorCountColor(1000, 10000, 20000);
         }
         sendBadge(format, badgeData);
       } catch (e) {

--- a/server.js
+++ b/server.js
@@ -3088,11 +3088,17 @@ camp.route(/^\/stackexchange\/([^\/]+)\/([^\/])\/([^\/]+)\.(svg|png|gif|jpg|json
 cache(function(data, match, sendBadge, request) {
   var site = match[1]; // eg, stackoverflow
   var info = match[2]; // either `r`
-  var user = match[3]; // eg, 232250
+  var item = match[3]; // eg, 232250
   var format = match[4];
+  var path;
+  if (info === 'r') {
+    path = 'users/'+item;
+  } else if (info === 't') {
+    path = 'tags/'+item+'/info';
+  }
   var options = {
     method: 'GET',
-    uri: 'https://api.stackexchange.com/2.2/users/'+user+'?site='+site,
+    uri: 'https://api.stackexchange.com/2.2/'+path+'?site='+site,
     encoding: null
   }
   var badgeData = getBadgeData(site, data);
@@ -3119,8 +3125,22 @@ cache(function(data, match, sendBadge, request) {
           } else {
             badgeData.colorscheme = 'brightgreen';
           }
-          sendBadge(format, badgeData);
+        } else if (info === 't') {
+          var count = data.items[0].count;
+          badgeData.text[1] = metric(count)+' questions';
+          if (count === 0) {
+            badgeData.colorscheme = 'red';
+          } else if (count < 1000) {
+            badgeData.colorscheme = 'yellow';
+          } else if (count < 10000) {
+            badgeData.colorscheme = 'yellowgreen';
+          } else if (count < 20000) {
+            badgeData.colorscheme = 'green';
+          } else {
+            badgeData.colorscheme = 'brightgreen';
+          }
         }
+        sendBadge(format, badgeData);
       } catch (e) {
         badgeData.text[1] = 'invalid';
         sendBadge(format, badgeData);

--- a/try.html
+++ b/try.html
@@ -525,6 +525,9 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th> Puppet Forge: </th>
   <td><img src='/puppetforge/mc/camptocamp.svg' alt=''/></td>
   <td><code>https://img.shields.io/puppetforge/mc/camptocamp.svg</code></td>
+  <tr><th> StackExchange: </th>
+  <td><img src='/stackexchange/tex/r/951.svg' alt=''/></td>
+  <td><code>https://img.shields.io/stackexchange/tex/r/951.svg</code></td>
   </tr>
 </tbody></table>
 

--- a/try.html
+++ b/try.html
@@ -529,6 +529,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/stackexchange/tex/r/951.svg' alt=''/></td>
   <td><code>https://img.shields.io/stackexchange/tex/r/951.svg</code></td>
   </tr>
+  <tr><th> StackExchange: </th>
+  <td><img src='/stackexchange/stackoverflow/t/augeas.svg' alt=''/></td>
+  <td><code>https://img.shields.io/stackexchange/stackoverflow/t/augeas.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h2> Your Badge </h2>


### PR DESCRIPTION
This adds StackExchange integration. Two modes are supported:

* user reputation: you need to specify the site name (e.g. stackoverflow, superuser, tex, etc.) and the user id.
* questions by tag: you need to supply a site name and tag name (e.g. 'augeas').