### PR TITLE
Update http://shields.io/ tool for new Sonarqube API (since 5.4)

### DIFF
--- a/server.js
+++ b/server.js
@@ -905,10 +905,11 @@ camp.route(/^\/sonar(.*)\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)
       }
 
       // Sonarqube API change: https://sonarqube.com/web_api/api/resources (deprecated since 5.4)
+      var apiUrl;
       if (version === '' || parseFloat(version) < 5.4) {
-          var apiUrl = scheme + '://' + serverUrl + '/api/resources?resource=' + buildType + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true';
+          apiUrl = scheme + '://' + serverUrl + '/api/resources?resource=' + buildType + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true';
       } else {
-          var apiUrl = scheme + '://' + serverUrl + '/api/measures/component?componentKey=' + buildType + '&metricKeys=' + encodeURIComponent(sonarMetricName);
+          apiUrl = scheme + '://' + serverUrl + '/api/measures/component?componentKey=' + buildType + '&metricKeys=' + encodeURIComponent(sonarMetricName);
       }
 
       var badgeData = getBadgeData(metricName.replace(/_/g, ' '), data);
@@ -922,10 +923,11 @@ camp.route(/^\/sonar(.*)\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)
           var data = JSON.parse(buffer);
 
           // Sonarqube API change: https://sonarqube.com/web_api/api/resources (deprecated since 5.4)
+          var value;
           if (version === '' || parseFloat(version) < 5.4) {
-              var value = data[0].msr[0].val;
+              value = data[0].msr[0].val;
           } else {
-              var value = parseInt(data.component.measures[0].value);
+              value = parseInt(data.component.measures[0].value);
           }
 
           if (value === undefined) {

--- a/try.html
+++ b/try.html
@@ -169,13 +169,21 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/coveralls/jekyll/jekyll/master.svg' alt=''/></td>
     <td><code>https://img.shields.io/coveralls/jekyll/jekyll/master.svg</code></td>
   </tr>
-  <tr><th> SonarQube Coverage: </th>
-    <td><img src='/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/coverage.svg' alt=''/></td>
-    <td><code>https://img.shields.io/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/coverage.svg</code></td>
+  <tr><th> SonarQube Coverage (API older 5.4): </th>
+    <td><img src='/sonar5.1/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/coverage.svg' alt=''/></td>
+    <td><code>https://img.shields.io/sonar5.1/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/coverage.svg</code></td>
   </tr>
-  <tr><th> SonarQube Tech Debt: </th>
-    <td><img src='/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/tech_debt.svg' alt=''/></td>
-    <td><code>https://img.shields.io/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/tech_debt.svg</code></td>
+  <tr><th> SonarQube Tech Debt (API older 5.4): </th>
+    <td><img src='/sonar5.1/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/tech_debt.svg' alt=''/></td>
+    <td><code>https://img.shields.io/sonar5.1/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/tech_debt.svg</code></td>
+  </tr>
+  <tr><th> SonarQube Coverage (API since 5.4): </th>
+    <td><img src='/sonar6.3/https/sonarqube.com/com.github.noraui:noraui/coverage.svg' alt=''/></td>
+    <td><code>https://img.shields.io/sonar6.3/https/sonarqube.com/com.github.noraui:noraui/coverage.svg</code></td>
+  </tr>
+  <tr><th> SonarQube Tech Debt (API since 5.4): </th>
+    <td><img src='/sonar6.3/https/sonarqube.com/com.github.noraui:noraui/tech_debt.svg' alt=''/></td>
+    <td><code>https://img.shields.io/sonar6.3/https/sonarqube.com/com.github.noraui:noraui/tech_debt.svg</code></td>
   </tr>
   <tr><th> TeamCity CodeBetter Coverage: </th>
     <td><img src='/teamcity/coverage/bt1242.svg' alt=''/></td>


### PR DESCRIPTION
Update http://shields.io/ tool for new Sonarqube API since version 5.4: https://sonarqube.com/web_api/api/resources (deprecated since 5.4)