### PR TITLE
Disallow unused variables and turn on a few recommended rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,15 +4,22 @@ env:
   es6: true
   mocha: true
 
+extends:
+  # Enable a set of unopinionated, style-agnostic rules which cover many
+  # likely errors.
+  - "eslint:recommended"
+
 rules:
+  # Disable some rules from eslint:recommended.
+  no-console: "off"
+  no-empty: ["error", { "allowEmptyCatch": true }]
+  # Allow unused parameters. In callbacks, removing them seems to obscure
+  # what the functions are doing.
+  no-unused-vars: ["error", {"args": "none"}]
+
   # We use semicolons.
   semi: ["error", "always"]
-  no-extra-semi: "error"
 
   # We keep whitespace cleaned up.
   no-trailing-spaces: "error"
   eol-last: "error"
-
-  # Prevent some likely errors.
-  no-redeclare: "error"
-  no-undef: "error"

--- a/lib/measure-text.js
+++ b/lib/measure-text.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var path = require('path');
-var fs = require('fs');
 var PDFDocument = require('pdfkit');
 var doc = new PDFDocument({size:'A4', layout:'landscape'});
 

--- a/lib/svg-to-img.js
+++ b/lib/svg-to-img.js
@@ -15,7 +15,7 @@ module.exports = function (svg, format, out, cb) {
   }
 
   var buf = Buffer.from('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + svg);
-  var stream = imageMagick(buf, 'image.' + format)
+  imageMagick(buf, 'image.' + format)
   .density(90)
   .background(format === 'jpg' ? '#FFFFFF' : 'none')
   .flatten()

--- a/server.js
+++ b/server.js
@@ -1807,7 +1807,6 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var vdata = versionColor(data.version);
       badgeData.text[1] = "[" + clojar + " \"" + data.version + "\"]";
       badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
@@ -2672,10 +2671,10 @@ cache(function(data, match, sendBadge, request) {
       badgeData.text[0] = data.label || nameMatch;
       badgeData.text[1] = statusMatch;
       if (statusMatch === 'up-to-date') {
-      	badgeData.text[1] = 'up to date';
+        badgeData.text[1] = 'up to date';
         badgeData.colorscheme = 'brightgreen';
       } else if (statusMatch === 'out-of-date') {
-      	badgeData.text[1] = 'out of date';
+        badgeData.text[1] = 'out of date';
         badgeData.colorscheme = 'yellow';
       } else if (statusMatch === 'update!') {
         badgeData.colorscheme = 'red';
@@ -4128,7 +4127,6 @@ cache(function(data, match, sendBadge, request) {
   var type = match[1];      // eg role
   var roleId = match[2];    // eg 3078
   var format = match[3];
-  var uri = 'https://galaxy.ansible.com/api/v1/roles/' + roleId + '/';
   var options = {
     json: true,
     uri: 'https://galaxy.ansible.com/api/v1/roles/' + roleId + '/',
@@ -4490,7 +4488,6 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var pluginVersion = data.version;
       if (data.tested) {
         var testedVersion = data.tested.replace(/[^0-9.]/g,'');
         badgeData.text[1] = testedVersion + ' tested';
@@ -4766,6 +4763,9 @@ cache(function(data, match, sendBadge, request) {
       case 'scheduled':
       case 'not_run':
         badgeData.colorscheme = 'yellow';
+        badgeData.text[1] = status.replace('_', ' ');
+        break;
+
       default:
         badgeData.text[1] = status.replace('_', ' ');
       }
@@ -5227,7 +5227,7 @@ cache(function(data, match, sendBadge, request) {
 // Gitter room integration.
 camp.route(/^\/gitter\/room\/([^\/]+\/[^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var userRepo = match[1];
+  // match[1] is the repo, which is not used.
   var format = match[2];
 
   var badgeData = getBadgeData('chat', data);
@@ -5783,10 +5783,10 @@ cache(function(data, match, sendBadge, request) {
 // Swagger Validator integration.
 camp.route(/^\/swagger\/(valid)\/(2\.0)\/(https?)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var type = match[1];        // e.g. `valid` for validate
-  var specVer = match[2];     // e.g. `2.0` for OpenAPI 2.0
-  var scheme = match[3];      // e.g. `https`
-  var swaggerUrl = match[4];  // e.g. `api.example.com/swagger.yaml`
+  // match[1] is not used                 // e.g. `valid` for validate
+  // match[2] is reserved for future use  // e.g. `2.0` for OpenAPI 2.0
+  var scheme = match[3];                  // e.g. `https`
+  var swaggerUrl = match[4];              // e.g. `api.example.com/swagger.yaml`
   var format = match[5];
 
   var badgeData = getBadgeData('swagger', data);
@@ -6368,50 +6368,10 @@ function phpLatestVersion(versions) {
 function phpStableVersion(version) {
   var rawVersion = omitv(version);
   try {
-    var versionData = phpNumberedVersionData(version);
+    var versionData = phpNumberedVersionData(rawVersion);
   } catch(e) {
     return false;
   }
   // normal or patch
   return (versionData.modifier === 3) || (versionData.modifier === 4);
-}
-
-// This searches the serverSecrets for a twitter consumer key
-// and secret, and exchanges them for a bearer token to use for all requests.
-function fetchTwitterToken() {
-  if (serverSecrets.twitter_consumer_key && serverSecrets.twitter_consumer_secret){
-    // fetch a bearer token good for this app session
-    // construct this bearer request with a base64 encoding of key:secret
-    // docs for this are here: https://dev.twitter.com/oauth/application-only
-    var twitter_bearer_credentials = escape(serverSecrets.twitter_consumer_key) + ':' + escape(serverSecrets.twitter_consumer_secret);
-    var options = {
-      url: 'https://api.twitter.com/oauth2/token',
-      headers: {
-        // is this the best way to base 64 encode a string?
-        Authorization: 'Basic ' +
-          Buffer.from(twitter_bearer_credentials).toString('base64'),
-        'Content-type': 'application/x-www-form-urlencoded;charset=UTF-8'
-      },
-      form: 'grant_type=client_credentials',
-      method: 'POST'
-    };
-    console.log('Fetching twitter bearer token...');
-    request(options,function(err,res,buffer){
-      if (err) {
-        console.error('Error fetching twitter bearer token, error: ', err);
-        return;
-      }
-      try {
-        var data = JSON.parse(buffer);
-        if (data.token_type === 'bearer') {
-          serverSecrets.twitter_bearer_token = data.access_token;
-          console.log('Fetched twitter bearer token');
-          return;
-        }
-        console.error('Error fetching twitter bearer token, data: %j', data);
-      } catch(e) {
-        console.error('Error fetching twitter bearer token, buffer: %s, ', buffer, e);
-      }
-    });
-  }
 }

--- a/test/lru-cache.spec.js
+++ b/test/lru-cache.spec.js
@@ -34,7 +34,7 @@ describe('The LRU cache', function () {
     cache.set('key1', 'value1');
     cache.set('key2', 'value2');
     cache.set('key3', 'value3');
-    var slot1 = cache.cache.get('key1');
+    cache.cache.get('key1');
     var slot2 = cache.cache.get('key2');
     var slot3 = cache.cache.get('key3');
     assert.equal(cache.cache.size, 2);

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -1,7 +1,6 @@
 var assert = require('assert');
 var http = require('http');
 var cproc = require('child_process');
-var fs = require('fs');
 
 // Test parameters
 var port = '1111';


### PR DESCRIPTION
`eslint:recommended` enables a bunch of [unopinionated, style-agnostic rules](http://eslint.org/docs/rules/) for common errors.

I've disabled one which we can't use (`no-console`), allowed empty catch blocks, and allowed unused parameters passed to functions, because removing them seems to obscure what the functions do.

The arguable one here is `no-fallthrough`. Fallthroughs are difficult to reason about, which I tend to agree outweighs duplicating a single line of code.

After these changes, the packagist badge is working the same as img.shields.io.

Clojars is one of the only version badges that's not using `versionColor`. It was invoked, but the result wasn't used. Seems like it would be better to make it consistent, but since that's a behavior change I'll open a separate PR.