### PR TITLE
Store raster badges in the LRU cache

### DIFF
--- a/lib/svg-to-img.js
+++ b/lib/svg-to-img.js
@@ -3,8 +3,8 @@ var LruCache = require('./lru-cache.js');
 
 var imageMagick = gm.subClass({ imageMagick: true });
 
-// The following is an arbitrary limit (~1.5MB, 1.5kB/image).
-var imgCache = new LruCache(1000);
+// The following is an arbitrary limit (~400kB, 2kB/image).
+var imgCache = new LruCache(200);
 
 module.exports = function (svg, format, out, cb) {
   var cacheIndex = format + svg;

--- a/lib/svg-to-img.js
+++ b/lib/svg-to-img.js
@@ -20,13 +20,10 @@ module.exports = function (svg, format, out, cb) {
   .background(format === 'jpg' ? '#FFFFFF' : 'none')
   .flatten()
   .stream(format, function (err, stdout, stderr) {
-    if (err) { console.error(err); }
-
-    stdout.on('end', function () {
-      imgCache.set(cacheIndex, [stdout]);
-      cb && cb();
-    });
-
+    if (err) { console.error(err); return; }
+    var chunks = [];
+    stdout.on('data', function(chunk) { chunks.push(chunk); });
+    stdout.on('end', function() { imgCache.set(cacheIndex, chunks); });
     stdout.pipe(out);
   });
 };
@@ -42,9 +39,9 @@ function DataStream(data) {
 util.inherits(DataStream, Readable);
 DataStream.prototype._read = function() {
   while (this.i < this.data.length) {
-    var stop = this.push(this.data[this.i]);
+    var keepPushing = this.push(this.data[this.i]);
     this.i++;
-    if (stop) { return; }
+    if (!keepPushing) { return; }
   }
   this.push(null);
 };


### PR DESCRIPTION
In ef1a5159, the switch to using imagemagick made a faulty use of the library by
listening for an 'end' event that is never raised. As a result, the cache was
never populated.

In d985f81f, a fix that takes care of the fact that the previously mentioned
dead code relies on a non-existent variable caused it to kill the server when a
raster badge is requested twice, as what it stored in the cache was the pipe
transmitting chunks, not the chunks themselves, and the pipe (a Socket object)
cannot be subsequently sent through a pipe. The following error occured instead:

    events.js:163
          throw er; // Unhandled 'error' event
          ^

    TypeError: Invalid non-string/buffer chunk
        at chunkInvalid (_stream_readable.js:395:10)
        at readableAddChunk (_stream_readable.js:150:12)
        at DataStream.Readable.push (_stream_readable.js:136:10)
        at DataStream._read (/home/m/shields/lib/svg-to-img.js:45:21)
        at DataStream.Readable.read (_stream_readable.js:350:10)
        at resume_ (_stream_readable.js:739:12)
        at _combinedTickCallback (internal/process/next_tick.js:80:11)
        at process._tickDomainCallback (internal/process/next_tick.js:128:9)

@paulmelnikow Could you have a look, please?