### PR TITLE
Show correct hostname and port in try.html URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,7 +12,13 @@ var camp = Camp.start({
   secure: secureServer
 });
 Camp.log.unpipe('warn', 'stderr');
-console.log('http://[::1]:' + serverPort + '/try.html');
+var tryUrl = require('url').format({
+  protocol: secureServer ? 'https' : 'http',
+  hostname: bindAddress,
+  port: serverPort,
+  pathname: 'try.html',
+});
+console.log(tryUrl);
 var domain = require('domain');
 var request = require('request');
 var fs = require('fs');


### PR DESCRIPTION
Before:

```sh
$ node server 1111 localhost
http://[::1]:1111/try.html
```

After:

```sh
$ node server 1111 localhost
http://localhost:1111/try.html
```