### PR TITLE
Add wercker v3 integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='https://img.shields.io/wercker/ci/54330318b4ce963d50020750.svg' alt=''/></td>
     <td><code>https://img.shields.io/wercker/ci/54330318b4ce963d50020750.svg</code></td>
   </tr>
+  <tr><th> Wercker (v3): </th>
+    <td><img src='https://img.shields.io/wercker/ci/wercker/docs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/wercker/ci/wercker/docs.svg</code></td>
+  </tr>
   <tr><th> TeamCity CodeBetter: </th>
     <td><img src='https://img.shields.io/teamcity/codebetter/bt428.svg' alt=''/></td>
     <td><code>https://img.shields.io/teamcity/codebetter/bt428.svg</code></td>

--- a/server.js
+++ b/server.js
@@ -310,7 +310,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Wercker integration
-camp.route(/^\/wercker\/ci\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/wercker\/ci\/([a-fA-F0-9]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var projectId = match[1];  // eg, `54330318b4ce963d50020750`
   var format = match[2];
@@ -318,6 +318,47 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     json: true,
     uri: 'https://app.wercker.com/getbuilds/' + projectId + '?limit=1'
+  };
+  var badgeData = getBadgeData('build', data);
+  request(options, function(err, res, json) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var build = json[0];
+
+      if (build.status === 'finished') {
+        if (build.result === 'passed') {
+          badgeData.colorscheme = 'brightgreen';
+          badgeData.text[1] = build.result;
+        } else {
+          badgeData.colorscheme = 'red';
+          badgeData.text[1] = build.result;
+        }
+      } else {
+        badgeData.text[1] = build.status;
+      }
+      sendBadge(format, badgeData);
+
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
+// Wercker V3 integration
+camp.route(/^\/wercker\/ci\/(.+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var owner = match[1];
+  var application = match[2];
+  var format = match[3];
+  var options = {
+    method: 'GET',
+    json: true,
+    uri: 'https://app.wercker.com/api/v3/applications/' + owner + '/' + application + '/builds?limit=1'
   };
   var badgeData = getBadgeData('build', data);
   request(options, function(err, res, json) {

--- a/try.html
+++ b/try.html
@@ -76,6 +76,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/wercker/ci/54330318b4ce963d50020750.svg' alt=''/></td>
     <td><code>https://img.shields.io/wercker/ci/54330318b4ce963d50020750.svg</code></td>
   </tr>
+  <tr><th> Wercker (v3): </th>
+    <td><img src='/wercker/ci/wercker/docs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/wercker/ci/wercker/docs.svg</code></td>
+  </tr>
   <tr><th> TeamCity CodeBetter: </th>
     <td><img src='/teamcity/codebetter/bt428.svg' alt=''/></td>
     <td><code>https://img.shields.io/teamcity/codebetter/bt428.svg</code></td>


### PR DESCRIPTION
This allows users to specify a owner + application name, instead of a application ID. 

Made the regex for the old endpoint a bit more strict so it wouldn't conflict with the new one.

It also uses the public, supported API.