### PR TITLE
Display the clojar name in clojure fashion

### DIFF
--- a/server.js
+++ b/server.js
@@ -1143,8 +1143,8 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var vdata = versionColor(data.version);
-      badgeData.text[1] = vdata.version;
-      badgeData.colorscheme = vdata.color;
+      badgeData.text[1] = "[" + clojar + " \"" + data.version + "\"]";
+      badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';


### PR DESCRIPTION
Instead of the current:

v + clojar-version number: v1.1.2

e.g.: [![pdfboxing](https://img.shields.io/clojars/v/pdfboxing.svg)](http://clojars.org/pdfboxing)

use full name and version (which can be cut & pasted and included in a project): [clojar-name "1.1.2"]

e.g. [!["clojars"](https://img.shields.io/badge/clojars.org-[pdfboxing%20"0.1.5"]-brightgreen.svg?style=flat-square)](https://clojars.org/pdfboxing) 

As per discussion: https://github.com/ato/clojars-web/pull/315#issuecomment-94726248