### PR TITLE
Update NPM dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:0.12-onbuild
+FROM node:5
 ENV INFOSITE http://shields.io
 EXPOSE 80

--- a/package.json
+++ b/package.json
@@ -16,23 +16,21 @@
     "url": "https://github.com/badges/shields"
   },
   "dependencies": {
-    "dot": "~1.0.3",
-    "svgo": "~0.5.1",
-    "pdfkit": "~0.7.1",
-    "phantomjs": "~1.9.2-6",
-    "es6-promise": "~2.1.0",
-    "request": "~2.55.0",
-    "redis": "~1.0.0",
-    "camp": "~16.0.0",
-    "semver": "~4.3.3",
-    "bower": "~1.4.1",
-    "promise": "~7.0.0",
+    "dot": "^1.0.3",
+    "svgo": "^0.6.4",
+    "pdfkit": "~0.7.2",
+    "phantomjs": "^2.1.7",
+    "request": "^2.70.0",
+    "redis": "^2.6.0-1",
+    "camp": "^16.1.1",
+    "semver": "^5.1.0",
+    "bower": "^1.7.9",
     "chrome-web-store-item-property": "^1.1.2"
   },
   "devDependencies": {
-    "ass": "~0.0.6",
-    "should": "~3.0.0",
-    "mocha": "~1.14.0"
+    "ass": "^0.0.6",
+    "should": "^8.3.0",
+    "mocha": "^2.4.5"
   },
   "scripts": {
     "test": "mocha -R spec test.js"
@@ -48,6 +46,5 @@
     "phantomjs-svg2png.js",
     "lru-cache.js",
     "logo"
-  ],
-  "engines": { "node": "0.10.x" }
+  ]
 }

--- a/suggest.js
+++ b/suggest.js
@@ -1,6 +1,5 @@
 var nodeUrl = require('url');
 var request = require('request');
-var Promise = require('promise');
 var serverSecrets;
 try {
   // Everything that cannot be checked in but is useful server-side


### PR DESCRIPTION
As Automattic/node-canvas#525 has been fixed, then this should fix #362.

In the upgrade process, remove `promise` as a dependency as it is now provided as part of ES6.

I noticed that after running `make`, `coverage.svg` is very slightly changed, so it is possible that there is a slight difference in the way fonts are handled; however, comparing the versions on shields.io to the ones my localhost, I cannot see the difference.

I realize there are a couple of other pull requests for upgrading the dependencies (#556,  #458).  This pull request would supplant these.
