### PR TITLE
Reduce page jumping while all the badges are loading

### DIFF
--- a/try.html
+++ b/try.html
@@ -22,7 +22,7 @@ hr { width: 40%; border-width: 1px 0 0 0; }
 a.photo { text-decoration: none; }
 a.photo>img { padding: 2px; border: 1px solid grey; }
 ul { text-align: left; margin-left: 25%; }
-table { width: 50%; margin: auto; }
+table { min-width: 50%; margin: auto; }
 table.centered > tbody > tr > td:first-child { text-align: right; }
 th, td { text-align: left; }
 h1, h2, h3 { font-style: italic; }
@@ -47,6 +47,11 @@ hr.spacing { border: 0; display: block; height: 3mm; }
 table.badge > tbody > tr > th,
 table.badge > tbody > tr > td > img,
 table.badge > tbody > tr > td > code { cursor: pointer; }
+#copyImg,
+.badge-img img {
+	height: 20px;
+	vertical-align: middle;
+}
 </style>
 
 <main id='main'>
@@ -67,7 +72,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 <section id='suggestedBadges'></section>
 
 <h3 id="build"> Build </h3>
-<table class='badge'><tbody>
+<table class='badge badge-img'><tbody>
   <tr><th> Travis: </th>
     <td><img src='/travis/rust-lang/rust.svg' alt=''/></td>
     <td><code>https://img.shields.io/travis/USER/REPO.svg</code></td>
@@ -984,7 +989,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </td></tr>
 </tbody></table>
 
-<p>
+<p class='badge-img'>
 <img src='/badge/color-brightgreen-brightgreen.svg' alt='brightgreen'/>
 <img src='/badge/color-green-green.svg' alt='green'/>
 <img src='/badge/color-yellowgreen-yellowgreen.svg' alt='yellowgreen'/>
@@ -1000,7 +1005,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 <p>
 The following styles are available (flat is the default as of Feb 1st 2015):
 </p>
-<table><tbody>
+<table class='badge-img'><tbody>
   <tr>
   <td><img src='/badge/style-plastic-green.svg?style=plastic' alt=''/></td>
   <td><code>https://img.shields.io/badge/style-plastic-green.svg?style=plastic</code></td>


### PR DESCRIPTION
Sets all the shield images to be 20px. Also allows the table to be wider than 50% so that the columns don't look squashed due to long urls.
