### PR TITLE
Fix grey Node.js version badges

### DIFF
--- a/server.js
+++ b/server.js
@@ -1354,7 +1354,7 @@ cache(function(data, match, sendBadge, request) {
       if (data.engines && data.engines.node) {
         var versionRange = data.engines.node;
         badgeData.text[1] = versionRange;
-        regularUpdate('http://nodejs.org/dist/latest/SHASUMS.txt',
+        regularUpdate('http://nodejs.org/dist/latest/SHASUMS256.txt',
           (24 * 3600 * 1000),
           function(shasums) {
             // tarball index start, tarball index end


### PR DESCRIPTION
I noticed all the Node.js versions badges were suddenly grey. Looks like with the Node.js 4.0 launch, they also changed from SHA1 to SHA256 and changed the name of the file with it. This updates the URL to get the current version of Node.js from.