### PR TITLE
Coverity also consistently uses "passing".

### DIFF
--- a/server.js
+++ b/server.js
@@ -766,6 +766,7 @@ cache(function(data, match, sendBadge, request) {
 
       if (data.message === 'passed') {
         badgeData.colorscheme = 'brightgreen'
+        badgeData.text[1] = 'passing';
       } else if (/^passed .* new defects$/.test(data.message)) {
         badgeData.colorscheme = 'yellow';
       } else if (data.message === 'pending') {


### PR DESCRIPTION
Follow-up on #575, #585.