### PR TITLE
Add CDNJS version integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,6 +407,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>
+  <tr><th data-keywords='cdn cdnjs'> CDNJS: </th>
+  <td><img src='https://img.shields.io/cdnjs/v/jquery.svg?maxAge=2592000' alt=''/></td>
+  <td><code>https://img.shields.io/cdnjs/v/jquery.svg</code></td>
+  </tr>
   <tr><th data-keywords='node'> npm: </th>
   <td><img src='https://img.shields.io/npm/v/npm.svg?maxAge=2592000' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/npm.svg</code></td>

--- a/server.js
+++ b/server.js
@@ -1408,6 +1408,32 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// CDNJS version integration
+camp.route(/^\/cdnjs\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var library = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
+  var format = match[2];
+  var apiUrl = 'https://api.cdnjs.com/libraries/' + library + '?fields=version';
+  var badgeData = getBadgeData('cdnjs', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var version = JSON.parse(buffer).version || 0;
+      var vdata = versionColor(version);
+      badgeData.text[1] = vdata.version;
+      badgeData.colorscheme = vdata.color;
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'not found';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // npm download integration.
 camp.route(/^\/npm\/dm\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -406,6 +406,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 </tbody></table>
 <h3 id="version"> Version </h3>
 <table class='badge'><tbody>
+  <tr><th data-keywords='cdn cdnjs'> CDNJS: </th>
+  <td><img src='/cdnjs/v/jquery.svg' alt=''/></td>
+  <td><code>https://img.shields.io/cdnjs/v/jquery.svg</code></td>
+  </tr>
   <tr><th data-keywords='node'> npm: </th>
   <td><img src='/npm/v/npm.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/npm.svg</code></td>


### PR DESCRIPTION
To show the latest(and usually the stable) version on CDNJS via CDNJS api.

![cdnjs-jquer-version-badge-example](https://cloud.githubusercontent.com/assets/3691490/19231628/ac820768-8f0d-11e6-9580-eee5cc08a9ef.png)

cc cdnjs/cdnjs#5060