### PR TITLE
Run apt-get update before installing packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-before_install: sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+before_install:
+  - sudo apt-get update -myqq
+  - sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
 language: node_js
 node_js:
   - 0.10


### PR DESCRIPTION
Fixes Travis CI build error:
https://travis-ci.org/badges/shields/builds/97102831

    $ sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
    Reading package lists... Done
    Building dependency tree       
    Reading state information... Done
    Package libgif-dev is not available, but is referred to by another package.
    This may mean that the package is missing, has been obsoleted, or is only available from another source
    E: Package 'libgif-dev' has no installation candidate

    The command "sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++" failed and exited with 100 during .