### PR TITLE
chore(docker): do not target a specific minor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:0.12.7-onbuild
+FROM node:0.12-onbuild
 ENV INFOSITE http://shields.io
 EXPOSE 80


### PR DESCRIPTION
Mostly to speed up the image pull. It was painfully slow.
Confirmed to work on latest docker.