### PR TITLE
Fix Gemnasium badge when status is update!

### DIFF
--- a/server.js
+++ b/server.js
@@ -2448,7 +2448,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'brightgreen';
       } else if (statusMatch === 'out-of-date') {
         badgeData.colorscheme = 'yellow';
-      } else if (statusMatch === 'up-to-date') {
+      } else if (statusMatch === 'update!') {
         badgeData.colorscheme = 'red';
       } else if (statusMatch === 'none') {
         badgeData.colorscheme = 'brightgreen';


### PR DESCRIPTION
up-to-date appears twice here, and update! nowhere. This causes badges like https://img.shields.io/gemnasium/resque/resque-web.svg to appear undefined, while there are actually red: https://gemnasium.com/resque/resque-web.svg