### PR TITLE
Add CocoaPods quality estimate badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -2690,6 +2690,34 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+camp.route(/^\/cocoapods\/metrics\/quality-estimate\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var spec = match[1];  // eg, AFNetworking
+  var format = match[2];
+  var apiUrl = 'http://metrics.cocoapods.org/api/v1/pods/' + spec;
+  var badgeData = getBadgeData('pod', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var estimate = data.cocoadocs.quality_estimate;
+      // CocoaPods official quality estimate visualization, as a 5-point grading scale:
+      // input >= 100 ? "5" : (input / 20) + 1
+      badgeData.colorscheme = floorCountColor(estimate, 60, 80, 100);
+      badgeData.text[0] = 'quality';
+      badgeData.text[1] = estimate;
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // GitHub tag integration.
 camp.route(/^\/github\/tag\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -841,6 +841,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/cocoapods/metrics/doc-percent/AFNetworking.svg' alt='' /></td>
     <td><code>https://img.shields.io/cocoapods/metrics/doc-percent/AFNetworking.svg</code></td>
   </tr>
+  <tr><th> CocoaPods: </th>
+    <td><img src='/cocoapods/metrics/quality-estimate/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/metrics/quality-estimate/AFNetworking.svg</code></td>
+  </tr>
   <tr><th> Ansible Role: </th>
     <td><img src='/ansible/role/3078.svg' alt=''/></td>
     <td><code>https://img.shields.io/ansible/role/3078.svg</code></td>


### PR DESCRIPTION
This new badge displays the quality estimate of a pod, as returned by the CocoaPods metrics API. 

This pull-request is based on the CocoaPods documentation percentage badge, already available (#442).

The tricky part is the color used for this estimate. The official CocoaPods website uses a [5-point grading scale](https://github.com/CocoaPods/cocoapods.org/blob/master/app.rb#L41-L43), with a quality estimate of 100 (or higher) being a perfect score (“5/5”). In the context of a Shield badge, I think displaying the raw quality estimate value is more appropriate, with the badge color scheme matching [60 (“3/5”) ; 80 (“4/5”) ; 100 (“5/5”)].
