### PR TITLE
Fix [crates] license badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -716,7 +716,7 @@ cache(function (data, match, sendBadge, request) {
       name: 'license',
       version: false,
       process: function (data, badgeData) {
-        badgeData.text[1] = data.crate.license;
+        badgeData.text[1] = data.versions[0].license;
         badgeData.colorscheme = 'blue';
       }
     }

--- a/service-tests/crates.js
+++ b/service-tests/crates.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'crates', title: 'crates.io' });
+module.exports = t;
+
+t.create('license')
+  .get('/l/libc.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('license'),
+    value: Joi.equal('MIT/Apache-2.0')
+  }));
+
+t.create('license (with version)')
+  .get('/l/libc/0.2.31.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('license'),
+    value: Joi.equal('MIT/Apache-2.0')
+  }));


### PR DESCRIPTION
License data was moved to crate versions in rust-lang/crates.io#803. Closes #1059.