### PR TITLE
Set the coverage npm script to use current specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "xml2js": "~0.4.16"
   },
   "scripts": {
-    "coverage:test:js": "istanbul cover _mocha 'test/**/*.spec.js' --dir coverage/js",
+    "coverage:test:js": "istanbul cover _mocha '*.spec.js' 'lib/*.spec.js' --dir coverage/js",
     "coverage:test:services": "istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services",
     "coverage:test": "npm run coverage:test:js && npm run coverage:test:services",
     "coverage:report": "istanbul report",

--- a/service-tests/runner/cli.js
+++ b/service-tests/runner/cli.js
@@ -97,6 +97,6 @@ if (prOption !== undefined) {
   }
 
   runner.toss();
-  // Invoke run() asynchronously, beacuse Mocha will not start otherwise.
+  // Invoke run() asynchronously, because Mocha will not start otherwise.
   process.nextTick(run);
 }


### PR DESCRIPTION
The coverage script was introduced in 5c147b8d91ca4f014dbdfb4f672246926bd9aa0a,
and the spec files were moved in c3ef232bf75e13f419af1ff832650f348c05804c.

Also, correct a small typo.

@paulmelnikow Could you review this patch, please?