### PR TITLE
fix docker command, add NetflixOSS OSSMETADATA osslifecycle support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -135,7 +135,7 @@ heroku open
 You can build and run the server locally using Docker. First build an image:
 
 ```console
-$ build -t shields ./
+$ docker build -t shields .
 Sending build context to Docker daemon 3.923 MB
 Step 0 : FROM node:0.12.7-onbuild
 …

--- a/server.js
+++ b/server.js
@@ -394,6 +394,51 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// NetflixOSS metadata integration
+camp.route(/^\/osslifecycle?\/([^\/]+\/[^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+  cache(function(data, match, sendBadge, request) {
+    var orgOrUserAndRepo = match[1];
+    var branch = match[2];
+    var format = match[3];
+    var url = 'https://raw.githubusercontent.com/' + orgOrUserAndRepo;
+    if (branch != null) {
+      url += "/" + branch + "/OSSMETADATA"
+    }
+    else {
+      url += "/master/OSSMETADATA";
+    }
+    var options = {
+      method: 'GET',
+      uri: url
+    };
+    var badgeData = getBadgeData('OSS Lifecycle', data);
+    request(options, function(err, res, body) {
+      if (err != null) {
+        console.error('NetflixOSS error: ' + err.stack);
+        if (res) { console.error(''+res); }
+        badgeData.text[1] = 'invalid';
+        sendBadge(format, badgeData);
+        return;
+      }
+      try {
+        var matchStatus = body.match(/osslifecycle\=([a-z]+)/im);
+        if (matchStatus === null) {
+          badgeData.text[1] = 'inaccessible';
+          sendBadge(format, badgeData);
+          return;
+        } else {
+          badgeData.text[1] = matchStatus[1];
+          sendBadge(format, badgeData);
+          return;
+        }
+      } catch(e) {
+        console.log(e);
+        badgeData.text[1] = 'inaccessible';
+        sendBadge(format, badgeData);
+      }
+    });
+}));
+
 // Shippable integration
 camp.route(/^\/shippable\/([^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function (data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -913,6 +913,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/stackexchange/stackoverflow/t/augeas.svg' alt=''/></td>
   <td><code>https://img.shields.io/stackexchange/stackoverflow/t/augeas.svg</code></td>
   </tr>
+  <tr><th> NetflixOSS Lifecycle: </th>
+    <td><img src='/osslifecycle/Netflix/osstracker.svg' alt=''/></td>
+    <td><code>https://img.shields.io/osslifecycle/Netflix/osstracker.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h2 id="your-badge"> Your Badge </h2>


### PR DESCRIPTION
Add support for github OSSMETADATA osslifecycle.  This is heavily used by Netflix OSS and is being considered by use across the TODO Group (Facebook, Yahoo, Microsoft, etc.).

also, fixed the command for docker ... didn't seem right as is
