### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "svgo": "~0.5.1",
     "pdfkit": "~0.7.1",
     "phantomjs-prebuilt": "~2.1.7",
-    "request": "~2.55.0",
+    "request": "~2.74.0",
     "redis": "~1.0.0",
     "camp": "~16.2.2",
     "semver": "~4.3.3",


### PR DESCRIPTION
shields currently has a 10 vulnerable dependency, introducing 18 different types of known vulnerabilities.

[ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency and [remote memory exposure](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.
You can see [Snyk test report](https://snyk.io/test/github/badges/shields) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, which uses the fixed `hawk` version , and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)