### PR TITLE
Add badge for NuGet download count, again

### DIFF
--- a/server.js
+++ b/server.js
@@ -3767,12 +3767,11 @@ function mapNugetFeed(pattern, offset, getInfo) {
 
           try {
             var data = JSON.parse(buffer);
-            data = data.data && data.data[0];
-            if (data) {
-              done(null, data);
-            } else {
+            if (!Array.isArray(data.data) || data.data.length !== 1) {
               done(new Error('Package not found in feed'));
+              return;
             }
+            done(null, data.data[0]);
           } catch (e) { done(e); }
         });
       });
@@ -3879,7 +3878,7 @@ function mapNugetFeed(pattern, offset, getInfo) {
       try {
         // Official NuGet server uses "totalDownloads" whereas MyGet uses
         // "totaldownloads" (lowercase D). Ugh.
-        var downloads = nugetData.totalDownloads || nugetData.totaldownloads;
+        var downloads = nugetData.totalDownloads || nugetData.totaldownloads || 0;
         badgeData.text[1] = metric(downloads);
         badgeData.colorscheme = downloadCountColor(downloads);
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -3864,11 +3864,10 @@ function mapNugetFeed(pattern, offset, getInfo) {
   camp.route(dtRegex,
   cache(function(data, match, sendBadge, request) {
     var info = getInfo(match);
-    var site = info.site;  // eg, `Chocolatey`, or `YoloDev`
     var repo = match[offset + 1];  // eg, `Nuget.Core`.
     var format = match[offset + 2];
     var apiUrl = info.feed;
-    var badgeData = getBadgeData(site, data);
+    var badgeData = getBadgeData('downloads', data);
     getNugetData(apiUrl, repo, request, function(err, nugetData) {
       if (err != null) {
         badgeData.text[1] = 'inaccessible';

--- a/try.html
+++ b/try.html
@@ -280,6 +280,18 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/chocolatey/dt/scriptcs.svg' alt=''/></td>
   <td><code>https://img.shields.io/chocolatey/dt/scriptcs.svg</code></td>
   </tr>
+  <tr><th> NuGet: </th>
+  <td><img src='/nuget/dt/Microsoft.AspNetCore.Mvc.svg' alt=''/></td>
+  <td><code>https://img.shields.io/nuget/dt/Microsoft.AspNetCore.Mvc.svg</code></td>
+  </tr>
+  <tr><th> MyGet: </th>
+  <td><img src='/myget/mongodb/dt/MongoDB.Driver.Core.svg' alt=''/></td>
+  <td><code>https://img.shields.io/myget/mongodb/dt/MongoDB.Driver.Core.svg</code></td>
+  </tr>
+  <tr><th> MyGet tenant: </th>
+  <td><img src='/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg' alt=''/></td>
+  <td><code>https://img.shields.iodotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg</code></td>
+  </tr>
   <tr><th data-keywords='python'> PyPI: </th>
   <td><img src='/pypi/dm/Django.svg' alt=''/></td>
   <td><code>https://img.shields.io/pypi/dm/Django.svg</code></td>

--- a/try.html
+++ b/try.html
@@ -290,7 +290,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
   <tr><th> MyGet tenant: </th>
   <td><img src='/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg' alt=''/></td>
-  <td><code>https://img.shields.iodotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg</code></td>
+  <td><code>https://img.shields.io/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg</code></td>
   </tr>
   <tr><th data-keywords='python'> PyPI: </th>
   <td><img src='/pypi/dm/Django.svg' alt=''/></td>


### PR DESCRIPTION
[NuGet download badges giveth](https://github.com/badges/shields/pull/179), and [NuGet download badges taketh away](https://github.com/badges/shields/commit/4df74acd6ce78d480fa37d11319ba13682e482f5).

Now they're back, in ~~[pog](https://www.youtube.com/watch?v=M_UR201plc8)~~ V3 form.

I switched the NuGet badges from the `SearchAutocompleteService` to the `SearchQueryService`. The SearchQueryService returns download counts in addition to version numbers.

This works for both NuGet and MyGet:
![](http://ss.dan.cx/2017/04/Shields.io_Quality_metadata_badges_for_open_sourc_17-22.15.50.png)

I also verified that the version number badges still work as expected:
![](http://ss.dan.cx/2017/04/Shields.io_Quality_metadata_badges_for_open_sourc_17-22.16.07.png)

I tried to keep the style as close to the original code as possible, although this code could do with some modernization (like using promises rather than callbacks) at some point. I'm happy to help with that 😃 

Closes #678