### PR TITLE
Add GitHub issue-nonpr badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -3218,21 +3218,26 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub issues integration.
-camp.route(/^\/github\/issues(-pr)?(-closed)?(-raw)?\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/issues(-pr)?(-nonpr)?(-closed)?(-raw)?\/([^\/]+)\/([^\/]+)\/?([^\/]+)?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var isPR = !!match[1];
-  var isClosed = !!match[2];
-  var isRaw = !!match[3];
-  var user = match[4];  // eg, badges
-  var repo = match[5];  // eg, shields
-  var ghLabel = match[6];  // eg, website
-  var format = match[7];
+  var isNonPR = !!match[2];
+  var isClosed = !!match[3];
+  var isRaw = !!match[4];
+  var user = match[5];  // eg, badges
+  var repo = match[6];  // eg, shields
+  var ghLabel = match[7];  // eg, website
+  var format = match[8];
   var apiUrl = githubApiUrl;
   var query = {};
   var issuesApi = false;  // Are we using the issues API instead of the repo one?
   if (isPR) {
     apiUrl += '/search/issues';
     query.q = 'is:pr is:' + (isClosed? 'closed': 'open') +
+      ' repo:' + user + '/' + repo;
+  } else if (isNonPR) {
+    apiUrl += '/search/issues';
+    query.q = 'is:issue is:' + (isClosed? 'closed': 'open') +
       ' repo:' + user + '/' + repo;
   } else {
     apiUrl += '/repos/' + user + '/' + repo;
@@ -3260,7 +3265,7 @@ cache(function(data, match, sendBadge, request) {
       var data = JSON.parse(buffer);
       var modifier = '';
       var issues;
-      if (isPR) {
+      if (isPR || isNonPR) {
         issues = data.total_count;
       } else {
         if (issuesApi) {

--- a/try.html
+++ b/try.html
@@ -719,6 +719,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-raw/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-raw/badges/shields.svg</code></td>
   </tr>
+  <tr><th data-keywords='GitHub issue' data-doc='githubDoc'> GitHub issues without pull requests: </th>
+    <td><img src='/github/issues-nonpr/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-nonpr/badges/shields.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub issue' data-doc='githubDoc'></th>
+    <td><img src='/github/issues-nonpr-raw/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-nonpr-raw/badges/shields.svg</code></td>
+  </tr>
   <tr><th data-keywords='GitHub issue' data-doc='githubDoc'> GitHub closed issues: </th>
     <td><img src='/github/issues-closed/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-closed/badges/shields.svg</code></td>


### PR DESCRIPTION
This adds a variant of the GitHub issue badge which only counts real issues and skips PRs. Issues normally counting pull requests as well doesn't seem intuitive, but I didn't want to change the default one to keep backwards compatibility. New syntax is:
```
 /github/issues-nonpr/user/repo.svg
```

Ref. #420 