### PR TITLE
Add basic NSP integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -5479,6 +5479,50 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// (nsp) node security project integration
+camp.route(/^\/nsp\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function (data, match, sendBadge, request) {
+
+  var pkg = match[1];
+  var format = match[2];
+
+  var deps = {};
+  deps[pkg] = '*';
+  var options = {
+    method: 'POST',
+    uri: 'https://api.nodesecurity.io/check',
+    json: {
+      package: {
+        // fake npm package
+        name: 'shields',
+        version: '0.0.0',
+        // by putting the target package in deps, it's deps will be recursively processed
+        // otherwise we'd need to fetch all the npm deps ourselves
+        dependencies: deps
+      }
+    }
+  };
+
+  var badgeData = getBadgeData('nsp', data);
+  request(options, function(err, res, json) {
+
+    if (err || res.statusCode !== 200 || !Array.isArray(json)) {
+      badgeData.text[1] = 'not available';
+      return sendBadge(format, badgeData);
+    }
+
+    if (!json.length) {
+      badgeData.colorscheme = 'brightgreen';
+      badgeData.text[1] = 'no known vulns';
+    } else {
+      badgeData.colorscheme = 'red';
+      badgeData.text[1] = json.length + ' advisories';
+    }
+
+    return sendBadge(format, badgeData);
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)*?)-(([^-]|--)*)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {


### PR DESCRIPTION
Howdy! This is my first contribution here, so feel free to let me know if I need to change anything about this PR.

This adds a _very_ basic [nsp](https://nodesecurity.io) (aka: node security project) integration. Currently, getting a status badge for a public npm package is annoying, since it requires setting up an org on their site, connecting with github, adding repos as projects, and then manually fetching the UUID they generate. (rather than allowing something sane like "github/user/repo" in their URLs) As such, I'd really like a shields.io badge I can drop in, because it works _beautifully_ for all my other badges. :smile: 

This uses the URL pattern `/nsp/:package.:format`, which uses the NSP API to check for a list of advisories for a "fake" `shields@0.0.0` package that sets `:package@*` as it's dependency. This is kind of a hack on my part, as otherwise you would need to fetch the project's entire `package.json`. I presume this design decision was to allow their CLI to easily work with private packages as well.

As such, this integration will only work for public/published npm packages as-is. This doesn't seem to big a deal, as I would imagine the other integrations have the same limitations. But if that's not the case, I'm more than happy to do more work here.

To make this more future-proof, maybe the URL scheme could be `/nsp/npm/:package.:format` so another namespace like `/nsp/github/:user/:repo.:format` could be supported in the future?
