### PR TITLE
Fetch Bower data using libraries.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "https://github.com/badges/shields"
   },
   "dependencies": {
-    "bower": "~1.7.9",
     "camp": "~16.2.3",
     "chrome-web-store-item-property": "~1.1.2",
     "dot": "~1.0.3",

--- a/server.js
+++ b/server.js
@@ -4280,51 +4280,74 @@ cache(function(data, match, sendBadge, request) {
 
 // Bower version integration.
 camp.route(/^\/bower\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `bootstrap`.
-  var format = match[2];
-  var badgeData = getBadgeData('bower', data);
-  var bower = require('bower');
-  bower.commands.info(repo, 'version')
-    .on('error', function() {
+cache((data, match, sendBadge, request) => {
+  const repo = match[1];  // eg, `bootstrap`.
+  const format = match[2];
+  const badgeData = getBadgeData('bower', data);
+
+  // API doc: https://libraries.io/api#project
+  const options = {
+    method: 'GET',
+    json: true,
+    uri: `https://libraries.io/api/bower/${repo}`,
+  };
+  if (serverSecrets && serverSecrets.libraries_io_api_key) {
+    options.qs = {
+      api_key: serverSecrets.libraries_io_api_key,
+    };
+  }
+  request(options, (err, res, data) => {
+    if (err != null) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
-    })
-    .on('end', function(version) {
-      try {
-        var vdata = versionColor(version);
-        badgeData.text[1] = vdata.version;
-        badgeData.colorscheme = vdata.color;
-        sendBadge(format, badgeData);
-      } catch(e) {
-        badgeData.text[1] = 'void';
-        sendBadge(format, badgeData);
-      }
-    });
+      return;
+    }
+    try {
+      const version = data.latest_stable_release.name;
+      const vdata = versionColor(version);
+      badgeData.text[1] = vdata.version;
+      badgeData.colorscheme = vdata.color;
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'void';
+      sendBadge(format, badgeData);
+    }
+  });
 }));
 
 // Bower license integration.
 camp.route(/^\/bower\/l\/(.*)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `bootstrap`.
-  var format = match[2];
-  var badgeData = getBadgeData('bower', data);
-  var bower = require('bower');
-  bower.commands.info(repo, 'license')
-    .on('error', function() {
+cache((data, match, sendBadge, request) => {
+  const repo = match[1];  // eg, `bootstrap`.
+  const format = match[2];
+  const badgeData = getBadgeData('bower', data);
+  // API doc: https://libraries.io/api#project
+  const options = {
+    method: 'GET',
+    json: true,
+    uri: `https://libraries.io/api/bower/${repo}`,
+  };
+  if (serverSecrets && serverSecrets.libraries_io_api_key) {
+    options.qs = {
+      api_key: serverSecrets.libraries_io_api_key,
+    };
+  }
+  request(options, (err, res, data) => {
+    if (err != null) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
-    })
-    .on('end', function(license) {
-      try {
-        badgeData.text[1] = license;
-        badgeData.colorscheme = 'blue';
-        sendBadge(format, badgeData);
-      } catch(e) {
-        badgeData.text[1] = 'void';
-        sendBadge(format, badgeData);
-      }
-    });
+      return;
+    }
+    try {
+      const license = data.normalized_licenses[0];
+      badgeData.text[1] = license;
+      badgeData.colorscheme = 'blue';
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'void';
+      sendBadge(format, badgeData);
+    }
+  });
 }));
 
 // Wheelmap integration.


### PR DESCRIPTION
- Avoid downloading bower packages via git
- Service is well resourced: https://libraries.io/team
- Same service used by https://bower.io/search/

A standard API key with https://libraries.io/ covers 60 requests per minute. Will that be enough for the public server?

Do you see any reason not to use `let`, `const`, template strings, and arrow functions in new code?