### PR TITLE
take out vim ':wq' mistake

### DIFF
--- a/try.html
+++ b/try.html
@@ -997,7 +997,6 @@ is where the current server got started.
 <a class='photo' href='https://github.com/sagiegurari'>
   <img alt='sagiegurari' src='https://avatars.githubusercontent.com/u/8112599?s=80'>
 </a>
-<p><small>:wq</small></p>
 </main>
 
 <dialog id='copyDialog'>


### PR DESCRIPTION
I'm assuming this is a mistake of some sort unless putting ':wq' at the
bottom of pages is the new version of putting the ![Created with
VIM](http://www.vim.org/images/vim_created.gif) logo on pages.