### PR TITLE
Add rc for secrets config and describe docker use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /ServerScript
 /secret.json
 /.github-user-tokens.json
+build
 
 # Installed npm modules
 node_modules
@@ -13,6 +14,7 @@ node_modules
 # Folder view configuration files
 .DS_Store
 Desktop.ini
+.idea
 
 # Thumbnail cache files
 ._*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -147,6 +147,22 @@ http://[::1]:80/try.html
 
 Assuming Docker is running locally, you should be able to get to the application at http://localhost:8080/try.html. If you run Docker in a virtual machine (such as boot2docker or Docker Machine) then you will need to replace `localhost` with the actual IP address of that virtual machine.
 
+## Passing secrets as docker environment variables
+Thanks to [rc](https://www.npmjs.com/package/rc), you can pass your shields secrets as env vars. This may be useful for CI purpose for example as credentials are often stored as env vars.
+```console
+# Assuming you have an env var $GITHUB_CLIENT_ID containing the client id (required for OAUTH authentication)
+docker run --rm -p 80:80 -e shields_gh_client_id=$GITHUB_CLIENT_ID shields
+```
+
+If you have several env vars, you may prefer using a temp env file
+```console
+# All env vars starting with shields_ will be passed to the docker container
+SHIELDS_ENV=`mktemp -t shieldsenvXXXXX`
+env | grep 'shields_' > $SHIELDS_ENV
+
+docker run --rm -p 80:80 --env-file=$SHIELDS_ENV shields
+```
+
 # Main Server Sysadmin
 
 - DNS round-robin between https://vps197850.ovh.net/try.html and https://vps244529.ovh.net/try.html.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "semver": "~4.3.3",
     "bower": "~1.4.1",
     "chrome-web-store-item-property": "^1.1.2",
-    "json-autosave": "~1.1.1"
+    "json-autosave": "~1.1.1",
+    "rc": "^1.1.6"
   },
   "scripts": {
     "test": "node test/test.js"

--- a/server.js
+++ b/server.js
@@ -26,7 +26,12 @@ try {
   // Everything that cannot be checked in but is useful server-side
   // is stored in this JSON data.
   serverSecrets = require('./secret.json');
-} catch(e) { console.error('No secret data (secret.json, see server.js):', e); }
+} catch(e) {
+  console.error('No secret data (secret.json, see server.js):', e);
+  serverSecrets = {};
+}
+require('rc')('shields', serverSecrets);
+
 if (serverSecrets && serverSecrets.gh_client_id) {
   githubAuth.setRoutes(camp);
 }


### PR DESCRIPTION
The package [`rc`](https://www.npmjs.com/package/rc) allows to extend your secrets config thanks to environment variables, config files, arguments, etc.
The most useful is the first one, for me, as we can pass env vars to a docker container. It's a way to have a own shields instance running without storing secrets into a file, but getting them as env vars.
#### For example:

``` console
# Assuming you have an env var $GITHUB_CLIENT_ID containing the client id
# required for OAUTH authentication
docker run --rm -p 80:80 -e shields_gh_client_id=$GITHUB_CLIENT_ID shields
```

or

``` console
# Pass the env vars to the docker container
SHIELDS_ENV=`mktemp -t shieldsenvXXXXX`
env | grep 'shields_' > $SHIELDS_ENV

docker run --rm -p 80:80 --env-file=$SHIELDS_ENV shields
```
