### PR TITLE
Clojars version support

### DIFF
--- a/server.js
+++ b/server.js
@@ -1088,6 +1088,33 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Clojars version integration
+camp.route(/^\/clojars\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var repo = match[1];  // eg, `prismic`.
+  var format = match[2];
+  var apiUrl = 'https://clojars.org/search?q=' + repo + '&format=json';
+  var badgeData = getBadgeData('clojars', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err !== null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var first = data.results[0];
+      var version = first.version;
+      var vdata = versionColor(version);
+      badgeData.text[1] = vdata.version;
+      badgeData.colorscheme = vdata.color;
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Gem version integration.
 camp.route(/^\/gem\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -1089,7 +1089,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Clojars version integration
-camp.route(/^\/clojars\/v\/(.+)((\/)(.+))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/clojars\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var clojar = match[1];  // eg, `prismic` or `foo/bar`.
   var format = match[2];

--- a/server.js
+++ b/server.js
@@ -1102,8 +1102,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var version = data.version;
-      var vdata = versionColor(version);
+      var vdata = versionColor(data.version);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -1089,11 +1089,11 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Clojars version integration
-camp.route(/^\/clojars\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/clojars\/v\/(.+)((\/)(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `prismic`.
+  var clojar = match[1];  // eg, `prismic` or `foo/bar`.
   var format = match[2];
-  var apiUrl = 'https://clojars.org/search?q=' + repo + '&format=json';
+  var apiUrl = 'https://clojars.org/' + clojar + '/latest-version.json';
   var badgeData = getBadgeData('clojars', data);
   request(apiUrl, function(err, res, buffer) {
     if (err !== null) {
@@ -1102,8 +1102,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var first = data.results[0];
-      var version = first.version;
+      var version = data.version;
       var vdata = versionColor(version);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;

--- a/try.html
+++ b/try.html
@@ -302,6 +302,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/packagist/vpre/symfony/symfony.svg' alt=''/></td>
   <td><code>https://img.shields.io/packagist/vpre/symfony/symfony.svg</code></td>
   </tr>
+  <tr><th> Clojars: </th>
+  <td><img src='/clojars/v/prismic.svg' alt=''/></td>
+  <td><code>https://img.shields.io/clojars/v/prismic.svg</code></td>
+  </tr>
   <tr><th> CocoaPods: </th>
   <td><img src='/cocoapods/v/AFNetworking.svg' alt='' /></td>
   <td><code>https://img.shields.io/cocoapods/v/AFNetworking.svg</code></td>


### PR DESCRIPTION
Based on the work already done by @erwan in this PR #388 

I've added the new endpoint to Clojars, with a simpler versioning:
https://github.com/ato/clojars-web/pull/315

This change parses the version data, that looks something like:

https://clojars.org/overtone/overtone/latest-version.json
or
https://clojars.org/overtone/latest-version.json

What do you think? Thanks