### PR TITLE
Change CodeShip domain

### DIFF
--- a/server.js
+++ b/server.js
@@ -3604,7 +3604,7 @@ cache(function(data, match, sendBadge, request) {
   var branch = match[2];
   var options = {
     method: 'GET',
-    uri: 'https://www.codeship.io/projects/' + projectId + '/status' + (branch != null ? '?branch=' + branch : '')
+    uri: 'https://codeship.com/projects/' + projectId + '/status' + (branch != null ? '?branch=' + branch : '')
   };
   var badgeData = getBadgeData('build', data);
   request(options, function(err, res) {


### PR DESCRIPTION
CodeShip badge show build inaccessible now.
https://img.shields.io/codeship/9d423a50-5ace-0133-11b8-624f61fe64ff.svg

According to CodeShip document, it use `codeship.com`, and `https://www.codeship.io` have SSL certificate problem.
https://codeship.com/documentation/faq/codeship-badge/
