### PR TITLE
Removed ability to specify the badge's label for the “website” service

### DIFF
--- a/server.js
+++ b/server.js
@@ -5908,22 +5908,21 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Test if a webpage is online
-camp.route(/^\/website(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+)(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+))?)?(-(([^-/]|--|\/\/)+))?\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/website(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+)(-(([^-/]|--|\/\/)+)-(([^-/]|--|\/\/)+))?)?\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var onlineMessage = escapeFormatSlashes(match[2] != null ? match[2] : "online");
   var offlineMessage = escapeFormatSlashes(match[4] != null ? match[4] : "offline");
   var onlineColor = escapeFormatSlashes(match[7] != null ? match[7] : "brightgreen");
   var offlineColor = escapeFormatSlashes(match[9] != null ? match[9] : "red");
-  var label = escapeFormatSlashes(match[12] != null ? match[12] : "website");
-  var userProtocol = match[14];
-  var userURI = match[15];
-  var format = match[16];
+  var userProtocol = match[11];
+  var userURI = match[12];
+  var format = match[13];
   var withProtocolURI = userProtocol + "://" + userURI;
   var options = {
     method: 'HEAD',
     uri: withProtocolURI,
   };
-  var badgeData = getBadgeData(label, data);
+  var badgeData = getBadgeData("website", data);
   badgeData.colorscheme = undefined;
   request(options, function(err, res) {
     // We consider all HTTP status codes below 310 as success.

--- a/try.html
+++ b/try.html
@@ -405,8 +405,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
   <tr><th data-keywords='website' data-doc='websiteDoc'> Website: </th>
-    <td><img src='/website-up-down-green-red-my--website/http/shields.io.svg' alt=''/></td>
-    <td><code>https://img.shields.io/website-up-down-green-red-my--website/http/shields.io.svg</code></td>
+    <td><img src='/website-up-down-green-red/http/shields.io.svg?label=my-website' alt=''/></td>
+    <td><code>https://img.shields.io/website-up-down-green-red/http/shields.io.svg?label=my-website</code></td>
   </tr>
   <tr><th data-keywords='cocoapods'> CocoaPods: </th>
     <td><img src='/cocoapods/dt/AFNetworking.svg' alt='' /></td>
@@ -1229,16 +1229,10 @@ is where the current server got started.
       <ul>
         <li>Nothing:
             <code>…/website/…</code></li>
-        <li>Badge label (displayed in the left part of the badge):
-            <code>…/website-label/…</code></li>
         <li>Online and offline text:
             <code>…/website-up-down/…</code></li>
-        <li>Online and offline text, then badge label:
-            <code>…/website-up-down-label/…</code></li>
         <li>Online and offline text, then online and offline colors:
             <code>…/website-up-down-green-orange/…</code></li>
-        <li>Online and offline text, then online and offline colors, then badge label:
-            <code>…/website-up-down-green-orange-label/…</code></li>
       </ul>
       <table class=centered><tbody>
           <tr><td>   Dashes <code>--</code>


### PR DESCRIPTION
@paulmelnikow Following your suggestion in https://github.com/badges/shields/pull/949#issuecomment-297454871, I removed the part of the regexp concerned with the badge's label, and adjusted the code accordingly.

The new version seems to work fine, I re-ran the tests below (moving the label to a query parameter where applicable).

```
http://127.0.0.1/website/https/img.shields.io/nonexistant/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|offline (red)
http://127.0.0.1/website/https/img.shields.io/badge/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|online (green)
http://127.0.0.1/website-up-down/https/img.shields.io/nonexistant/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|down (red)
http://127.0.0.1/website-up-down/https/img.shields.io/badge/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|up (green)
http://127.0.0.1/website-up-down-blue-orange/https/img.shields.io/nonexistant/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|down (orange)
http://127.0.0.1/website-up-down-blue-orange/https/img.shields.io/badge/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|up (blue)
http://127.0.0.1/website---u--//p---d--own//-blue-orange/https/img.shields.io/badge/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|-u-/p- (blue)
http://127.0.0.1/website---u--//p---d--own//---blue-orange/https/img.shields.io/nonexistant/foo-bar-green.svg.svg?label=si-t-e/do/-cs
si-t-e/do/-cs|d-own/- (orange)
http://127.0.0.1/website-up-down/https/img.shields.io/website-up-down/https/img.shields.io.svg.svg?label=so-meta
so-meta|up (green)
http://127.0.0.1/website---u--//p-%EF%BB%BF--d--own//---blue-orange/https/img.shields.io/nonexistant/foo-bar-green.svg.svg?label=-si-t-e/do/-cs
-si-t-e/do/-cs|-d-own/- (orange)
http://127.0.0.1/website-online-unavailable-blue-red/https/en.wikipedia.org/wiki/Documentation.svg?label=docs
docs|online (blue)
http://127.0.0.1/website-up-down-blue-orange/http/shields.io.svg
website|up (blue)
http://127.0.0.1/website-up-down-blue-orange/http/shields.io/nonexistant.svg
website|down (orange)
http://127.0.0.1/website-up-down/http/shields.io.svg
website|up (green)
http://127.0.0.1/website-up-down/http/shields.io/nonexistant.svg
website|down (red)
http://127.0.0.1/website/http/shields.io.svg
website|online (green)
http://127.0.0.1/website/http/shields.io/nonexistant.svg
website|offline (red)
```