### PR TITLE
Add support for swagger.io validator

### DIFF
--- a/try.html
+++ b/try.html
@@ -902,6 +902,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/amo/stars/dustman.svg' alt=''/></td>
     <td><code>https://img.shields.io/amo/stars/dustman.svg</code></td>
   </tr>
+  <tr><th> Swagger Validator: </th>
+    <td><img src='/swagger/valid/2.0/https/bitbucket.org/api/swagger.json.svg' alt=''/></td>
+    <td><code>https://img.shields.io/swagger/valid/2.0/https/bitbucket.org/api/swagger.json.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="miscellaneous"> Longer Miscellaneous </h3>


### PR DESCRIPTION
The [OpenAPI Specification](http://swagger.io/specification/) (formerly known as the Swagger RESTful API Documentation Specification) defines a format for describing RESTful APIs.  The Swagger project provides a set of tools for working with this format, including a [hosted validator](https://github.com/swagger-api/validator-badge) which provides a validation badge and JSON result.  This commit adds shields.io support for this badge.

The service currently only provides validation of files conforming to version 2.0 of the OpenAPI Specification.  This commit adds a path component for specifying the version under the assumption that the validator may support version 3.0 or later as they are released.

It accepts the URL to validate as two path components, a scheme followed by the rest of the URL, to match the convention used for the JIRA host and webpage online shields.

I hope you find it useful.  Thanks for considering,
Kevin