### PR TITLE
Fix .png generation and width computation with Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:6.9.2-alpine
 
-RUN apk add --update gettext
+RUN apk add --no-cache gettext imagemagick librsvg ttf-dejavu
+ENV FALLBACK_FONT_PATH /usr/share/fonts/ttf-dejavu/DejaVuSans.ttf
 
 RUN mkdir -p /usr/src/app
 RUN mkdir /usr/src/app/private
@@ -9,7 +10,8 @@ WORKDIR /usr/src/app
 ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 COPY package.json /usr/src/app/
-RUN npm install
+RUN npm install && \
+    rm -rf /tmp/npm-* /root/.npm
 COPY . /usr/src/app
 
 CMD envsubst < secret.tpl.json > ./private/secret.json && npm start

--- a/lib/measure-text.js
+++ b/lib/measure-text.js
@@ -16,7 +16,11 @@ function loadFont(path, callback) {
   }
 }
 
-loadFont(path.join(__dirname, '..', 'Verdana.ttf'));
+loadFont(path.join(__dirname, '..', 'Verdana.ttf'), function (err) {
+  if (err && process.env.FALLBACK_FONT_PATH) {
+    loadFont(process.env.FALLBACK_FONT_PATH);
+  }
+});
 doc = doc.fontSize(11);
 
 function measure(str) {


### PR DESCRIPTION
Current Docker image computes width using the 'Helvetica-Bold' fallback font from pdfkit, (because Verdana.ttf can't be found). Width computation is not correct when using some non-Latin characters, like привет, which leads to overlapping texts.

Also only svg rendering works, as the imagemagick libs and DejaVu font are not installed.

This pull request fixes both issues by installing the missing libs and adding a `FALLBACK_FONT_PATH` environment variable. If Verdana.ttf can't be loaded, the font file pointed by `FALLBACK_FONT_PATH` will be loaded. In the docker image, `FALLBACK_FONT_PATH` is set to `/usr/share/fonts/ttf-dejavu/DejaVuSans.ttf`.