### PR TITLE
Record minimum Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
     "node-fetch": "^1.6.3",
     "opn-cli": "^3.1.0",
     "sinon": "^2.1.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }


### PR DESCRIPTION
The decision to drop support for Node 5 was discussed in #902 and #964. Windows Vista is not even [supported by Microsoft anymore](https://support.microsoft.com/en-us/help/22882/windows-vista-end-of-support). Developing for old platforms puts drag on the Node community as a whole. No one likes developing for old platforms, and the good resources for learning JavaScript are in ES6.

There are reasonable arguments for keeping long-term support, like wide use across many projects. They might apply to the gh-pages library, and could consider supporting Node 6 in the library for as long as it's in LTS. However they do not apply to the Shields server. Even users who are self-hosting should be able to run current Node somehow (in Docker, if nothing else). We should be mindful of our limited sysadmin resources, moving forward as the new platforms reach stability.