### PR TITLE
Add chrome extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "camp": "~16.0.0",
     "semver": "~4.3.3",
     "bower": "~1.4.1",
-    "promise": "~7.0.0"
+    "promise": "~7.0.0",
+    "chrome-web-store-item-property": "^1.1.2"
   },
   "devDependencies": {
     "ass": "~0.0.6",

--- a/try.html
+++ b/try.html
@@ -383,6 +383,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/packagecontrol/dt/Package%20Control.svg' alt=''/></td>
   <td><code>https://img.shields.io/packagecontrol/dt/Package%20Control.svg</code></td>
   </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
+  </tr>
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>
@@ -513,6 +517,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th data-keywords='dub'> DUB: </th>
   <td><img src='/dub/v/vibe-d.svg' alt=''/></td>
   <td><code>https://img.shields.io/dub/v/vibe-d.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+  <td><img src='/chrome-web-store/v/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+  <td><code>https://img.shields.io/chrome-web-store/v/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
 </tbody></table>
 
@@ -753,6 +761,18 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th> Waffle.io: </th>
     <td><img src='/waffle/label/evancohen/smart-mirror/in%20progress.svg' alt=''/></td>
     <td><code>https://img.shields.io/waffle/label/evancohen/smart-mirror/in%20progress.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/rating/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/rating/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
 </tbody></table>
 


### PR DESCRIPTION
* Version, Downloads, Price, Rating and Rating Count for chrome app,
chrome extension and chrome theme.
* Google does not provide a public API for chrome web store.
* Use `chrome-web-store-item-property`.
    * Gather meta information from chrome web store.

see #505, #636

I re-send pull request. #505 still works fine :)