### PR TITLE
fix errored in ansible role badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -3722,8 +3722,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       if (type === 'role') {
-        badgeData.text[1] = json.summary_fields.owner.username +
-          '.' + json.name;
+        badgeData.text[1] = json.namespace + '.' + json.name;
         badgeData.colorscheme = 'blue';
       } else {
         badgeData.text[1] = 'unknown';


### PR DESCRIPTION
From several months ago, ansible role badges show `errored`.
For example, https://img.shields.io/ansible/role/3078.svg on http://shields.io/ got [![Ansible Role](https://img.shields.io/ansible/role/3078.svg)]().
Ansible Galaxy API now returns `namespace` instead of `summary_fields.owner.username`.
see https://galaxy.ansible.com/api/v1/roles/3078/.