### PR TITLE
Use standard version color for clojars

### DIFF
--- a/server.js
+++ b/server.js
@@ -1798,7 +1798,7 @@ cache(function(data, match, sendBadge, request) {
       var data = JSON.parse(buffer);
       var vdata = versionColor(data.version);
       badgeData.text[1] = "[" + clojar + " \"" + data.version + "\"]";
-      badgeData.colorscheme = 'brightgreen';
+      badgeData.colorscheme = versionColor(data.version).color;
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';


### PR DESCRIPTION
Disallowing unused variables (#916) revealed that the result of `versionColor` was not being used for Clojars. It's one of the only badges using a non-standard version color. Seems like consistency is a good thing, helpful for users.

Tested locally, and works as intended.