### PR TITLE
Fix Jenkins job name with '/'

### DIFF
--- a/server.js
+++ b/server.js
@@ -3849,12 +3849,12 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Jenkins build status integration
-camp.route(/^\/jenkins(-ci)?\/s\/(http(s)?)\/((?:[^\/]+)(?:\/.+?)?)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/jenkins(?:-ci)?\/s\/(http(?:s)?)\/([^\/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var scheme = match[2];  // http(s)
-  var host = match[4];  // jenkins.qa.ubuntu.com
-  var job = match[5];  // precise-desktop-amd64_default
-  var format = match[6];
+  var scheme = match[1];  // http(s)
+  var host = match[2];  // example.org:8080
+  var job = match[3];  // folder/job
+  var format = match[4];
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job + '/api/json?tree=color'
@@ -3902,12 +3902,12 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Jenkins tests integration
-camp.route(/^\/jenkins(-ci)?\/t\/(http(s)?)\/((?:[^\/]+)(?:\/.+?)?)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/jenkins(?:-ci)?\/t\/(http(?:s)?)\/([^\/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var scheme = match[2];  // http(s)
-  var host = match[4];  // jenkins.qa.ubuntu.com
-  var job = match[5];  // precise-desktop-amd64_default
-  var format = match[6];
+  var scheme = match[1];  // http(s)
+  var host = match[2];  // example.org:8080
+  var job = match[3];  // folder/job
+  var format = match[4];
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job
@@ -3958,12 +3958,12 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Jenkins coverage integration
-camp.route(/^\/jenkins(-ci)?\/c\/(http(s)?)\/((?:[^\/]+)(?:\/.+?)?)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/jenkins(?:-ci)?\/c\/(http(?:s)?)\/([^\/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var scheme = match[2];  // http(s)
-  var host = match[4];  // jenkins.qa.ubuntu.com
-  var job = match[5];  // precise-desktop-amd64_default
-  var format = match[6];
+  var scheme = match[1];  // http(s)
+  var host = match[2];  // example.org:8080
+  var job = match[3];  // folder/job
+  var format = match[4];
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job

--- a/server.js
+++ b/server.js
@@ -3859,6 +3859,9 @@ cache(function(data, match, sendBadge, request) {
     json: true,
     uri: scheme + '://' + host + '/job/' + job + '/api/json?tree=color'
   };
+  if( job.indexOf('/') > -1 ) {
+    options.uri = scheme + '://' + host + '/' + job + '/api/json?tree=color';
+  }
 
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
@@ -3913,6 +3916,10 @@ cache(function(data, match, sendBadge, request) {
     uri: scheme + '://' + host + '/job/' + job
       + '/lastBuild/api/json?tree=actions[failCount,skipCount,totalCount]'
   };
+  if( job.indexOf('/') > -1 ) {
+    options.uri = scheme + '://' + host + '/' + job
+      + '/lastBuild/api/json?tree=actions[failCount,skipCount,totalCount]';
+  }
 
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
@@ -3969,6 +3976,10 @@ cache(function(data, match, sendBadge, request) {
     uri: scheme + '://' + host + '/job/' + job
       + '/lastBuild/cobertura/api/json?tree=results[elements[name,denominator,numerator,ratio]]'
   };
+  if( job.indexOf('/') > -1 ) {
+    options.uri = scheme + '://' + host + '/' + job
+      + '/lastBuild/cobertura/api/json?tree=results[elements[name,denominator,numerator,ratio]]';
+  }
 
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {

--- a/try.html
+++ b/try.html
@@ -145,16 +145,16 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
       <td><code>https://img.shields.io/snap-ci/ThoughtWorksStudios/eb_deployer/master.svg</code></td>
   </tr>
   <tr><th> Jenkins: </th>
-    <td><img src='/jenkins/s/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg' alt=''/></td>
-    <td><code>https://img.shields.io/jenkins/s/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg</code></td>
+    <td><img src='/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg</code></td>
   </tr>
   <tr><th> Jenkins tests: </th>
-    <td><img src='/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg' alt=''/></td>
-    <td><code>https://img.shields.io/jenkins/t/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg</code></td>
+    <td><img src='/jenkins/t/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/t/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg</code></td>
   </tr>
   <tr><th> Jenkins coverage: </th>
-    <td><img src='/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg' alt=''/></td>
-    <td><code>https://img.shields.io/jenkins/c/https/jenkins.qa.ubuntu.com/address-book-service-utopic-i386-ci.svg</code></td>
+    <td><img src='/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg</code></td>
   </tr>
   <tr><th> Coveralls: </th>
     <td><img src='/coveralls/jekyll/jekyll.svg' alt=''/></td>


### PR DESCRIPTION
Amended to allow '/' in Jenkins job name. It also allows user to just copy and paste the Job URL to get the badge.

```
https://img.shields.io/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg
```

For backward compatibility, ``https://img.shields.io/jenkins/s/https/jenkins.qa.ubuntu.com/precise-desktop-amd64_default.svg`` style URL is kept to work.

Fixes #858.