### PR TITLE
Add apistatus online/offline intregration

### DIFF
--- a/server.js
+++ b/server.js
@@ -3132,6 +3132,44 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// API Status type integration.
+camp.route(/^\/apistatus\/t\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var targetUrl = new Buffer(match[1], 'base64');
+  var format = match[2];
+  var url = 'http://api.apistatus.org/?url=' + targetUrl;
+  var badgeData = getBadgeData('API', data);
+  request(url, function(err, res, buffer) {
+    try {
+      var res = JSON.parse(buffer);
+      if (res.online) {
+        var scode = res.statusCode;
+        var badgeText = scode + ' ' + res.statusType;
+        badgeData.text[1] = badgeText;
+        if (scode >= 200 && scode < 300) {
+          badgeData.colorscheme = "brightgreen";
+        } else if (scode >= 300 && scode < 400) {
+          badgeData.colorscheme = "yellowgreen";
+        } else if (scode >= 400 && scode < 500) {
+          badgeData.colorscheme = "orange";
+        } else if (scode >= 500 && scode < 600) {
+          badgeData.colorscheme = "red";
+        } else {
+          badgeData.colorscheme = "blue";
+        }
+        
+      } else {
+        badgeData.text[1] = "Offline";
+        badgeData.colorscheme = "red";
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)+)-(([^-]|--)+)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/server.js
+++ b/server.js
@@ -3169,8 +3169,8 @@ cache(function(data, match, sendBadge, request) {
         }
         
       } else {
-        badgeData.text[1] = "Offline";
-        badgeData.colorscheme = "red";
+        badgeData.text[1] = "n/a";
+        badgeData.colorscheme = "lightgrey";
       }
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -3108,12 +3108,12 @@ cache(function(data, match, sendBadge, request) {
 ));
 
 // API Status online/offline integration.
-camp.route(/^\/apistatus\/o\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/apistatus\/online\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var targetUrl = new Buffer(match[1], 'base64');
   var format = match[2];
   var url = 'http://api.apistatus.org/?url=' + targetUrl;
-  var badgeData = getBadgeData('API', data);
+  var badgeData = getBadgeData('api', data);
   request(url, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -3123,10 +3123,10 @@ cache(function(data, match, sendBadge, request) {
     try {
       var status = JSON.parse(buffer);
       if (status.online) {
-        badgeData.text[1] = "Online";
+        badgeData.text[1] = "online";
         badgeData.colorscheme = "brightgreen";
       } else {
-        badgeData.text[1] = "Offline";
+        badgeData.text[1] = "offline";
         badgeData.colorscheme = "red";
       }
       sendBadge(format, badgeData);
@@ -3137,13 +3137,13 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// API Status type integration.
-camp.route(/^\/apistatus\/t\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+// API Status code integration.
+camp.route(/^\/apistatus\/status\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var targetUrl = new Buffer(match[1], 'base64');
   var format = match[2];
   var url = 'http://api.apistatus.org/?url=' + targetUrl;
-  var badgeData = getBadgeData('API', data);
+  var badgeData = getBadgeData('status', data);
   request(url, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -3154,7 +3154,7 @@ cache(function(data, match, sendBadge, request) {
       var res = JSON.parse(buffer);
       if (res.online) {
         var scode = res.statusCode;
-        var badgeText = scode + ' ' + res.statusType;
+        var badgeText = scode;
         badgeData.text[1] = badgeText;
         if (scode >= 200 && scode < 300) {
           badgeData.colorscheme = "brightgreen";

--- a/server.js
+++ b/server.js
@@ -3115,6 +3115,11 @@ cache(function(data, match, sendBadge, request) {
   var url = 'http://api.apistatus.org/?url=' + targetUrl;
   var badgeData = getBadgeData('API', data);
   request(url, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
     try {
       var status = JSON.parse(buffer);
       if (status.online) {
@@ -3140,6 +3145,11 @@ cache(function(data, match, sendBadge, request) {
   var url = 'http://api.apistatus.org/?url=' + targetUrl;
   var badgeData = getBadgeData('API', data);
   request(url, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
     try {
       var res = JSON.parse(buffer);
       if (res.online) {

--- a/server.js
+++ b/server.js
@@ -3107,6 +3107,31 @@ cache(function(data, match, sendBadge, request) {
   })}
 ));
 
+// API Status online/offline integration.
+camp.route(/^\/apistatus\/o\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var targetUrl = new Buffer(match[1], 'base64');
+  var format = match[2];
+  var url = 'http://api.apistatus.org/?url=' + targetUrl;
+  var badgeData = getBadgeData('API', data);
+  request(url, function(err, res, buffer) {
+    try {
+      var status = JSON.parse(buffer);
+      if (status.online) {
+        badgeData.text[1] = "Online";
+        badgeData.colorscheme = "brightgreen";
+      } else {
+        badgeData.text[1] = "Offline";
+        badgeData.colorscheme = "red";
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)+)-(([^-]|--)+)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/try.html
+++ b/try.html
@@ -529,6 +529,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/gem/u/raphink.svg' alt=''/></td>
   <td><code>https://img.shields.io/gem/u/raphink.svg</code></td>
   </tr>
+  <tr><th> apistatus.org: </th>
+  <td><img src='/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg' alt=''/></td>
+  <td><code>https://img.shields.io/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h2 id="your-badge"> Your Badge </h2>
@@ -728,6 +732,9 @@ is where the current server got started.
 </a>
 <a class='photo' href='https://github.com/raphink'>
   <img alt='raphink' src='https://avatars.githubusercontent.com/u/650430?s=80'>
+</a>
+<a class='photo' href='https://github.com/montanaflynn'>
+  <img alt='montanaflynn' src='https://avatars.githubusercontent.com/u/24260?s=80'>
 </a>
 <p><small>:wq</small></p>
 </main>

--- a/try.html
+++ b/try.html
@@ -529,9 +529,13 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/gem/u/raphink.svg' alt=''/></td>
   <td><code>https://img.shields.io/gem/u/raphink.svg</code></td>
   </tr>
-  <tr><th> apistatus.org: </th>
+  <tr><th> APIstatus.org: </th>
   <td><img src='/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg' alt=''/></td>
   <td><code>https://img.shields.io/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg</code></td>
+  </tr>
+  <tr><th> APIstatus.org: </th>
+  <td><img src='/apistatus/t/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg' alt=''/></td>
+  <td><code>https://img.shields.io/apistatus/t/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg</code></td>
   </tr>
 </tbody></table>
 

--- a/try.html
+++ b/try.html
@@ -529,13 +529,13 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/gem/u/raphink.svg' alt=''/></td>
   <td><code>https://img.shields.io/gem/u/raphink.svg</code></td>
   </tr>
-  <tr><th> APIstatus.org: </th>
-  <td><img src='/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg' alt=''/></td>
+  <tr><th> APIstatus.org online: </th>
+  <td><img src='/apistatus/online/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg' alt=''/></td>
   <td><code>https://img.shields.io/apistatus/o/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvMjAw.svg</code></td>
   </tr>
-  <tr><th> APIstatus.org: </th>
-  <td><img src='/apistatus/t/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg' alt=''/></td>
-  <td><code>https://img.shields.io/apistatus/t/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg</code></td>
+  <tr><th> APIstatus.org code: </th>
+  <td><img src='/apistatus/status/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg' alt=''/></td>
+  <td><code>https://img.shields.io/apistatus/s/aHR0cHM6Ly9tb2NrYmluLmNvbS9zdGF0dXMvNTAy.svg</code></td>
   </tr>
 </tbody></table>
 


### PR DESCRIPTION
Here's an integration for my new apistatus service, which I think will be great for adding to API readme's and docs. The last URL segment is a base64 encoded URL which my API makes a request to and returns structured data about the response. 

I also made a [simple website](http://apistatus.org) that does the base64 encoding, sends a request with a preview of the response and generates the badge URL. 
