### PR TITLE
Add support for custom MyGet tenants

### DIFF
--- a/server.js
+++ b/server.js
@@ -3435,6 +3435,16 @@ mapNugetFeed('myget\\/(.*)', 1, function(match) {
   };
 });
 
+// MyGet (custom tenant, e.g. dotnet.myget.org)
+mapNugetFeed('(.*)\.myget\\/(.*)', 1, function(match) {
+  var tenant = match[1];
+  var feed = match[2];
+  return {
+    site: feed,
+    feed: 'https://' + tenant + '.myget.org/F/' + feed + '/api/v3'
+  };
+});
+
 // Puppet Forge modules
 camp.route(/^\/puppetforge\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {


### PR DESCRIPTION
Add support for custom MyGet tenants (e.g. dotnet.myget.org)

Sample shield URL would be: `https://img.shields.io/dotnet.myget/dotnet-coreclr/v/Microsoft.DotNet.CoreCLR.svg`