### PR TITLE
gh_token does not pass to githubRequest()

### DIFF
--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -14,6 +14,13 @@ autosave(githubUserTokensFile, {data:[]}).then(function(f) {
   for (var i = 0; i < githubUserTokens.data.length; i++) {
     addGithubToken(githubUserTokens.data[i]);
   }
+  
+  // Personal tokens allow access to GitHub private repositories.
+  // You can manage your personal GitHub token at
+  // <https://github.com/settings/tokens>.
+  if (serverSecrets && serverSecrets.gh_token) {
+    addGithubToken(serverSecrets.gh_token);
+  }
 }).catch(function(e) { console.error('Could not create ' + githubUserTokensFile); });
 
 function setRoutes(server) {
@@ -200,12 +207,6 @@ function rmGithubToken(token) {
   }
 }
 
-// Personal tokens allow access to GitHub private repositories.
-// You can manage your personal GitHub token at
-// <https://github.com/settings/tokens>.
-if (serverSecrets && serverSecrets.gh_token) {
-  addGithubToken(serverSecrets.gh_token);
-}
 
 // Act like request(), but tweak headers and query to avoid hitting a rate
 // limit.

--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -14,7 +14,7 @@ autosave(githubUserTokensFile, {data:[]}).then(function(f) {
   for (var i = 0; i < githubUserTokens.data.length; i++) {
     addGithubToken(githubUserTokens.data[i]);
   }
-  
+
   // Personal tokens allow access to GitHub private repositories.
   // You can manage your personal GitHub token at
   // <https://github.com/settings/tokens>.


### PR DESCRIPTION
In trying to setup and connect shields to a github enterprise install I found that the `gh_token` specified in serverSecrets.json was not available when the `githubRequest()` method in `github-auth.js` was invoked.

I'm not sure what the intended purpose of the `gh_token` value in serverSecrets is given that it does not seem to work in this scenario, so I do not know if this is breaking something else that gh_token was being used for that I am not aware of, but by making the change in this PR all the github badges I tried all started to work when shields was configured against our GHE installation.  

Without this change `getReqRemainingToken()` would always return an empty list.


secret.json
```
{
  "gh_token": "MYTOKEN"
}
```

run command:

```
docker run \
  -d \
  -p 443:443 \
  -v /path/to/secret.json:/usr/src/app/private/secret.json \
  -v /path/to/my.key:/usr/src/app/private/my.key \
  -v /path/to/my.cer:/usr/src/app/private/my.cer \
  --name shields \
  --env GITHUB_URL=https://github.enterprisedomain.com/api/v3 \
  --env HTTPS=true \
  --env HTTPS_KEY=/usr/src/app/private/my.key \
  --env HTTPS_CRT=/usr/src/app/private/my.cer \
  shields
```

Without the change included here badges such as `github/tag/user/repo.svg` and `github/issues/user/repo.svg` always return none/undefined respectively.