### PR TITLE
Add [Discord] badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -6142,7 +6142,12 @@ cache((data, match, sendBadge, request) => {
 
   request(apiUrl, (err, res, buffer) => {
     const badgeData = getBadgeData('chat', data);
-    if (err != null || res.statusCode !== 200) {
+    if (res && res.statusCode === 404) {
+      badgeData.text[1] = 'invalid server';
+      sendBadge(format, badgeData);
+      return;
+    }
+    if (err != null || !res || res.statusCode !== 200) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
       return;

--- a/server.js
+++ b/server.js
@@ -6133,6 +6133,33 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Discord integration
+camp.route(/^\/discord\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache((data, match, sendBadge, request) => {
+  const serverID = match[1];
+  const format = match[2];
+  const apiUrl = `https://discordapp.com/api/guilds/${serverID}/widget.json`;
+
+  request(apiUrl, (err, res, buffer) => {
+    const badgeData = getBadgeData('chat', data);
+    if (err != null || res.statusCode !== 200) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      const data = JSON.parse(buffer);
+      const members = Array.isArray(data.members) ? data.members : [];
+      badgeData.text[1] = members.length + ' online';
+      badgeData.colorscheme = 'brightgreen';
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)*?)-(([^-]|--)*)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,
 function(data, match, end, ask) {

--- a/service-tests/discord.js
+++ b/service-tests/discord.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'discord', title: 'Discord' });
+module.exports = t;
+
+t.create('gets status for Reactiflux')
+  .get('/102860784329052160.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('chat'),
+    value: Joi.string().regex(/^[0-9]+ online$/),
+  }));
+
+t.create('invalid server ID')
+  .get('/12345.json')
+  .expectJSON({ name: 'chat', value: 'inaccessible' });
+
+t.create('connection error')
+  .get('/102860784329052160.json')
+  .networkOff()
+  .expectJSON({ name: 'chat', value: 'inaccessible' });

--- a/service-tests/discord.js
+++ b/service-tests/discord.js
@@ -15,6 +15,14 @@ t.create('gets status for Reactiflux')
 
 t.create('invalid server ID')
   .get('/12345.json')
+  .expectJSON({ name: 'chat', value: 'invalid server' });
+
+t.create('server error')
+  .get('/12345.json')
+  .intercept(nock => nock('https://discordapp.com/')
+    .get('/api/guilds/12345/widget.json')
+    .reply(500, 'Something broke')
+  )
   .expectJSON({ name: 'chat', value: 'inaccessible' });
 
 t.create('connection error')

--- a/try.html
+++ b/try.html
@@ -969,6 +969,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/uptimerobot/ratio/7/m778918918-3e92c097147760ee39d02d36.svg' alt=''/></td>
     <td><code>https://img.shields.io/uptimerobot/ratio/7/m778918918-3e92c097147760ee39d02d36.svg</code></td>
   </tr>
+  <tr><th> Discord: </th>
+    <td><img src='/discord/102860784329052160.svg' alt=''/></td>
+    <td><code>https://img.shields.io/discord/102860784329052160.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="miscellaneous"> Longer Miscellaneous </h3>


### PR DESCRIPTION
Adds a badge for Discord, along with a test.

![](http://ss.dan.cx/2017/04/Shields.io_Quality_metadata_badges_for_open_sourc_29-18.16.27.png)

For reference, their official badge looks like this:
![](https://discordapp.com/api/guilds/102860784329052160/widget.png)