### PR TITLE
Add [GitHub] search hit counter badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -3514,6 +3514,38 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// GitHub search hit counter.
+camp.route(/^\/github\/search\/([^\/]+)\/([^\/]+)\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var user = match[1];
+  var repo = match[2];
+  var search = match[3];
+  var format = match[4];
+  var query = {q: search + ' repo:' + user + '/' + repo};
+  var badgeData = getBadgeData(search + ' counter', data);
+  githubAuth.request(request, githubApiUrl + '/search/code', query, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var body = JSON.parse(buffer);
+      if (body.message === 'Validation Failed') {
+        badgeData.text[1] = 'repo not found';
+        sendBadge(format, badgeData);
+        return;
+      }
+      badgeData.text[1] = metric(body.total_count);
+      badgeData.colorscheme = 'blue';
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Bitbucket issues integration.
 camp.route(/^\/bitbucket\/issues(-raw)?\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -58,3 +58,17 @@ t.create('downloads for specific asset with slash')
 t.create('downloads for unknown release')
   .get('/downloads/atom/atom/does-not-exist/total.json')
   .expectJSON({ name: 'downloads', value: 'none' });
+
+t.create('hit counter')
+  .get('/search/torvalds/linux/goto.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('goto counter'),
+    value: Joi.string().regex(/^[0-9]*(k|M|G|T|P|E|Z|Y)$/),
+  }));
+
+t.create('hit counter for nonexistent repo')
+  .get('/search/torvalds/not-linux/goto.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('goto counter'),
+    value: Joi.string().regex(/^repo not found$/),
+  }));

--- a/try.html
+++ b/try.html
@@ -814,6 +814,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/size/webcaetano/craft/build/craft.min.js.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/size/webcaetano/craft/build/craft.min.js.svg</code></td>
   </tr>
+  <tr><th data-keywords='GitHub search hit counter' data-doc='githubDoc'> Github search hit counter: </th>
+    <td><img src='/github/search/torvalds/linux/goto.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/search/torvalds/linux/goto.svg</code></td>
+  </tr>
   <tr><th> Bitbucket issues: </th>
     <td><img src='/bitbucket/issues/atlassian/python-bitbucket.svg' alt=''/></td>
     <td><code>https://img.shields.io/bitbucket/issues/atlassian/python-bitbucket.svg</code></td>


### PR DESCRIPTION
These badges would be used to show, for example, how many `goto` statements
your project has.