### PR TITLE
[Github] Add 2 new badges for Github pull request state and review

### DIFF
--- a/lib/github-helpers.js
+++ b/lib/github-helpers.js
@@ -1,0 +1,181 @@
+var githubAuth = require('./github-auth.js');
+var githubApiUrl = process.env.GITHUB_URL || 'https://api.github.com';
+
+/**
+ * Get the latest review of every reviewer then extract the review states
+ * @private
+ * @param reviews: array of Github reviews
+ * @returns {Array}
+ * @example
+ *  reviews = [
+ *    {reviewer: 'Bob', state: 'CHANGES_REQUESTED'},
+ *    {reviewer: 'Henri', state: 'APPROVED'},
+ *    {reviewer: 'Bob', state: 'APPROVED'}
+ *  ]
+ *  returns ['APPROVED', 'APPROVED']
+ */
+function extractLatestReviewStates(reviews) {
+  var lastStateByUser = {};
+  // reviews are ordered chronologically, so the last review of each user is the most relevant
+  for (var i = 0, l = reviews.length; i < l; i++) {
+    lastStateByUser[reviews[i].user.login] = reviews[i].state;
+  }
+  var lastReviewStates = [];
+  for (var user in lastStateByUser) {
+    if (lastStateByUser.hasOwnProperty(user)) {
+      lastReviewStates.push(lastStateByUser[user]);
+    }
+  }
+  return lastReviewStates;
+}
+
+/**
+ * Compute the text and color for the pull request review badge
+ * @public
+ * @param user: Github user name or organization name
+ * @param repo: Github repository name
+ * @param issue: Github issue ID
+ * @param request
+ * @param next: callback called once badge name and color are found
+ */
+function getPrReviewBadgeData(user, repo, issue, request, next) {
+  var badgePartialData = {
+    text: 'inaccessible',
+    colorscheme: 'lightgrey'
+  };
+
+  var requestedReviewersUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/pulls/' + issue + '/requested_reviewers';
+  githubAuth.request(request, requestedReviewersUrl, {}, function (err, res, buffer) {
+    if (err) {
+      console.log(err);
+      next(badgePartialData);
+      return;
+    }
+    try {
+      var pendingReviewers = JSON.parse(buffer);
+      if (pendingReviewers.length > 0) {
+        // there are still some requested reviewers that did not review the PR yet
+        badgePartialData.text = 'pending';
+        badgePartialData.colorscheme = 'yellow';
+        next(badgePartialData);
+      } else { // no pending reviewer
+        var reviewsUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/pulls/' + issue + '/reviews';
+        githubAuth.request(request, reviewsUrl, {}, function (err, res, buffer) {
+          if (err) {
+            console.log(err);
+            next(badgePartialData);
+            return;
+          }
+          try {
+            var reviews = JSON.parse(buffer);
+            if (reviews.length === 0) {
+              // no requested reviewer and no review done => no review for this pull request
+              badgePartialData.text = 'none';
+              badgePartialData.colorscheme = 'lightgrey';
+            } else {
+              var lastestReviewStates = extractLatestReviewStates(reviews);
+
+              // review state values: COMMENT, APPROVED, CHANGES_REQUESTED, DISMISSED
+              if (lastestReviewStates.indexOf('CHANGES_REQUESTED') > -1) {
+                // there is at least 1 review that requests changes
+                badgePartialData.text = 'need changes';
+                badgePartialData.colorscheme = 'red';
+              } else if (lastestReviewStates.indexOf('APPROVED') > -1) {
+                // there is at least 1 review approved, and no review that requests changes
+                badgePartialData.text = 'approved';
+                badgePartialData.colorscheme = 'green';
+              } else {
+                // reviews are comments or dismissed
+                badgePartialData.text = 'pending';
+                badgePartialData.colorscheme = 'yellow';
+              }
+            }
+          } catch (err) {
+            console.log(err);
+          }
+          next(badgePartialData);
+        });
+      }
+    } catch (err) {
+      console.log(err);
+      next(badgePartialData);
+    }
+  });
+}
+
+/**
+ * Compute the text and color for the pull request state badge
+ * @public
+ * @param user: Github user name or organization name
+ * @param repo: Github repository name
+ * @param issue: Github issue ID
+ * @param request
+ * @param next: callback called once badge name and color are found
+ */
+function getPrStateBadgeData(user, repo, issue, request, next) {
+  var badgePartialData = {
+    text: 'inaccessible',
+    colorscheme: 'lightgrey',
+    colorB: null
+  };
+
+  var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/pulls/' + issue;
+  githubAuth.request(request, apiUrl, {}, function (err, res, buffer) {
+    if (err !== null) {
+      console.log(err);
+      next(badgePartialData);
+      return;
+    }
+
+    try {
+      var pr = JSON.parse(buffer);
+
+      var responseIsIssueLike = pr.hasOwnProperty('state') &&
+        pr.hasOwnProperty('merged') &&
+        pr.hasOwnProperty('mergeable') &&
+        pr.hasOwnProperty('mergeable_state');
+
+      if (responseIsIssueLike) {
+        if (pr.state === 'closed') {
+          // PR is closed => check if it was merged or not
+          if (pr.merged) {
+            badgePartialData.text = 'merged';
+            badgePartialData.colorscheme = null;
+            badgePartialData.colorB = '#6e5494'; // purple-ish color from Github
+          } else {
+            badgePartialData.text = 'closed';
+            badgePartialData.colorscheme = 'red';
+          }
+        } else if (pr.state === 'open') {
+          // 'clean', 'unstable', 'dirty' or 'unknown'
+          switch (pr.mergeable_state) {
+            case 'clean':
+              badgePartialData.text = 'mergeable';
+              break;
+            case 'dirty':
+              badgePartialData.text = 'has conflicts';
+              break;
+            case 'behind':
+              badgePartialData.text = 'need rebase';
+              break;
+            default:
+              badgePartialData.text = pr.mergeable_state;
+          }
+          if (pr.mergeable === null) {
+            badgePartialData.colorscheme = 'lightgrey';
+          } else if (pr.mergeable) {
+            badgePartialData.colorscheme = (['unstable', 'behind'].indexOf(pr.mergeable_state) > -1) ? 'yellow' : 'green';
+          } else { // pr.mergeable === false
+            badgePartialData.colorscheme = 'red';
+          }
+        }
+      }
+    } catch(err) {
+      console.log(err);
+    }
+    next(badgePartialData);
+  });
+}
+
+exports.getPrReviewBadgeData = getPrReviewBadgeData;
+exports.getPrStateBadgeData = getPrStateBadgeData;

--- a/server.js
+++ b/server.js
@@ -3290,6 +3290,43 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Github pull request review state (pending, approved, need changes...) integration.
+camp.route(/^\/github\/pr-review\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function (data, match, sendBadge, request) {
+  var user = match[1];  // e.g. badges
+  var repo = match[2];  // e.g. shields
+  var issue = match[3];  // e.g. 123
+  var format = match[4];
+
+  var getPrReviewBadgeData = require('./lib/github-helpers.js').getPrReviewBadgeData;
+
+  getPrReviewBadgeData(user, repo, issue, request, function (badgePartialData) {
+    var badgeData = getBadgeData('pull request review', data);
+    badgeData.text[1] = badgePartialData.text;
+    badgeData.colorscheme = badgePartialData.colorscheme;
+    sendBadge(format, badgeData);
+  });
+}));
+
+// Github pull request state (open/close + mergeability) integration.
+camp.route(/^\/github\/pr-state\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function (data, match, sendBadge, request) {
+  var user = match[1];  // e.g. badges
+  var repo = match[2];  // e.g. shields
+  var issue = match[3];  // e.g. 123
+  var format = match[4];
+
+  var getPrStateBadgeData = require('./lib/github-helpers.js').getPrStateBadgeData;
+
+  getPrStateBadgeData(user, repo, issue, request, function (badgePartialData) {
+    var badgeData = getBadgeData('pull request state', data);
+    badgeData.text[1] = badgePartialData.text;
+    badgeData.colorscheme = badgePartialData.colorscheme;
+    badgeData.colorB = badgePartialData.colorB;
+    sendBadge(format, badgeData);
+  });
+}));
+
 // GitHub forks integration.
 camp.route(/^\/github\/forks\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -58,3 +58,403 @@ t.create('downloads for specific asset with slash')
 t.create('downloads for unknown release')
   .get('/downloads/atom/atom/does-not-exist/total.json')
   .expectJSON({ name: 'downloads', value: 'none' });
+
+// pull request state
+
+t.create('Pull request state, regular case')
+  .get('/pr-state/badges/shields/578.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull request state'),
+    value: Joi.equal('closed', 'merged', 'mergeable', 'has conflicts', 'need rebase')
+  }));
+
+t.create('Pull request state, closed pull request')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: null,
+        mergeable_state: 'unknown',
+        merged: false,
+        state: 'closed'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'closed'
+  });
+
+t.create('Pull request state, merged pull request')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: null,
+        mergeable_state: 'unknown',
+        merged: true,
+        state: 'closed'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'merged'
+  });
+
+t.create('Pull request state, pull request with unknown state')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: null,
+        mergeable_state: 'unknown',
+        merged: false,
+        state: 'open'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'unknown'
+  });
+
+t.create('Pull request state, mergeable pull request')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: true,
+        mergeable_state: 'clean',
+        merged: false,
+        state: 'open'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'mergeable'
+  });
+
+t.create('Pull request state, pull request with conflicts')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: false,
+        mergeable_state: 'dirty',
+        merged: false,
+        state: 'open'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'has conflicts'
+  });
+
+t.create('Pull request state, pull request that needs rebase')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: false,
+        mergeable_state: 'behind',
+        merged: false,
+        state: 'open'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'need rebase'
+  });
+
+t.create('Pull request state, mergeable pull request but build unstable')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, {
+        mergeable: true,
+        mergeable_state: 'unstable',
+        merged: false,
+        state: 'open'
+      })
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'unstable'
+  });
+
+t.create('Pull request state, valid response but not a Github issue')
+  .get('/pr-state/badges/shields/-1.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull request state'),
+    value: Joi.equal('inaccessible')
+  }));
+
+t.create('Pull request state, invalid response')
+  .get('/pr-state/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578')
+      .query(true)
+      .reply(200, 'This should be JSON')
+  )
+  .expectJSON({
+    name: 'pull request state',
+    value: 'inaccessible'
+  });
+
+t.create('Pull request state, request error')
+  .get('/pr-state/badges/shields/578.json')
+  .networkOff()
+  .expectJSON({
+    name: 'pull request state',
+    value: 'inaccessible'
+  });
+
+// pull request review
+
+t.create('Pull request review, no requested reviewer')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'none'
+  });
+
+t.create('Pull request review, one pending requested reviewer')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [{login: 'bob'}])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'pending'
+  });
+
+t.create('Pull request review, 1 review, 1 approved')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [{state: 'APPROVED', user: {login: 'bob'}}])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'approved'
+  });
+
+t.create('Pull request review, 1 review, 1 changes requested')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'CHANGES_REQUESTED', user: {login: 'bob'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'need changes'
+  });
+
+t.create('Pull request review, 1 review, 1 comment')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'COMMENT', user: {login: 'bob'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'pending'
+  });
+
+t.create('Pull request review, 2 reviews, 1 user, 1 comment then 1 approved')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'COMMENT', user: {login: 'bob'}},
+        {state: 'APPROVED', user: {login: 'bob'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'approved'
+  });
+
+t.create('Pull request review, 2 reviews, 1 user, 1 changes requested then 1 approved')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'CHANGES_REQUESTED', user: {login: 'bob'}},
+        {state: 'APPROVED', user: {login: 'bob'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'approved'
+  });
+
+t.create('Pull request review, 2 reviews, 2 users, 1 comment and 1 approved')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'COMMENT', user: {login: 'bob'}},
+        {state: 'APPROVED', user: {login: 'henri'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'approved'
+  });
+
+t.create('Pull request review, 2 reviews, 2 users, 1 changes requested and 1 approved')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, [
+        {state: 'CHANGES_REQUESTED', user: {login: 'bob'}},
+        {state: 'APPROVED', user: {login: 'henri'}}
+      ])
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'need changes'
+  });
+
+t.create('Pull request review, first request error')
+  .get('/pr-review/badges/shields/578.json')
+  .networkOff()
+  .expectJSON({
+    name: 'pull request review',
+    value: 'inaccessible'
+  });
+
+t.create('Pull request review, first request ok, second request error')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .networkOff()
+  .expectJSON({
+    name: 'pull request review',
+    value: 'inaccessible'
+  });
+
+t.create('Pull request review, invalid response on first request')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, 'unparsable text')
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'inaccessible'
+  });
+
+t.create('Pull request review, invalid response on second request')
+  .get('/pr-review/badges/shields/578.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/requested_reviewers')
+      .query(true)
+      .reply(200, [])
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/pulls/578/reviews')
+      .query(true)
+      .reply(200, 'unparsable text')
+  )
+  .expectJSON({
+    name: 'pull request review',
+    value: 'inaccessible'
+  });

--- a/try.html
+++ b/try.html
@@ -790,6 +790,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-pr-closed-raw/cdnjs/cdnjs.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-pr-closed-raw/cdnjs/cdnjs.svg</code></td>
   </tr>
+  <tr><th data-keywords='GitHub pullrequest pr state merge mergeability' data-doc='githubDoc'> GitHub pull request state: </th>
+    <td><img src='/github/pr-state/badges/shields/578.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/pr-state/badges/shields/578.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub pullrequest pr state review' data-doc='githubDoc'> GitHub pull request review: </th>
+    <td><img src='/github/pr-review/badges/shields/578.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/pr-review/badges/shields/578.svg</code></td>
+  </tr>
   <tr><th data-keywords='GitHub contributor' data-doc='githubDoc'> GitHub contributors: </th>
     <td><img src='/github/contributors/cdnjs/cdnjs.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/contributors/cdnjs/cdnjs.svg</code></td>


### PR DESCRIPTION
**Github pull request state**

URL pattern:

```
/github/pr-state/<user>/<repo>/<issueId>.<format>
```

The issue (which ID is provided in the URL) must be a pull-request.

The following states are handled:
- `inaccessible` (lightgrey) if the request failed or the response was not 
  a json-formatted issue
- `closed` (red) if the PR is closed and not merged
- `merged` (Github purple-ish) if the PR is closed and merged
- `mergeable` (green) if the PR is open and clean (build OK, no conflicts detected, rebased on latest version of the base branch)
- `unstable` (yellow) if the PR is open but unstabe
- `has conflicts` (red) if the PR is open but not mergeable (conflicts with base branch detected)
- `unknown` (lightgrey) if the PR is open but the mergeability is not computed yet ([more details here](http://stackoverflow.com/questions/30619549/why-does-github-api-return-an-unknown-mergeable-state-in-a-pull-request))

**Github pull request review**

URL pattern:

```
/github/pr-review/<user>/<repo>/<issueId>.<format>
```

The issue (which ID is provided in the URL) must be a pull-request.

The following states are handled:
- `inaccessible` (lightgrey) if the request failed or the response was not 
  a json-formatted issue
- `none` (lightgrey) if no review has been requested
- `pending` (yellow) if there are still reviewers that didn't perform the review OR if no review has been approved or requested changes
- `approved` (green) if at least 1 review has been approved and none requested changes
- `need changes` (red) if at least 1 review requested changes

*Note: Only the latest review of every reviewer is taken into account.*