### PR TITLE
.editorconfig file to help all contributors to align to a common project standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+
+[*.{js,json,html,css}]
+charset = utf-8
+indent_size = 2


### PR DESCRIPTION
Based on my experience with previous pull requests, since I was using different formatting rules, it was a bit hard to work with my IDE which kept on formatting the file based on different rules.
This basic editorconfig settings should help out with that and enable contributors to set their IDEs/Editors to use it and prevent mistakes.
For me personally the issue was with the indent set to 4 spaces for js files in my projects while in this project you use 2 spaces. And since it is a bit not standard, this should help out.
Naturally contributors would need to actually use it.