### PR TITLE
GitHub (pre-)releases

### DIFF
--- a/server.js
+++ b/server.js
@@ -3172,14 +3172,14 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub release integration
-camp.route(/^\/github\/release\/([^\/]+\/[^\/]+)(\/all)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/release\/([^\/]+\/[^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var userRepo = match[1];  // eg, qubyte/rubidium
   var allReleases = match[2];
   var format = match[3];
   var apiUrl = githubApiUrl + '/repos/' + userRepo + '/releases';
   var badgeData = getBadgeData('release', data);
-  if (!allReleases) {
+  if (allReleases === undefined) {
     apiUrl = apiUrl + '/latest';
   }
   if (badgeData.template === 'social') {
@@ -3193,7 +3193,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      if (allReleases) {
+      if (allReleases === 'all') {
         data = data[0];
       }
       var version = data.tag_name;

--- a/server.js
+++ b/server.js
@@ -3203,6 +3203,38 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// GitHub release integration, with pre-releases.
+camp.route(/^\/github\/release\/([^\/]+)\/([^\/]+)\/all\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var user = match[1];  // eg, qubyte/rubidium
+  var repo = match[2];
+  var format = match[3];
+  var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/releases';
+  var badgeData = getBadgeData('release', data);
+  if (badgeData.template === 'social') {
+    badgeData.logo = badgeData.logo || logos.github;
+  }
+  githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var data = JSON.parse(buffer);
+      var version = data[0].tag_name;
+      var prerelease = data[0].prerelease;
+      var vdata = versionColor(version);
+      badgeData.text[1] = vdata.version;
+      badgeData.colorscheme = prerelease ? 'orange' : 'blue';
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'none';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // GitHub commits since integration.
 camp.route(/^\/github\/commits-since\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -507,6 +507,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/github/release/qubyte/rubidium.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release/qubyte/rubidium.svg</code></td>
   </tr>
+  <tr><th data-doc='githubDoc'> GitHub (pre-)release: </th>
+  <td><img src='/github/release/qubyte/rubidium/all.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/release/qubyte/rubidium/all.svg</code></td>
+  </tr>
   <tr><th data-doc='githubDoc'> GitHub commits: </th>
   <td><img src='/github/commits-since/SubtitleEdit/subtitleedit/3.4.7.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/commits-since/SubtitleEdit/subtitleedit/3.4.7.svg</code></td>


### PR DESCRIPTION
Fixes #688 

Added the `/github/release/user/repo/all.svg` endpoint that shows the latest release, including pre-releases.