### PR TITLE
Support npm scopes

### DIFF
--- a/server.js
+++ b/server.js
@@ -986,9 +986,9 @@ cache(function(data, match, sendBadge, request) {
 // npm download integration.
 camp.route(/^\/npm\/dm\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var user = match[1];  // eg, `localeval`.
+  var pkg = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
   var format = match[2];
-  var apiUrl = 'https://api.npmjs.org/downloads/point/last-month/' + user;
+  var apiUrl = 'https://api.npmjs.org/downloads/point/last-month/' + pkg;
   var badgeData = getBadgeData('downloads', data);
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
@@ -1022,7 +1022,7 @@ cache(function(data, match, sendBadge, request) {
 // npm version integration.
 camp.route(/^\/npm\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `localeval`.
+  var repo = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
   var format = match[2];
   var apiUrl = 'https://registry.npmjs.org/' + repo + '/latest';
   var badgeData = getBadgeData('npm', data);
@@ -1050,7 +1050,7 @@ cache(function(data, match, sendBadge, request) {
 // npm license integration.
 camp.route(/^\/npm\/l\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, "express"
+  var repo = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
   var format = match[2];
   var apiUrl = 'http://registry.npmjs.org/' + repo + '/latest';
   var badgeData = getBadgeData('license', data);
@@ -1080,7 +1080,7 @@ cache(function(data, match, sendBadge, request) {
 // npm node version integration.
 camp.route(/^\/node\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `localeval`.
+  var repo = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
   var format = match[2];
   var apiUrl = 'https://registry.npmjs.org/' + repo + '/latest';
   var badgeData = getBadgeData('node', data);


### PR DESCRIPTION
As reported in #429, this PR allows support for npm scopes via encoding the package name. The issue is that scopes use a separator character which is the same as the URL path separator.

## Without encoding (does not work)

```shell
curl -i https://registry.npmjs.org/@wilmoore/accessor/latest
```

###### The headers indicate:

```
HTTP/1.1 401 Unauthorized
npm-notice: ERROR: you cannot fetch versions for scoped packages
```

## With encoding (works)

```shell
curl -i https://registry.npmjs.org/%40wilmoore%2Faccessor/latest
```

###### The headers now indicate:

```
HTTP/1.1 200 OK
Content-Type: application/json
```

###### The JSON result looks like:

```json
{
  "name": "@wilmoore/accessor",
  "description": "Higher-Order getter/setter.",
  "version": "0.2.0",
  "author": {
    "name": "Wil Moore III",
    "email": "wil.moore@wilmoore.com"
  },
  "bugs": {
    "url": "https://github.com/wilmoore/accessor.js/issues"
  },
  "dependencies": {},
  "devDependencies": {
    "istanbul": "^0.3.13",
    "nodemon": "^1.3.7",
    "standard": "^3.7.1",
    "tap-spec": "^2.2.2",
    "tape": "^4.0.0",
    "tape-catch": "^1.0.4"
  },
  "homepage": "https://github.com/wilmoore/accessor.js",
  "keywords": [
    "Object.defineProperty",
    "accessor",
    "accessors",
    "define",
    "defineProperty",
    "get",
    "getter",
    "higher-order",
    "object",
    "properties",
    "property",
    "set",
    "setter"
  ],
  "license": "MIT",
  "main": "index.js",
  "private": false,
  "repository": {
    "type": "git",
    "url": "git+https://github.com/wilmoore/accessor.js.git"
  },
  "scripts": {
    "cover": "istanbul cover test.js",
    "dev": "nodemon -x 'npm run test --silent' -e 'js json'",
    "standard": "standard",
    "test": "npm run standard --silent && node test.js | tap-spec"
  },
  "gitHead": "71e71d4c91fb69c304c53d9ebf2918e69242325a",
  "_id": "@wilmoore/accessor@0.2.0",
  "_shasum": "ff1f79d19048a419f72dfa557c4db3a8d211f901",
  "_from": ".",
  "_npmVersion": "2.8.4",
  "_nodeVersion": "0.12.0",
  "_npmUser": {
    "name": "wilmoore",
    "email": "wil.moore@wilmoore.com"
  },
  "maintainers": [
    {
      "name": "wilmoore",
      "email": "wil.moore@wilmoore.com"
    }
  ],
  "dist": {
    "shasum": "ff1f79d19048a419f72dfa557c4db3a8d211f901",
    "tarball": "http://registry.npmjs.org/@wilmoore/accessor/-/accessor-0.2.0.tgz"
  },
  "directories": {}
}
```

There is one caveat. The downloads tracking API for scoped packages is closed off. This is easy to spot by simply looking at any npm package page for a scoped package (no downloads are show).

- https://www.npmjs.com/package/@wilmoore/accessor
- https://www.npmjs.com/package/@yummies/inherit-loader

This is a known issue as noted at https://github.com/npm/download-counts/issues/23. For now, this resolves the license and version links as depicted below:

## version image

![](https://cloudup.com/c9ZuUbrtuLt+)

## license image

![](https://cloudup.com/c5aL1s4y9vs+)

## downloads images (no data seems to be captured)

![](https://cloudup.com/c-Wavp_w4dB+)
