### PR TITLE
Use pdfkit instead of canvas

### DIFF
--- a/badge.js
+++ b/badge.js
@@ -2,18 +2,7 @@ var fs = require('fs');
 var path = require('path');
 var SVGO = require('svgo');
 var dot = require('dot');
-
-// Initialize what will be used for automatic text measurement.
-var Canvas = require('canvas');
-var canvasElement = new Canvas(0, 0);   // Width and height are irrelevant.
-var canvasContext = canvasElement.getContext('2d');
-var CanvasFont = Canvas.Font;
-try {
-  var opensans = new CanvasFont('Verdana',
-      path.join(__dirname, 'Verdana.ttf'));
-  canvasContext.addFont(opensans);
-} catch(e) {}
-canvasContext.font = '11px Verdana, "DejaVu Sans"';
+var measureTextWidth = require('./measure-text');
 
 // cache templates.
 var templates = {};
@@ -75,9 +64,9 @@ function makeImage(data, cb) {
     data.logoPadding = 0;
   }
   data.widths = [
-    (canvasContext.measureText(data.text[0]).width|0) + 10
+    (measureTextWidth(data.text[0])|0) + 10
       + data.logoWidth + data.logoPadding,
-    (canvasContext.measureText(data.text[1]).width|0) + 10,
+    (measureTextWidth(data.text[1])|0) + 10,
   ];
   if (data.links === undefined) {
     data.links = ['', ''];

--- a/measure-text.js
+++ b/measure-text.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var path = require('path');
+var PDFDocument = require('pdfkit');
+
+var doc = (new PDFDocument({size:'A4', layout:'landscape'}))
+  .font(path.join(__dirname, 'Verdana.ttf'))
+  .fontSize(11);
+
+module.exports = measure;
+function measure(str) {
+  return doc.widthOfString(str);
+}

--- a/measure-text.js
+++ b/measure-text.js
@@ -1,11 +1,17 @@
 'use strict';
 
 var path = require('path');
+var fs = require('fs');
 var PDFDocument = require('pdfkit');
 
-var doc = (new PDFDocument({size:'A4', layout:'landscape'}))
-  .font(path.join(__dirname, 'Verdana.ttf'))
-  .fontSize(11);
+var doc = (new PDFDocument({size:'A4', layout:'landscape'}));
+try {
+  doc = doc.font(path.join(__dirname, 'Verdana.ttf'));
+} catch (ex) {
+  doc = doc.font('Helvetica-Bold')
+  console.warn('Could not load font file "Verdana.ttf", text widths will therefore be approximate', ex);
+}
+doc = doc.fontSize(11);
 
 module.exports = measure;
 function measure(str) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "dot": "~1.0.3",
     "svgo": "~0.5.1",
-    "canvas": "~1.1.2",
+    "pdfkit": "~0.7.1",
     "phantomjs": "~1.9.2-6",
     "es6-promise": "~2.1.0",
     "request": "~2.55.0",


### PR DESCRIPTION
This removes the dependency on the native "canvas" module and instead uses pdfkit.  I did this because I was unable to get canvas installed on my machine.  I'm not sure if this will perform better or worse, but it seems like something that may be worth benchmarking.