### PR TITLE
Improve running with Docker, private GitHub repos and add support for `version/x.y.z` tags

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 node_modules/
+secret.env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,2 @@
 node_modules/
-secret.env
+shields.env

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ Thumbs.db
 # Files that might appear on external disks
 .Spotlight-V100
 .Trashes
+
+# Docker env file containing secrets
+secret.env

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,5 @@ Thumbs.db
 .Spotlight-V100
 .Trashes
 
-# Docker env file containing secrets
-secret.env
+# Docker env configuration file
+shields.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,21 @@
-FROM node:6.4.0-onbuild
-ENV INFOSITE http://shields.io
+FROM node:6.9.2-alpine
+
+RUN apk add --update gettext
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ARG NODE_ENV
+ENV NODE_ENV $NODE_ENV
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app
+
+ENV GH_CLIENT_ID=null \
+    GH_CLIENT_SECRET=null \
+    SHIELDS_IP=null \
+    INFOSITE="http://shields.io"
+
+CMD envsubst < secret.tpl.json > secret.json && npm start
+
 EXPOSE 80

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,16 +128,14 @@ You can build and run the server locally using Docker. First build an image:
 ```console
 $ docker build -t shields ./
 Sending build context to Docker daemon 3.923 MB
-Step 0 : FROM node:6.4.0-onbuild
 …
-Removing intermediate container c4678889953f
 Successfully built 4471b442c220
 ```
 
 Then run the container:
 
 ```console
-$ docker run --rm -p 8080:80 -v "$(pwd)/secret.json":/usr/src/app/secret.json --name shields shields
+$ docker run --rm -p 8080:80 --env-file secret.env --name shields shields
 
 > gh-badges@1.1.2 start /usr/src/app
 > node server.js
@@ -164,6 +162,9 @@ sl_insight_userUuid
 ```
 
 (Gathered from `cat secret.json | jq keys | grep -o '".*"' | sed 's/"//g'`.)
+
+The `secret.tpl.json` is a template file used by the Docker container to set the secrets based on
+environment variables.
 
 # Main Server Sysadmin
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -132,13 +132,13 @@ Sending build context to Docker daemon 3.923 MB
 Successfully built 4471b442c220
 ```
 
-Optionally, create a file called `secret.env` that contains the needed configuration. See
+Optionally, create a file called `shields.env` that contains the needed configuration. See
 `secret.example.env` for an example.
 
 Then run the container:
 
 ```console
-$ docker run --rm -p 8080:80 --env-file secret.env --name shields shields
+$ docker run --rm -p 8080:80 --env-file shields.env --name shields shields
 
 > gh-badges@1.1.2 start /usr/src/app
 > node server.js
@@ -157,6 +157,7 @@ bintray_apikey
 bintray_user
 gh_client_id
 gh_client_secret
+gh_token
 gitter_dev_secret
 shieldsIps
 shieldsSecret

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -126,11 +126,14 @@ heroku open
 You can build and run the server locally using Docker. First build an image:
 
 ```console
-$ docker build -t shields ./
+$ docker build -t shields .
 Sending build context to Docker daemon 3.923 MB
 …
 Successfully built 4471b442c220
 ```
+
+Optionally, create a file called `secret.env` that contains the needed configuration. See
+`secret.example.env` for an example.
 
 Then run the container:
 

--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -2,6 +2,7 @@ var querystring = require('querystring');
 var request = require('request');
 var autosave = require('json-autosave');
 var serverSecrets;
+var baseUrl = process.env.BASE_URL || "http://shields.io";
 try {
   // Everything that cannot be checked in but is useful server-side
   // is stored in this JSON data.
@@ -23,7 +24,7 @@ function setRoutes(server) {
     }
     var query = querystring.stringify({
       client_id: serverSecrets.gh_client_id,
-      redirect_uri: 'https://img.shields.io/github-auth/done',
+      redirect_uri: baseUrl + '/github-auth/done',
     });
     ask.res.statusCode = 302;  // Found.
     ask.res.setHeader('Location', 'https://github.com/login/oauth/authorize?' + query);

--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -2,7 +2,7 @@ var querystring = require('querystring');
 var request = require('request');
 var autosave = require('json-autosave');
 var serverSecrets;
-var baseUrl = process.env.BASE_URL || "http://shields.io";
+var baseUrl = process.env.BASE_URL || "https://shields.io";
 try {
   // Everything that cannot be checked in but is useful server-side
   // is stored in this JSON data.
@@ -10,7 +10,7 @@ try {
 } catch(e) {}
 var githubUserTokens;
 var githubUserTokensFile = '.github-user-tokens.json';
-autosave(githubUserTokensFile, {data:[]}).then(function(f) {
+var tokensPromise = autosave(githubUserTokensFile, {data:[]}).then(function(f) {
   githubUserTokens = f;
   for (var i = 0; i < githubUserTokens.data.length; i++) {
     addGithubToken(githubUserTokens.data[i]);
@@ -206,9 +206,11 @@ function rmGithubToken(token) {
 // Personal tokens allow access to GitHub private repositories.
 // You can manage your personal GitHub token at
 // <https://github.com/settings/tokens>.
-if (serverSecrets && serverSecrets.gh_token) {
-  addGithubToken(serverSecrets.gh_token);
-}
+tokensPromise.then(function(tokens) {
+  if (serverSecrets && serverSecrets.gh_token) {
+    addGithubToken(serverSecrets.gh_token);
+  }
+});
 
 // Act like request(), but tweak headers and query to avoid hitting a rate
 // limit.

--- a/secret.example.env
+++ b/secret.example.env
@@ -1,0 +1,5 @@
+BASE_URL=https://img.shields.io
+# Create your GitHub OAuth application here: https://github.com/settings/developers
+GH_CLIENT_ID=insert_client_id
+GH_CLIENT_SECRET=insert_client_secret
+SHIELDS_IP=insert_shields_ip

--- a/secret.example.env
+++ b/secret.example.env
@@ -1,5 +1,0 @@
-BASE_URL=https://img.shields.io
-# Create your GitHub OAuth application here: https://github.com/settings/developers
-GH_CLIENT_ID=insert_client_id
-GH_CLIENT_SECRET=insert_client_secret
-SHIELDS_IP=insert_shields_ip

--- a/secret.tpl.json
+++ b/secret.tpl.json
@@ -1,0 +1,5 @@
+{
+  "gh_client_id": "${GH_CLIENT_ID}",
+  "gh_client_secret": "${GH_CLIENT_SECRET}",
+  "shieldsIps": [ "${SHIELDS_IP}" ]
+}

--- a/secret.tpl.json
+++ b/secret.tpl.json
@@ -1,5 +1,6 @@
 {
   "gh_client_id": "${GH_CLIENT_ID}",
   "gh_client_secret": "${GH_CLIENT_SECRET}",
-  "shieldsIps": [ "${SHIELDS_IP}" ]
+  "shieldsIps": [ "${SHIELDS_IP}" ],
+  "gh_token": "${GH_TOKEN}"
 }

--- a/server.js
+++ b/server.js
@@ -2913,6 +2913,7 @@ cache(function(data, match, sendBadge, request) {
       badgeData.colorscheme = vdata.color;
       sendBadge(format, badgeData);
     } catch(e) {
+      console.error('GitHub error: ' + e);
       badgeData.text[1] = 'none';
       sendBadge(format, badgeData);
     }
@@ -3944,8 +3945,8 @@ cache(function(data, match, sendBadge, request) {
 camp.route(/^\/codeship\/([^\/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var projectId = match[1];  // eg, `ab123456-00c0-0123-42de-6f98765g4h32`.
-  var format = match[3];
-  var branch = match[2];
+  var format = match[3]; 
+  var branch = match[2]; // eg, `ab123456-00c0-0123-42de-6f98765g4h32/master`.
   var options = {
     method: 'GET',
     uri: 'https://codeship.com/projects/' + projectId + '/status' + (branch != null ? '?branch=' + branch : '')
@@ -5891,6 +5892,8 @@ function versionColor(version) {
   var first = version[0];
   if (first === 'v') {
     first = version[1];
+  } else if (/^version\/[0-9]/.test(version)) {
+    version = 'v' + version.substring(8);
   } else if (/^[0-9]/.test(version)) {
     version = 'v' + version;
   }
@@ -5941,7 +5944,7 @@ function latestVersion(versions) {
   var version = '';
   var origVersions = versions;
   versions = versions.filter(function(version) {
-    return (/^v?[0-9]/).test(version);
+    return (/^(v|version\/)?[0-9]/).test(version);
   });
   try {
     version = semver.maxSatisfying(versions, '');

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 var secureServer = !!process.env.HTTPS;
 var serverPort = +process.env.PORT || +process.argv[2] || (secureServer? 443: 80);
 var bindAddress = process.env.BIND_ADDRESS || process.argv[3] || '::';
-var infoSite = process.env.INFOSITE || "http://shields.io";
+var infoSite = process.env.INFOSITE || "https://shields.io";
 var githubApiUrl = process.env.GITHUB_URL || 'https://api.github.com';
 var Camp = require('camp');
 var camp = Camp.start({

--- a/shields.example.env
+++ b/shields.example.env
@@ -1,0 +1,19 @@
+# Base URL for redirects etc.
+BASE_URL=https://shields.io
+# Where your homepage is
+INFOSITE=https://shields.io
+
+# GitHub settings
+GITHUB_URL=https://api.github.com
+# Create your GitHub OAuth application here: https://github.com/settings/developers
+GH_CLIENT_ID=insert_client_id
+GH_CLIENT_SECRET=insert_client_secret
+# Create your Personal Access Token here: https://github.com/settings/tokens
+GH_TOKEN=insert_token
+
+# Server settings
+PORT=80
+BIND_ADDRESS=::
+
+# IP address of your Shields server. You may use your DNS here, but that's less secure
+SHIELDS_IP=insert_shields_ip


### PR DESCRIPTION
I wanted to set up a Shield server that could access private repositories, but there was no support for adding a GitHub key with that scope. I added this in `lib/github-auth.js`.

EDIT: turns out there was support for private repos already, but through `gh_token` in secrets.json. Apparently I missed this and adjusted my PR accordingly. 

I also added support for the less popular version tag format `version/x.y.z`. This was a minor tweak to the `latestVersion` and `versionColor` functions in `server.js`.

Lastly I added support for configuring `secrets.json` using the environment. For this I added a `secrets.tpl.json` that is evaluated on Docker run. This is inspired by [beevelop/docker-shields](https://github.com/beevelop/docker-shields)

Let me know if these changes are PR worthy. If some tweaking/consolidation needs to be done I'm willing to commit to that.

Cheers!

PS: this is related to https://github.com/badges/shields/issues/593