### PR TITLE
(GH-638) Added basic badge integration for homebrew

### DIFF
--- a/index.html
+++ b/index.html
@@ -515,6 +515,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='https://img.shields.io/dub/v/vibe-d.svg' alt=''/></td>
   <td><code>https://img.shields.io/dub/v/vibe-d.svg</code></td>
   </tr>
+  <tr><th data-keywords='homebrew'> homebrew: </th>
+  <td><img src='https://img.shields.io/homebrew/v/cake.svg' alt=''/></td>
+  <td><code>https://img.shields.io/homebrew/v/cake.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="social"> Social </h3>

--- a/server.js
+++ b/server.js
@@ -4814,6 +4814,36 @@ cache(function(data, match, sendBadge, request) {
   sendBadge(format, badgeData);
 }));
 
+// homebrew integration
+// Example: /homebrew/v/cake.svg
+camp.route(/^\/homebrew\/v\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var package = match[1];
+  var format = match[2];
+  var apiUrl = 'http://braumeister.org/formula/' + package + '/version';
+
+  var badgeData = getBadgeData('homebrew', data);
+  request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var version = data.stable;
+
+      var vdata = versionColor(version);
+      badgeData.text[1] = vdata.version;
+      badgeData.colorscheme = vdata.color;
+
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // StackExchange integration.
 camp.route(/^\/stackexchange\/([^\/]+)\/([^\/])\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -518,6 +518,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/aur/version/yaourt.svg' alt=''/></td>
   <td><code>https://img.shields.io/aur/version/yaourt.svg</code></td>
   </tr>
+  <tr><th data-keywords='homebrew'> homebrew: </th>
+  <td><img src='/homebrew/v/cake.svg' alt=''/></td>
+  <td><code>https://img.shields.io/homebrew/v/cake.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="social"> Social </h3>


### PR DESCRIPTION
This relates to #638 where a request was made to support querying of homebrew package version, using the API provided by http://braumeister.org/.

I am very new to shields.io, so I may not have done this correctly.  I stitched this together by referencing a number of similar systems.

Please let me know if there is anything that needs to change.