### PR TITLE
Add Package Control support

### DIFF
--- a/server.js
+++ b/server.js
@@ -1263,7 +1263,7 @@ cache(function(data, match, sendBadge, request) {
       case 't':
         // all-time downloads are already compiled
         downloads = data.installs.total;
-        badgeData.text[1] = metric(downloads) + ' total';
+        badgeData.text[1] = metric(downloads);
         break;
       }
       badgeData.colorscheme = downloadCountColor(downloads);

--- a/server.js
+++ b/server.js
@@ -1211,16 +1211,13 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Package Control integration.
-camp.route(/^\/packagecontrol\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/packagecontrol\/(dm|dw|dd|dt)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var userRepo = match[1];  // eg, `Package%20Control`.
-  var format = match[2];
+  var info = match[1];  // either `dm`, `dw`, `dd` or dt`.
+  var userRepo = match[2];  // eg, `Package%20Control`.
+  var format = match[3];
   var apiUrl = 'https://packagecontrol.io/packages/' + userRepo + '.json';
   var badgeData = getBadgeData('downloads', data);
-  if (userRepo.substr(-14) === '/:package_name') {
-    badgeData.text[1] = 'invalid';
-    return sendBadge(format, badgeData);
-  }
   request(apiUrl, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1228,10 +1225,47 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-
-      var downloads = data.package.installs.total;
-      badgeData.text[1] = metric(downloads) + ' total';
-        
+      var downloads = 0;
+      switch (info.charAt(1)) {
+      case 'm':
+        // daily downloads are separated by Operating System
+        var platforms = data.installs.daily.data;
+        platforms.forEach(function(platform) {
+          // loop through the first 30 days or 1 month
+          for (var i = 0; i < 30; i++) {
+            // add the downloads for that day for that platform
+            downloads += platform.totals[i];
+          }
+        });
+        badgeData.text[1] = metric(downloads) + '/month';
+        break;
+      case 'w':
+        // daily downloads are separated by Operating System
+        var platforms = data.installs.daily.data;
+        platforms.forEach(function(platform) {
+          // loop through the first 7 days or 1 week
+          for (var i = 0; i < 7; i++) {
+            // add the downloads for that day for that platform
+            downloads += platform.totals[i];
+          }
+        });
+        badgeData.text[1] = metric(downloads) + '/week';
+        break;
+      case 'd':
+        // daily downloads are separated by Operating System
+        var platforms = data.installs.daily.data;
+        platforms.forEach(function(platform) {
+          // use the downloads from yesterday
+          downloads += platform.totals[1];
+        });
+        badgeData.text[1] = metric(downloads) + '/day';
+        break;
+      case 't':
+        // all-time downloads are already compiled
+        downloads = data.installs.total;
+        badgeData.text[1] = metric(downloads) + ' total';
+        break;
+      }
       badgeData.colorscheme = downloadCountColor(downloads);
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -1231,7 +1231,6 @@ cache(function(data, match, sendBadge, request) {
 
       var downloads = data.package.installs.total;
       badgeData.text[1] = metric(downloads) + ' total';
-      break;
         
       badgeData.colorscheme = downloadCountColor(downloads);
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -1210,6 +1210,38 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Package Control integration.
+camp.route(/^\/packagecontrol\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var userRepo = match[1];  // eg, `Package%20Control`.
+  var format = match[2];
+  var apiUrl = 'https://packagecontrol.io/packages/' + userRepo + '.json';
+  var badgeData = getBadgeData('downloads', data);
+  if (userRepo.substr(-14) === '/:package_name') {
+    badgeData.text[1] = 'invalid';
+    return sendBadge(format, badgeData);
+  }
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+
+      var downloads = data.package.installs.total;
+      badgeData.text[1] = metric(downloads) + ' total';
+      break;
+        
+      badgeData.colorscheme = downloadCountColor(downloads);
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // npm download integration.
 camp.route(/^\/npm\/dm\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -351,6 +351,22 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/dub/dt/vibe-d/0.7.23.svg' alt=''/></td>
   <td><code>https://img.shields.io/dub/dt/vibe-d/0.7.23.svg</code></td>
   </tr>
+  <tr><th data-keywords='sublime'> Package Control: </th>
+  <td><img src='/packagecontrol/dm/Package%20Control.svg' alt=''/></td>
+  <td><code>https://img.shields.io/packagecontrol/dm/Package%20Control.svg</code></td>
+  </tr>
+  <tr><th data-keywords='sublime'> Package Control: </th>
+  <td><img src='/packagecontrol/dw/Package%20Control.svg' alt=''/></td>
+  <td><code>https://img.shields.io/packagecontrol/dw/Package%20Control.svg</code></td>
+  </tr>
+  <tr><th data-keywords='sublime'> Package Control: </th>
+  <td><img src='/packagecontrol/dd/Package%20Control.svg' alt=''/></td>
+  <td><code>https://img.shields.io/packagecontrol/dd/Package%20Control.svg</code></td>
+  </tr>
+  <tr><th data-keywords='sublime'> Package Control: </th>
+  <td><img src='/packagecontrol/dt/Package%20Control.svg' alt=''/></td>
+  <td><code>https://img.shields.io/packagecontrol/dt/Package%20Control.svg</code></td>
+  </tr>
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>


### PR DESCRIPTION
Hi!

I added PackageControl to the supported providers. I copied the code from the Packagist block right above since their behaviour is the same.

Here is an example of the response format : https://packagecontrol.io/packages/Laravel%205%20Snippets.json

Also, I haven't been able to test it, since I don't have a development environment setup.

Thanks!