### PR TITLE
Badge text modified to reflect actual style name

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,8 +680,8 @@ The following styles are available (flat is the default as of Feb 1st 2015):
   <td><code>https://img.shields.io/badge/style-flat-green.svg?style=flat</code></td>
   </tr>
   <tr>
-  <td><img src='https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square' alt=''/></td>
-  <td><code>https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square</code></td>
+  <td><img src='https://img.shields.io/badge/style-flat--square-green.svg?style=flat-square' alt=''/></td>
+  <td><code>https://img.shields.io/badge/style-flat--square-green.svg?style=flat-square</code></td>
   </tr>
 </tbody></table>
 


### PR DESCRIPTION
The badge demonstrating use of style `flat-square` was titled "flat-square*d*" (extra "d" at the end), which invited confusion.