### PR TITLE
shield for the Waffle API

### DIFF
--- a/server.js
+++ b/server.js
@@ -4907,7 +4907,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Waffle.io integration
-camp.route(/^\/waffle\/cards\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/waffle\/label\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var user = match[1];  // eg, evancohen
   var repo = match[2];  // eg, smart-mirror
@@ -4926,21 +4926,19 @@ cache(function(data, match, sendBadge, request) {
       }
       var count = 0;
       var color;
-      var name;
       for (var i = 0; i < cards.length; i++) {
         var cardMetadata = cards[i].githubMetadata;
-        if(cardMetadata.labels && cardMetadata.labels.length > 0){
-            for(var j = 0; j < cardMetadata.labels.length; j++){
+        if (cardMetadata.labels && cardMetadata.labels.length > 0) {
+            for (var j = 0; j < cardMetadata.labels.length; j++) {
                 var label = cardMetadata.labels[j];
-                if(label.name == ghLabel){
+                if (label.name === ghLabel) {
                     count++;
                     color = label.color;
-                    name = label.name;
                 }
             }
         }
       }
-      badgeData.text[0] = data.label || name || ghLabel;
+      badgeData.text[0] = data.label || ghLabel;
       badgeData.text[1] = '' + count;
       badgeData.colorscheme = null;
       badgeData.colorB = '#' + (color || '78bdf2');

--- a/server.js
+++ b/server.js
@@ -4940,10 +4940,10 @@ cache(function(data, match, sendBadge, request) {
             }
         }
       }
-      badgeData.text[0] = data.label || name;
+      badgeData.text[0] = data.label || name || ghLabel;
       badgeData.text[1] = '' + count;
       badgeData.colorscheme = null;
-      badgeData.colorB = '#' + color;
+      badgeData.colorB = '#' + (color || '78bdf2');
       sendBadge(format, badgeData);
 
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -4907,34 +4907,41 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Waffle.io integration
-camp.route(/^\/waffle\/column\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/waffle\/cards\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var user = match[1];  // eg, potherca
-  var repo = match[2];  // eg, GraphvizWebEditor
-  var ghLabel = match[3] || 'ready';  // eg, waffle:%20ready%20for%20development
+  var user = match[1];  // eg, evancohen
+  var repo = match[2];  // eg, smart-mirror
+  var ghLabel = match[3] || 'ready';  // eg, in%20progress
   var format = match[4];
-  var apiUrl = 'https://api.waffle.io/' + user + '/' + repo + '/columns';
+  var apiUrl = 'https://api.waffle.io/' + user + '/' + repo + '/cards';
   var badgeData = getBadgeData('issues', data);
 
   request(apiUrl, function(err, res, buffer) {
     try {
-      var list = JSON.parse(buffer);
-      if (list.length === 0) {
+      var cards = JSON.parse(buffer);
+      if (cards.length === 0) {
         badgeData.text[1] = 'absent';
         sendBadge(format, badgeData);
         return;
       }
-      var column;
-      for (var i = 0; i < list.length; i++) {
-        var column = list[i];
-        var name = column.label? column.label.name: column.displayName;
-        var color = column.label? column.label.color: '78bdf2';
-        if (name === ghLabel) {
-          break;
+      var count = 0;
+      var color;
+      var name;
+      for (var i = 0; i < cards.length; i++) {
+        var cardMetadata = cards[i].githubMetadata;
+        if(cardMetadata.labels && cardMetadata.labels.length > 0){
+            for(var j = 0; j < cardMetadata.labels.length; j++){
+                var label = cardMetadata.labels[j];
+                if(label.name == ghLabel){
+                    count++;
+                    color = label.color;
+                    name = label.name;
+                }
+            }
         }
       }
-      badgeData.text[0] = data.label || column.displayName || name;
-      badgeData.text[1] = '' + column.issues.length;
+      badgeData.text[0] = data.label || name;
+      badgeData.text[1] = '' + count;
       badgeData.colorscheme = null;
       badgeData.colorB = '#' + color;
       sendBadge(format, badgeData);

--- a/try.html
+++ b/try.html
@@ -747,8 +747,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/maintenance/yes/2016.svg</code></td>
   </tr>
   <tr><th> Waffle.io: </th>
-    <td><img src='/waffle/column/potherca/GraphvizWebEditor/waffle:%20in%20progress.svg' alt=''/></td>
-    <td><code>https://img.shields.io/waffle/column/potherca/GraphvizWebEditor/waffle:%20in%20progress.svg</code></td>
+    <td><img src='/waffle/cards/evancohen/smart-mirror/in%20progress.svg' alt=''/></td>
+    <td><code>https://img.shields.io/cards/column/evancohen/smart-mirror/in%20progress.svg</code></td>
   </tr>
 </tbody></table>
 

--- a/try.html
+++ b/try.html
@@ -747,8 +747,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/maintenance/yes/2016.svg</code></td>
   </tr>
   <tr><th> Waffle.io: </th>
-    <td><img src='/waffle/cards/evancohen/smart-mirror/in%20progress.svg' alt=''/></td>
-    <td><code>https://img.shields.io/cards/column/evancohen/smart-mirror/in%20progress.svg</code></td>
+    <td><img src='/waffle/label/evancohen/smart-mirror/in%20progress.svg' alt=''/></td>
+    <td><code>https://img.shields.io/waffle/label/evancohen/smart-mirror/in%20progress.svg</code></td>
   </tr>
 </tbody></table>
 


### PR DESCRIPTION
Based on the conversation in #257 and the available API referenced in waffleio/waffle.io#2466 I've modified the existing shield to work with the new endpoint.

**Some Examples:**
- waffle/cards/evancohen/smart-mirror/next.svg 
<img width="50" alt="next" src="https://cloud.githubusercontent.com/assets/1198365/14198462/41a948c2-f78f-11e5-9485-fc9dacb6c96c.png">

- waffle/cards/evancohen/smart-mirror/in%20progress.svg
<img width="86" alt="in progress" src="https://cloud.githubusercontent.com/assets/1198365/14198465/46c4c584-f78f-11e5-9010-ed2449cc730a.png">

- waffle/cards/evancohen/smart-mirror/needs%20review.svg
<img width="96" alt="needs review" src="https://cloud.githubusercontent.com/assets/1198365/14198467/4ad78508-f78f-11e5-8a33-07e6ce2c5abd.png">

**Restrictions**

- Unfortunately the current API does not let you look at cards that are unlabeled, for instance you could not have a count of the number of cards in [backlog](https://waffle.io/evancohen/smart-mirror).

- By default Waffle comes with a label called `ready`. This is used for the "default" badge, ie: 
waffle/cards/evancohen/smart-mirror.svg. 
This becomes a problem when you remove the default label, at which point it wont return anything and will give you:
<img width="56" alt="ready" src="https://cloud.githubusercontent.com/assets/1198365/14198711/21ae9510-f792-11e5-939a-3a7e12216c38.png">

- When a label has 0 items in it we can't get the color, so we default to #78bdf2 (see above)