### PR TITLE
fix website bug (`maxAge`/`style` conflict)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1250,7 +1250,10 @@ function markupDialog(tr) {
     var img = copyForm.img.value;
     var style = copyForm.style.value;
     // Default style doesn't show.
-    if (style !== 'flat') { img += '?style=' + style; }
+    if (style !== 'flat') {
+      if (img.match(/\?/)) { img += '&'; } else { img += '?'; }
+      img += 'style=' + style;
+    }
     var md = '[![' + trname + '](' + img + ')](' + url + ')';
     var rst = '.. image:: ' + img + '   :target: ' + url;
     copyMarkdown.value = md;


### PR DESCRIPTION
When a querystring is already present in the image (e.g. `?maxAge=...`), the style option does not work because the code still appends `?style=...` to it.

This patch tries to be a little smarter.