### PR TITLE
Fix regexp used for matching services in pull requests

### DIFF
--- a/service-tests/runner/cli.js
+++ b/service-tests/runner/cli.js
@@ -40,7 +40,7 @@ function getTitle (repoSlug, pullRequest) {
 // [Travis Sonar] Support user token authentication -> ['travis', 'sonar']
 // [CRAN CPAN CTAN] Add test coverage => ['cran', 'cpan', 'ctan']
 function servicesForTitle (title) {
-  const matches = title.match(/^\[(.+)\]$/);
+  const matches = title.match(/\[(.+)\]/);
   if (matches === null) {
     return [];
   }

--- a/service-tests/runner/cli.js
+++ b/service-tests/runner/cli.js
@@ -40,7 +40,7 @@ function getTitle (repoSlug, pullRequest) {
 // [Travis Sonar] Support user token authentication -> ['travis', 'sonar']
 // [CRAN CPAN CTAN] Add test coverage => ['cran', 'cpan', 'ctan']
 function servicesForTitle (title) {
-  const matches = title.match(/\[([\w ]+)\]/);
+  const matches = title.match(/^\[(.+)\]$/);
   if (matches === null) {
     return [];
   }


### PR DESCRIPTION
According to the [Mozilla documentation about regular expressions](https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions), the special character `\w` is equivalent to `[A-Za-z0-9_]`, which does not include the hype charachter (i.e. '-'). This cause the matching of services containing an hype fail (e.g. 'maven-central').

~Also, both starting character (i.e. '[') and ending character (i.e. ']') have been enforced in the regular expression.~

Another option (probably less readable) could be ~`/^\[([\w\-]+)\]$/`~ `/\[([\w\-]+)\]/`.

This has been reported by @paulmelnikow [here](https://github.com/badges/shields/pull/957#issuecomment-298206267).