### PR TITLE
Support NodeJS 4.x - Upgrade Canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "dot": "~1.0.3",
     "svgo": "~0.5.1",
-    "canvas": "~1.1.2",
+    "canvas": "~1.3.0",
     "phantomjs": "~1.9.2-6",
     "es6-promise": "~2.1.0",
     "request": "~2.55.0",


### PR DESCRIPTION
Updating Canvas to 1.3.0 allows this to build under NodeJS 4.x
