### PR TITLE
Add a link to C# port of Shield style badge lib.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ Other systems that produce badges following the same design, hosted elsewhere, a
 | shielded                          | JavaScript | [shielded][shielded issues]  |
 | [buckler.repl.ca][]               | Go         | [buckler][buckler issues]    |
 | old img.shields.io (discontinued) | Python     | [img.shields.io-old][]       |
+| DotBadge                          | C#         | [DotBadge](https://github.com/rebornix/DotBadge/issues) |
 
 Please report **bugs** and discuss implementation specific concerns (performance characteristics, etc.) in the repository for the respective implementation.
 


### PR DESCRIPTION
When we try to add a badge service to [visual studio gallery](visualstudiogallery.msdn.microsoft.com), we find Shield is the best option but there is no .NET implementation. So we port it to [.NET](https://github.com/rebornix/DotBadge) for better code integration.

I'll appreciate it if you can add a link to C# port of Shield badge library and CLI, which can bring more audience to this tiny draft project. But we can understand if you don't, as it's not an official one :)