### PR TITLE
Record minimum required Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "svgo": "~0.7.1",
     "xml2js": "~0.4.16"
   },
+  "engines" : {
+    "node" : ">=5.10"
+  },
   "scripts": {
     "lint": "eslint '**/*.js'",
     "test:js": "mocha 'test/**/*.spec.js'",


### PR DESCRIPTION
`lib/load-logos.js` uses `Buffer.from(string)` added in 5.10.0
https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_class_method_buffer_from_string_encoding