### PR TITLE
fix default value for githubUserTokens

### DIFF
--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -7,7 +7,7 @@ try {
   // is stored in this JSON data.
   serverSecrets = require('../private/secret.json');
 } catch(e) {}
-var githubUserTokens;
+var githubUserTokens = {data:[]};
 var githubUserTokensFile = './private/github-user-tokens.json';
 autosave(githubUserTokensFile, {data:[]}).then(function(f) {
   githubUserTokens = f;


### PR DESCRIPTION
The server.js fails if this variable is not defined with a sensible default value.