### PR TITLE
remove imagelayers.io port number

### DIFF
--- a/server.js
+++ b/server.js
@@ -4810,7 +4810,7 @@ cache(function(data, match, sendBadge, request) {
     body: {
       "repos": [{"name": path, "tag": tag}]
     },
-    uri: 'https://imagelayers.io:8888/registry/analyze'
+    uri: 'https://imagelayers.io/registry/analyze'
   };
   request(options, function(err, res, buffer) {
     if (err != null) {


### PR DESCRIPTION
From several weeks ago, image layers badges has been unavailable.
- https://img.shields.io/imagelayers/image-size/_/ubuntu/latest.svg (without maxAge)
- https://img.shields.io/imagelayers/layers/_/ubuntu/latest.svg (without maxAge)

Currently https://imagelayers.io/ works with POST https://imagelayers.io/registry/analyze instead of https://imagelayers.io:8888/registry/analyze, access to 8888 port timed out.

``` console
$ openssl s_client -connect imagelayers.io:8888                                                                                                                       
connect: Operation timed out
connect:errno=60
```

It seems no changes on API response without port number.

``` console
$ curl -s -X POST -d '{"repos": [{"name": "library/ubuntu", "tag": "latest"}]}' https://imagelayers.io/registry/analyze | jq '.[0].repo'
{
  "name": "library/ubuntu",
  "tag": "latest",
  "size": 120759015,
  "count": 5
}
```
