### PR TITLE
Enable npm version for specific tag

### DIFF
--- a/server.js
+++ b/server.js
@@ -1629,11 +1629,20 @@ cache(function (data, match, sendBadge, request) {
 }));
 
 // npm version integration.
-camp.route(/^\/npm\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/npm\/v\/(@[^\/]*)?\/?([^\/]*)\/?([^\/]*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = encodeURIComponent(match[1]);  // eg, "express" or "@user/express"
-  var format = match[2];
-  var apiUrl = 'https://registry.npmjs.org/-/package/' + repo + '/dist-tags';
+  var scope = match[1];   // "@user"
+  var repo = match[2];    // "express"
+  var tag = match[3];     // "next"
+  var format = match[4];  // ".svg"
+  var pkg = encodeURIComponent(scope
+    ? scope + '/' + repo
+    : repo);
+
+  if (!tag) {
+    tag = 'latest';
+  }
+  var apiUrl = 'https://registry.npmjs.org/-/package/' + pkg + '/dist-tags';
   var badgeData = getBadgeData('npm', data);
   // Using the Accept header because of this bug:
   // <https://github.com/npm/npmjs.org/issues/163>
@@ -1645,7 +1654,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var version = data.latest;
+      var version = data[tag];
       var vdata = versionColor(version);
       badgeData.text[1] = vdata.version;
       badgeData.colorscheme = vdata.color;

--- a/server.js
+++ b/server.js
@@ -1634,16 +1634,18 @@ cache(function(data, match, sendBadge, request) {
   var scope = match[1];   // "@user"
   var repo = match[2];    // "express"
   var tag = match[3];     // "next"
-  var format = match[4];  // ".svg"
+  var format = match[4];  // "svg"
   var pkg = encodeURIComponent(scope
     ? scope + '/' + repo
     : repo);
-
-  if (!tag) {
+  var name = 'npm';
+  if (tag) {
+    name += '@' + tag;
+  } else {
     tag = 'latest';
   }
   var apiUrl = 'https://registry.npmjs.org/-/package/' + pkg + '/dist-tags';
-  var badgeData = getBadgeData('npm', data);
+  var badgeData = getBadgeData(name, data);
   // Using the Accept header because of this bug:
   // <https://github.com/npm/npmjs.org/issues/163>
   request(apiUrl, { headers: { 'Accept': '*/*' } }, function(err, res, buffer) {

--- a/try.html
+++ b/try.html
@@ -423,9 +423,17 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/npm/v/npm.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/npm.svg</code></td>
   </tr>
+  <tr><th data-keywords='node'> npm (tag): </th>
+  <td><img src='/npm/v/npm/next.svg' alt=''/></td>
+  <td><code>https://img.shields.io/npm/v/npm/next.svg</code></td>
+  </tr>
   <tr><th data-keywords='node'> npm (scoped): </th>
   <td><img src='/npm/v/@cycle/core.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/@cycle/core.svg</code></td>
+  </tr>
+  <tr><th data-keywords='node'> npm (scoped with tag): </th>
+  <td><img src='/npm/v/@cycle/core/canary.svg' alt=''/></td>
+  <td><code>https://img.shields.io/npm/v/@cycle/core/canary.svg</code></td>
   </tr>
   <tr><th> node: </th>
   <td><img src='/node/v/gh-badges.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -423,13 +423,13 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/npm/v/npm.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/npm.svg</code></td>
   </tr>
-  <tr><th data-keywords='node'> npm (tag): </th>
-  <td><img src='/npm/v/npm/next.svg' alt=''/></td>
-  <td><code>https://img.shields.io/npm/v/npm/next.svg</code></td>
-  </tr>
   <tr><th data-keywords='node'> npm (scoped): </th>
   <td><img src='/npm/v/@cycle/core.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/@cycle/core.svg</code></td>
+  </tr>
+  <tr><th data-keywords='node'> npm (tag): </th>
+  <td><img src='/npm/v/npm/next.svg' alt=''/></td>
+  <td><code>https://img.shields.io/npm/v/npm/next.svg</code></td>
   </tr>
   <tr><th data-keywords='node'> npm (scoped with tag): </th>
   <td><img src='/npm/v/@cycle/core/canary.svg' alt=''/></td>


### PR DESCRIPTION
Allows for getting the npm version of a tag by appending `/<tag>` to the url.

<img width="856" alt="screenshot 2017-03-31 14 27 08" src="https://cloud.githubusercontent.com/assets/5419074/24566210/337fd9ec-161e-11e7-91ef-6fa4a9fb5662.png">

[x-ref] #925