### PR TITLE
Use new add-on and infrastructure on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,13 @@
-before_install:
-  - sudo apt-get update -myqq
-  - sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
+addons:
+  apt:
+    packages:
+    - libcairo2-dev
+    - libjpeg8-dev
+    - libpango1.0-dev
+    - libgif-dev
+    - build-essential
+    - g++
+
 language: node_js
 node_js:
   - 6


### PR DESCRIPTION
Use apt add-on to install dependencies instead of raw apt-get commands, and use the new container-based infrastructure.

Ref:
https://docs.travis-ci.com/user/installing-dependencies/
https://docs.travis-ci.com/user/ci-environment/