### PR TITLE
Add route for Jenkins code coverage

### DIFF
--- a/try.html
+++ b/try.html
@@ -136,6 +136,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg' alt=''/></td>
     <td><code>https://img.shields.io/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg</code></td>
   </tr>
+  <tr><th> Jenkins coverage: </th>
+    <td><img src='/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg</code></td>
+  </tr>
   <tr><th> Coveralls: </th>
     <td><img src='/coveralls/jekyll/jekyll.svg' alt=''/></td>
     <td><code>https://img.shields.io/coveralls/jekyll/jekyll.svg</code></td>


### PR DESCRIPTION
This provides a new route to get code coverage from Jenkins. It uses the [Cobertura plugin](https://wiki.jenkins-ci.org/display/JENKINS/Cobertura+Plugin) to get the coverage results of the last build.
For example: `https://img.shields.io/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg`
This PR uses Jenkins HTTP auth suggested in https://github.com/badges/shields/pull/579.