### PR TITLE
Allow customization and removal of version prefixes.

### DIFF
--- a/server.js
+++ b/server.js
@@ -450,6 +450,7 @@ cache(function (data, match, sendBadge, request) {
   var crate = match[2];  // crate name, e.g. rustc-serialize
   var version = match[3];  // crate version in semver format, optional, e.g. 0.1.2
   var format = match[4];
+  var prefix = data.prefix;
   var modes = {
     'd': {
       name: 'downloads',
@@ -476,7 +477,7 @@ cache(function (data, match, sendBadge, request) {
       version: true,
       process: function (data, badgeData) {
         version = data.version? data.version.num: data.crate.max_version;
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
       }
@@ -1090,6 +1091,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://packagist.org/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('packagist', data);
+  var prefix = data.prefix;
   if (userRepo.substr(-14) === '/:package_name') {
     badgeData.text[1] = 'invalid';
     return sendBadge(format, badgeData);
@@ -1137,7 +1139,7 @@ cache(function(data, match, sendBadge, request) {
         //if (!!aliasesMap[stableVersion]) {
         //  stableVersion = aliasesMap[stableVersion];
         //}
-        var vdata = versionColor(stableVersion);
+        var vdata = versionColor(stableVersion, prefix);
         badgeText = vdata.version;
         badgeColor = vdata.color;
         break;
@@ -1146,7 +1148,7 @@ cache(function(data, match, sendBadge, request) {
         //if (!!aliasesMap[unstableVersion]) {
         //  unstableVersion = aliasesMap[unstableVersion];
         //}
-        var vdata = versionColor(unstableVersion);
+        var vdata = versionColor(unstableVersion, prefix);
         badgeText = vdata.version;
         badgeColor = 'orange';
         break;
@@ -1290,6 +1292,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://registry.npmjs.org/' + repo + '/latest';
   var badgeData = getBadgeData('npm', data);
+  var prefix = data.prefix;
   // Using the Accept header because of this bug:
   // <https://github.com/npm/npmjs.org/issues/163>
   request(apiUrl, { headers: { 'Accept': '*/*' } }, function(err, res, buffer) {
@@ -1301,7 +1304,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var version = data.version;
-      var vdata = versionColor(version);
+      var vdata = versionColor(version, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
@@ -1400,6 +1403,7 @@ camp.route(/^\/bintray\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var path = match[1]; // :subject/:repo/:package (e.g. asciidoctor/maven/asciidoctorj)
   var format = match[2];
+  var prefix = data.prefix;
 
   var options = {
     method: 'GET',
@@ -1425,7 +1429,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var vdata = versionColor(data.name);
+      var vdata = versionColor(data.name, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
@@ -1443,6 +1447,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://clojars.org/' + clojar + '/latest-version.json';
   var badgeData = getBadgeData('clojars', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err !== null) {
       badgeData.text[1] = 'inaccessible';
@@ -1451,7 +1456,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var vdata = versionColor(data.version);
+      var vdata = versionColor(data.version, prefix);
       badgeData.text[1] = "[" + clojar + " \"" + data.version + "\"]";
       badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
@@ -1469,6 +1474,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://rubygems.org/api/v1/gems/' + repo + '.json';
   var badgeData = getBadgeData('gem', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1478,7 +1484,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var version = data.version;
-      var vdata = versionColor(version);
+      var vdata = versionColor(version, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
@@ -1636,6 +1642,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://pypi.python.org/pypi/' + egg + '/json';
   var badgeData = getBadgeData('pypi', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1664,7 +1671,7 @@ cache(function(data, match, sendBadge, request) {
         sendBadge(format, badgeData);
       } else if (info === 'v') {
         var version = data.info.version;
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
@@ -1799,6 +1806,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://pub.dartlang.org/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('pub', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1810,7 +1818,7 @@ cache(function(data, match, sendBadge, request) {
       // Grab the latest stable version, or an unstable
       var versions = data.versions;
       var version = latestVersion(versions);
-      var vdata = versionColor(version);
+      var vdata = versionColor(version, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
@@ -1829,6 +1837,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://hex.pm/api/packages/' + repo;
   var badgeData = getBadgeData('hex', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1857,7 +1866,7 @@ cache(function(data, match, sendBadge, request) {
         sendBadge(format, badgeData);
       } else if (info === 'v') {
         var version = data.releases[0].version;
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
@@ -2369,6 +2378,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://hackage.haskell.org/package/' + repo + '/' + repo + '.cabal';
   var badgeData = getBadgeData('hackage', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -2384,7 +2394,8 @@ cache(function(data, match, sendBadge, request) {
       // we'll render the 'invalid' badge below, which is the correct thing
       // to do.
       var version = versionLines[0].replace(/\s+/, '').split(/:/)[1];
-      badgeData.text[1] = 'v' + version;
+      var vdata = versionColor(version, prefix);
+      badgeData.text[1] = vdata.version;
       if (version[0] === '0') {
         badgeData.colorscheme = 'orange';
       } else {
@@ -2436,6 +2447,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var apiUrl = 'https://trunk.cocoapods.org/api/v1/pods/' + spec + '/specs/latest';
   var badgeData = getBadgeData('pod', data);
+  var prefix = data.prefix;
   badgeData.colorscheme = null;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
@@ -2457,10 +2469,8 @@ cache(function(data, match, sendBadge, request) {
       }).join(' | ');
       version = version.replace(/^v/, "");
       if (type === 'v') {
-        badgeData.text[1] = version;
-        if (/^\d/.test(badgeData.text[1])) {
-          badgeData.text[1] = 'v' + version;
-        }
+        var vdata = versionColor(version, prefix);
+        badgeData.text[1] = vdata.version;
         badgeData.colorB = '#5BA7E9';
       } else if (type === 'p') {
         badgeData.text[0] = 'platform';
@@ -2513,6 +2523,7 @@ cache(function(data, match, sendBadge, request) {
   var repo = match[2];
   var format = match[3];
   var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/tags';
+  var prefix = data.prefix;
   // Using our OAuth App secret grants us 5000 req/hour
   // instead of the standard 60 req/hour.
   if (serverSecrets) {
@@ -2538,7 +2549,7 @@ cache(function(data, match, sendBadge, request) {
       var data = JSON.parse(buffer);
       var versions = data.map(function(e) { return e.name; });
       var tag = latestVersion(versions);
-      var vdata = versionColor(tag);
+      var vdata = versionColor(tag, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
@@ -2556,6 +2567,7 @@ cache(function(data, match, sendBadge, request) {
   var repo = match[2];
   var format = match[3];
   var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/releases/latest';
+  var prefix = data.prefix;
   // Using our OAuth App secret grants us 5000 req/hour
   // instead of the standard 60 req/hour.
   if (serverSecrets) {
@@ -2581,7 +2593,7 @@ cache(function(data, match, sendBadge, request) {
       var data = JSON.parse(buffer);
       var version = data.tag_name;
       var prerelease = data.prerelease;
-      var vdata = versionColor(version);
+      var vdata = versionColor(version, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = prerelease ? 'orange' : 'blue';
       sendBadge(format, badgeData);
@@ -2991,6 +3003,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://supermarket.getchef.com/api/v1/cookbooks/' + cookbook + '/versions/latest';
   var badgeData = getBadgeData('cookbook', data);
+  var prefix = data.prefix;
 
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
@@ -3002,7 +3015,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var version = data.version;
-      var vdata = versionColor(version);
+      var vdata = versionColor(version, prefix);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
@@ -3058,6 +3071,7 @@ function mapNugetFeed(pattern, offset, getInfo) {
     var format = match[offset + 2];
     var apiUrl = info.feed;
     var badgeData = getBadgeData(site, data);
+    var prefix = data.prefix;
     getNugetPackage(apiUrl, repo, null, request, function(err, data) {
       if (err != null) {
         badgeData.text[1] = 'inaccessible';
@@ -3066,7 +3080,8 @@ function mapNugetFeed(pattern, offset, getInfo) {
       }
       try {
         var version = data.NormalizedVersion || data.Version;
-        badgeData.text[1] = 'v' + version;
+        var vdata = versionColor(version, prefix);
+        badgeData.text[1] = vdata.version;
         if (version.indexOf('-') !== -1) {
           badgeData.colorscheme = 'yellow';
         } else if (version[0] === '0') {
@@ -3090,6 +3105,7 @@ function mapNugetFeed(pattern, offset, getInfo) {
     var format = match[offset + 2];
     var apiUrl = info.feed;
     var badgeData = getBadgeData(site, data);
+    var prefix = data.prefix;
     getNugetPackage(apiUrl, repo, true, request, function(err, data) {
       if (err != null) {
         badgeData.text[1] = 'inaccessible';
@@ -3098,7 +3114,8 @@ function mapNugetFeed(pattern, offset, getInfo) {
       }
       try {
         var version = data.NormalizedVersion || data.Version;
-        badgeData.text[1] = 'v' + version;
+        var vdata = versionColor(version, prefix);
+        badgeData.text[1] = vdata.version;
         if (version.indexOf('-') !== -1) {
           badgeData.colorscheme = 'yellow';
         } else if (version[0] === '0') {
@@ -3171,6 +3188,7 @@ cache(function(data, match, sendBadge, request) {
     uri: 'https://forgeapi.puppetlabs.com/v3/modules/' + user + '-' + module
   };
   var badgeData = getBadgeData('puppetforge', data);
+  var prefix = data.prefix;
   request(options, function dealWithData(err, res, json) {
     if (err != null || (json.length !== undefined && json.length === 0)) {
       badgeData.text[1] = 'inaccessible';
@@ -3180,7 +3198,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       if (info === 'v') {
         if (json.current_release) {
-          var vdata = versionColor(json.current_release.version);
+          var vdata = versionColor(json.current_release.version, prefix);
           badgeData.text[1] = vdata.version;
           badgeData.colorscheme = vdata.color;
         } else {
@@ -3459,6 +3477,7 @@ cache(function(data, match, sendBadge, request) {
   var query = "g:" + encodeURIComponent(groupId) + "+AND+a:" + encodeURIComponent(artifactId);
   var apiUrl = 'https://search.maven.org/solrsearch/select?rows=1&q='+query;
   var badgeData = getBadgeData('maven-central', data);
+  var prefix = data.prefix;
   request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -3468,7 +3487,8 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var version = data.response.docs[0].latestVersion;
-      badgeData.text[1] = 'v' + version;
+      var vdata = versionColor(version, prefix);
+      badgeData.text[1] = vdata.version;
       if (version === '0' || /SNAPSHOT/.test(version)) {
         badgeData.colorscheme = 'orange';
       } else {
@@ -3489,6 +3509,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var badgeData = getBadgeData('bower', data);
   var bower = require('bower');
+  var prefix = data.prefix;
   bower.commands.info(repo, 'version')
     .on('error', function() {
       badgeData.text[1] = 'inaccessible';
@@ -3496,7 +3517,7 @@ cache(function(data, match, sendBadge, request) {
     })
     .on('end', function(version) {
       try {
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
@@ -3569,6 +3590,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'http://api.wordpress.org/plugins/info/1.0/' + plugin + '.json';
   var badgeData = getBadgeData('plugin', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -3578,7 +3600,8 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var version = data.version;
-      badgeData.text[1] = 'v' + version;
+      var vdata = versionColor(version, prefix);
+      badgeData.text[1] = vdata.version;
       if (version[0] === '0') {
         badgeData.colorscheme = 'orange';
       } else {
@@ -3848,6 +3871,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var apiUrl = 'https://atom.io/api/packages/' + repo;
   var badgeData = getBadgeData('apm', data);
+  var prefix = data.prefix;
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -3862,7 +3886,8 @@ cache(function(data, match, sendBadge, request) {
       sendBadge(format, badgeData);
       return;
     }
-    badgeData.text[1] = 'v' + version;
+    var vdata = versionColor(version, prefix);
+    badgeData.text[1] = vdata.version;
     badgeData.colorscheme = 'green';
     sendBadge(format, badgeData);
   });
@@ -3991,6 +4016,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var badgeData = getBadgeData('cpan', data);
   var url = 'https://api.metacpan.org/v0/release/'+pkg;
+  var prefix = data.prefix;
   request(url, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -4002,7 +4028,7 @@ cache(function(data, match, sendBadge, request) {
 
       if (info === 'v') {
         var version = data.version;
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
       } else if (info === 'l') {
@@ -4026,6 +4052,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var url = 'http://www.ctan.org/json/pkg/' + pkg;
   var badgeData = getBadgeData('ctan', data);
+  var prefix = data.prefix;
   request(url, function (err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -4037,7 +4064,7 @@ cache(function(data, match, sendBadge, request) {
 
       if (info === 'v') {
         var version = data.version.number;
-        var vdata = versionColor(version);
+        var vdata = versionColor(version, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
@@ -4066,6 +4093,7 @@ cache(function (data, match, sendBadge, request) {
   var version = match[3]; // version (1.2.3 or latest)
   var format = match[4];
   var apiUrl = 'http://code.dlang.org/api/packages/'+pkg;
+  var prefix = data.prefix;
   if (version) {
     apiUrl += '/' + version;
   }
@@ -4101,7 +4129,7 @@ cache(function (data, match, sendBadge, request) {
             break;
         }
         if (version) {
-            badgeData.text[1] += ' ' + versionColor(version).version;
+            badgeData.text[1] += ' ' + versionColor(version, prefix).version;
         }
         badgeData.colorscheme = downloadCountColor(downloads);
         sendBadge(format, badgeData);
@@ -4120,6 +4148,7 @@ cache(function (data, match, sendBadge, request) {
   var pkg = match[2];  // package name, e.g. vibe-d
   var format = match[3];
   var apiUrl = 'http://code.dlang.org/api/packages/' + pkg;
+  var prefix = data.prefix;
   if (info === 'v') {
     apiUrl += '/latest';
   } else if (info === 'l') {
@@ -4135,7 +4164,7 @@ cache(function (data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       if (info === 'v') {
-        var vdata = versionColor(data);
+        var vdata = versionColor(data, prefix);
         badgeData.text[1] = vdata.version;
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
@@ -4583,12 +4612,16 @@ function floorCountColor(value, yellow, yellowgreen, green) {
   }
 }
 
-function versionColor(version) {
+function versionColor(version, prefix) {
   var first = version[0];
+  if (undefined === prefix) {
+    prefix = ''
+  }
   if (first === 'v') {
     first = version[1];
+    version = prefix + version.substring(1);
   } else if (/^[0-9]/.test(version)) {
-    version = 'v' + version;
+    version = prefix + version;
   }
   if (first === '0' || (version.indexOf('-') !== -1)) {
     return { version: version, color: 'orange' };


### PR DESCRIPTION
Gentlemen; imagine, if you will, a simpler world. A world unfettered by superfluous clutter. A cleaner, articulate, more eloquent way of being. That world is here and now.

This PR removes (by default) the `v` prefix for all version type shields. It also allows configuration of custom prefixes by way of the GET parameter `prefix`.

Think about it, why would you want **FILTHY** old this:

![Disgusting!](https://img.shields.io/npm/v/npm.svg "Disgusting!")

When you could have **AMAZING** new this:

![Delectable!](https://shields-io-version-prefix.herokuapp.com/npm/v/npm.svg "Delectable!")

Or even **GLORIOUS** this:

![Wow!](https://shields-io-version-prefix.herokuapp.com/packagist/v/symfony/symfony.svg?prefix=motherflippin%27%20 "WOW!")

What is this sorcery? I'll let zero-time Academy Award® winner, Leonardo DiCaprio tell you in his own words:

![It's the way of the future.](http://media.tumblr.com/6787481b692cfde31d3dda9448d44ea5/tumblr_inline_mi47dvpJFz1qz4rgp.gif "It's the way of the future.")

L-Dizzle is right, and you know it. A merge for this PR is a merge for the future. Not just your future, but for your children's futures. The future of the human race as we know it.

Merge today!