### PR TITLE
Get tests passing in Node v5

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -14,9 +14,9 @@ function test(target, tests) {
         'notEqual', 'notDeepEqual', 'notStrictEqual', 'notDeepStrictEqual',
         'fail', 'doesNotThrow', 'throws',
         ].forEach(function(k) {
-          assert[k] = function(...args) {
+          assert[k] = function() {
             try {
-              assertion[k].apply(null, args);
+              assertion[k].apply(null, arguments);
             } catch(e) { reject(e); }
           };
         });


### PR DESCRIPTION
Node 5 is the version running on the server.

Rest parameters are enabled by default in Node 6, but require a
compatibility flag in Node 5.

http://node.green/#ES2015-syntax-rest-parameters

Fixes #802