### PR TITLE
Remove unused / unnecessary test fixtures

### DIFF
--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -1,1 +1,0 @@
-require('../gh-badge.js');

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -1,3 +1,0 @@
-require('../server.js');
-console.log('ready');
-process.on('SIGTERM', function() { process.exit(0); });

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -15,7 +15,7 @@ var url = 'http://127.0.0.1:' + port + '/';
 describe('The CLI', function () {
 
   it('should provide a help message', function(done) {
-    var child = cproc.spawn('node', ['test/cli-test.js']);
+    var child = cproc.spawn('node', ['gh-badge.js']);
     var buffer = '';
     child.stdout.on('data', function(chunk) {
       buffer += ''+chunk;
@@ -28,7 +28,7 @@ describe('The CLI', function () {
 
   it('should produce default badges', function(done) {
     var child = cproc.spawn('node',
-      ['test/cli-test.js', 'cactus', 'grown']);
+      ['gh-badge.js', 'cactus', 'grown']);
     child.stdout.once('data', function(chunk) {
       var buffer = ''+chunk;
       assert.ok(isSvg(buffer));
@@ -40,7 +40,7 @@ describe('The CLI', function () {
 
   it('should produce colorschemed badges', function(done) {
     var child = cproc.spawn('node',
-      ['test/cli-test.js', 'cactus', 'grown', ':green']);
+      ['gh-badge.js', 'cactus', 'grown', ':green']);
     child.stdout.once('data', function(chunk) {
       var buffer = ''+chunk;
       assert.ok(isSvg(buffer));
@@ -50,7 +50,7 @@ describe('The CLI', function () {
 
   it('should produce right-color badges', function(done) {
     var child = cproc.spawn('node',
-      ['test/cli-test.js', 'cactus', 'grown', '#abcdef']);
+      ['gh-badge.js', 'cactus', 'grown', '#abcdef']);
     child.stdout.once('data', function(chunk) {
       var buffer = ''+chunk;
       assert(buffer.includes('#abcdef'), '#abcdef');
@@ -60,7 +60,7 @@ describe('The CLI', function () {
 
   it('should produce PNG badges', function(done) {
     var child = cproc.spawn('node',
-      ['test/cli-test.js', 'cactus', 'grown', '.png']);
+      ['gh-badge.js', 'cactus', 'grown', '.png']);
     child.stdout.once('data', function(chunk) {
       assert.ok(isPng(chunk));
       done();


### PR DESCRIPTION
`server-test.js` is not used anymore, and `gh-badge.js` can be used directly.