### PR TITLE
Update Gratipay shields

### DIFF
--- a/server.js
+++ b/server.js
@@ -1028,7 +1028,7 @@ cache(function(data, match, sendBadge, request) {
   if (type === '') { type = '/user'; }
   if (type === '/user') { user = '~' + user; }
   var apiUrl = 'https://gratipay.com/' + user + '/public.json';
-  var badgeData = getBadgeData('tips', data);
+  var badgeData = getBadgeData('receives', data);
   if (badgeData.template === 'social') {
     badgeData.logo = badgeData.logo || logos.gratipay;
   }

--- a/server.js
+++ b/server.js
@@ -1020,7 +1020,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Gratipay integration.
-camp.route(/^\/(?:gittip|gratipay(\/user|\/team)?)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/(?:gittip|gratipay(\/user|\/team|\/project)?)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];  // eg, `user`.
   var user = match[2];  // eg, `dougwilson`.

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -9,7 +9,7 @@ module.exports = t;
 t.create('Receiving')
   .get('/Gratipay.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('tips'),
+    name: Joi.equal('receives'),
     value: Joi.string().regex(/^\$[0-9]+(\.[0-9]{2})?\/week/)
   }));
 
@@ -20,4 +20,4 @@ t.create('Empty')
     .get('/Gratipay/public.json')
     .reply(200, { receiving : 0.00 })
   )
-  .expectJSON({ name: 'tips', value: '$0/week'});
+  .expectJSON({ name: 'receives', value: '$0/week'});

--- a/try.html
+++ b/try.html
@@ -652,7 +652,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
 </tbody></table>
 
-<h3 id="miscellaneous"> Funding </h3>
+<h3 id="miscellaneous"> Miscellaneous </h3>
 <table class='badge'><tbody>
   <tr><th> Gratipay User: </th>
     <td><img src='/gratipay/user/dougwilson.svg' alt=''/></td>
@@ -670,10 +670,6 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/beerpay/hashdog/scrapfy-chrome-extension.svg' alt=''/></td>
     <td><code>https://img.shields.io/beerpay/hashdog/scrapfy-chrome-extension.svg</code></td>
   </tr>
-</tbody></table>
-
-<h3 id="miscellaneous"> Miscellaneous </h3>
-<table class='badge'><tbody>
   <tr><th> Code Climate: </th>
     <td><img src='/codeclimate/github/kabisaict/flow.svg' alt=''/></td>
     <td><code>https://img.shields.io/codeclimate/github/kabisaict/flow.svg</code></td>

--- a/try.html
+++ b/try.html
@@ -658,9 +658,9 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/gratipay/user/dougwilson.svg' alt=''/></td>
     <td><code>https://img.shields.io/gratipay/user/dougwilson.svg</code></td>
   </tr>
-  <tr><th> Gratipay Team: </th>
+  <tr><th> Gratipay Project: </th>
     <td><img src='/gratipay/team/shields.svg' alt=''/></td>
-    <td><code>https://img.shields.io/gratipay/team/shields.svg</code></td>
+    <td><code>https://img.shields.io/gratipay/project/shields.svg</code></td>
   </tr>
   <tr><th> Bountysource: </th>
     <td><img src='/bountysource/team/mozilla-core/activity.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -654,12 +654,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
 
 <h3 id="miscellaneous"> Miscellaneous </h3>
 <table class='badge'><tbody>
-  <tr><th> Gratipay User: </th>
-    <td><img src='/gratipay/user/dougwilson.svg' alt=''/></td>
-    <td><code>https://img.shields.io/gratipay/user/dougwilson.svg</code></td>
-  </tr>
-  <tr><th> Gratipay Project: </th>
-    <td><img src='/gratipay/team/shields.svg' alt=''/></td>
+  <tr><th> Gratipay: </th>
+    <td><img src='/gratipay/project/shields.svg' alt=''/></td>
     <td><code>https://img.shields.io/gratipay/project/shields.svg</code></td>
   </tr>
   <tr><th> Bountysource: </th>

--- a/try.html
+++ b/try.html
@@ -652,7 +652,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
 </tbody></table>
 
-<h3 id="miscellaneous"> Miscellaneous </h3>
+<h3 id="miscellaneous"> Funding </h3>
 <table class='badge'><tbody>
   <tr><th> Gratipay User: </th>
     <td><img src='/gratipay/user/dougwilson.svg' alt=''/></td>
@@ -670,6 +670,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/beerpay/hashdog/scrapfy-chrome-extension.svg' alt=''/></td>
     <td><code>https://img.shields.io/beerpay/hashdog/scrapfy-chrome-extension.svg</code></td>
   </tr>
+</tbody></table>
+
+<h3 id="miscellaneous"> Miscellaneous </h3>
+<table class='badge'><tbody>
   <tr><th> Code Climate: </th>
     <td><img src='/codeclimate/github/kabisaict/flow.svg' alt=''/></td>
     <td><code>https://img.shields.io/codeclimate/github/kabisaict/flow.svg</code></td>


### PR DESCRIPTION
See https://github.com/gratipay/grtp.co/issues/163.

This PR updates "tips" to "receives" on the Gratipay shields to better reflect recent terminology and creates a new group called "Funding" where related shields can be placed.

- ~~copy changes in `try.html` to `index.html`.~~ supposedly generated from `try.html`.
- [x] reticket 4bd6b2b8a604772e8466fa52e67d57a8c47876a2 to new PR --> https://github.com/badges/shields/issues/1054