### PR TITLE
Allow image labels to contain right padding

### DIFF
--- a/badge.js
+++ b/badge.js
@@ -56,6 +56,7 @@ function makeImage(data, cb) {
   }
   // Logo.
   data.logoWidth = +data.logoWidth || (data.logo? 14: 0);
+  data.rightPad = +data.rightPad || 0
   data.logoPadding = (data.logo? 3: 0);
   // String coercion.
   data.text[0] = '' + data.text[0];
@@ -70,7 +71,7 @@ function makeImage(data, cb) {
   if (textWidth1 % 2 === 0) { textWidth1++; }
   if (textWidth2 % 2 === 0) { textWidth2++; }
   data.widths = [
-    textWidth1 + 10 + data.logoWidth + data.logoPadding,
+    textWidth1 + 10 + data.logoWidth + data.logoPadding + data.rightPad,
     textWidth2 + 10,
   ];
   if (data.links === undefined) {

--- a/server.js
+++ b/server.js
@@ -189,6 +189,7 @@ function cache(f) {
 
     var cacheIndex = match[0] + '?label=' + data.label + '&style=' + data.style
       + '&logo=' + data.logo + '&logoWidth=' + data.logoWidth
+      + '&rightPad=' + data.rightPad
       + '&link=' + data.link;
     // Should we return the data right away?
     var cached = requestCache.get(cacheIndex);
@@ -5193,7 +5194,7 @@ function getLabel(label, data) {
   return data.label || label;
 }
 
-// data (URL query) can include `label`, `style`, `logo`, `logoWidth`, `link`.
+// data (URL query) can include `label`, `style`, `logo`, `logoWidth`, `rightPad`, `link`.
 // It can also include `maxAge`.
 function getBadgeData(defaultLabel, data) {
   var label = getLabel(defaultLabel, data);
@@ -5213,12 +5214,17 @@ function getBadgeData(defaultLabel, data) {
     data.logo = 'data:' + data.logo;
   }
 
+  if (data.rightPad !== undefined && !/^[0-9]+$/.test(data.rightPad)) {
+    data.rightPad = 0;
+  }
+
   return {
     text: [label, 'n/a'],
     colorscheme: 'lightgrey',
     template: template,
     logo: data.logo,
     logoWidth: +data.logoWidth,
+    rightPad: data.rightPad,
     links: data.link,
   };
 }

--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -4,7 +4,7 @@
     <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
   </g>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="{{=it.widths[0]/2+1}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]-it.rightPad)/2+1}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -18,8 +18,8 @@
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding-it.rightPad)/2}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding-it.rightPad)/2}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[1])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.escapeXml(it.text[1])}}</text>
   </g>

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -17,8 +17,8 @@
   </g>
 
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="{{=it.widths[0]/2+1}}" y="14" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=it.widths[0]/2+1}}" y="13">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]-it.rightPad)/2+1}}" y="14" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]-it.rightPad)/2+1}}" y="13">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[1])}}</text>
     <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="13">{{=it.escapeXml(it.text[1])}}</text>
   </g>

--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -24,8 +24,8 @@
     <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
   {{?}}
   <g fill="#333" text-anchor="middle" font-family="Helvetica Neue,Helvetica,Arial,sans-serif" font-weight="700" font-size="11px" line-height="14px">
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="15" fill="#fff">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="14">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding-it.rightPad)/2}}" y="15" fill="#fff">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding-it.rightPad)/2}}" y="14">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
     {{?(it.text[1] && it.text[1].length)}}
     <text x="{{=it.widths[0]+it.widths[1]/2+6}}" y="15" fill="#fff">{{=it.escapeXml(it.text[1])}}</text>
     <a xlink:href="{{=it.links[1]}}">


### PR DESCRIPTION
Useful when you are stacking several shields vertically, it can be more visually appealing to have the left labels align

**Before:**
![Before Right Padding](https://dl.dropboxusercontent.com/u/49805/shields_before.png)

-----

**After:**
![After Right Padding](https://dl.dropboxusercontent.com/u/49805/shields_after.png)

