### PR TITLE
Allow token authentication on github

### DIFF
--- a/server.js
+++ b/server.js
@@ -4540,6 +4540,11 @@ var githubHeaders = {
   'Accept': 'application/vnd.github.v3+json'
 };
 
+// You can manage your personal github token at https://github.com/settings/tokens
+if (serverSecrets && serverSecrets.gh_token) {
+  githubHeaders['Authorization'] = 'token ' + serverSecrets.gh_token;
+}
+
 // Given a number, string with appropriate unit in the metric system, SI.
 // Note: numbers beyond the peta- cannot be represented as integers in JS.
 var metricPrefix = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];


### PR DESCRIPTION
This allows connecting to github using a private token, accessing to private and enterprise github repositories.