### PR TITLE
Updated matching to remove redundant python versions.

### DIFF
--- a/server.js
+++ b/server.js
@@ -1639,6 +1639,15 @@ cache(function(data, match, sendBadge, request) {
             versions.push(matched[1]);
           }
         }
+        ['2', '3'].forEach(function(version) {
+            if (versions.some(function(element, index, array) { return new RegExp('^' + version + '\\.\\d$').exec(element); })) {
+                versions.forEach(function(element, index, array) {
+                    if (element === version) {
+                        array.splice(index, 1);
+                    }
+                });
+            }
+        });
         if (!versions.length) {
           versions.push('not found');
         }

--- a/server.js
+++ b/server.js
@@ -1640,13 +1640,13 @@ cache(function(data, match, sendBadge, request) {
           }
         }
         ['2', '3'].forEach(function(version) {
-            if (versions.some(function(element, index, array) { return new RegExp('^' + version + '\\.\\d$').exec(element); })) {
-                versions.forEach(function(element, index, array) {
-                    if (element === version) {
-                        array.splice(index, 1);
-                    }
-                });
-            }
+          if (versions.some(function(element, index, array) { return new RegExp('^' + version + '\\.\\d$').exec(element); })) {
+            versions.forEach(function(element, index, array) {
+              if (element === version) {
+                array.splice(index, 1);
+              }
+            });
+          }
         });
         if (!versions.length) {
           versions.push('not found');

--- a/server.js
+++ b/server.js
@@ -1641,11 +1641,13 @@ cache(function(data, match, sendBadge, request) {
         }
         ['2', '3'].forEach(function(version) {
           if (versions.some(function(element, index, array) { return new RegExp('^' + version + '\\.\\d$').exec(element); })) {
+            var filteredVersions = [];
             versions.forEach(function(element, index, array) {
-              if (element === version) {
-                array.splice(index, 1);
+              if (element !== version) {
+                filteredVersions.push(element);
               }
             });
+            versions = filteredVersions;
           }
         });
         if (!versions.length) {


### PR DESCRIPTION
This should remove redundant version numbers such as:
```{2, 2.6, 2.7} -> {2.6, 2.7}```
or
```{2, 3.2} -> {2, 3.2}```
or
```{3, 3.0} -> {3.0}```