### PR TITLE
[Add-on] Add star ratings for Chrome web store & Mozilla addons

### DIFF
--- a/server.js
+++ b/server.js
@@ -5300,7 +5300,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Chrome web store integration
-camp.route(/^\/chrome-web-store\/(v|d|price|rating|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/chrome-web-store\/(v|d|price|rating|stars|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var storeId = match[2];  // eg, nimelepbpejjlbmoobocpfnjhihnpked
@@ -5333,6 +5333,17 @@ cache(function(data, match, sendBadge, request) {
           badgeData.text[0] = data.label || 'rating';
           badgeData.text[1] = rating;
           badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
+        } else if (type === 'stars') {
+          var rating = Math.round(value.ratingValue);
+          badgeData.text[0] = data.label || 'rating';
+          badgeData.text[1] = '';
+          while (badgeData.text[1].length < rating) {
+            badgeData.text[1] += '★';
+          }
+          while (badgeData.text[1].length < 5) {
+            badgeData.text[1] += '☆';
+          }
+          badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
         } else if (type === 'rating-count') {
           var ratingCount = value.ratingCount;
           badgeData.text[0] = data.label || 'rating count';
@@ -5348,7 +5359,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Mozilla addons integration
-camp.route(/^\/amo\/(v|d|rating|users)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/amo\/(v|d|rating|stars|users)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var addonId = match[2];
@@ -5388,6 +5399,18 @@ cache(function(data, match, sendBadge, request) {
           var rating = parseInt(data.addon.rating, 10);
           badgeData.text[0] = 'rating';
           badgeData.text[1] = rating + '/5';
+          badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
+          break;
+        case 'stars':
+          var rating = parseInt(data.addon.rating, 10);
+          badgeData.text[0] = 'rating';
+          badgeData.text[1] = '';
+          while (badgeData.text[1].length < rating) {
+            badgeData.text[1] += '★';
+          }
+          while (badgeData.text[1].length < 5) {
+            badgeData.text[1] += '☆';
+          }
           badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
           break;
         case 'users':

--- a/try.html
+++ b/try.html
@@ -866,6 +866,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/chrome-web-store/rating/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
   <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/stars/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/stars/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
     <td><img src='/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
     <td><code>https://img.shields.io/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
@@ -880,6 +884,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th data-keywords='amo firefox'> Mozilla Add-on: </th>
     <td><img src='/amo/rating/dustman.svg' alt=''/></td>
     <td><code>https://img.shields.io/amo/rating/dustman.svg</code></td>
+  </tr>
+  <tr><th data-keywords='amo firefox'> Mozilla Add-on: </th>
+    <td><img src='/amo/stars/dustman.svg' alt=''/></td>
+    <td><code>https://img.shields.io/amo/stars/dustman.svg</code></td>
   </tr>
 </tbody></table>
 


### PR DESCRIPTION
### Usage:
Show a rating out of 5 using stars

### Example Badges:
![](https://img.shields.io/badge/rating-%E2%98%86%E2%98%86%E2%98%86%E2%98%86%E2%98%86-red.svg?style=flat-square)
![](https://img.shields.io/badge/rating-%E2%98%85%E2%98%86%E2%98%86%E2%98%86%E2%98%86-dfb317.svg?style=flat-square)
![](https://img.shields.io/badge/rating-%E2%98%85%E2%98%85%E2%98%86%E2%98%86%E2%98%86-a4a61d.svg?style=flat-square)
![](https://img.shields.io/badge/rating-%E2%98%85%E2%98%85%E2%98%85%E2%98%86%E2%98%86-97ca00.svg?style=flat-square)
![](https://img.shields.io/badge/rating-%E2%98%85%E2%98%85%E2%98%85%E2%98%85%E2%98%86-brightgreen.svg?style=flat-square)
![](https://img.shields.io/badge/rating-%E2%98%85%E2%98%85%E2%98%85%E2%98%85%E2%98%85-brightgreen.svg?style=flat-square)

Colors are using `floorCountColor(rating, 2, 3, 4);` function

codes for stars:

Character | Entity | Hexadecimal | Decimal | URL encoded
:---: | :---: | :---: | :---: | :---:
★ | `&starf;` `&bigstar;` | `&#x02605;` | `&#9733;` | `%E2%98%85`
☆ | `&star;` | `&#x02606;` | `&#9734;` | `%E2%98%86`

Tried using the all the different codes for the stars, but wont work due to the [`&` being replaced with `&amp;`](https://github.com/badges/shields/blob/master/badge.js#L21)