### PR TITLE
Visual Studio Online has been renamed Visual Studio Team Services

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
       <td><img src='https://img.shields.io/circleci/project/BrightFlair/PHP.Gt/master.svg' alt=''/></td>
       <td><code>https://img.shields.io/circleci/token/YOURTOKEN/project/BrightFlair/PHP.Gt/master.svg</code></td>
   </tr>
-  <tr><th data-doc='visualStudioOnline'> Visual Studio Online: </th>
+  <tr><th data-doc='visualStudioTeamServices'> Visual Studio Team Services: </th>
       <td><img src='https://img.shields.io/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg' alt=''/></td>
       <td><code>https://img.shields.io/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg</code></td>
   </tr>
@@ -1038,7 +1038,7 @@ is where the current server got started.
 </dialog>
 
 <div id=documentation style='display:none'>
-  <div id=visualStudioOnline>
+  <div id=visualStudioTeamServices>
     <p>To obtain your own badge, you will first need to enable badges for your
     project:
     </p>

--- a/server.js
+++ b/server.js
@@ -4566,7 +4566,7 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Visual Studio Online build integration.
+// Visual Studio Team Services build integration.
 camp.route(/^\/vso\/build\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var name = match[1];    // User name

--- a/try.html
+++ b/try.html
@@ -128,7 +128,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
       <td><img src='/circleci/project/BrightFlair/PHP.Gt/master.svg' alt=''/></td>
       <td><code>https://img.shields.io/circleci/token/YOURTOKEN/project/BrightFlair/PHP.Gt/master.svg</code></td>
   </tr>
-  <tr><th data-doc='visualStudioOnline'> Visual Studio Online: </th>
+  <tr><th data-doc='visualStudioTeamServices'> Visual Studio Team services: </th>
       <td><img src='/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg' alt=''/></td>
       <td><code>https://img.shields.io/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg</code></td>
   </tr>
@@ -1037,7 +1037,7 @@ is where the current server got started.
 </dialog>
 
 <div id=documentation style='display:none'>
-  <div id=visualStudioOnline>
+  <div id=visualStudioTeamServices>
     <p>To obtain your own badge, you will first need to enable badges for your
     project:
     </p>


### PR DESCRIPTION
Visual Studio Online has been renamed Visual Studio Team Services

Also, you could change the vso in the link into vsts (or add an alias to have backward compatibility)

Regards,

Thomas P.