### PR TITLE
Fix bug in website badge, allow specifying website name (left part of badge)

### DIFF
--- a/server.js
+++ b/server.js
@@ -5833,21 +5833,22 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Test if a webpage is online
-camp.route(/^\/website(-(([^-]|--)*?)-(([^-]|--)*)(-(([^-]|--)+)-(([^-]|--)+))?)?\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/website(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+)(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+))?)?(-(([^-/]|--|\/\/)+))?\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var onlineMessage = escapeFormat(match[2] != null ? match[2] : "online");
-  var offlineMessage = escapeFormat(match[4] != null ? match[4] : "offline");
-  var onlineColor = escapeFormat(match[7] != null ? match[7] : "brightgreen");
-  var offlineColor = escapeFormat(match[9] != null ? match[9] : "red");
-  var userProtocol = match[11];
-  var userURI = match[12];
-  var format = match[13];
+  var onlineMessage = escapeFormatSlashes(match[2] != null ? match[2] : "online");
+  var offlineMessage = escapeFormatSlashes(match[4] != null ? match[4] : "offline");
+  var onlineColor = escapeFormatSlashes(match[7] != null ? match[7] : "brightgreen");
+  var offlineColor = escapeFormatSlashes(match[9] != null ? match[9] : "red");
+  var label = escapeFormatSlashes(match[12] != null ? match[12] : "website");
+  var userProtocol = match[14];
+  var userURI = match[15];
+  var format = match[16];
   var withProtocolURI = userProtocol + "://" + userURI;
   var options = {
     method: 'HEAD',
     uri: withProtocolURI,
   };
-  var badgeData = getBadgeData('website', data);
+  var badgeData = getBadgeData(label, data);
   badgeData.colorscheme = undefined;
   request(options, function(err, res) {
     // We consider all HTTP status codes below 310 as success.
@@ -6158,6 +6159,13 @@ function escapeFormat(t) {
     // Double underscore and double dash.
     .replace(/__/g, '_').replace(/--/g, '-');
 }
+
+function escapeFormatSlashes(t) {
+  return escapeFormat(t)
+    // Double slash
+    .replace(/\/\//g, '/');
+}
+
 
 function sixHex(s) { return /^[0-9a-fA-F]{6}$/.test(s); }
 

--- a/try.html
+++ b/try.html
@@ -393,8 +393,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
   <tr><th data-keywords='website' data-doc='websiteDoc'> Website: </th>
-    <td><img src='/website-up-down-green-red/http/shields.io.svg' alt=''/></td>
-    <td><code>https://img.shields.io/website-up-down-green-red/http/shields.io.svg</code></td>
+    <td><img src='/website-up-down-green-red-my--website/http/shields.io.svg' alt=''/></td>
+    <td><code>https://img.shields.io/website-up-down-green-red-my--website/http/shields.io.svg</code></td>
   </tr>
   <tr><th data-keywords='cocoapods'> CocoaPods: </th>
     <td><img src='/cocoapods/dt/AFNetworking.svg' alt='' /></td>
@@ -1201,10 +1201,16 @@ is where the current server got started.
       <ul>
         <li>Nothing:
             <code>…/website/…</code></li>
+        <li>Badge label (displayed in the left part of the badge):
+            <code>…/website-label/…</code></li>
         <li>Online and offline text:
             <code>…/website-up-down/…</code></li>
+        <li>Online and offline text, then badge label:
+            <code>…/website-up-down-label/…</code></li>
         <li>Online and offline text, then online and offline colors:
             <code>…/website-up-down-green-orange/…</code></li>
+        <li>Online and offline text, then online and offline colors, then badge label:
+            <code>…/website-up-down-green-orange-label/…</code></li>
       </ul>
       <table class=centered><tbody>
           <tr><td>   Dashes <code>--</code>
@@ -1214,6 +1220,10 @@ is where the current server got started.
           <tr><td>   Underscores <code>__</code>
             </td><td>  →
             </td><td>  <code>_</code> Underscore <br/>
+          </td></tr>
+          <tr><td>   Slashes <code>//</code>
+            </td><td>  →
+            </td><td>  <code>/</code> Slash <br/>
           </td></tr>
           <tr><td>   <code>_</code> or Space <code>&nbsp;</code>
             </td><td>  →


### PR DESCRIPTION
@paulmelnikow Thanks for merging #720.

I double-checked the regexp, and realised that there was still a bug when the `up-down` and colour options were specified. Sorry about that, hopefully this regexp fixes these issues (I tested it more thoroughly at https://regex101.com/r/xTAHin/1).

I also added support for specifying the left part of the badge, so that one can easily make badges that look like `docs|online`, `downloads|online`, `official site|up` and so on. This change is backwards-compatible, as it can only occur when an odd number of options is present (either `SiteName`, or `up-down-SiteName`, or `up-down-green-red-SiteName`, in addition to the previously supported formats “empty”, `up-down` and `up-down-green-red` which all had an even number of options).

Could you have a look at this PR?