### PR TITLE
Migrate to the new container based infra on Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-before_install:
-  - sudo apt-get update -myqq
-  - sudo apt-get install libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev build-essential g++
 language: node_js
 node_js:
   - 6
@@ -16,3 +13,14 @@ notifications:
 
 git:
   depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - libcairo2-dev
+    - libjpeg8-dev
+    - libpango1.0-dev
+    - libgif-dev
+    - build-essential


### PR DESCRIPTION
Use the "apt" add-on to install apt packages instead of using "apt-get"
command directly, and then move to the new container-based
infrastructure, which can speed up the build process.

PS: package "g++" removed from the list since it's already the
dependency of package "build-essential", no need to duplicate it.

Reference:
- https://docs.travis-ci.com/user/ci-environment/
- https://docs.travis-ci.com/user/installing-dependencies/
- https://github.com/travis-ci/apt-package-whitelist/
