### PR TITLE
Fix service coverage script and linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+/coverage

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "coverage:test:js": "istanbul cover _mocha '*.spec.js' 'lib/*.spec.js' --dir coverage/js",
-    "coverage:test:services": "istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services",
+    "coverage:test:services": "istanbul cover _mocha service-tests/runner/cli.js --dir coverage/services -- --delay",
     "coverage:test": "npm run coverage:test:js && npm run coverage:test:services",
     "coverage:report": "istanbul report",
     "coverage:report:reopen": "opn coverage/lcov-report/index.html",

--- a/service-tests/README.md
+++ b/service-tests/README.md
@@ -259,11 +259,9 @@ By checking code coverage, we can make sure we've covered all our bases.
 We can generate a coverage report and open it:
 
 ```
-npm run coverage:test:services -- -- --only=travis
+npm run coverage:test:services -- --only=travis
 npm run coverage:report:open
 ```
-
-Note the two sets of double dashes.
 
 After searching `server.js` for the Travis code, we see that we've missed a
 big block: the error branch in the request callback. To test that, we simulate


### PR DESCRIPTION
This fixes two issues:

1. We don't want to lint `/coverage`, which is where we're sending the coverage reports.

2. The `--delay` argument was received by `istanbul` instead of `_mocha`, so `global.run` is `undefined`. That resulted in this stack trace:

```
$ npm run coverage:test:services -- -- --only=maven-central

> gh-badges@1.3.0 coverage:test:services /Users/fabriziocucci/git/shields
> istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services "--" "--only=maven-central"

=============================================================================
Writing coverage object [/Users/fabriziocucci/git/shields/coverage/services/coverage.json]
Writing coverage reports at [/Users/fabriziocucci/git/shields/coverage/services]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 60.47% ( 78/129 )
Branches     : 26.92% ( 7/26 )
Functions    : 50% ( 9/18 )
Lines        : 60% ( 72/120 )
================================================================================
internal/process/next_tick.js:142
      throw new TypeError('callback is not a function');
      ^

TypeError: callback is not a function
    at process.nextTick (internal/process/next_tick.js:142:13)
    at Object.<anonymous> (/Users/fabriziocucci/git/shields/service-tests/runner/cli.js:9:4713)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions.(anonymous function) [as .js] (/Users/fabriziocucci/git/shields/node_modules/istanbul/lib/hook.js:107:24)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
    at /Users/fabriziocucci/git/shields/node_modules/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/Users/fabriziocucci/git/shields/node_modules/mocha/lib/mocha.js:219:14)
    at Mocha.run (/Users/fabriziocucci/git/shields/node_modules/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/Users/fabriziocucci/git/shields/node_modules/mocha/bin/_mocha:459:18)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Object.Module._extensions.(anonymous function) [as .js] (/Users/fabriziocucci/git/shields/node_modules/istanbul/lib/hook.js:109:37)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Function.Module.runMain (module.js:590:10)
    at runFn (/Users/fabriziocucci/git/shields/node_modules/istanbul/lib/command/common/run-with-cover.js:122:16)
    at /Users/fabriziocucci/git/shields/node_modules/istanbul/lib/command/common/run-with-cover.js:251:17
    at /Users/fabriziocucci/git/shields/node_modules/istanbul/lib/util/file-matcher.js:68:16
    at /Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:52:16
    at /Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:361:13
    at /Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:52:16
    at done (/Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:246:17)
    at /Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:44:16
    at /Users/fabriziocucci/git/shields/node_modules/async/lib/async.js:358:17
    at LOOP (fs.js:1739:14)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)

npm ERR! Darwin 15.6.0
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "coverage:test:services" "--" "--" "--only=maven-central"
npm ERR! node v6.6.0
npm ERR! npm  v3.10.3
npm ERR! code ELIFECYCLE
npm ERR! gh-badges@1.3.0 coverage:test:services: `istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services "--" "--only=maven-central"`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the gh-badges@1.3.0 coverage:test:services script 'istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services "--" "--only=maven-central"'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the gh-badges package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     istanbul cover _mocha --delay service-tests/runner/cli.js --dir coverage/services "--" "--only=maven-central"
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs gh-badges
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls gh-badges
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/fabriziocucci/git/shields/npm-debug.log
```

Thanks to @fabriziocucci for the [bug reports](https://github.com/badges/shields/pull/957#issuecomment-298166712).