### PR TITLE
Support [GitHub] releases containing a / in the tag

### DIFF
--- a/server.js
+++ b/server.js
@@ -3119,7 +3119,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub release-download-count integration.
-camp.route(/^\/github\/downloads\/([^\/]+)\/([^\/]+)(\/[^\/]+)?\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/downloads\/([^\/]+)\/([^\/]+)(\/.+)?\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var user = match[1];  // eg, qubyte/rubidium
   var repo = match[2];

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -26,3 +26,35 @@ t.create('File size for "not a regular file"')
     name: Joi.equal('size'),
     value: Joi.string().regex(/^not a regular file$/),
   }));
+
+t.create('downloads for release without slash')
+  .get('/downloads/atom/atom/v0.190.0/total.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('downloads'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? v0\.190\.0$/)
+  }));
+
+t.create('downloads for specific asset without slash')
+  .get('/downloads/atom/atom/v0.190.0/atom-amd64.deb.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('downloads'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? v0\.190\.0 \[atom-amd64\.deb\]$/)
+  }));
+
+t.create('downloads for release with slash')
+  .get('/downloads/NHellFire/dban/stable/v2.2.8/total.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('downloads'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? stable\/v2\.2\.8$/)
+  }));
+
+t.create('downloads for specific asset with slash')
+  .get('/downloads/NHellFire/dban/stable/v2.2.8/dban-2.2.8_i586.iso.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('downloads'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? stable\/v2\.2\.8 \[dban-2\.2\.8_i586\.iso\]$/)
+  }));
+
+t.create('downloads for unknown release')
+  .get('/downloads/atom/atom/does-not-exist/total.json')
+  .expectJSON({ name: 'downloads', value: 'none' });


### PR DESCRIPTION
Currently they 404 if they contain a / (such as stable/v1.0.0). I've tested this and it doesn't break any of the other download count badges.
