### PR TITLE
Add ImageLayers.io Docker Hub layer information service

### DIFF
--- a/try.html
+++ b/try.html
@@ -669,6 +669,15 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/docker/pulls/mashape/kong.svg' alt=''/></td>
   <td><code>https://img.shields.io/docker/pulls/mashape/kong.svg</code></td>
   </tr>
+  <tr><th data-keywords='imagelayers'> ImageLayers Size: </th>
+  <td><img src='/imagelayers/image-size/_/ubuntu/latest.svg' alt=''/></td>
+  <td><code>https://img.shields.io/imagelayers/image-size/_/ubuntu/latest.svg</code></td>
+  </tr>
+  </tr>
+  <tr><th data-keywords='imagelayers'> ImageLayers Layers: </th>
+  <td><img src='/imagelayers/layers/_/ubuntu/latest.svg' alt=''/></td>
+  <td><code>https://img.shields.io/imagelayers/layers/_/ubuntu/latest.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="miscellaneous"> Longer Miscellaneous </h3>


### PR DESCRIPTION
This adds a ImageLayers.io badge (which resembles the same data in their own badge). I wanted to use their badge. But it didn't conform to the look of all the other ones I was already using from shields.io.

This also adds a small `filesize` package. It was a quick way to do humanized file sizes. If this undesirable, I can try and rework it without.