### PR TITLE
Use `new Buffer()` instead of `Buffer()`

### DIFF
--- a/lib/load-logos.js
+++ b/lib/load-logos.js
@@ -12,7 +12,8 @@ var loadLogos = function() {
 
     // eg, github
     var name = filename.slice(0, -('.svg'.length));
-    logos[name] = 'data:image/svg+xml;base64,' + Buffer(svg).toString('base64');
+    logos[name] = 'data:image/svg+xml;base64,' +
+      Buffer.from(svg).toString('base64');
   });
   return logos;
 };

--- a/lib/svg-to-img.js
+++ b/lib/svg-to-img.js
@@ -14,7 +14,7 @@ module.exports = function (svg, format, out, cb) {
     return;
   }
 
-  var buf = new Buffer('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + svg);
+  var buf = Buffer.from('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + svg);
   var stream = imageMagick(buf, 'image.' + format)
   .density(90)
   .background(format === 'jpg' ? '#FFFFFF' : 'none')

--- a/server.js
+++ b/server.js
@@ -6324,7 +6324,8 @@ function fetchTwitterToken() {
       url: 'https://api.twitter.com/oauth2/token',
       headers: {
         // is this the best way to base 64 encode a string?
-        Authorization: 'Basic '+(new Buffer(twitter_bearer_credentials)).toString('base64'),
+        Authorization: 'Basic ' +
+          Buffer.from(twitter_bearer_credentials).toString('base64'),
         'Content-type': 'application/x-www-form-urlencoded;charset=UTF-8'
       },
       form: 'grant_type=client_credentials',


### PR DESCRIPTION
The following warning is emitted by Node.js:

> DeprecationWarning: Using Buffer without `new` will soon stop working. Use `new
> Buffer()`, or preferably `Buffer.from()`, `Buffer.allocUnsafe()` or
> `Buffer.alloc()` instead.

This patch removes this warning.

@paulmelnikow may you review this patch, please?