### PR TITLE
added support for download counter on folders at Sourceforge

### DIFF
--- a/server.js
+++ b/server.js
@@ -3970,12 +3970,13 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // SourceForge integration.
-camp.route(/^\/sourceforge\/([^\/]+)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/sourceforge\/([^\/]+)\/([^/]*)\/?(.*).(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var info = match[1];      // eg, 'dm'
   var project = match[2];   // eg, 'sevenzip`.
-  var format = match[3];
-  var apiUrl = 'http://sourceforge.net/projects/' + project + '/files/stats/json';
+  var folder = match[3];
+  var format = match[4];
+  var apiUrl = 'http://sourceforge.net/projects/' + project + '/files/' + folder + '/stats/json';
   var badgeData = getBadgeData('sourceforge', data);
   var time_period, start_date, end_date;
   if (info.charAt(0) === 'd') {

--- a/try.html
+++ b/try.html
@@ -346,6 +346,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/sourceforge/dt/sevenzip.svg' alt=''/></td>
   <td><code>https://img.shields.io/sourceforge/dt/sevenzip.svg</code></td>
   </tr>
+  <tr><th> SourceForge: </th>
+  <td><img src='/sourceforge/dt/arianne/stendhal.svg' alt=''/></td>
+  <td><code>https://img.shields.io/sourceforge/dt/arianne/stendhal.svg</code></td>
+  </tr>
   <tr><th data-keywords='atom'> apm: </th>
   <td><img src='/apm/dm/vim-mode.svg' alt=''/></td>
   <td><code>https://img.shields.io/apm/dm/vim-mode.svg</code></td>


### PR DESCRIPTION
This pull requests allows to display the Sourceforge download count of a project folder.

On Sourceforge, projects are like organisations on Github. They may contain multiple repositories and download areas for individual software developed by the same group.

For example the [Arianne Project](https://sourceforge.net/projects/arianne/) consists of [Stendhal](https://sourceforge.net/projects/arianne/files/stendhal/) and [Marauroa](https://sourceforge.net/projects/arianne/files/marauroa/). So in the Github readme file of [Stendhal](https://github.com/arianne/stendhal) and [Marauroa](https://github.com/arianne/marauroa) I like to display their individual counts. Not the download count of the complete Arianne project/organisation.

The attached pull requests allows to optionally specify a download folder. If it is omitted the project count is used. Thus, this change is fully compatible to existing badge uses.