### PR TITLE
[Github] Optionally add name to release badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -3241,13 +3241,16 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub release integration
-camp.route(/^\/github\/release\/([^\/]+\/[^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/release(-name)?\/([^\/]+)\/([^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var userRepo = match[1];  // eg, qubyte/rubidium
-  var allReleases = match[2];
-  var format = match[3];
-  var apiUrl = githubApiUrl + '/repos/' + userRepo + '/releases';
-  var badgeData = getBadgeData('release', data);
+  var showName = !!match[1];
+  var user = match[2];  // eg, qubyte
+  var repo = match[3];  // eg, rubidium
+  var allReleases = match[4];
+  var format = match[5];
+  var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/releases';
+  var labelText = showName? repo + ' release': 'release'
+  var badgeData = getBadgeData(labelText, data);
   if (allReleases === undefined) {
     apiUrl = apiUrl + '/latest';
   }

--- a/server.js
+++ b/server.js
@@ -3250,7 +3250,7 @@ cache(function(data, match, sendBadge, request) {
   var allReleases = match[5];
   var format = match[6];
   var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/releases';
-  var labelText = showName? repo + (isRaw? '': ' release'): 'release'
+  var labelText = showName? repo + (isRaw? '': ' release'): 'release';
   var badgeData = getBadgeData(labelText, data);
   if (allReleases === undefined) {
     apiUrl = apiUrl + '/latest';

--- a/server.js
+++ b/server.js
@@ -3241,15 +3241,16 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub release integration
-camp.route(/^\/github\/release(-name)?\/([^\/]+)\/([^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/release(-name)?(-raw)?\/([^\/]+)\/([^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var showName = !!match[1];
-  var user = match[2];  // eg, qubyte
-  var repo = match[3];  // eg, rubidium
-  var allReleases = match[4];
-  var format = match[5];
+  var isRaw = !!match[2];
+  var user = match[3];  // eg, qubyte
+  var repo = match[4];  // eg, rubidium
+  var allReleases = match[5];
+  var format = match[6];
   var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/releases';
-  var labelText = showName? repo + ' release': 'release'
+  var labelText = showName? repo + (isRaw? '': ' release'): 'release'
   var badgeData = getBadgeData(labelText, data);
   if (allReleases === undefined) {
     apiUrl = apiUrl + '/latest';

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -146,10 +146,38 @@ t.create('Release')
     value: Joi.string()
   }));
 
-t.create('(pre-)Release')
+t.create('Release + name')
+  .get('/release-name/photonstorm/phaser.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('phaser release'),
+    value: Joi.string()
+  }));
+
+t.create('Release + name + raw')
+  .get('/release-name-raw/photonstorm/phaser.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('phaser'),
+    value: Joi.string()
+  }));
+
+t.create('(Pre-)Release')
   .get('/release/photonstorm/phaser/all.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('release'),
+    value: Joi.string()
+  }));
+
+t.create('(Pre-)Release + name')
+  .get('/release-name/photonstorm/phaser/all.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('phaser release'),
+    value: Joi.string()
+  }));
+
+t.create('(Pre-)Release + name + raw')
+  .get('/release-name-raw/photonstorm/phaser/all.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('phaser'),
     value: Joi.string()
   }));
 

--- a/try.html
+++ b/try.html
@@ -543,6 +543,11 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/github/release-name/qubyte/rubidium.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release-name/qubyte/rubidium.svg</code></td>
   </tr>
+  </tr>
+  <tr><th data-doc='githubDoc'> GitHub release + name + raw: </th>
+  <td><img src='/github/release-name-raw/qubyte/rubidium.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/release-name-raw/qubyte/rubidium.svg</code></td>
+  </tr>
   <tr><th data-doc='githubDoc'> GitHub (pre-)release: </th>
   <td><img src='/github/release/qubyte/rubidium/all.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release/qubyte/rubidium/all.svg</code></td>
@@ -551,6 +556,11 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th data-doc='githubDoc'> GitHub (pre-)release + name: </th>
   <td><img src='/github/release-name/qubyte/rubidium/all.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release-name/qubyte/rubidium/all.svg</code></td>
+  </tr>
+  </tr>
+  <tr><th data-doc='githubDoc'> GitHub (pre-)release + name + raw: </th>
+  <td><img src='/github/release-name-raw/qubyte/rubidium/all.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/release-name-raw/qubyte/rubidium/all.svg</code></td>
   </tr>
   <tr><th data-doc='githubDoc'> GitHub commits: </th>
   <td><img src='/github/commits-since/SubtitleEdit/subtitleedit/3.4.7.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -538,9 +538,19 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/github/release/qubyte/rubidium.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release/qubyte/rubidium.svg</code></td>
   </tr>
+  </tr>
+  <tr><th data-doc='githubDoc'> GitHub release + name: </th>
+  <td><img src='/github/release-name/qubyte/rubidium.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/release-name/qubyte/rubidium.svg</code></td>
+  </tr>
   <tr><th data-doc='githubDoc'> GitHub (pre-)release: </th>
   <td><img src='/github/release/qubyte/rubidium/all.svg' alt=''/></td>
   <td><code>https://img.shields.io/github/release/qubyte/rubidium/all.svg</code></td>
+  </tr>
+  </tr>
+  <tr><th data-doc='githubDoc'> GitHub (pre-)release + name: </th>
+  <td><img src='/github/release-name/qubyte/rubidium/all.svg' alt=''/></td>
+  <td><code>https://img.shields.io/github/release-name/qubyte/rubidium/all.svg</code></td>
   </tr>
   <tr><th data-doc='githubDoc'> GitHub commits: </th>
   <td><img src='/github/commits-since/SubtitleEdit/subtitleedit/3.4.7.svg' alt=''/></td>


### PR DESCRIPTION
This PR makes it possible to add a name to the Github release badge.
This is useful if your project wants to show the various release of used
components.