### PR TITLE
Reduce page jumping while all the badges are loading

### DIFF
--- a/try.html
+++ b/try.html
@@ -47,10 +47,9 @@ hr.spacing { border: 0; display: block; height: 3mm; }
 table.badge > tbody > tr > th,
 table.badge > tbody > tr > td > img,
 table.badge > tbody > tr > td > code { cursor: pointer; }
-#copyImg,
-.badge-img img {
-	height: 20px;
-	vertical-align: middle;
+table.badge > tbody > tr > td > img, .badge-img img, #copyImg {
+  height: 20px;
+  vertical-align: middle;
 }
 </style>
 
@@ -72,7 +71,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 <section id='suggestedBadges'></section>
 
 <h3 id="build"> Build </h3>
-<table class='badge badge-img'><tbody>
+<table class='badge'><tbody>
   <tr><th> Travis: </th>
     <td><img src='/travis/rust-lang/rust.svg' alt=''/></td>
     <td><code>https://img.shields.io/travis/USER/REPO.svg</code></td>


### PR DESCRIPTION
Commit c486c0dcd1fcc88c75d5bd1755aab583f0cdd4e6 missed a large number of badges
on the webpage. This includes all relevant badges.

@paulmelnikow Could you review this patch, please?