### PR TITLE
Added support for online/offline website badge.

### DIFF
--- a/server.js
+++ b/server.js
@@ -5122,6 +5122,52 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Test if a webpage is online
+camp.route(/^\/website(-(([^-]|--)*?)-(([^-]|--)*)(-(([^-]|--)+)-(([^-]|--)+))?)?\/(.+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var onlineMessage = escapeFormat(match[2] != null ? match[2] : "online");
+  var offlineMessage = escapeFormat(match[4] != null ? match[4] : "offline");
+  var onlineColor = escapeFormat(match[7] != null ? match[7] : "brightgreen");
+  var offlineColor = escapeFormat(match[9] != null ? match[9] : "red");
+  var userProtocol = match[11];
+  var userURI = match[12];
+  var format = match[13];
+  var withProtocolURI = userProtocol + "://" + userURI;
+  var options = {
+    method: 'HEAD',
+    uri: withProtocolURI,
+  };
+  var badgeData = getBadgeData('website', data);
+  badgeData.colorscheme = undefined;
+  request(options, function(err, res) {
+    try {
+      // We consider all HTTP status codes below 310 as success.
+      if (err != null || res.statusCode >= 310) {
+        badgeData.text[1] = offlineMessage;
+        if (sixHex(offlineColor)) {
+          badgeData.colorB = '#' + offlineColor;
+        } else {
+          badgeData.colorscheme = offlineColor;
+        }
+        sendBadge(format, badgeData);
+        return;
+      } else {
+        badgeData.text[1] = onlineMessage;
+        if (sixHex(onlineColor)) {
+          badgeData.colorB = '#' + onlineColor;
+        } else {
+          badgeData.colorscheme = onlineColor;
+        }
+        sendBadge(format, badgeData);
+        return;
+      }
+    } catch(e) {
+      badge({text: ['error', 'bad badge'], colorscheme: 'red'},
+        makeSend(format, ask.res, end));
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)*?)-(([^-]|--)*)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/try.html
+++ b/try.html
@@ -387,6 +387,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
     <td><code>https://img.shields.io/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
+  <tr><th data-keywords='website' data-doc='websiteDoc'> Website: </th>
+  <td><img src='https://img.shields.io/website-up-down-green-red/http/shields.io.svg' alt=''/></td>
+  <td><code>https://img.shields.io/website-up-down-green-red/http/shields.io.svg</code></td>
+  </tr>
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>
@@ -1120,6 +1124,48 @@ is where the current server got started.
       definitions/, BUILD_DEFINITION_ID is after that.'>
     <p>Your badge will then have the form
       <code>https://img.shields.io/vso/build/TEAM_NAME/PROJECT_ID/BUILD_DEFINITION_ID</code>.
+    </p>
+  </div>
+  <div id="websiteDoc">
+    <p>The badge is of the form <code>https://img.shields.io/website[OPTIONS]/PROTOCOL/URLREST.svg</code>,
+       the simplest case being <code>https://img.shields.io/website/http/www.website.com.svg</code>.
+       More options are described below.
+    </p>
+    <p>The whole URL is obtained by concatenating the <code>PROTOCOL</code> (<code>http</code> or <code>https</code>, for example)
+       with the <code>URLREST</code> (separating them with <code>://</code>).
+    </p>
+    <p>
+       The existance of a specific path on the server can be checked by appending a path after the domain name, e.g.
+       <code>https://img.shields.io/website/http/www.website.com/path/to/page.html.svg</code>.
+    </p>
+    <p>The URLREST should be URLEncoded:
+       <input type="text" id="websiteDocUrlField" placeholder="Paste your URL (without the protocol) here" />
+       <input type="button" onclick="(function(el) { el.value = encodeURIComponent(el.value); })(document.getElementById('websiteDocUrlField'))" value="Encode" />
+       <input type="button" onclick="(function(el) { el.value = decodeURIComponent(el.value); })(document.getElementById('websiteDocUrlField'))" value="Decode" />
+    </p>
+    <p><code>[OPTIONS]</code> can be:
+       <ul>
+         <li>Nothing:
+             <code>…/website/…</code></li>
+         <li>Online and offline text:
+             <code>…/website-up-down/…</code></li>
+         <li>Online and offline text, then online and offline colors:
+             <code>…/website-up-down-green-orange/…</code></li>
+       </ul>
+       <table class=centered><tbody>
+           <tr><td>   Dashes <code>--</code>
+             </td><td>  →
+             </td><td>  <code>-</code> Dash
+           </td></tr>
+           <tr><td>   Underscores <code>__</code>
+             </td><td>  →
+             </td><td>  <code>_</code> Underscore <br/>
+           </td></tr>
+           <tr><td>   <code>_</code> or Space <code>&nbsp;</code>
+             </td><td>  →
+             </td><td>  <code>&nbsp;</code> Space
+           </td></tr>
+       </tbody></table>
     </p>
   </div>
 </div>


### PR DESCRIPTION
This can be useful for a [documentation|online] badge, for example, to avoid putting an always-green one.

Please do review the code from a security standpoint, as I'm not a node.js expert. I just based myself on the other vendors. Among other concerns, since it's accepting and fetching a user-provided URL, are there any port number or IPs on the server's local network that an attacker could somehow probe with this?