### PR TITLE
Fix bug in website badge (regexp was too greedy)

### DIFF
--- a/server.js
+++ b/server.js
@@ -5123,7 +5123,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Test if a webpage is online
-camp.route(/^\/website(-(([^-]|--)*?)-(([^-]|--)*)(-(([^-]|--)+)-(([^-]|--)+))?)?\/(.+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/website(-(([^-]|--)*?)-(([^-]|--)*)(-(([^-]|--)+)-(([^-]|--)+))?)?\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var onlineMessage = escapeFormat(match[2] != null ? match[2] : "online");
   var offlineMessage = escapeFormat(match[4] != null ? match[4] : "offline");


### PR DESCRIPTION
@espadrine Thanks for merging PR #639. I tested it a bit, and it seems it doesn't work when a path is given (instead of just a domain name).

I think I found the cause of the bug, it seems I got caught by a greedy regexp when separating the domain name from the rest of the URL in the syntax, and part of the domain + URL is gobbled up in the group matching the protocol. Hopefully this patch fixes that.
