### PR TITLE
Fixed Dockerfile and improved doc regarding `secret.json`.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:0.12-onbuild
+FROM node:6.4.0-onbuild
 ENV INFOSITE http://shields.io
 EXPOSE 80

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ You can build and run the server locally using Docker. First build an image:
 ```console
 $ docker build -t shields ./
 Sending build context to Docker daemon 3.923 MB
-Step 0 : FROM node:0.12.7-onbuild
+Step 0 : FROM node:6.4.0-onbuild
 …
 Removing intermediate container c4678889953f
 Successfully built 4471b442c220
@@ -146,7 +146,7 @@ Successfully built 4471b442c220
 Then run the container:
 
 ```console
-$ docker run --rm -p 8080:80 shields
+$ docker run --rm -p 8080:80 -v "$(pwd)/secret.json":/usr/src/app/secret.json --name shields shields
 
 > gh-badges@1.1.2 start /usr/src/app
 > node server.js


### PR DESCRIPTION
Current `Dockerfile` was not working and documentation was lacking regarding

Fixed Dockerfile and improved doc regarding `secret.json`.

```
$ docker run --rm -p 8080:80 -v "$(pwd)/secret.json":/usr/src/app/secret.json --name shields shields
> gh-badges@1.2.2 start /usr/src/app
> node server.js

http://[::1]:80/try.html
```