### PR TITLE
add wordpress.org active installs shield

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,6 +771,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='https://img.shields.io/wordpress/plugin/r/akismet.svg?maxAge=2592000' alt=''/></td>
     <td><code>https://img.shields.io/wordpress/plugin/r/akismet.svg</code></td>
   </tr>
+  <tr><th> WordPress active: </th>
+    <td><img src='https://img.shields.io/wordpress/plugin/ai/akismet.svg' alt=''/></td>
+  <td><code>https://img.shields.io/wordpress/plugin/ai/akismet.svg</code></td>
+  </tr>
   <tr><th> Codacy grade: </th>
     <td><img src='https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg?maxAge=2592000' alt=''/></td>
     <td><code>https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg</code></td>

--- a/server.js
+++ b/server.js
@@ -4401,6 +4401,36 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// wordpress plugin active installs integration.
+// example: https://img.shields.io/wordpress/plugin/ai/akismet.svg for https://wordpress.org/plugins/akismet
+camp.route(/^\/wordpress\/plugin\/ai\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var plugin = match[1];  // eg, `akismet`.
+  var format = match[2];
+  var apiUrl = 'http://api.wordpress.org/plugins/info/1.0/' + plugin + '.json?fields=active_installs';
+  var badgeData = getBadgeData('active installs', data);
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var total = JSON.parse(buffer).active_installs;
+      badgeData.text[1] = metric(total) + '+';
+      if (total === 0) {
+        badgeData.colorscheme = 'red';
+      } else {
+        badgeData.colorscheme = floorCountColor(total, 10, 100, 1000);
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // wordpress plugin rating integration.
 // example: https://img.shields.io/wordpress/plugin/r/akismet.svg for https://wordpress.org/plugins/akismet
 camp.route(/^\/wordpress\/plugin\/r\/(.*)\.(svg|png|gif|jpg|json)$/,

--- a/try.html
+++ b/try.html
@@ -770,6 +770,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/wordpress/plugin/r/akismet.svg' alt=''/></td>
     <td><code>https://img.shields.io/wordpress/plugin/r/akismet.svg</code></td>
   </tr>
+  <tr><th> WordPress active: </th>
+  <td><img src='/wordpress/plugin/ai/akismet.svg' alt=''/></td>
+  <td><code>https://img.shields.io/wordpress/plugin/ai/akismet.svg</code></td>
+  </tr>
   <tr><th> Codacy grade: </th>
     <td><img src='/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg' alt=''/></td>
     <td><code>https://img.shields.io/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg</code></td>


### PR DESCRIPTION
i have made a badge for wordpress-active-installs.
this is a number which is rounded-down and then a + is added at the end to show that at least a number of sites are actively using this plugin.