### PR TITLE
fix npm version badge for scoped packages

### DIFF
--- a/server.js
+++ b/server.js
@@ -1357,7 +1357,7 @@ camp.route(/^\/npm\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var repo = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
   var format = match[2];
-  var apiUrl = 'https://registry.npmjs.org/' + repo + '/latest';
+  var apiUrl = 'https://registry.npmjs.org/-/package/' + repo + '/dist-tags';
   var badgeData = getBadgeData('npm', data);
   // Using the Accept header because of this bug:
   // <https://github.com/npm/npmjs.org/issues/163>
@@ -1369,7 +1369,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var version = data.version;
+      var version = data.latest;
       var vdata = versionColor(version);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;

--- a/try.html
+++ b/try.html
@@ -378,6 +378,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/npm/v/npm.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/npm.svg</code></td>
   </tr>
+  <tr><th data-keywords='node'> npm (scoped): </th>
+  <td><img src='/npm/v/@cycle/core.svg' alt=''/></td>
+  <td><code>https://img.shields.io/npm/v/@cycle/core.svg</code></td>
+  </tr>
   <tr><th> node: </th>
   <td><img src='/node/v/gh-badges.svg' alt=''/></td>
   <td><code>https://img.shields.io/node/v/gh-badges.svg</code></td>


### PR DESCRIPTION
Support for npm version for scoped packages at `registry.npmjs.org/[package]/latest` seems to have been removed. However, you can get the version from `registry.npmjs.org/-/package/[package]/dist-tags`.

This pull request partially addresses #429. For full support (download counts) we'll need to wait on npm. Looks like they are working on it though https://github.com/npm/download-counts/issues/23