### PR TITLE
Fix broken Dockerfile to use official node image instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
-FROM ubuntu:14.04
-RUN apt-get update && apt-get install -y node npm
-RUN apt-get update && apt-get install -y libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
-RUN npm cache clean -f
-RUN npm install -g n
-RUN n stable
-RUN npm install canvas
-RUN mkdir -p /var/app
-ADD package.json /var/app/package.json
-RUN cd /var/app && npm install
-ADD . /var/app
-
+FROM node:0.12.7-onbuild
 ENV INFOSITE http://shields.io
-WORKDIR /var/app
-CMD npm run start
+EXPOSE 80

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -127,6 +127,32 @@ make deploy
 heroku open
 ```
 
+# Docker
+
+You can build and run the server locally using Docker. First build an image:
+
+```console
+$ build -t shields ./
+Sending build context to Docker daemon 3.923 MB
+Step 0 : FROM node:0.12.7-onbuild
+…
+Removing intermediate container c4678889953f
+Successfully built 4471b442c220
+```
+
+Then run the container:
+
+```console
+$ docker run --rm -p 8080:80 shields
+
+> gh-badges@1.1.2 start /usr/src/app
+> node server.js
+
+http://[::1]:80/try.html
+```
+
+Assuming Docker is running locally, you should be able to get to the application at http://localhost:8080/try.html. If you run Docker in a virtual machine (such as boot2docker or Docker Machine) then you will need to replace `localhost` with the actual IP address of that virtual machine.
+
 # Links
 
 See <https://github.com/h5bp/lazyweb-requests/issues/150> for a story of the


### PR DESCRIPTION
As I was working on #538, I ran the server in Docker. But the default `Dockerfile` was broken. I updated to use the official Node image with `ONBUILD` hooks instead. Also added some information about it in the docs (the two commands I were using together to build and run).

I did try Node 4.0.0, but it looks like some other dependencies are still broken on 4.0.0 (namely https://github.com/socketio/socket.io/issues/2228). 