### PR TITLE
Update Docker API hostname

### DIFF
--- a/server.js
+++ b/server.js
@@ -4419,7 +4419,7 @@ cache(function(data, match, sendBadge, request) {
     user = 'library';
   }
   var path = user + '/' + repo;
-  var url = 'https://registry.hub.docker.com/v2/repositories/' + path + '/stars/count/';
+  var url = 'https://hub.docker.com/v2/repositories/' + path + '/stars/count/';
   var badgeData = getBadgeData('docker stars', data);
   request(url, function(err, res, buffer) {
     if (err != null) {
@@ -4450,7 +4450,7 @@ cache(function(data, match, sendBadge, request) {
     user = 'library';
   }
   var path = user + '/' + repo;
-  var url = 'https://registry.hub.docker.com/v2/repositories/' + path;
+  var url = 'https://hub.docker.com/v2/repositories/' + path;
   var badgeData = getBadgeData('docker pulls', data);
   request(url, function(err, res, buffer) {
     if (err != null) {


### PR DESCRIPTION
The ``registry.hub.docker.com`` domain name has been deprecated, and we should use ``hub.docker.com`` now instead. 

This PR updates the hostname, so that shields will not break when ``registry.hub.docker.com`` is removed in the future.