### PR TITLE
Support for Bintray version badge.

### DIFF
--- a/index.html
+++ b/index.html
@@ -379,6 +379,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='https://img.shields.io/packagist/vpre/symfony/symfony.svg' alt=''/></td>
   <td><code>https://img.shields.io/packagist/vpre/symfony/symfony.svg</code></td>
   </tr>
+  <tr><th> Bintray: </th>
+  <td><img src='https://img.shields.io/bintray/v/asciidoctor/maven/asciidoctorj.svg' alt=''/></td>
+  <td><code>https://img.shields.io/bintray/v/asciidoctor/maven/asciidoctorj.svg</code></td>
+  </tr>
   <tr><th> Clojars: </th>
   <td><img src='https://img.shields.io/clojars/v/prismic.svg' alt=''/></td>
   <td><code>https://img.shields.io/clojars/v/prismic.svg</code></td>

--- a/server.js
+++ b/server.js
@@ -1379,7 +1379,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var vdata = versionColor(data.name);
-      badgeData.text[1] = 'v' + data.name;
+      badgeData.text[1] = vdata.version;
       badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -1348,6 +1348,47 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Bintray version integration
+camp.route(/^\/bintray\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var path = match[1]; // :subject/:repo/:package (e.g. asciidoctor/maven/asciidoctorj)
+  var format = match[2];
+
+  var options = {
+    method: 'GET',
+    uri: 'https://bintray.com/api/v1/packages/' + path + '/versions/_latest',
+    headers: {
+      Accept: 'application/json'
+    }
+  };
+
+  if (serverSecrets && serverSecrets.bintray_user) {
+    options.auth = {
+      user: serverSecrets.bintray_user,
+      pass: serverSecrets.bintray_apikey
+    }
+  }
+
+  var badgeData = getBadgeData('bintray', data);
+  request(options, function(err, res, buffer) {
+    if (err !== null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var vdata = versionColor(data.name);
+      badgeData.text[1] = 'v' + data.name;
+      badgeData.colorscheme = 'brightgreen';
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Clojars version integration
 camp.route(/^\/clojars\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -378,6 +378,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/packagist/vpre/symfony/symfony.svg' alt=''/></td>
   <td><code>https://img.shields.io/packagist/vpre/symfony/symfony.svg</code></td>
   </tr>
+  <tr><th> Bintray: </th>
+  <td><img src='/bintray/v/asciidoctor/maven/asciidoctorj.svg' alt=''/></td>
+  <td><code>https://img.shields.io/bintray/v/asciidoctor/maven/asciidoctorj.svg</code></td>
+  </tr>
   <tr><th> Clojars: </th>
   <td><img src='/clojars/v/prismic.svg' alt=''/></td>
   <td><code>https://img.shields.io/clojars/v/prismic.svg</code></td>


### PR DESCRIPTION
Addresses #58 by supporting a badge showing the latest version of
a Bintray package.

Ran a test locally and it seemed to work fine. You'd need to get an API key from Bintray to put in `secret.json` and work with them on the rate limit question.