### PR TITLE
Github: Support PR/issues with labels, full count

### DIFF
--- a/server.js
+++ b/server.js
@@ -3370,10 +3370,9 @@ cache(function(data, match, sendBadge, request) {
     (isClosed? ' is:closed': ' is:open') +
     (hasLabel? ' label:' + ghLabel: '');
 
-  var closedText = isClosed? 'closed ': '';
   var labelText = isRaw? '': (hasLabel? ghLabel + ' ': '');
   var targetText = isPR? 'pull requests': 'issues';
-  var badgeData = getBadgeData(closedText + labelText + targetText, data);
+  var badgeData = getBadgeData(labelText + targetText, data);
   if (badgeData.template === 'social') {
     badgeData.logo = badgeData.logo || logos.github;
   }
@@ -3386,7 +3385,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var issues = data.total_count;
-      var rightText = isRaw? '': (isClosed? ' closed': ' open');
+      var rightText = isClosed? ' closed': (isRaw? '': ' open');
       badgeData.text[1] = metric(issues) + rightText;
       badgeData.colorscheme = (issues > 0)? 'yellow': 'brightgreen';
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -3361,22 +3361,14 @@ cache(function(data, match, sendBadge, request) {
   var repo = match[5];  // eg, shields
   var ghLabel = match[6];  // eg, website
   var format = match[7];
-  var apiUrl = githubApiUrl;
+  var apiUrl = githubApiUrl + '/search/issues';
   var query = {};
-  var issuesApi = false;  // Are we using the issues API instead of the repo one?
-  if (isPR) {
-    apiUrl += '/search/issues';
-    query.q = 'is:pr is:' + (isClosed? 'closed': 'open') +
-      ' repo:' + user + '/' + repo;
-  } else {
-    apiUrl += '/repos/' + user + '/' + repo;
-    if (isClosed || ghLabel !== undefined) {
-      apiUrl += '/issues';
-      if (isClosed) { query.state = 'closed'; }
-      if (ghLabel !== undefined) { query.labels = ghLabel; }
-      issuesApi = true;
-    }
-  }
+  var hasLabel = (ghLabel !== undefined);
+
+  query.q = 'repo:' + user + '/' + repo +
+    (isPR? ' is:pr': ' is:issue') +
+    (isClosed? ' is:closed': ' is:open') +
+    (hasLabel? ' label:' + ghLabel: '');
 
   var closedText = isClosed? 'closed ': '';
   var targetText = isPR? 'pull requests': 'issues';
@@ -3392,23 +3384,9 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var modifier = '';
-      var issues;
-      if (isPR) {
-        issues = data.total_count;
-      } else {
-        if (issuesApi) {
-          issues = data.length;
-          if (res.headers['link'] &&
-              res.headers['link'].indexOf('rel="last"') >= 0) {
-            modifier = '+';
-          }
-        } else {
-          issues = data.open_issues_count;
-        }
-      }
+      var issues = data.total_count;
       var rightText = isRaw? '': (isClosed? ' closed': ' open');
-      badgeData.text[1] = metric(issues) + modifier + rightText;
+      badgeData.text[1] = metric(issues) + rightText;
       badgeData.colorscheme = (issues > 0)? 'yellow': 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -3371,8 +3371,9 @@ cache(function(data, match, sendBadge, request) {
     (hasLabel? ' label:' + ghLabel: '');
 
   var closedText = isClosed? 'closed ': '';
+  var labelText = isRaw? '': (hasLabel? ghLabel + ' ': '');
   var targetText = isPR? 'pull requests': 'issues';
-  var badgeData = getBadgeData(closedText + targetText, data);
+  var badgeData = getBadgeData(closedText + labelText + targetText, data);
   if (badgeData.template === 'social') {
     badgeData.logo = badgeData.logo || logos.github;
   }

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -205,3 +205,87 @@ t.create('hit counter for nonexistent repo')
     name: Joi.equal('goto counter'),
     value: Joi.string().regex(/^repo not found$/),
   }));
+
+t.create('open issues')
+  .get('/issues/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('open issues (raw)')
+  .get('/issues-raw/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('open pull requests')
+  .get('/issues-pr/cdnjs/cdnjs.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('open pull requests (raw)')
+  .get('/issues-pr-raw/cdnjs/cdnjs.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('closed issues')
+  .get('/issues-closed/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('closed issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
+  }));
+
+t.create('closed issues (raw)')
+  .get('/issues-closed-raw/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('closed issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('closed pull requests')
+  .get('/issues-pr-closed/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('closed pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
+  }));
+
+t.create('closed pull requests (raw)')
+  .get('/issues-pr-closed-raw/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('closed pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('open issues by label')
+  .get('/issues/badges/shields/vendor-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('vendor-badge issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('open issues by label (raw)')
+  .get('/issues-raw/badges/shields/vendor-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('open pull requests by label')
+  .get('/issues-pr/badges/shields/vendor-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('vendor-badge pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('open pull requests by label (raw)')
+  .get('/issues-pr-raw/badges/shields/vendor-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -20,60 +20,75 @@ t.create('Contributors')
     value: Joi.string().regex(/^\w+$/)
   }));
 
-t.create('GitHub closed pull request')
-  .get('/issues-pr-closed/badges/shields.json')
+t.create('GitHub open issues')
+  .get('/issues/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed pull requests'),
-    value: Joi.string().regex(/^\w+\sclosed$/)
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
-t.create('GitHub closed pull request raw')
-  .get('/issues-pr-closed-raw/badges/shields.json')
+t.create('GitHub open issues raw')
+  .get('/issues-raw/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed pull requests'),
-    value: Joi.string().regex(/^\w+?$/)
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
   }));
 
-t.create('GitHub pull request')
-  .get('/issues-pr/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('pull requests'),
-    value: Joi.string().regex(/^\w+\sopen$/)
-  }));
-
-t.create('GitHub pull request raw')
-  .get('/issues-pr-raw/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('pull requests'),
-    value: Joi.string().regex(/^\w+?$/)
-  }));
 
 t.create('GitHub closed issues')
   .get('/issues-closed/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed issues'),
-    value: Joi.string().regex(/^\w+\+?\sclosed$/)
+    name: Joi.equal('issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
   }));
 
-t.create('GitHub closed issues raw')
-  .get('/issues-closed-raw/badges/shields.json')
+t.create('GitHub open issues by label')
+  .get('/issues/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed issues'),
-    value: Joi.string().regex(/^\w+\+?$/)
+    name: Joi.equal('service-badge issues'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
-t.create('GitHub issues')
-  .get('/issues/badges/shields.json')
+t.create('GitHub open issues raw by label')
+  .get('/issues-raw/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('issues'),
-    value: Joi.string().regex(/^\w+\sopen$/)
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
   }));
 
-t.create('GitHub issues raw')
-  .get('/issues-raw/badges/shields.json')
+t.create('GitHub open pull request')
+  .get('/issues-pr/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
-    value: Joi.string().regex(/^\w+$/)
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('GitHub open pull request raw')
+  .get('/issues-pr-raw/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('GitHub open pull requests by label')
+  .get('/issues-pr/badges/shields/service-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('service-badge pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('GitHub open pull requests raw by label')
+  .get('/issues-pr-raw/badges/shields/service-badge.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
+  }));
+
+t.create('GitHub closed pull request')
+  .get('/issues-pr-closed/badges/shields.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('pull requests'),
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
   }));
 
 t.create('Followers')
@@ -204,88 +219,4 @@ t.create('hit counter for nonexistent repo')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('goto counter'),
     value: Joi.string().regex(/^repo not found$/),
-  }));
-
-t.create('open issues')
-  .get('/issues/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
-  }));
-
-t.create('open issues (raw)')
-  .get('/issues-raw/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
-  }));
-
-t.create('open pull requests')
-  .get('/issues-pr/cdnjs/cdnjs.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
-  }));
-
-t.create('open pull requests (raw)')
-  .get('/issues-pr-raw/cdnjs/cdnjs.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
-  }));
-
-t.create('closed issues')
-  .get('/issues-closed/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
-  }));
-
-t.create('closed issues (raw)')
-  .get('/issues-closed-raw/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
-  }));
-
-t.create('closed pull requests')
-  .get('/issues-pr-closed/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
-  }));
-
-t.create('closed pull requests (raw)')
-  .get('/issues-pr-closed-raw/badges/shields.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
-  }));
-
-t.create('open issues by label')
-  .get('/issues/badges/shields/vendor-badge.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('vendor-badge issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
-  }));
-
-t.create('open issues by label (raw)')
-  .get('/issues-raw/badges/shields/vendor-badge.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
-  }));
-
-t.create('open pull requests by label')
-  .get('/issues-pr/badges/shields/vendor-badge.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('vendor-badge pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
-  }));
-
-t.create('open pull requests by label (raw)')
-  .get('/issues-pr-raw/badges/shields/vendor-badge.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('pull requests'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?$/)
   }));

--- a/try.html
+++ b/try.html
@@ -794,13 +794,13 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-raw/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-raw/badges/shields.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'> GitHub issues by-label:</th>
-    <td><img src='/github/issues/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues/badges/shields/vendor-badge.svg</code></td>
+  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub pull requests: </th>
+    <td><img src='/github/issues-pr/cdnjs/cdnjs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr/cdnjs/cdnjs.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-raw/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-raw/badges/shields/vendor-badge.svg</code></td>
+  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'></th>
+    <td><img src='/github/issues-pr-raw/cdnjs/cdnjs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr-raw/cdnjs/cdnjs.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub issue' data-doc='githubDoc'> GitHub closed issues: </th>
     <td><img src='/github/issues-closed/badges/shields.svg' alt=''/></td>
@@ -810,13 +810,21 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-closed-raw/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-closed-raw/badges/shields.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub pull requests: </th>
-    <td><img src='/github/issues-pr/cdnjs/cdnjs.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr/cdnjs/cdnjs.svg</code></td>
+  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub closed pull requests: </th>
+    <td><img src='/github/issues-pr-closed/cdnjs/cdnjs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr-closed/cdnjs/cdnjs.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-pr-raw/cdnjs/cdnjs.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr-raw/cdnjs/cdnjs.svg</code></td>
+    <td><img src='/github/issues-pr-closed-raw/cdnjs/cdnjs.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr-closed-raw/cdnjs/cdnjs.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'> GitHub issues by-label:</th>
+    <td><img src='/github/issues/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues/badges/shields/vendor-badge.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'></th>
+    <td><img src='/github/issues-raw/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-raw/badges/shields/vendor-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'>GitHub pull requests by-label:</th>
     <td><img src='/github/issues-pr/badges/shields/vendor-badge.svg' alt=''/></td>
@@ -825,14 +833,6 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'></th>
     <td><img src='/github/issues-pr-raw/badges/shields/vendor-badge.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-pr-raw/badges/shields/vendor-badge.svg</code></td>
-  </tr>
-  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub closed pull requests: </th>
-    <td><img src='/github/issues-pr-closed/cdnjs/cdnjs.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr-closed/cdnjs/cdnjs.svg</code></td>
-  </tr>
-  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-pr-closed-raw/cdnjs/cdnjs.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr-closed-raw/cdnjs/cdnjs.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub contributor' data-doc='githubDoc'> GitHub contributors: </th>
     <td><img src='/github/contributors/cdnjs/cdnjs.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -794,6 +794,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-raw/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-raw/badges/shields.svg</code></td>
   </tr>
+  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'> GitHub issues by-label:</th>
+    <td><img src='/github/issues/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues/badges/shields/vendor-badge.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'></th>
+    <td><img src='/github/issues-raw/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-raw/badges/shields/vendor-badge.svg</code></td>
+  </tr>
   <tr><th data-keywords='GitHub issue' data-doc='githubDoc'> GitHub closed issues: </th>
     <td><img src='/github/issues-closed/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-closed/badges/shields.svg</code></td>
@@ -802,10 +810,6 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-closed-raw/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-closed-raw/badges/shields.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'> label:</th>
-    <td><img src='/github/issues-raw/badges/shields/website.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-raw/badges/shields/website.svg</code></td>
-  </tr>
   <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub pull requests: </th>
     <td><img src='/github/issues-pr/cdnjs/cdnjs.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-pr/cdnjs/cdnjs.svg</code></td>
@@ -813,6 +817,14 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'></th>
     <td><img src='/github/issues-pr-raw/cdnjs/cdnjs.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-pr-raw/cdnjs/cdnjs.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'>GitHub pull requests by-label:</th>
+    <td><img src='/github/issues-pr/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr/badges/shields/vendor-badge.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'></th>
+    <td><img src='/github/issues-pr-raw/badges/shields/vendor-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr-raw/badges/shields/vendor-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub closed pull requests: </th>
     <td><img src='/github/issues-pr-closed/cdnjs/cdnjs.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -806,33 +806,25 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/issues-closed/badges/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-closed/badges/shields.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub issue' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-closed-raw/badges/shields.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-closed-raw/badges/shields.svg</code></td>
-  </tr>
   <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'> GitHub closed pull requests: </th>
     <td><img src='/github/issues-pr-closed/cdnjs/cdnjs.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/issues-pr-closed/cdnjs/cdnjs.svg</code></td>
   </tr>
-  <tr><th data-keywords='GitHub pullrequest pr' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-pr-closed-raw/cdnjs/cdnjs.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr-closed-raw/cdnjs/cdnjs.svg</code></td>
-  </tr>
   <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'> GitHub issues by-label:</th>
-    <td><img src='/github/issues/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues/badges/shields/vendor-badge.svg</code></td>
+    <td><img src='/github/issues/badges/shields/service-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues/badges/shields/service-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub issue label' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-raw/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-raw/badges/shields/vendor-badge.svg</code></td>
+    <td><img src='/github/issues-raw/badges/shields/service-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-raw/badges/shields/service-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'>GitHub pull requests by-label:</th>
-    <td><img src='/github/issues-pr/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr/badges/shields/vendor-badge.svg</code></td>
+    <td><img src='/github/issues-pr/badges/shields/service-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr/badges/shields/service-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequests label' data-doc='githubDoc'></th>
-    <td><img src='/github/issues-pr-raw/badges/shields/vendor-badge.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/issues-pr-raw/badges/shields/vendor-badge.svg</code></td>
+    <td><img src='/github/issues-pr-raw/badges/shields/service-badge.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/issues-pr-raw/badges/shields/service-badge.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub contributor' data-doc='githubDoc'> GitHub contributors: </th>
     <td><img src='/github/contributors/cdnjs/cdnjs.svg' alt=''/></td>


### PR DESCRIPTION
This PR includes the following:
- Simplified the code, but kept it full-featured
  - Use the issues API for all calls to Github
  - Got rid of the repos API for some of the queries
- It now displays more exact issue numbers (no longer indicates `30+`)
- It can now display the number of PRs by label too (not just issues only)
- Can display the used label name too for completeness

This fixes #839
This fixes #420
This implements #862 partly

![image](https://user-images.githubusercontent.com/388198/27613091-8a53b488-5b91-11e7-9073-18cb74b4da47.png)