### PR TITLE
Add CodeCov Private Repository Support

### DIFF
--- a/server.js
+++ b/server.js
@@ -1540,13 +1540,24 @@ cache(function(data, match, sendBadge, request) {
   var userRepo = match[1];  // eg, `github/codecov/example-python`.
   var branch = match[2];
   var format = match[3];
+  var token = data['token'];  // for private repositories (?token=1234)
   var apiUrl = {
     url: 'https://codecov.io/' + userRepo + '/coverage.svg',
     followRedirect: false,
     method: 'HEAD',
   };
+  // Query Params
+  queryParams = [];
   if (branch) {
-    apiUrl.url += '?branch=' + branch;
+    queryParams.push({name: 'branch', value: branch})
+  }
+  if (token) {
+    queryParams.push({name: 'token', value: token})
+  }
+  for (i = 0; i < queryParams.length; i++) {
+    var param = queryParams[i];
+    var sep = (i == 0 ? '?' : '&');
+    apiUrl.url += sep + param.name + '=' + param.value;
   }
   var badgeData = getBadgeData('coverage', data);
   request(apiUrl, function(err, res) {

--- a/server.js
+++ b/server.js
@@ -1536,7 +1536,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Codecov integration.
-camp.route(/^\/codecov\/c\/(?:t:([A-Za-z1-9]+))?[+\/]?([^\/]+\/[^\/]+\/[^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codecov\/c\/(?:token\/(\w+))?[+\/]?([^\/]+\/[^\/]+\/[^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var token = match[1];
   var userRepo = match[2];  // eg, `github/codecov/example-python`.

--- a/server.js
+++ b/server.js
@@ -1535,12 +1535,12 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Codecov integration.
-camp.route(/^\/codecov\/c\/([^\/]+\/[^\/]+\/[^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codecov\/c\/(?:t:([A-Za-z1-9]+))?[+\/]?([^\/]+\/[^\/]+\/[^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var userRepo = match[1];  // eg, `github/codecov/example-python`.
-  var branch = match[2];
-  var format = match[3];
-  var token = data['token'];  // for private repositories (?token=1234)
+  var token = match[1];
+  var userRepo = match[2];  // eg, `github/codecov/example-python`.
+  var branch = match[3];
+  var format = match[4];
   var apiUrl = {
     url: 'https://codecov.io/' + userRepo + '/coverage.svg',
     followRedirect: false,

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ var fs = require('fs');
 var LruCache = require('./lru-cache.js');
 var badge = require('./badge.js');
 var svg2img = require('./svg-to-img.js');
+var querystring = require('querystring');
 var serverSecrets;
 try {
   // Everything that cannot be checked in but is useful server-side
@@ -1547,18 +1548,14 @@ cache(function(data, match, sendBadge, request) {
     method: 'HEAD',
   };
   // Query Params
-  queryParams = [];
+  queryParams = {};
   if (branch) {
-    queryParams.push({name: 'branch', value: branch})
+    queryParams.branch = branch;
   }
   if (token) {
-    queryParams.push({name: 'token', value: token})
+    queryParams.token = token;
   }
-  for (i = 0; i < queryParams.length; i++) {
-    var param = queryParams[i];
-    var sep = (i == 0 ? '?' : '&');
-    apiUrl.url += sep + param.name + '=' + param.value;
-  }
+  apiUrl.url += '?' + querystring.stringify(queryParams);
   var badgeData = getBadgeData('coverage', data);
   request(apiUrl, function(err, res) {
     if (err != null) {

--- a/try.html
+++ b/try.html
@@ -166,7 +166,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
   <tr><th> Codecov private: </th>
     <td><img src='/codecov/c/github/codecov/example-python.svg' alt=''/></td>
-    <td><code>https://img.shields.io/codecov/c/t:YOURTOKEN/github/codecov/example-python.svg</code></td>
+    <td><code>https://img.shields.io/codecov/c/token/YOURTOKEN/github/codecov/example-python.svg</code></td>
   </tr>
   <tr><th> Coverity Scan: </th>
     <td><img src='/coverity/scan/3997.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -166,7 +166,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
   <tr><th> Codecov private: </th>
     <td><img src='/codecov/c/github/codecov/example-python.svg' alt=''/></td>
-    <td><code>https://img.shields.io/codecov/c/github/codecov/example-python.svg?token=foo</code></td>
+    <td><code>https://img.shields.io/codecov/c/t:YOURTOKEN/github/codecov/example-python.svg</code></td>
   </tr>
   <tr><th> Coverity Scan: </th>
     <td><img src='/coverity/scan/3997.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -160,6 +160,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/codecov/c/github/codecov/example-python.svg' alt=''/></td>
     <td><code>https://img.shields.io/codecov/c/github/codecov/example-python.svg</code></td>
   </tr>
+  <tr><th> Codecov branch: </th>
+    <td><img src='/codecov/c/github/codecov/example-python/master.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codecov/c/github/codecov/example-python/master.svg</code></td>
+  </tr>
+  <tr><th> Codecov private: </th>
+    <td><img src='/codecov/c/github/codecov/example-python.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codecov/c/github/codecov/example-python.svg?token=foo</code></td>
+  </tr>
   <tr><th> Coverity Scan: </th>
     <td><img src='/coverity/scan/3997.svg' alt=''/></td>
     <td><code>https://img.shields.io/coverity/scan/3997.svg</code></td>


### PR DESCRIPTION
This PR adds the ability for CodeCov badges to be generated for private repositories. CodeCov supports a badge token which can be passed via a the `token` query param. 

Also added documentation to `try.html`