### PR TITLE
Add CocoaPods documentation percentage

### DIFF
--- a/server.js
+++ b/server.js
@@ -2034,7 +2034,6 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'http://metrics.cocoapods.org/api/v1/pods/' + spec;
   var badgeData = getBadgeData('pod', data);
-  badgeData.colorscheme = null;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';

--- a/server.js
+++ b/server.js
@@ -2038,6 +2038,7 @@ cache(function(data, match, sendBadge, request) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
+      return;
     }
     try {
       var data = JSON.parse(buffer);

--- a/server.js
+++ b/server.js
@@ -2028,6 +2028,32 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+camp.route(/^\/cocoapods\/metrics\/doc-percent\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var spec = match[1];  // eg, AFNetworking
+  var format = match[2];
+  var apiUrl = 'http://metrics.cocoapods.org/api/v1/pods/' + spec;
+  var badgeData = getBadgeData('pod', data);
+  badgeData.colorscheme = null;
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var percentage = data.cocoadocs.doc_percent;
+      badgeData.colorscheme = coveragePercentageColor(percentage);
+      badgeData.text[0] = 'docs';
+      badgeData.text[1] = percentage + '%'
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // GitHub tag integration.
 camp.route(/^\/github\/tag\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -518,6 +518,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/cocoapods/p/AFNetworking.svg' alt='' /></td>
     <td><code>https://img.shields.io/cocoapods/p/AFNetworking.svg</code></td>
   </tr>
+  <tr><th> CocoaPods: </th>
+    <td><img src='/cocoapods/metrics/doc-percent/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/metrics/doc-percent/AFNetworking.svg</code></td>
+  </tr>
   <tr><th> Wheelmap: </th>
     <td><img src='/wheelmap/a/2323004600.svg' alt='' /></td>
     <td><code>https://img.shields.io/wheelmap/a/2323004600.svg</code></td>


### PR DESCRIPTION
This shield displays the percentage of a Pod's API that is documented as returned by the CocoaPods metrics API. It can be quite useful when figuring out if you'd like to bring in a third-party dependency.

The entire list of metrics is available [here](http://metrics.cocoapods.org/api/v1/pods/AFNetworking). This  endpoint could easily be expanded to support more metrics as needed.