### PR TITLE
Changing 'semaphoreapp.com' to 'semaphoreci.com'

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ What kind of metadata can you convey using badges?
 * [reposs](https://github.com/rexfinn/reposs)
 * [ruby-gem-downloads-badge](https://github.com/bogdanRada/ruby-gem-downloads-badge/)
 * [Scrutinizer](https://scrutinizer-ci.com/)
-* [Semaphore](https://semaphoreapp.com)
+* [Semaphore](https://semaphoreci.com)
 * [Travis CI](https://github.com/travis-ci/travis-ci/issues/630#issuecomment-38054967)
 * [Version Badge](http://badge.fury.io/)
 * [VersionEye](https://www.versioneye.com/)


### PR DESCRIPTION
<https://semaphoreci.com> is now our primary domain.