### PR TITLE
Add anchors for direct linking

### DIFF
--- a/try.html
+++ b/try.html
@@ -62,7 +62,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 
 <section id='suggestedBadges'></section>
 
-<h3> Build </h3>
+<h3 id="build"> Build </h3>
 <table class='badge'><tbody>
   <tr><th> Travis: </th>
     <td><img src='/travis/joyent/node.svg' alt=''/></td>
@@ -165,7 +165,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
       <td><code>https://img.shields.io/sensiolabs/i/45afb680-d4e6-4e66-93ea-bcfa79eb8a87.svg</code></td>
   </tr>
 </tbody></table>
-<h3> Downloads </h3>
+<h3 id="downloads"> Downloads </h3>
 <table class='badge'><tbody>
   <tr><th data-keywords='node'> npm: </th>
   <td><img src='/npm/dm/localeval.svg' alt=''/></td>
@@ -272,7 +272,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><code>https://img.shields.io/puppetforge/dt/camptocamp/openldap.svg</code></td>
   </tr>
 </tbody></table>
-<h3> Version </h3>
+<h3 id="version"> Version </h3>
 <table class='badge'><tbody>
   <tr><th data-keywords='node'> npm: </th>
   <td><img src='/npm/v/npm.svg' alt=''/></td>
@@ -384,7 +384,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
 </tbody></table>
 
-<h3> Miscellaneous </h3>
+<h3 id="miscellaneous"> Miscellaneous </h3>
 <table class='badge'><tbody>
   <tr><th> Gratipay: </th>
     <td><img src='/gratipay/JSFiddle.svg' alt=''/></td>
@@ -531,7 +531,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
 </tbody></table>
 
-<h2> Your Badge </h2>
+<h2 id="your-badge"> Your Badge </h2>
 
 <form action='javascript:makeImage()' id='imageMaker'>
   <input class='short' name='subject' placeholder='subject'/>
@@ -581,7 +581,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 <img src='/badge/color-ff69b4-ff69b4.svg' alt='ff69b4'/>
 </p>
 
-<h2> Styles </h2>
+<h2 id="styles"> Styles </h2>
 <p>
 The following styles are available (flat is the default as of Feb 1st 2015):
 </p>
@@ -609,7 +609,7 @@ We also support <code>.json</code>, <code>.png</code> and a few others,
 but use them responsibly.
 </p>
 
-<h2> Like This? </h2>
+<h2 id="like-this"> Like This? </h2>
 
 <p>
 Tell your favorite badge service to use it! <br/>
@@ -629,7 +629,7 @@ And tell us, we might be able to bring it to you anyway!
 is where the current server got started.
 </p>
 
-<h2> Contributors </h2>
+<h2 id="contributors"> Contributors </h2>
 
 <a class='photo' href='https://github.com/espadrine'>
   <img alt='espadrine' src='https://gravatar.com/avatar/8c3bee0764c781e1b0b8c2e53f0f11fe'>


### PR DESCRIPTION
I've often wanted to point people to http://shields.io/#styles, but couldn't, because the \<h2> had no ID.  Let's fix that!