### PR TITLE
another nexus repo pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ Desktop.ini
 ._*
 Thumbs.db
 
+# eclipse
+.project
+.settings
+
 # Files that might appear on external disks
 .Spotlight-V100
 .Trashes

--- a/server.js
+++ b/server.js
@@ -4376,6 +4376,81 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+function nexusRequest(data, match, sendBadge, request, urlCallback, dataCallback) {
+  var scheme = match[1]; // http(s)
+  var host = match[3]; // nexus.example.com
+  var groupId = match[4]; // eg, `com.google.inject`
+  var artifactId = match[5]; // eg, `guice`
+  var format = match[6] || "gif";
+  var apiUrl = scheme + '://' + host + urlCallback(encodeURIComponent(groupId), encodeURIComponent(artifactId));
+  var badgeData = getBadgeData('nexus', data);
+  request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
+	 if (err != null) {
+	   badgeData.text[1] = 'inaccessible';
+	   sendBadge(format, badgeData);
+	   return;
+	 }
+	 try {
+	   var parsed = JSON.parse(buffer);
+	   var version = dataCallback(parsed);
+
+	   if (version === '0' || /SNAPSHOT/.test(version)) {
+		 badgeData.colorscheme = 'orange';
+		 if (version !== '0') {
+		    badgeData.text[1] = version;
+		 } else {
+	        badgeData.text[1] = 'undefined';
+		 }
+	   } else {
+		 badgeData.colorscheme = 'blue';
+		 badgeData.text[1] = version;
+	   }
+	   sendBadge(format, badgeData);
+	 } catch(e) {
+	   badgeData.text[1] = 'invalid';
+	   sendBadge(format, badgeData);
+	 }
+  });
+}
+
+function isSnapshotVersion(version) {
+  var pattern = /(\d+\.)*\d\-SNAPSHOT/;
+  return version.match(pattern);
+}
+
+// standalone sonatype nexus installation
+camp.route(/^\/nexus\/r\/(http(s)?)\/((?:[^\/]+)(?:\/.+?)?)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  nexusRequest(data, match, sendBadge, request, function(groupId, artifactId) {
+      return '/service/local/lucene/search?g=' + groupId + '&a=' + artifactId;
+  }, function(parsed) {
+      return parsed.data[0].latestRelease;
+  });
+}));
+
+camp.route(/^\/nexus\/s\/(http(s)?)\/((?:[^\/]+)(?:\/.+?)?)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  nexusRequest(data, match, sendBadge, request, function(groupId, artifactId) {
+      return '/service/local/lucene/search?g=' + groupId + '&a=' + artifactId;
+  }, function(parsed) {
+	  var latest = '0';
+	  // only want to match 1.2.3-SNAPSHOT style versions, which may not always be in
+	  // 'latestSnapshot' so check 'version' as well before continuing to next entry
+	  parsed.data.every(function(artifact) {
+	     if (isSnapshotVersion(artifact.latestSnapshot)) {
+	        latest = artifact.latestSnapshot;
+	        return;
+	     }
+	     if (isSnapshotVersion(artifact.version)) {
+	        latest = artifact.version;
+	        return;
+	     }
+	     return true;
+	  });
+      return latest;
+  });
+}));
+
 // Bower version integration.
 camp.route(/^\/bower\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/try.html
+++ b/try.html
@@ -558,6 +558,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/maven-central/v/org.apache.maven/apache-maven.svg' alt=''/></td>
   <td><code>https://img.shields.io/maven-central/v/org.apache.maven/apache-maven.svg</code></td>
   </tr>
+  <tr><th> Sonatype Nexus (Releases): </th>
+  <td><img src='/nexus/r/https/oss.sonatype.org/com.google.guava/guava.svg' alt=''/></td>
+  <td><code>https://img.shields.io/nexus/r/https/oss.sonatype.org/com.google.guava/guava.svg</code></td>
+  </tr>
+  <tr><th> Sonatype Nexus (Snapshots): </th>
+  <td><img src='/nexus/s/https/oss.sonatype.org/com.google.guava/guava.svg' alt=''/></td>
+  <td><code>https://img.shields.io/nexus/s/https/oss.sonatype.org/com.google.guava/guava.svg</code></td>
+  </tr>
   <tr><th> WordPress plugin: </th>
   <td><img src='/wordpress/plugin/v/akismet.svg' alt=''/></td>
   <td><code>https://img.shields.io/wordpress/plugin/v/akismet.svg</code></td>


### PR DESCRIPTION
this pr is based on #786, also fix #783 , and try to  simplify codes and add another api pattern to use nexus resolve api.

new API pattern is compatible with #786 :

```/nexus/(r|s|<repo-name>)/(http|https)/<nexus.host>[:port][/<entry-path>]/<group>/<artifact>[:k1=v1[:k2=v2[...]]].<format>```

- for `/nexus/[rs]/...` pattern, use the search api of the nexus server, and
- for `/nexus/<repo-name>/...` pattern, use the resolve api of the nexus server.

@jgangemi
