### PR TITLE
Avoid sending dummy requests to packagist

### DIFF
--- a/server.js
+++ b/server.js
@@ -989,6 +989,10 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://packagist.org/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('downloads', data);
+  if (userRepo.substr(-14) === '/:package_name') {
+    badgeData.text[1] = 'invalid';
+    return sendBadge(format, badgeData);
+  }
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1027,6 +1031,10 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://packagist.org/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('packagist', data);
+  if (userRepo.substr(-14) === '/:package_name') {
+    badgeData.text[1] = 'invalid';
+    return sendBadge(format, badgeData);
+  }
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1105,6 +1113,10 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://packagist.org/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('license', data);
+  if (userRepo.substr(-14) === '/:package_name') {
+    badgeData.text[1] = 'invalid';
+    return sendBadge(format, badgeData);
+  }
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';


### PR DESCRIPTION
I spotted a bunch of 404s in the packagist logs that are due to people publishing things like https://github.com/thephpleague/skeleton and other people not editing the READMEs before publishing I suppose. 

Anyway I hope the fix is appropriate and acceptable.