### PR TITLE
[maven-central] Add the ability to filter by version prefix

### DIFF
--- a/server.js
+++ b/server.js
@@ -4337,11 +4337,12 @@ cache(function(data, match, sendBadge, request) {
 
 // Maven-Central artifact version integration
 // (based on repo1.maven.org rather than search.maven.org because of #846)
-camp.route(/^\/maven-central\/v\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/maven-central\/v\/([^\/]*)\/([^\/]*)(?:\/([^\/]*))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var groupId = match[1]; // eg, `com.google.inject`
   var artifactId = match[2]; // eg, `guice`
-  var format = match[3] || "gif"; // eg, `guice`
+  var versionPrefix = match[3] || ''; // eg, `1.`
+  var format = match[4] || 'gif'; // eg, `svg`
   var metadataUrl = 'http://repo1.maven.org/maven2'
     + '/' + encodeURIComponent(groupId).replace(/\./g, '/')
     + '/' + encodeURIComponent(artifactId)
@@ -4360,7 +4361,11 @@ cache(function(data, match, sendBadge, request) {
         return;
       }
       try {
-        var version = data.metadata.versioning[0].latest[0];
+        var versions = data.metadata.versioning[0].versions[0].version.reverse();
+        var version = versions.find(function(version){
+          return version.indexOf(versionPrefix) === 0;
+        });
+
         badgeData.text[1] = 'v' + version;
         if (version === '0' || /SNAPSHOT/.test(version)) {
           badgeData.colorscheme = 'orange';

--- a/service-tests/maven-central.js
+++ b/service-tests/maven-central.js
@@ -13,6 +13,13 @@ t.create('latest version')
     value: Joi.string().regex(/^v(.*)$/)
 }));
 
+t.create('latest 0.8 version')
+  .get('/v/com.github.fabriziocucci/yacl4j/0.8.json') // http://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('maven-central'),
+    value: Joi.string().regex(/^v0\.8(.*)$/)
+  }));
+
 t.create('inexistent artifact')
   .get('/v/inexistent-group-id/inexistent-artifact-id.json')
   .expectJSON({ name: 'maven-central', value: 'invalid' });

--- a/try.html
+++ b/try.html
@@ -555,8 +555,12 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><code>https://img.shields.io/puppetforge/v/vStone/percona.svg</code></td>
   </tr>
   <tr><th> Maven Central: </th>
-  <td><img src='/maven-central/v/org.apache.maven/apache-maven/3.svg' alt=''/></td>
-  <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven/3.svg</code></td>
+  <td><img src='/maven-central/v/org.apache.maven/apache-maven.svg' alt=''/></td>
+  <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven.svg</code></td>
+  </tr>
+  <tr><th> Maven Central with version prefix filter: </th>
+  <td><img src='/maven-central/v/org.apache.maven/apache-maven/2.svg' alt=''/></td>
+  <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven/2.svg</code></td>
   </tr>
   <tr><th> WordPress plugin: </th>
   <td><img src='/wordpress/plugin/v/akismet.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -555,8 +555,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><code>https://img.shields.io/puppetforge/v/vStone/percona.svg</code></td>
   </tr>
   <tr><th> Maven Central: </th>
-  <td><img src='/maven-central/v/org.apache.maven/apache-maven.svg' alt=''/></td>
-  <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven.svg</code></td>
+  <td><img src='/maven-central/v/org.apache.maven/apache-maven/3.svg' alt=''/></td>
+  <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven/3.svg</code></td>
   </tr>
   <tr><th> WordPress plugin: </th>
   <td><img src='/wordpress/plugin/v/akismet.svg' alt=''/></td>


### PR DESCRIPTION
On my github project page, I need to be able to display the latest version of each maintenance branch.
This is currently impossible, since maven badge display the latest version without any consideration to branches.
E.g `https://img.shields.io/maven-central/v/org.apache.maven/apache-maven` displays version `v3.5.0`

With this PR you can define the badge as:
`https://img.shields.io/maven-central/v/org.apache.maven/apache-maven/3.3.svg` to display the latest 3.3 version which is currently `v3.3.9`.

This is not a breaking change. The first url will keep working.