### PR TITLE
- added support for jacoco code coverage in jenkins

### DIFF
--- a/try.html
+++ b/try.html
@@ -152,9 +152,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg' alt=''/></td>
     <td><code>https://img.shields.io/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg</code></td>
   </tr>
-  <tr><th> Jenkins coverage: </th>
+  <tr><th> Jenkins coverage (cobertura): </th>
     <td><img src='/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg' alt=''/></td>
     <td><code>https://img.shields.io/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg</code></td>
+  </tr>
+  <tr><th> Jenkins coverage (jacoco): </th>
+    <!-- cheat an reuse the 'cobertura' image, no known public jenkins jacoco jobs at this time -->
+    <td><img src='/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/j/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg</code></td>
   </tr>
   <tr><th> Coveralls: </th>
     <td><img src='/coveralls/jekyll/jekyll.svg' alt=''/></td>


### PR DESCRIPTION
this adds support for code coverage using jacoco in jenkins (and also refactors some of the common request handling into it's own function).

at this time, i don't know of any public jenkins installations that have a jacoco job, image is generated using the `cobertura` link but is listed as the `jacoco` link.
