### PR TITLE
Add CocoaPods downloads badges.

### DIFF
--- a/server.js
+++ b/server.js
@@ -2719,6 +2719,47 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Cocoapods Downloads integration.
+camp.route(/^\/cocoapods\/(dm|dw|dt)\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var info = match[1]; // One of these: "dm", "dw", "dt"
+  var spec = match[2];  // eg, AFNetworking
+  var format = match[3];
+  var apiUrl = 'http://metrics.cocoapods.org/api/v1/pods/' + spec;
+  var badgeData = getBadgeData('pod', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var downloads = 0;
+      badgeData.text[0] = getLabel('downloads', data);
+      switch (info.charAt(1)) {
+        case 'm':
+          downloads = data.stats.download_month;
+          badgeData.text[1] = metric(downloads) + '/month';
+          break;
+        case 'w':
+          downloads = data.stats.download_week;
+          badgeData.text[1] = metric(downloads) + '/week';
+          break;
+        case 't':
+          downloads = data.stats.download_total;
+          badgeData.text[1] = metric(downloads);
+          break;
+      }
+      badgeData.colorscheme = downloadCountColor(downloads);
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // GitHub tag integration.
 camp.route(/^\/github\/tag\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -2760,6 +2760,43 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// CocoaPods Apps Integration
+camp.route(/^\/cocoapods\/(aw|at)\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var info = match[1]; // One of these: "aw", "at"
+  var spec = match[2];  // eg, AFNetworking
+  var format = match[3];
+  var apiUrl = 'http://metrics.cocoapods.org/api/v1/pods/' + spec;
+  var badgeData = getBadgeData('pod', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var data = JSON.parse(buffer);
+      badgeData.text[0] = getLabel('apps', data);
+      var apps = 0
+      switch (info.charAt(1)) {
+        case 'w':
+          var apps = data.stats.app_week;
+          badgeData.text[1] = metric(apps) + '/week';
+          break;
+        case 't':
+          var apps = data.stats.app_total;
+          badgeData.text[1] = metric(apps);
+          break;
+      }
+      badgeData.colorscheme = downloadCountColor(apps);
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // GitHub tag integration.
 camp.route(/^\/github\/tag\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -391,6 +391,18 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/website-up-down-green-red/http/shields.io.svg' alt=''/></td>
   <td><code>https://img.shields.io/website-up-down-green-red/http/shields.io.svg</code></td>
   </tr>
+  <tr><th data-keywords='cocoapods'> CocoaPods: </th>
+    <td><img src='/cocoapods/dt/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/dt/AFNetworking.svg</code></td>
+  </tr>
+  <tr><th data-keywords='cocoapods'> CocoaPods: </th>
+    <td><img src='/cocoapods/dm/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/dm/AFNetworking.svg</code></td>
+  </tr>
+  <tr><th data-keywords='cocoapods'> CocoaPods: </th>
+    <td><img src='/cocoapods/dw/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/dw/AFNetworking.svg</code></td>
+  </tr>
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>

--- a/try.html
+++ b/try.html
@@ -858,6 +858,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/bithound/devDependencies/github/rexxars/sse-channel.svg</code></td>
   </tr>
   <tr><th> CocoaPods: </th>
+    <td><img src='/cocoapods/at/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/at/AFNetworking.svg</code></td>
+  </tr>
+  <tr><th> CocoaPods: </th>
+    <td><img src='/cocoapods/aw/AFNetworking.svg' alt='' /></td>
+    <td><code>https://img.shields.io/cocoapods/aw/AFNetworking.svg</code></td>
+  </tr>
+  <tr><th> CocoaPods: </th>
     <td><img src='/cocoapods/p/AFNetworking.svg' alt='' /></td>
     <td><code>https://img.shields.io/cocoapods/p/AFNetworking.svg</code></td>
   </tr>


### PR DESCRIPTION
Expands CocoaPods integration using `metrics.cocoapods.org`.
Tried my best to match the existing style for other package managers.

Also cc @orta @segiddins @kylef as core CocoaPods people.