### PR TITLE
Implement Codacy coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ What kind of metadata can you convey using badges?
 ## Services using the Shields standard
 * [Badger](https://github.com/badges/badgerbadgerbadger)
 * [badges2svg](https://github.com/bfontaine/badges2svg)
+* [Codacy](https://www.codacy.com)
 * [Code Climate](https://codeclimate.com/changelog/510d4fde56b102523a0004bf)
 * [Coveralls](https://coveralls.io/)
 * [Forkability](http://basicallydan.github.io/forkability/)

--- a/server.js
+++ b/server.js
@@ -2498,6 +2498,37 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+camp.route(/^\/codacy\/coverage\/(?!grade\/)([^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var projectId = match[1];  // eg. e27821fb6289410b8f58338c7e0bc686
+  var branch = match[2];
+  var format = match[3];
+
+  queryParams = {};
+  if (branch) {
+    queryParams.branch = branch;
+  }
+  var query = querystring.stringify(queryParams);
+  var url = 'https://www.codacy.com/project/badge/coverage/' + projectId + '?' + query;
+  var badgeData = getBadgeData('coverage', data);
+  fetchFromSvg(request, url, function(err, res) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      badgeData.text[1] = res;
+      badgeData.colorscheme = coveragePercentageColor(parseInt(res));
+      sendBadge(format, badgeData);
+
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Hackage version integration.
 camp.route(/^\/hackage\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -2450,7 +2450,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Codacy integration
-camp.route(/^\/codacy?\/([^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codacy\/(?:grade\/)?(?!coverage\/)([^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var projectId = match[1];  // eg. e27821fb6289410b8f58338c7e0bc686
   var branch = match[2];

--- a/server.js
+++ b/server.js
@@ -2461,7 +2461,7 @@ cache(function(data, match, sendBadge, request) {
     queryParams.branch = branch;
   }
   var query = querystring.stringify(queryParams);
-  var url = 'https://www.codacy.com/project/badge/' + projectId + '?' + query;
+  var url = 'https://www.codacy.com/project/badge/grade/' + projectId + '?' + query;
   var badgeData = getBadgeData('code quality', data);
   fetchFromSvg(request, url, function(err, res) {
     if (err != null) {

--- a/try.html
+++ b/try.html
@@ -666,13 +666,21 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/wordpress/plugin/r/akismet.svg' alt=''/></td>
     <td><code>https://img.shields.io/wordpress/plugin/r/akismet.svg</code></td>
   </tr>
-  <tr><th> Codacy: </th>
-    <td><img src='/codacy/e27821fb6289410b8f58338c7e0bc686.svg' alt=''/></td>
-    <td><code>https://img.shields.io/codacy/e27821fb6289410b8f58338c7e0bc686.svg</code></td>
+  <tr><th> Codacy grade: </th>
+    <td><img src='https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg</code></td>
   </tr>
-  <tr><th> Codacy branch: </th>
-    <td><img src='/codacy/e27821fb6289410b8f58338c7e0bc686/master.svg' alt=''/></td>
-    <td><code>https://img.shields.io/codacy/e27821fb6289410b8f58338c7e0bc686/master.svg</code></td>
+  <tr><th> Codacy branch grade: </th>
+    <td><img src='https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686/master.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686/master.svg</code></td>
+  </tr>
+  <tr><th> Codacy coverage: </th>
+    <td><img src='https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd.svg</code></td>
+  </tr>
+  <tr><th> Codacy branch coverage: </th>
+    <td><img src='https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg' alt=''/></td>
+    <td><code>https://img.shields.io/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg</code></td>
   </tr>
   <tr><th> Libscore: </th>
     <td><img src='/libscore/s/jQuery.svg' alt=''/></td>


### PR DESCRIPTION
I've just started using Codacy in preference to Scrutinizer. I noticed Shields had a Codacy grade indicator, but no coverage indicator, so here's the implementation.

+ The existing grade badge has been changed, but is backwards compatible (so people using the URL _without_ the `grade/` part still continue getting the correct grade.
+ New URLs for Codacy shields identify the `grade/` or `coverage/`.

Tested locally, please let me know if there are any questions.