### PR TITLE
Make David badge green for "dependencies: none". Fix #413

### DIFF
--- a/server.js
+++ b/server.js
@@ -1652,6 +1652,8 @@ cache(function(data, match, sendBadge, request) {
       } else if (status === 'uptodate') {
         badgeData.colorscheme = 'brightgreen';
         status = 'up-to-date';
+      } else if (status === 'none') {
+        badgeData.colorscheme = 'brightgreen';
       }
       badgeData.text[1] = status;
       sendBadge(format, badgeData);


### PR DESCRIPTION
This way David badges behave the same as Gemnasium.