### PR TITLE
sonar - do not default to %, more metric support

### DIFF
--- a/server.js
+++ b/server.js
@@ -551,8 +551,16 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
       var buildType = match[3];  // eg, `ru.yandex.qatools.allure:allure-core:master`.
       var metricName = match[4];
       var format = match[5];
+
+      var sonarMetricName = metricName;
+
+      if (metricName === 'tech_debt') {
+        //special condition for backwards compatibility
+        sonarMetricName = 'sqale_debt_ratio';
+      }
+
       var apiUrl = scheme + '://' + serverUrl + '/api/resources?resource=' + buildType
-          + '&depth=0&metrics=' + encodeURIComponent(metricName) + '&includetrends=true';
+          + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true';
 
       var badgeData = getBadgeData(metricName.replace(/_/g, ' '), data);
 
@@ -610,7 +618,7 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
             } else {
               badgeData.colorscheme = 'lightgrey';
             }
-          } else if (metricName === 'sqale_debt_ratio') {
+          } else if (metricName === 'sqale_debt_ratio' || metricName === 'tech_debt') {
             // colors are based on sonarqube default rating grid and display colors
             // [0,0.1)   ==> A (green)
             // [0.1,0.2) ==> B (yellowgreen)

--- a/server.js
+++ b/server.js
@@ -556,6 +556,8 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
         sonarMetricName = 'sqale_debt_ratio';
       } else if (metricName === 'loc' || metricName === 'lines_of_code') {
         sonarMetricName = 'ncloc';
+      } else if (metricName === 'fortify_rating') {
+        sonarMetricName = 'fortify-security-rating';
       } else {
         sonarMetricName = metricName
       }
@@ -582,6 +584,21 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
           if (metricName.indexOf('coverage') !== -1) {
             badgeData.text[1] = value.toFixed(0) + '%';
             badgeData.colorscheme = coveragePercentageColor(value);
+          } else if (metricName === 'fortify_rating') {
+            badgeData.text[1] = value + '/5';
+            if (value === 0) {
+              badgeData.colorscheme = 'red';
+            } else if (value === 1) {
+              badgeData.colorscheme = 'orange';
+            } else if (value === 2) {
+              badgeData.colorscheme = 'yellow';
+            } else if (value === 3) {
+              badgeData.colorscheme = 'yellowgreen';
+            } else if (value === 4) {
+              badgeData.colorscheme = 'green';
+            } else {
+              badgeData.colorscheme = 'brightgreen';
+            }
           } else if (metricName === 'tech_debt') {
             // colors are based on sonarqube default rating grid and display colors
             // [0,0.1)   ==> A (green)

--- a/server.js
+++ b/server.js
@@ -554,14 +554,14 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
       var sonarMetricName;
       if (metricName === 'tech_debt') {
         sonarMetricName = 'sqale_debt_ratio';
-      } else if (metricName === 'lines') {
+      } else if (metricName === 'loc' || metricName === 'lines_of_code') {
         sonarMetricName = 'ncloc';
       } else {
         sonarMetricName = metricName
       }
       var apiUrl = scheme + '://' + serverUrl + '/api/resources?resource=' + buildType
           + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true';
-      var badgeData = getBadgeData(metricName.replace('_', ' '), data);
+      var badgeData = getBadgeData(metricName.replace(/_/g, ' '), data);
 
       request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
         if (err != null) {

--- a/server.js
+++ b/server.js
@@ -594,6 +594,7 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
 
           } else if (metricName === 'fortify-security-rating') {
             badgeData.text[1] = value + '/5';
+
             if (value === 0) {
               badgeData.colorscheme = 'red';
             } else if (value === 1) {
@@ -604,8 +605,10 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
               badgeData.colorscheme = 'yellowgreen';
             } else if (value === 4) {
               badgeData.colorscheme = 'green';
-            } else {
+            } else if (value === 5) {
               badgeData.colorscheme = 'brightgreen';
+            } else {
+              badgeData.colorscheme = 'lightgrey';
             }
           } else if (metricName === 'sqale_debt_ratio') {
             // colors are based on sonarqube default rating grid and display colors
@@ -623,10 +626,10 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
               badgeData.colorscheme = 'yellow';
             } else if (value > 10) {
               badgeData.colorscheme = 'yellowgreen';
-            } else if (value > 1) {
-              badgeData.colorscheme = 'green';
-            } else {
+            } else if (value > 0) {
               badgeData.colorscheme = 'brightgreen';
+            } else {
+              badgeData.colorscheme = 'lightgrey';
             }
           } else {
             badgeData.text[1] = metric(value);

--- a/server.js
+++ b/server.js
@@ -551,21 +551,9 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
       var buildType = match[3];  // eg, `ru.yandex.qatools.allure:allure-core:master`.
       var metricName = match[4];
       var format = match[5];
-      var sonarMetricName;
-      if (metricName === 'tech_debt') {
-        sonarMetricName = 'sqale_debt_ratio';
-      } else if (metricName === 'loc' || metricName === 'lines_of_code') {
-        sonarMetricName = 'ncloc';
-      } else if (metricName === 'fortify_rating') {
-        sonarMetricName = 'fortify-security-rating';
-      } else if (['blocker', 'critical', 'major', 'minor', 'info'].indexOf(metricName) !== -1) {
-        sonarMetricName = metricName + '_violations';
-      } else {
-        sonarMetricName = metricName
-      }
       var apiUrl = scheme + '://' + serverUrl + '/api/resources?resource=' + buildType
-          + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true';
-      console.log('apiurl', apiUrl);
+          + '&depth=0&metrics=' + encodeURIComponent(metricName) + '&includetrends=true';
+
       var badgeData = getBadgeData(metricName.replace(/_/g, ' '), data);
 
       request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
@@ -587,24 +575,24 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
           if (metricName.indexOf('coverage') !== -1) {
             badgeData.text[1] = value.toFixed(0) + '%';
             badgeData.colorscheme = coveragePercentageColor(value);
-          } else if (/^\w+_violations$/.test(sonarMetricName)) {
+          } else if (/^\w+_violations$/.test(metricName)) {
             badgeData.text[1] = value;
             badgeData.colorscheme = 'brightgreen';
             if (value > 0) {
-              if (metricName === 'blocker') {
+              if (metricName === 'blocker_violations') {
                 badgeData.colorscheme = 'red';
-              } else if (metricName === 'critical') {
+              } else if (metricName === 'critical_violations') {
                 badgeData.colorscheme = 'orange';
-              } else if (metricName === 'major') {
+              } else if (metricName === 'major_violations') {
                 badgeData.colorscheme = 'yellow';
-              } else if (metricName === 'minor') {
+              } else if (metricName === 'minor_violations') {
                 badgeData.colorscheme = 'yellowgreen';
-              } else if (metricName === 'info') {
+              } else if (metricName === 'info_violations') {
                 badgeData.colorscheme = 'green';
               }
             }
 
-          } else if (metricName === 'fortify_rating') {
+          } else if (metricName === 'fortify-security-rating') {
             badgeData.text[1] = value + '/5';
             if (value === 0) {
               badgeData.colorscheme = 'red';
@@ -619,7 +607,7 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
             } else {
               badgeData.colorscheme = 'brightgreen';
             }
-          } else if (metricName === 'tech_debt') {
+          } else if (metricName === 'sqale_debt_ratio') {
             // colors are based on sonarqube default rating grid and display colors
             // [0,0.1)   ==> A (green)
             // [0.1,0.2) ==> B (yellowgreen)
@@ -642,7 +630,7 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
             }
           } else {
             badgeData.text[1] = metric(value);
-            badgeData.colorscheme = 'green';
+            badgeData.colorscheme = 'brightgreen';
           }
           sendBadge(format, badgeData);
         } catch(e) {


### PR DESCRIPTION
Changed to default to metric(value) instead of value + '%'.  % is shown for any coverage metrics.  Added special handling for fortify-security-rating metric.  Changed to use brightgreen instead of green for the "best" value for metrics to be more consistent with other badges.

Note:
I originally had another pull request that I closed, https://github.com/badges/shields/pull/447.  I didn't realize you could add ?label= and some of the changes I made in that pull request are unnecessary.
