### PR TITLE
Add github license integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -2113,6 +2113,54 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// GitHub license integration.
+camp.route(/^\/github\/license\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var user = match[1];  // eg, mashape
+  var repo = match[2];  // eg, apistatus
+  var format = match[3];
+  var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo;
+  var badgeData = getBadgeData('license', data);
+  // Using our OAuth App secret grants us 5000 req/hour
+  // instead of the standard 60 req/hour.
+  if (serverSecrets) {
+    apiUrl += '?client_id=' + serverSecrets.gh_client_id
+      + '&client_secret=' + serverSecrets.gh_client_secret;
+  }
+  // Custom user-agent and accept headers are required
+  // http://developer.github.com/v3/#user-agent-required
+  // https://developer.github.com/v3/licenses/
+  var customHeaders = {
+    'User-Agent': 'Shields.io',
+    'Accept': 'application/vnd.github.drax-preview+json'
+  };
+  request(apiUrl, { headers: customHeaders }, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      if ((+res.headers['x-ratelimit-remaining']) === 0) {
+        return;  // Hope for the best in the cache.
+      } else if (res.statusCode === 404) {
+        throw new Error(); // Show invalid badge in this case
+      }
+      var body = JSON.parse(buffer);
+      if (body.license != null) {
+        badgeData.text[1] = body.license.name;
+        badgeData.colorscheme = 'blue';
+        sendBadge(format, badgeData);
+      } else {
+        badgeData.text[1] = 'unknown';
+        sendBadge(format, badgeData);
+      }
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Chef cookbook integration.
 camp.route(/^\/cookbook\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -2138,12 +2138,15 @@ cache(function(data, match, sendBadge, request) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
+      return;
     }
     try {
       if ((+res.headers['x-ratelimit-remaining']) === 0) {
         return;  // Hope for the best in the cache.
       } else if (res.statusCode === 404) {
-        throw new Error(); // Show invalid badge in this case
+        badgeData.text[1] = 'repo not found';
+        sendBadge(format, badgeData);
+        return;
       }
       var body = JSON.parse(buffer);
       if (body.license != null) {
@@ -2151,7 +2154,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'blue';
         sendBadge(format, badgeData);
       } else {
-        badgeData.text[1] = 'unknown';
+        badgeData.text[1] = 'unknown license';
         sendBadge(format, badgeData);
       }
     } catch(e) {

--- a/try.html
+++ b/try.html
@@ -514,6 +514,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/github/followers/espadrine.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/followers/espadrine.svg</code></td>
   </tr>
+  <tr><th data-keywords='github license'> GitHub license: </th>
+  <td><img src='/github/license/mashape/apistatus.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/license/mashape/apistatus.svg</code></td>
+  </tr>
   <tr><th> WordPress rating: </th>
   <td><img src='/wordpress/plugin/r/akismet.svg' alt=''/></td>
   <td><code>https://img.shields.io/wordpress/plugin/r/akismet.svg</code></td>
@@ -752,6 +756,9 @@ is where the current server got started.
 </a>
 <a class='photo' href='https://github.com/raphink'>
   <img alt='raphink' src='https://avatars.githubusercontent.com/u/650430?s=80'>
+</a>
+<a class='photo' href='https://github.com/montanaflynn'>
+  <img alt='montanaflynn' src='https://avatars.githubusercontent.com/u/24260?s=80'>
 </a>
 <p><small>:wq</small></p>
 </main>


### PR DESCRIPTION
Added a license badge using the new [GitHub license API](https://developer.github.com/v3/licenses/#get-a-repositorys-license). Not sure what happened to #280 & #315 but the badge wasn't available in master and using the official API seems to be a better solution.