### PR TITLE
Up-to-date ServiceTester's constructor in Service tests example

### DIFF
--- a/service-tests/README.md
+++ b/service-tests/README.md
@@ -307,7 +307,7 @@ Complete example
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
-const t = new ServiceTester('Travis', '/travis');
+const t = new ServiceTester({ id: 'travis', title: 'Travis CI' });
 module.exports = t;
 
 t.create('build status on default branch')


### PR DESCRIPTION
Service tests guideline uses out-of-date constructor of ServiceTester. 