### PR TITLE
Improve CTAN error handling and fix non-svg 404 badges

### DIFF
--- a/server.js
+++ b/server.js
@@ -4832,8 +4832,9 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = vdata.color;
         sendBadge(format, badgeData);
       } else if (info === 'l') {
+        badgeData.text[0] = 'license';
         var license = data.license;
-        if (license) {
+        if (Array.isArray(license) && license.length > 0) {
           // API returns licenses inconsistently ordered, so fix the order.
           badgeData.text[1] = license.sort().join(',');
           badgeData.colorscheme = 'blue';

--- a/try.html
+++ b/try.html
@@ -704,8 +704,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/cpan/l/Config-Augeas.svg</code></td>
   </tr>
   <tr><th data-keywords='tex'> CTAN: </th>
-    <td><img src='/ctan/l/tex.svg' alt='' /></td>
-    <td><code>https://img.shields.io/ctan/l/tex.svg</code></td>
+    <td><img src='/ctan/l/novel.svg' alt='' /></td>
+    <td><code>https://img.shields.io/ctan/l/novel.svg</code></td>
   </tr>
   <tr><th> Wheelmap: </th>
     <td><img src='/wheelmap/a/2323004600.svg' alt='' /></td>


### PR DESCRIPTION
Fix #921 

I started work today on some vcr-style tests. They send requests to the server, record the responses to vendor requests, and then play the vendor requests back later. The library I'm using is a little buggy. The suite isn't ready for prime time. I'll add tests as I go. Hopefully there will be a meaningful amount of coverage by the time I've gotten the library under control.

I'm very open to input: https://github.com/paulmelnikow/shields-tests

These are the CTAN tests:
https://github.com/paulmelnikow/shields-tests/blob/master/vendor/ctan/spec.js