### PR TITLE
Nudge forward style checks a la eslint-config-standard

### DIFF
--- a/.eslintrc-preferred.yml
+++ b/.eslintrc-preferred.yml
@@ -1,0 +1,14 @@
+rules:
+  # From eslint-config-standard.
+  arrow-spacing: ["error", { "before": true, "after": true }]
+  brace-style: ["error", "1tbs", { "allowSingleLine": true }]
+  func-style: ["error", "declaration", { "allowArrowFunctions": true }]
+  indent: ["error", 2, { "SwitchCase": 1 }]
+  key-spacing: ["error", { "beforeColon": false, "afterColon": true }]
+  no-trailing-spaces: "error"
+  quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]
+
+  # Shields additions.
+  no-var: "error"
+  prefer-const: "error"
+  strict: "error"

--- a/.eslintrc-preferred.yml
+++ b/.eslintrc-preferred.yml
@@ -2,6 +2,7 @@ rules:
   # From eslint-config-standard.
   arrow-spacing: ["error", { "before": true, "after": true }]
   brace-style: ["error", "1tbs", { "allowSingleLine": true }]
+  camelcase: ["error", { "properties": "never" }]
   func-style: ["error", "declaration", { "allowArrowFunctions": true }]
   indent: ["error", 2, { "SwitchCase": 1 }]
   key-spacing: ["error", { "beforeColon": false, "afterColon": true }]

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,17 +1,1 @@
-# Keep lib/.eslintrc.yml and service-tests/.eslintrc.yml in sync. For Windows
-# compatibility, the files are duplicated instead of symlinked.
-
-rules:
-  # From eslint-config-standard.
-  arrow-spacing: ["error", { "before": true, "after": true }]
-  brace-style: ["error", "1tbs", { "allowSingleLine": true }]
-  func-style: ["error", "declaration", { "allowArrowFunctions": true }]
-  indent: ["error", 2, { "SwitchCase": 1 }]
-  key-spacing: ["error", { "beforeColon": false, "afterColon": true }]
-  no-trailing-spaces: "error"
-  quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]
-
-  # Shields additions.
-  no-var: "error"
-  prefer-const: "error"
-  strict: "error"
+extends: '../.eslintrc-preferred.yml'

--- a/lib/.eslintrc.yml
+++ b/lib/.eslintrc.yml
@@ -1,0 +1,17 @@
+# Keep lib/.eslintrc.yml and service-tests/.eslintrc.yml in sync. For Windows
+# compatibility, the files are duplicated instead of symlinked.
+
+rules:
+  # From eslint-config-standard.
+  arrow-spacing: ["error", { "before": true, "after": true }]
+  brace-style: ["error", "1tbs", { "allowSingleLine": true }]
+  func-style: ["error", "declaration", { "allowArrowFunctions": true }]
+  indent: ["error", 2, { "SwitchCase": 1 }]
+  key-spacing: ["error", { "beforeColon": false, "afterColon": true }]
+  no-trailing-spaces: "error"
+  quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]
+
+  # Shields additions.
+  no-var: "error"
+  prefer-const: "error"
+  strict: "error"

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,20 +1,22 @@
+'use strict';
+
 const fs = require('fs');
 
 // We can either use a process-wide object regularly saved to a JSON file,
 // or a Redis equivalent (for multi-process / when the filesystem is unreliable.
-var redis;
-var useRedis = false;
+let redis;
+let useRedis = false;
 if (process.env.REDISTOGO_URL) {
-  var redisToGo = require('url').parse(process.env.REDISTOGO_URL);
+  const redisToGo = require('url').parse(process.env.REDISTOGO_URL);
   redis = require('redis').createClient(redisToGo.port, redisToGo.hostname);
   redis.auth(redisToGo.auth.split(':')[1]);
   useRedis = true;
 }
 
-var analytics = {};
+let analytics = {};
 
-var analyticsAutoSaveFileName = process.env.SHIELDS_ANALYTICS_FILE || './analytics.json';
-var analyticsAutoSavePeriod = 10000;
+const analyticsAutoSaveFileName = process.env.SHIELDS_ANALYTICS_FILE || './analytics.json';
+const analyticsAutoSavePeriod = 10000;
 setInterval(function analyticsAutoSave() {
   if (useRedis) {
     redis.set(analyticsAutoSaveFileName, JSON.stringify(analytics));
@@ -24,7 +26,7 @@ setInterval(function analyticsAutoSave() {
 }, analyticsAutoSavePeriod);
 
 function defaultAnalytics() {
-  var analytics = Object.create(null);
+  const analytics = Object.create(null);
   // In case something happens on the 36th.
   analytics.vendorMonthly = new Array(36);
   resetMonthlyAnalytics(analytics.vendorMonthly);
@@ -43,7 +45,7 @@ function defaultAnalytics() {
 
 // Auto-load analytics.
 function analyticsAutoLoad() {
-  var defaultAnalyticsObject = defaultAnalytics();
+  const defaultAnalyticsObject = defaultAnalytics();
   if (useRedis) {
     redis.get(analyticsAutoSaveFileName, function(err, value) {
       if (err == null && value != null) {
@@ -52,7 +54,7 @@ function analyticsAutoLoad() {
         try {
           analytics = JSON.parse(value);
           // Extend analytics with a new value.
-          for (var key in defaultAnalyticsObject) {
+          for (const key in defaultAnalyticsObject) {
             if (!(key in analytics)) {
               analytics[key] = defaultAnalyticsObject[key];
             }
@@ -70,7 +72,7 @@ function analyticsAutoLoad() {
     try {
       analytics = JSON.parse(fs.readFileSync(analyticsAutoSaveFileName));
       // Extend analytics with a new value.
-      for (var key in defaultAnalyticsObject) {
+      for (const key in defaultAnalyticsObject) {
         if (!(key in analytics)) {
           analytics[key] = defaultAnalyticsObject[key];
         }
@@ -85,15 +87,15 @@ function analyticsAutoLoad() {
   }
 }
 
-var lastDay = (new Date()).getDate();
+let lastDay = (new Date()).getDate();
 function resetMonthlyAnalytics(monthlyAnalytics) {
-  for (var i = 0; i < monthlyAnalytics.length; i++) {
+  for (let i = 0; i < monthlyAnalytics.length; i++) {
     monthlyAnalytics[i] = 0;
   }
 }
 function incrMonthlyAnalytics(monthlyAnalytics) {
   try {
-    var currentDay = (new Date()).getDate();
+    const currentDay = (new Date()).getDate();
     // If we changed month, reset empty days.
     while (lastDay !== currentDay) {
       // Assumption: at least a hit a month.

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const logos = require('./load-logos')();
 
 function toArray(val) {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const {
   isDataUri,

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -1,28 +1,30 @@
-var fs = require('fs');
-var path = require('path');
-var SVGO = require('svgo');
-var dot = require('dot');
-var measureTextWidth = require('./measure-text.js');
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const SVGO = require('svgo');
+const dot = require('dot');
+const measureTextWidth = require('./measure-text.js');
 
 // cache templates.
-var templates = {};
-var templateFiles = fs.readdirSync(path.join(__dirname, '..', 'templates'));
+const templates = {};
+const templateFiles = fs.readdirSync(path.join(__dirname, '..', 'templates'));
 dot.templateSettings.strip = false;  // Do not strip whitespace.
 templateFiles.forEach(function(filename) {
   if (filename[0] === '.') { return; }
-  var templateData = fs.readFileSync(
+  const templateData = fs.readFileSync(
     path.join(__dirname, '..', 'templates', filename)).toString();
-  var extension = path.extname(filename).slice(1);
-  var style = filename.slice(0, -(('-template.' + extension).length));
+  const extension = path.extname(filename).slice(1);
+  const style = filename.slice(0, -(('-template.' + extension).length));
   // Compile the template. Necessary to always have a working template.
   templates[style + '-' + extension] = dot.template(templateData);
   if (extension === 'svg') {
     // Substitute dot code.
-    var mapping = new Map();
-    var mappingIndex = 1;
-    var untemplatedSvg = templateData.replace(/{{.*?}}/g, function(match) {
+    const mapping = new Map();
+    let mappingIndex = 1;
+    const untemplatedSvg = templateData.replace(/{{.*?}}/g, function(match) {
       // Weird substitution that currently works for all templates.
-      var mapKey = '99999990' + mappingIndex + '.1';
+      const mapKey = '99999990' + mappingIndex + '.1';
       mappingIndex++;
       mapping.set(mapKey, match);
       return mapKey;
@@ -35,10 +37,10 @@ templateFiles.forEach(function(filename) {
         return;
       }
       // Substitute dot code back.
-      var svg = object.data;
-      var unmappedKeys = [];
+      let svg = object.data;
+      const unmappedKeys = [];
       mapping.forEach(function(value, key) {
-        var keySubstituted = false;
+        let keySubstituted = false;
         svg = svg.replace(RegExp(key, 'g'), function() {
           keySubstituted = true;
           return value;
@@ -76,14 +78,14 @@ function addEscapers(data) {
   data.capitalize = capitalize;
 }
 
-var colorscheme = require(path.join(__dirname, 'colorscheme.json'));
+const colorscheme = require(path.join(__dirname, 'colorscheme.json'));
 
 function compressSvg(string, callback) {
-  var svgo = new SVGO();
+  const svgo = new SVGO();
   svgo.optimize(string, callback);
 }
 
-var cssColor = /^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/;
+const cssColor = /^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/;
 
 function makeImage(data, cb) {
   if (data.format !== 'json') {
@@ -93,7 +95,7 @@ function makeImage(data, cb) {
     data.template = 'flat';
   }
   if (data.colorscheme) {
-    var pickedColorscheme = colorscheme[data.colorscheme];
+    let pickedColorscheme = colorscheme[data.colorscheme];
     if (!pickedColorscheme) {
       pickedColorscheme = colorscheme.red;
     }
@@ -113,8 +115,8 @@ function makeImage(data, cb) {
     data.logoPadding = 0;
   }
 
-  var textWidth1 = (measureTextWidth(data.text[0])|0);
-  var textWidth2 = (measureTextWidth(data.text[1])|0);
+  let textWidth1 = (measureTextWidth(data.text[0])|0);
+  let textWidth2 = (measureTextWidth(data.text[1])|0);
   // Increase chances of pixel grid alignment.
   if (textWidth1 % 2 === 0) { textWidth1++; }
   if (textWidth2 % 2 === 0) { textWidth2++; }
@@ -125,15 +127,16 @@ function makeImage(data, cb) {
   if (data.links === undefined) {
     data.links = ['', ''];
   } else {
-    for (var i = 0; i < data.links.length; i++) {
+    for (let i = 0; i < data.links.length; i++) {
       data.links[i] = escapeXml(data.links[i]);
     }
   }
 
-  var template = templates[data.template + '-' + data.format];
+  const template = templates[data.template + '-' + data.format];
   addEscapers(data);
+  let result;
   try {
-    var result = template(data);
+    result = template(data);
   } catch(e) {
     cb('', e);
     return;

--- a/lib/badge.spec.js
+++ b/lib/badge.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const badge = require('./badge');
 const isSvg = require('is-svg');

--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -5,7 +5,7 @@
 'use strict';
 
 function versionFormatter(version) {
-  var first = version[0];
+  let first = version[0];
   if (first === 'v') {
     first = version[1];
   } else if (/^[0-9]/.test(version)) {

--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -1,18 +1,20 @@
-var querystring = require('querystring');
-var request = require('request');
-var autosave = require('json-autosave');
-var serverSecrets;
-var baseUrl = process.env.BASE_URL || "https://shields.io";
+'use strict';
+
+const querystring = require('querystring');
+const request = require('request');
+const autosave = require('json-autosave');
+let serverSecrets;
+const baseUrl = process.env.BASE_URL || 'https://shields.io';
 try {
   // Everything that cannot be checked in but is useful server-side
   // is stored in this JSON data.
   serverSecrets = require('../private/secret.json');
 } catch(e) {}
-var githubUserTokens = {data:[]};
-var githubUserTokensFile = './private/github-user-tokens.json';
-autosave(githubUserTokensFile, {data:[]}).then(function(f) {
+let githubUserTokens = {data: []};
+const githubUserTokensFile = './private/github-user-tokens.json';
+autosave(githubUserTokensFile, {data: []}).then(function(f) {
   githubUserTokens = f;
-  for (var i = 0; i < githubUserTokens.data.length; i++) {
+  for (let i = 0; i < githubUserTokens.data.length; i++) {
     addGithubToken(githubUserTokens.data[i]);
   }
   // Personal tokens allow access to GitHub private repositories.
@@ -28,7 +30,7 @@ function setRoutes(server) {
     if (!(serverSecrets && serverSecrets.gh_client_id)) {
       return end('This server is missing GitHub client secrets.');
     }
-    var query = querystring.stringify({
+    const query = querystring.stringify({
       client_id: serverSecrets.gh_client_id,
       redirect_uri: baseUrl + '/github-auth/done',
     });
@@ -44,7 +46,7 @@ function setRoutes(server) {
     if (!data.code) {
       return end('GitHub OAuth authentication failed to provide a code.');
     }
-    var options = {
+    const options = {
       url: 'https://github.com/login/oauth/access_token',
       headers: {
         'Content-type': 'application/x-www-form-urlencoded;charset=UTF-8',
@@ -59,10 +61,11 @@ function setRoutes(server) {
     };
     request(options, function(err, res, body) {
       if (err != null) { return end('The connection to GitHub failed.'); }
+      let content;
       try {
-        var content = querystring.parse(body);
+        content = querystring.parse(body);
       } catch(e) { return end('The GitHub OAuth token could not be parsed.'); }
-      var token = content.access_token;
+      const token = content.access_token;
       if (!token) {
         return end('The GitHub OAuth process did not return a user token.');
       }
@@ -96,10 +99,10 @@ function setRoutes(server) {
 }
 
 function sendTokenToAllServers(token) {
-  var ips = serverSecrets.shieldsIps;
+  const ips = serverSecrets.shieldsIps;
   return Promise.all(ips.map(function(ip) {
     return new Promise(function(resolve, reject) {
-      var options = {
+      const options = {
         url: 'https://' + ip + '/github-auth/add-token',
         method: 'POST',
         form: {
@@ -127,8 +130,8 @@ function sendTokenToAllServers(token) {
 // Track rate limit requests remaining.
 
 // Ideally, we would want priority queues here.
-var reqRemaining = new Map();  // From token to requests remaining.
-var reqReset = new Map();  // From token to timestamp.
+const reqRemaining = new Map();  // From token to requests remaining.
+const reqReset = new Map();  // From token to timestamp.
 
 // token: client token as a string.
 // reqs: number of requests remaining.
@@ -147,23 +150,23 @@ function utcEpochSeconds() {
   return ((Date.now() / 1000) >>> 0);
 }
 
-var userTokenRateLimit = 12500;
+const userTokenRateLimit = 12500;
 
 // Return false if the token cannot reasonably be expected to perform
 // a GitHub request.
 function isTokenUsable(token, now) {
-  var reqs = reqRemaining.get(token);
-  var reset = reqReset.get(token);
+  const reqs = reqRemaining.get(token);
+  const reset = reqReset.get(token);
   // We don't want to empty more than 3/4 of a user's rate limit.
-  var hasRemainingReqs = reqs > (userTokenRateLimit / 4);
-  var isBeyondRateLimitReset = reset < now;
+  const hasRemainingReqs = reqs > (userTokenRateLimit / 4);
+  const isBeyondRateLimitReset = reset < now;
   return hasRemainingReqs || isBeyondRateLimitReset;
 }
 
 // Return a list of tokens (as strings) which can be used for a GitHub request,
 // with a reasonable chance that the request will succeed.
 function usableTokens() {
-  var now = utcEpochSeconds();
+  const now = utcEpochSeconds();
   return githubUserTokens.data.filter(function(token) {
     return isTokenUsable(token, now);
   });
@@ -175,12 +178,12 @@ function getReqRemainingToken() {
   // Go through the user tokens.
   // Among usable ones, use the one with the highest number of remaining
   // requests.
-  var tokens = usableTokens();
-  var highestReq = -1;
-  var highestToken;
-  for (var i = 0; i < tokens.length; i++) {
-    var token = tokens[i];
-    var reqs = reqRemaining.get(token);
+  const tokens = usableTokens();
+  let highestReq = -1;
+  let highestToken;
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const reqs = reqRemaining.get(token);
     if (reqs > highestReq) {
       highestReq = reqs;
       highestToken = token;
@@ -201,7 +204,7 @@ function addGithubToken(token) {
 function rmGithubToken(token) {
   rmReqRemaining(token);
   // Remove it only if it is in there.
-  var idx = githubUserTokens.data.indexOf(token);
+  const idx = githubUserTokens.data.indexOf(token);
   if (idx >= 0) {
     githubUserTokens.data.splice(idx, 1);
   }
@@ -213,11 +216,11 @@ function githubRequest(request, url, query, cb) {
   query = query || {};
   // A special User-Agent is required:
   // http://developer.github.com/v3/#user-agent-required
-  var headers = {
+  const headers = {
     'User-Agent': 'Shields.io',
     'Accept': 'application/vnd.github.v3+json',
   };
-  var githubToken = getReqRemainingToken();
+  const githubToken = getReqRemainingToken();
 
   if (githubToken != null) {
     // Typically, GitHub user tokens grants us 12500 req/hour.
@@ -229,16 +232,16 @@ function githubRequest(request, url, query, cb) {
     query.client_secret = serverSecrets.gh_client_secret;
   }
 
-  var qs = querystring.stringify(query);
+  const qs = querystring.stringify(query);
   if (qs) { url += '?' + qs; }
   request(url, {headers: headers}, function(err, res, buffer) {
     if (githubToken != null) {
       if (res.statusCode === 401) {  // Unauthorized.
         rmGithubToken(githubToken);
       } else {
-        var remaining = +res.headers['x-ratelimit-remaining'];
+        const remaining = +res.headers['x-ratelimit-remaining'];
         // reset is in UTC epoch seconds.
-        var reset = +res.headers['x-ratelimit-reset'];
+        const reset = +res.headers['x-ratelimit-reset'];
         setReqRemaining(githubToken, remaining, reset);
         if (remaining === 0) { return; }  // Hope for the best in the cache.
       }
@@ -249,8 +252,8 @@ function githubRequest(request, url, query, cb) {
 
 function constEq(a, b) {
   if (a.length !== b.length) { return false; }
-  var zero = 0;
-  for (var i = 0; i < a.length; i++) {
+  let zero = 0;
+  for (let i = 0; i < a.length; i++) {
     zero |= a.charCodeAt(i) ^ b.charCodeAt(i);
   }
   return (zero === 0);

--- a/lib/load-logos.js
+++ b/lib/load-logos.js
@@ -1,22 +1,24 @@
-var fs = require('fs');
-var path = require('path');
+'use strict';
 
-var loadLogos = function() {
+const fs = require('fs');
+const path = require('path');
+
+function loadLogos () {
   // Cache svg logos from disk in base64 string
-  var logos = {};
-  var logoDir = path.join(__dirname, '..', 'logo');
-  var logoFiles = fs.readdirSync(logoDir);
+  const logos = {};
+  const logoDir = path.join(__dirname, '..', 'logo');
+  const logoFiles = fs.readdirSync(logoDir);
   logoFiles.forEach(function(filename) {
     if (filename[0] === '.') { return; }
     // filename is eg, github.svg
-    var svg = fs.readFileSync(logoDir + '/' + filename).toString();
+    const svg = fs.readFileSync(logoDir + '/' + filename).toString();
 
     // eg, github
-    var name = filename.slice(0, -('.svg'.length));
+    const name = filename.slice(0, -('.svg'.length));
     logos[name] = 'data:image/svg+xml;base64,' +
       Buffer.from(svg).toString('base64');
   });
   return logos;
-};
+}
 
 module.exports = loadLogos;

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Zero-pad a number in a string.
 // eg. 4 becomes 04 but 17 stays 17.
 function pad(string) {

--- a/lib/lru-cache.js
+++ b/lib/lru-cache.js
@@ -1,6 +1,8 @@
+'use strict';
+
 // In-memory KV, remove the oldest data when the capacity is reached.
 
-var typeEnum = {
+const typeEnum = {
   unit: 0,
   heap: 1,
 };
@@ -24,22 +26,22 @@ function Cache(capacity, type) {
 
 Cache.prototype = {
   set: function addToCache(cacheKey, cached) {
-    var slot = this.cache.get(cacheKey);
+    let slot = this.cache.get(cacheKey);
     if (slot === undefined) {
       slot = new CacheSlot(cacheKey, cached);
       this.cache.set(cacheKey, slot);
     }
     this.makeNewest(slot);
-    var numItemsToRemove = this.limitReached();
+    const numItemsToRemove = this.limitReached();
     if (numItemsToRemove > 0) {
-      for (var i = 0; i < numItemsToRemove; i++) {
+      for (let i = 0; i < numItemsToRemove; i++) {
         this.removeOldest();
       }
     }
   },
 
   get: function getFromCache(cacheKey) {
-    var slot = this.cache.get(cacheKey);
+    const slot = this.cache.get(cacheKey);
     if (slot !== undefined) {
       this.makeNewest(slot);
       return slot.value;
@@ -51,10 +53,10 @@ Cache.prototype = {
   },
 
   makeNewest: function makeNewestSlot(slot) {
-    var previousNewest = this.newest;
+    const previousNewest = this.newest;
     if (previousNewest === slot) { return; }
-    var older = slot.older;
-    var newer = slot.newer;
+    const older = slot.older;
+    const newer = slot.newer;
 
     if (older !== null) {
       older.newer = newer;
@@ -77,7 +79,7 @@ Cache.prototype = {
   },
 
   removeOldest: function removeOldest() {
-    var cacheKey = this.oldest.key;
+    const cacheKey = this.oldest.key;
     if (this.oldest !== null) {
       this.oldest = this.oldest.newer;
       if (this.oldest !== null) {
@@ -112,8 +114,8 @@ Cache.prototype = {
 };
 
 // In bytes.
-var heapSize;
-var heapSizeTimeout;
+let heapSize;
+let heapSizeTimeout;
 function getHeapSize() {
   if (heapSizeTimeout == null) {
     // Compute the heap size every 60 seconds.

--- a/lib/lru-cache.spec.js
+++ b/lib/lru-cache.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const LRU = require('./lru-cache');
 

--- a/lib/luarocks-version.js
+++ b/lib/luarocks-version.js
@@ -29,9 +29,9 @@ exports.compareVersionLists = compareVersionLists;
 // 'rc', 'pre', 'beta', 'alpha' are converted to negative numbers
 function parseVersion(versionString) {
   versionString = versionString.toLowerCase().replace('-', '.');
-  let versionList = [];
+  const versionList = [];
   versionString.split('.').forEach(function(versionPart) {
-    let parsedPart = /(\d*)([a-z]*)(\d*)/.exec(versionPart);
+    const parsedPart = /(\d*)([a-z]*)(\d*)/.exec(versionPart);
     if (parsedPart[1]) {
       versionList.push(parseInt(parsedPart[1]));
     }

--- a/lib/measure-text.js
+++ b/lib/measure-text.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var path = require('path');
-var PDFDocument = require('pdfkit');
-var doc = new PDFDocument({size:'A4', layout:'landscape'});
+const path = require('path');
+const PDFDocument = require('pdfkit');
+let doc = new PDFDocument({size: 'A4', layout: 'landscape'});
 
 // Attempt to use a particular font.
 // callback: (optional) takes an error if it failed.

--- a/lib/php-version.js
+++ b/lib/php-version.js
@@ -15,17 +15,18 @@ const {listCompare} = require('./version.js');
 // and https://github.com/badges/shields/issues/319#issuecomment-74411045
 function compare(v1, v2) {
   // Omit the starting `v`.
-  var rawv1 = omitv(v1);
-  var rawv2 = omitv(v2);
+  const rawv1 = omitv(v1);
+  const rawv2 = omitv(v2);
+  let v1data, v2data;
   try {
-    var v1data = numberedVersionData(rawv1);
-    var v2data = numberedVersionData(rawv2);
+    v1data = numberedVersionData(rawv1);
+    v2data = numberedVersionData(rawv2);
   } catch(e) {
     return asciiVersionCompare(rawv1, rawv2);
   }
 
   // Compare the numbered part (eg, 1.0.0 < 2.0.0).
-  var numbersCompare = listCompare(v1data.numbers, v2data.numbers);
+  const numbersCompare = listCompare(v1data.numbers, v2data.numbers);
   if (numbersCompare !== 0) {
     return numbersCompare;
   }
@@ -49,8 +50,8 @@ function compare(v1, v2) {
 exports.compare = compare;
 
 function latest(versions) {
-  var latest = versions[0];
-  for (var i = 1; i < versions.length; i++) {
+  let latest = versions[0];
+  for (let i = 1; i < versions.length; i++) {
     if (compare(latest, versions[i]) < 0) {
       latest = versions[i];
     }
@@ -61,9 +62,10 @@ exports.latest = latest;
 
 // Whether a version is stable.
 function isStable(version) {
-  var rawVersion = omitv(version);
+  const rawVersion = omitv(version);
+  let versionData;
   try {
-    var versionData = numberedVersionData(rawVersion);
+    versionData = numberedVersionData(rawVersion);
   } catch(e) {
     return false;
   }
@@ -101,8 +103,8 @@ function asciiVersionCompare(v1, v2) {
 function numberedVersionData(version) {
   // A version has a numbered part and a modifier part
   // (eg, 1.0.0-patch, 2.0.x-dev).
-  var parts = version.split('-');
-  var numbered = parts[0];
+  const parts = version.split('-');
+  const numbered = parts[0];
 
   // Aliases that get caught here.
   if (numbered === 'dev') {
@@ -113,13 +115,13 @@ function numberedVersionData(version) {
     };
   }
 
-  var modifierLevel = 3;
-  var modifierLevelCount = 0;
+  let modifierLevel = 3;
+  let modifierLevelCount = 0;
 
   if (parts.length > 1) {
-    var modifier = parts[parts.length - 1];
-    var firstLetter = modifier.charCodeAt(0);
-    var modifierLevelCountString;
+    const modifier = parts[parts.length - 1];
+    const firstLetter = modifier.charCodeAt(0);
+    let modifierLevelCountString;
 
     // Modifiers: alpha < beta < RC < normal < patch < dev
     if (firstLetter === 97) { // a
@@ -164,14 +166,14 @@ function numberedVersionData(version) {
   }
 
   // Try to convert to a list of numbers.
-  var toNum = function(s) {
-    var n = +s;
+  function toNum (s) {
+    let n = +s;
     if (n !== n) {  // If n is NaN…
       n = 0xffffffff;
     }
     return n;
-  };
-  var numberList = numbered.split('.').map(toNum);
+  }
+  const numberList = numbered.split('.').map(toNum);
 
   return {
     numbers: numberList,

--- a/lib/server-secrets.js
+++ b/lib/server-secrets.js
@@ -1,3 +1,5 @@
+'use strict';
+
 // Everything that cannot be checked in but is useful server-side is stored in
 // a JSON data file: private/secret.json.
 

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -1,6 +1,8 @@
-var nodeUrl = require('url');
-var request = require('request');
-var serverSecrets = require('./server-secrets');
+'use strict';
+
+const nodeUrl = require('url');
+const request = require('request');
+const serverSecrets = require('./server-secrets');
 
 // data: {url}, JSON-serializable object.
 // end: function(json), with json of the form:
@@ -8,28 +10,29 @@ var serverSecrets = require('./server-secrets');
 //    - link: target as a string URL.
 //    - badge: shields image URL.
 //    - name: string
-var suggest = function(data, end, ask) {
-  var origin = ask.req.headers['origin'];
+function suggest (data, end, ask) {
+  const origin = ask.req.headers['origin'];
   if (/^https?:\/\/shields\.io$/.test(origin)) {
     ask.res.setHeader('Access-Control-Allow-Origin', origin);
   } else {
     ask.res.setHeader('Access-Control-Allow-Origin', 'null');
-    end({err:'Disallowed'});
+    end({err: 'Disallowed'});
     return;
   }
+  let url;
   try {
-    var url = nodeUrl.parse(data.url);
-  } catch(e) { end({err:''+e}); return; }
+    url = nodeUrl.parse(data.url);
+  } catch(e) { end({err: ''+e}); return; }
   findSuggestions(url, end);
-};
+}
 
 // url: string
 // cb: function({badges})
-var findSuggestions = function(url, cb) {
-  var userRepo = url.pathname.slice(1).split('/');
-  var user = userRepo[0];
-  var repo = userRepo[1];
-  var promises = [];
+function findSuggestions (url, cb) {
+  const userRepo = url.pathname.slice(1).split('/');
+  const user = userRepo[0];
+  const repo = userRepo[1];
+  let promises = [];
   if (url.hostname === 'github.com') {
     promises = promises.concat([
       githubIssues(user, repo),
@@ -40,71 +43,74 @@ var findSuggestions = function(url, cb) {
   }
   promises.push(twitterPage(url));
   Promise.all(promises).then(function(badges) {
-    cb({badges:badges.filter(function(b) { return b != null; })});
+    cb({badges: badges.filter(function(b) { return b != null; })});
   }).catch(function(err) {
-    cb({badges:[], err:err});
+    cb({badges: [], err: err});
   });
-};
+}
 
-var twitterPage = function(url) {
-  var schema = url.protocol.slice(0, -1);
-  var host = url.host;
-  var path = url.path;
+function twitterPage (url) {
+  const schema = url.protocol.slice(0, -1);
+  const host = url.host;
+  const path = url.path;
   return Promise.resolve({
     name: 'Twitter',
     link: 'https://twitter.com/intent/tweet?text=Wow:&url=' + encodeURIComponent(url),
     badge: 'https://img.shields.io/twitter/url/' + schema + '/' + host + path + '.svg?style=social',
   });
-};
-var githubIssues = function(user, repo) {
-  var userRepo = user + '/' + repo;
+}
+
+function githubIssues (user, repo) {
+  const userRepo = user + '/' + repo;
   return Promise.resolve({
     name: 'GitHub issues',
     link: 'https://github.com/' + userRepo + '/issues',
     badge: 'https://img.shields.io/github/issues/' + userRepo + '.svg',
   });
-};
-var githubForks = function(user, repo) {
-  var userRepo = user + '/' + repo;
+}
+
+function githubForks (user, repo) {
+  const userRepo = user + '/' + repo;
   return Promise.resolve({
     name: 'GitHub forks',
     link: 'https://github.com/' + userRepo + '/network',
     badge: 'https://img.shields.io/github/forks/' + userRepo + '.svg',
   });
-};
-var githubStars = function(user, repo) {
-  var userRepo = user + '/' + repo;
+}
+
+function githubStars (user, repo) {
+  const userRepo = user + '/' + repo;
   return Promise.resolve({
     name: 'GitHub stars',
     link: 'https://github.com/' + userRepo + '/stargazers',
     badge: 'https://img.shields.io/github/stars/' + userRepo + '.svg',
   });
-};
+}
 
 // user: eg, qubyte
 // repo: eg, rubidium
 // returns a promise of {link, badge, name}
-var githubLicense = function(user, repo) {
+function githubLicense (user, repo) {
   return new Promise(function(resolve, reject) {
     // Step 1: Get the repo's default branch.
-    var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '';
+    let apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '';
     // Using our OAuth App secret grants us 5000 req/hour
     // instead of the standard 60 req/hour.
     if (serverSecrets) {
       apiUrl += '?client_id=' + serverSecrets.gh_client_id
         + '&client_secret=' + serverSecrets.gh_client_secret;
     }
-    var badgeData = {text:['license',''], colorscheme:'blue'};
+    const badgeData = {text: ['license',''], colorscheme: 'blue'};
     // A special User-Agent is required:
     // http://developer.github.com/v3/#user-agent-required
     request(apiUrl, { headers: { 'User-Agent': 'Shields.io' } }, function(err, res, buffer) {
       if (err != null) { resolve(null); return; }
       try {
         if ((+res.headers['x-ratelimit-remaining']) === 0) { resolve(null); return; }
-        var data = JSON.parse(buffer);
-        var defaultBranch = data.default_branch;
+        const data = JSON.parse(buffer);
+        const defaultBranch = data.default_branch;
         // Step 2: Get the SHA-1 hash of the branch tip.
-        var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/branches/' + defaultBranch;
+        let apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/branches/' + defaultBranch;
         if (serverSecrets) {
           apiUrl += '?client_id=' + serverSecrets.gh_client_id
             + '&client_secret=' + serverSecrets.gh_client_secret;
@@ -113,10 +119,10 @@ var githubLicense = function(user, repo) {
           if (err != null) { resolve(null); return; }
           try {
             if ((+res.headers['x-ratelimit-remaining']) === 0) { resolve(null); return; }
-            var data = JSON.parse(buffer);
-            var branchTip = data.commit.sha;
+            const data = JSON.parse(buffer);
+            const branchTip = data.commit.sha;
             // Step 3: Get the tree at the commit.
-            var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/git/trees/' + branchTip;
+            let apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/git/trees/' + branchTip;
             if (serverSecrets) {
               apiUrl += '?client_id=' + serverSecrets.gh_client_id
                 + '&client_secret=' + serverSecrets.gh_client_secret;
@@ -125,12 +131,12 @@ var githubLicense = function(user, repo) {
               if (err != null) { resolve(null); return; }
               try {
                 if ((+res.headers['x-ratelimit-remaining']) === 0) { resolve(null); return; }
-                var data = JSON.parse(buffer);
-                var treeArray = data.tree;
-                var licenseBlob;
-                var licenseFilename;
+                const data = JSON.parse(buffer);
+                const treeArray = data.tree;
+                let licenseBlob;
+                let licenseFilename;
                 // Crawl each file in the root directory
-                for (var i = 0; i < treeArray.length; i++) {
+                for (let i = 0; i < treeArray.length; i++) {
                   if (treeArray[i].type != 'blob') {
                     continue;
                   }
@@ -144,8 +150,8 @@ var githubLicense = function(user, repo) {
                 if (!licenseBlob) { resolve(null); return; }
 
                 // Step 4: Get the license blob.
-                var apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/git/blobs/' + licenseBlob;
-                var link = 'https://raw.githubusercontent.com/' +
+                let apiUrl = 'https://api.github.com/repos/' + user + '/' + repo + '/git/blobs/' + licenseBlob;
+                const link = 'https://raw.githubusercontent.com/' +
                   [user, repo, defaultBranch, licenseFilename].join('/');
 
                 if (serverSecrets) {
@@ -159,7 +165,7 @@ var githubLicense = function(user, repo) {
                   if (err != null) { resolve(null); return; }
                   try {
                     if ((+res.headers['x-ratelimit-remaining']) === 0) { resolve(null); return; }
-                    var license = guessLicense(buffer);
+                    const license = guessLicense(buffer);
                     if (license) {
                       badgeData.text[1] = license;
                       resolve({
@@ -182,10 +188,10 @@ var githubLicense = function(user, repo) {
       } catch(e) { reject(e); return; }
     });
   });
-};
+}
 
 // Key phrases for common licenses
-var licensePhrases = {
+const licensePhrases = {
   'Apache 1.1': 'apache (software )?license,? (version)? 1\\.1',
   'Apache 2': 'apache (software )?license,? (version)? 2',
   'Original BSD': 'all advertising materials mentioning features or use of this software must display the following acknowledgement',
@@ -213,18 +219,18 @@ var licensePhrases = {
   'CC0': 'cc0',
   'Unlicense': 'this is free and unencumbered software released into the public domain',
 };
-var licenseCodes = Object.keys(licensePhrases);
-var spaceMetaRegex = new RegExp(' ', 'g');
+const licenseCodes = Object.keys(licensePhrases);
+const spaceMetaRegex = new RegExp(' ', 'g');
 
 // Spaces can be any whitespace
-for (var i = 0; i < licenseCodes.length; i++) {
+for (let i = 0; i < licenseCodes.length; i++) {
   licensePhrases[licenseCodes[i]] = licensePhrases[licenseCodes[i]].replace(spaceMetaRegex, '\\s+');
 }
 
 // Try to guess the license based on the text and return an abbreviated name (or null if not recognized).
-var guessLicense = function(text) {
-  var licenseRegex;
-  for (var i = 0; i < licenseCodes.length; i++) {
+function guessLicense (text) {
+  let licenseRegex;
+  for (let i = 0; i < licenseCodes.length; i++) {
     licenseRegex = licensePhrases[licenseCodes[i]];
     if (text.match(new RegExp(licenseRegex, 'i'))) {
       return licenseCodes[i];
@@ -232,18 +238,18 @@ var guessLicense = function(text) {
   }
   // Not a recognized license
   return null;
-};
+}
 
 
-var shieldsBadge = function(badgeData) {
+function shieldsBadge (badgeData) {
   return ('https://img.shields.io/badge/'
     + escapeField(badgeData.text[0])
     + '-' + escapeField(badgeData.text[1])
     + '-' + badgeData.colorscheme + '.svg');
-};
+}
 
-var escapeField = function(s) {
+function escapeField (s) {
   return encodeURIComponent(s.replace(/-/g, '--').replace(/_/g, '__'));
-};
+}
 
 module.exports = suggest;

--- a/lib/svg-to-img.js
+++ b/lib/svg-to-img.js
@@ -1,21 +1,23 @@
-var gm = require('gm');
-var LruCache = require('./lru-cache.js');
+'use strict';
 
-var imageMagick = gm.subClass({ imageMagick: true });
+const gm = require('gm');
+const LruCache = require('./lru-cache.js');
+
+const imageMagick = gm.subClass({ imageMagick: true });
 
 // The following is an arbitrary limit (~1.5MB, 1.5kB/image).
-var imgCache = new LruCache(1000);
+const imgCache = new LruCache(1000);
 
 module.exports = function (svg, format, callback) {
-  var cacheIndex = format + svg;
+  const cacheIndex = format + svg;
   if (imgCache.has(cacheIndex)) {
     // We own a cache for this svg conversion.
-    var result = imgCache.get(cacheIndex);
+    const result = imgCache.get(cacheIndex);
     callback(null, result);
     return;
   }
 
-  var buf = Buffer.from('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + svg);
+  const buf = Buffer.from('<?xml version="1.0" encoding="UTF-8" standalone="yes"?>' + svg);
   imageMagick(buf, 'image.' + format)
   .density(90)
   .background(format === 'jpg' ? '#FFFFFF' : 'none')

--- a/lib/svg-to-img.spec.js
+++ b/lib/svg-to-img.spec.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const assert = require('assert');
 const badge = require('./badge');
 const isPng = require('is-png');

--- a/lib/test-config.js
+++ b/lib/test-config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = {
   port: 1111
 };

--- a/lib/text-formatters.js
+++ b/lib/text-formatters.js
@@ -5,7 +5,7 @@
 'use strict';
 
 function starRating(rating) {
-  var stars = '';
+  let stars = '';
   while (stars.length < rating) { stars += '★'; }
   while (stars.length < 5) { stars += '☆'; }
   return stars;
@@ -24,19 +24,19 @@ function currencyFromCode(code) {
 exports.currencyFromCode = currencyFromCode;
 
 function ordinalNumber(n) {
-  var s=["ᵗʰ","ˢᵗ","ⁿᵈ","ʳᵈ"], v=n%100;
+  const s=['ᵗʰ','ˢᵗ','ⁿᵈ','ʳᵈ'], v=n%100;
   return n+(s[(v-20)%10]||s[v]||s[0]);
 }
 exports.ordinalNumber = ordinalNumber;
 
 // Given a number, string with appropriate unit in the metric system, SI.
 // Note: numbers beyond the peta- cannot be represented as integers in JS.
-var metricPrefix = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
-var metricPower = metricPrefix
+const metricPrefix = ['k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'];
+const metricPower = metricPrefix
     .map(function(a, i) { return Math.pow(1000, i + 1); });
 function metric(n) {
-  for (var i = metricPrefix.length - 1; i >= 0; i--) {
-    var limit = metricPower[i];
+  for (let i = metricPrefix.length - 1; i >= 0; i--) {
+    const limit = metricPower[i];
     if (n >= limit) {
       n = Math.round(n / limit);
       return ''+n + metricPrefix[i];

--- a/lib/version.js
+++ b/lib/version.js
@@ -12,8 +12,8 @@ const semver = require('semver');
 // Given a list of versions (as strings), return the latest version.
 // Return undefined if no version could be found.
 function latest(versions) {
-  var version = '';
-  var origVersions = versions;
+  let version = '';
+  let origVersions = versions;
   versions = versions.filter(function(version) {
     return (/^v?[0-9]/).test(version);
   });
@@ -31,8 +31,8 @@ function latest(versions) {
 exports.latest = latest;
 
 function listCompare(a, b) {
-  var alen = a.length, blen = b.length;
-  for (var i = 0; i < alen; i++) {
+  const alen = a.length, blen = b.length;
+  for (let i = 0; i < alen; i++) {
     if (a[i] < b[i]) {
       return -1;
     } else if (a[i] > b[i]) {
@@ -48,10 +48,10 @@ exports.listCompare = listCompare;
 // Take a list of string versions.
 // Return the latest, or undefined, if there are none.
 function latestDottedVersion(versions) {
-  var len = versions.length;
+  const len = versions.length;
   if (len === 0) { return; }
-  var version = versions[0];
-  for (var i = 1; i < len; i++) {
+  let version = versions[0];
+  for (let i = 1; i < len; i++) {
     if (compareDottedVersion(version, versions[i]) < 0) {
       version = versions[i];
     }
@@ -62,19 +62,22 @@ function latestDottedVersion(versions) {
 // Take string versions.
 // -1 if v1 < v2, 1 if v1 > v2, 0 otherwise.
 function compareDottedVersion(v1, v2) {
-  var parts1 = /([0-9\.]+)(.*)$/.exec(v1);
-  var parts2 = /([0-9\.]+)(.*)$/.exec(v2);
+  const parts1 = /([0-9\.]+)(.*)$/.exec(v1);
+  const parts2 = /([0-9\.]+)(.*)$/.exec(v2);
   if (parts1 != null && parts2 != null) {
-    var numbers1 = parts1[1];
-    var numbers2 = parts2[1];
-    var distinguisher1 = parts1[2];
-    var distinguisher2 = parts2[2];
-    var numlist1 = numbers1.split('.').map(function(e) { return +e; });
-    var numlist2 = numbers2.split('.').map(function(e) { return +e; });
-    var cmp = listCompare(numlist1, numlist2);
-    if (cmp !== 0) { return cmp; }
-    else { return distinguisher1 < distinguisher2? -1:
-                  distinguisher1 > distinguisher2? 1: 0; }
+    const numbers1 = parts1[1];
+    const numbers2 = parts2[1];
+    const distinguisher1 = parts1[2];
+    const distinguisher2 = parts2[2];
+    const numlist1 = numbers1.split('.').map(function(e) { return +e; });
+    const numlist2 = numbers2.split('.').map(function(e) { return +e; });
+    const cmp = listCompare(numlist1, numlist2);
+    if (cmp !== 0) {
+      return cmp;
+    } else {
+      return distinguisher1 < distinguisher2? -1:
+        distinguisher1 > distinguisher2? 1: 0;
+    }
   }
   return v1 < v2? -1: v1 > v2? 1: 0;
 }

--- a/service-tests/.eslintrc.yml
+++ b/service-tests/.eslintrc.yml
@@ -1,17 +1,1 @@
-# Keep lib/.eslintrc.yml and service-tests/.eslintrc.yml in sync. For Windows
-# compatibility, the files are duplicated instead of symlinked.
-
-rules:
-  # From eslint-config-standard.
-  arrow-spacing: ["error", { "before": true, "after": true }]
-  brace-style: ["error", "1tbs", { "allowSingleLine": true }]
-  func-style: ["error", "declaration", { "allowArrowFunctions": true }]
-  indent: ["error", 2, { "SwitchCase": 1 }]
-  key-spacing: ["error", { "beforeColon": false, "afterColon": true }]
-  no-trailing-spaces: "error"
-  quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]
-
-  # Shields additions.
-  no-var: "error"
-  prefer-const: "error"
-  strict: "error"
+extends: '../.eslintrc-preferred.yml'

--- a/service-tests/.eslintrc.yml
+++ b/service-tests/.eslintrc.yml
@@ -1,0 +1,17 @@
+# Keep lib/.eslintrc.yml and service-tests/.eslintrc.yml in sync. For Windows
+# compatibility, the files are duplicated instead of symlinked.
+
+rules:
+  # From eslint-config-standard.
+  arrow-spacing: ["error", { "before": true, "after": true }]
+  brace-style: ["error", "1tbs", { "allowSingleLine": true }]
+  func-style: ["error", "declaration", { "allowArrowFunctions": true }]
+  indent: ["error", 2, { "SwitchCase": 1 }]
+  key-spacing: ["error", { "beforeColon": false, "afterColon": true }]
+  no-trailing-spaces: "error"
+  quotes: ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": true }]
+
+  # Shields additions.
+  no-var: "error"
+  prefer-const: "error"
+  strict: "error"

--- a/service-tests/ansible.js
+++ b/service-tests/ansible.js
@@ -9,22 +9,22 @@ module.exports = t;
 t.create('ansible role name')
  .get('/role/14542.json')
  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('role'),
-    value: Joi.equal('openwisp.openwisp2')
+   name: Joi.equal('role'),
+   value: Joi.equal('openwisp.openwisp2')
  }));
 
 t.create('ansible role download counts')
  .get('/role/d/14542.json')
  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('role downloads'),
-    value: Joi.string().regex(/^[0-9]+[kMG]?$/)
+   name: Joi.equal('role downloads'),
+   value: Joi.string().regex(/^[0-9]+[kMG]?$/)
  }));
 
 t.create('unkown role')
  .get('/role/000.json')
  .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('role'),
-    value: Joi.equal('not found')
+   name: Joi.equal('role'),
+   value: Joi.equal('not found')
  }));
 
 t.create('connection error')

--- a/service-tests/bower.js
+++ b/service-tests/bower.js
@@ -75,8 +75,8 @@ t.create('Version label should be `no releases` if no offical version. eg. bower
   .get('/v/bootstrap.json')
   .intercept(nock => nock('https://libraries.io')
     .get('/api/bower/bootstrap')
-    .reply(200, { latest_stable_release : { name: null } })) //or just `{}`
+    .reply(200, { latest_stable_release: { name: null } })) //or just `{}`
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('bower'),
     value: Joi.equal('no releases')
-}));
+  }));

--- a/service-tests/codetally.js
+++ b/service-tests/codetally.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
-const t = new ServiceTester({ id : 'codetally', title: 'Codetally' });
+const t = new ServiceTester({ id: 'codetally', title: 'Codetally' });
 module.exports = t;
 
 // This test will extract the currency value from the
@@ -25,6 +25,6 @@ t.create('Empty')
   .get('/triggerman722/colorstrap.json')
   .intercept(nock => nock('http://www.codetally.com')
     .get('/formattedshield/triggerman722/colorstrap')
-    .reply(200, { currency_sign:'$', amount:'0.00', multiplier:'', currency_abbreviation:'CAD' })
+    .reply(200, { currency_sign: '$', amount: '0.00', multiplier: '', currency_abbreviation: 'CAD' })
   )
   .expectJSON({ name: 'codetally', value: ' $0.00 '});

--- a/service-tests/conda.js
+++ b/service-tests/conda.js
@@ -1,9 +1,9 @@
-'use-strict';
+'use strict';
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
-const t = new ServiceTester({id:'conda', title:'Conda'});
+const t = new ServiceTester({id: 'conda', title: 'Conda'});
 module.exports = t;
 
 t.create('version')

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
-const t = new ServiceTester({ id : 'gratipay', title: 'Gratipay' });
+const t = new ServiceTester({ id: 'gratipay', title: 'Gratipay' });
 module.exports = t;
 
 t.create('Receiving')
@@ -18,6 +18,6 @@ t.create('Empty')
   .get('/Gratipay.json')
   .intercept(nock => nock('https://gratipay.com')
     .get('/Gratipay/public.json')
-    .reply(200, { receiving : 0.00 })
+    .reply(200, { receiving: 0.00 })
   )
   .expectJSON({ name: 'receives', value: '$0/week'});

--- a/service-tests/jetbrains.js
+++ b/service-tests/jetbrains.js
@@ -71,8 +71,8 @@ t.create('missing required XML element')
                      <!-- no required idea-plugin element here -->
                    </category>
                  </plugin-repository>`), {
-          'Content-Type': 'text/xml;charset=UTF-8'
-        })
+                   'Content-Type': 'text/xml;charset=UTF-8'
+                 })
   .expectJSON({ name: 'downloads', value: 'invalid' });
 
 t.create('missing required XML attribute')
@@ -97,8 +97,8 @@ t.create('missing required XML attribute')
                      </idea-plugin>
                    </category>
                  </plugin-repository>`), {
-          'Content-Type': 'text/xml;charset=UTF-8'
-        })
+                   'Content-Type': 'text/xml;charset=UTF-8'
+                 })
   .expectJSON({ name: 'downloads', value: 'invalid' });
 
 t.create('empty XML')
@@ -106,8 +106,8 @@ t.create('empty XML')
   .intercept(nock => nock('https://plugins.jetbrains.com')
     .get('/plugins/list?pluginId=9435')
     .reply(200, '<?xml version="1.0" encoding="UTF-8"?>'), {
-          'Content-Type': 'text/xml;charset=UTF-8'
-        })
+      'Content-Type': 'text/xml;charset=UTF-8'
+    })
   .expectJSON({ name: 'downloads', value: 'invalid' });
 
 t.create('404 status code')

--- a/service-tests/maintenance.js
+++ b/service-tests/maintenance.js
@@ -5,9 +5,7 @@ const ServiceTester = require('./runner/service-tester');
 const t = new ServiceTester({ id: 'maintenance', title: 'Maintenance' });
 module.exports = t;
 
-// variables for testing
-var now = new Date();
-var current_year = now.getUTCFullYear();
+const currentYear = (new Date()).getUTCFullYear();
 
 t.create('yes last maintained 2016 (no)')
   .get('/yes/2016.json')
@@ -18,9 +16,9 @@ t.create('no longer maintained 2017 (no)')
   .expectJSON({ name: 'maintained', value: 'no! (as of 2017)' });
 
 t.create('yes this year (yes)')
-  .get('/yes/' + current_year + '.json')
+  .get('/yes/' + currentYear + '.json')
   .expectJSON({ name: 'maintained', value: 'yes' });
 
-t.create('until end of ' + current_year + ' (yes)')
-  .get('/until end of ' + current_year + '/' + current_year + '.json')
-  .expectJSON({ name: 'maintained', value: 'until end of ' + current_year });
+t.create('until end of ' + currentYear + ' (yes)')
+  .get('/until end of ' + currentYear + '/' + currentYear + '.json')
+  .expectJSON({ name: 'maintained', value: 'until end of ' + currentYear });

--- a/service-tests/maven-central.js
+++ b/service-tests/maven-central.js
@@ -11,7 +11,7 @@ t.create('latest version')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('maven-central'),
     value: Joi.string().regex(/^v(.*)$/)
-}));
+  }));
 
 t.create('inexistent artifact')
   .get('/v/inexistent-group-id/inexistent-artifact-id.json')
@@ -26,5 +26,5 @@ t.create('xml parsing error')
   .get('/v/com.github.fabriziocucci/yacl4j.json')
   .intercept(nock => nock('http://repo1.maven.org/maven2')
     .get('/com/github/fabriziocucci/yacl4j/maven-metadata.xml')
-    .reply(200, "this should be a valid xml"))
+    .reply(200, 'this should be a valid xml'))
   .expectJSON({ name: 'maven-central', value: 'invalid' });

--- a/service-tests/nexus.js
+++ b/service-tests/nexus.js
@@ -11,7 +11,7 @@ t.create('search release version')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('nexus'),
     value: Joi.string().regex(/^4(\.\d+)+$/)
-}));
+  }));
 
 t.create('search release version of an inexistent artifact')
   .get('/r/https/repository.jboss.org/nexus/jboss/inexistent-artifact-id.json')
@@ -22,7 +22,7 @@ t.create('search snapshot version')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('nexus'),
     value: Joi.string().regex(/-SNAPSHOT$/)
-}));
+  }));
 
 t.create('search snapshot version not in latestSnapshot')
   .get('/s/https/repository.jboss.org/nexus/com.progress.fuse/fusehq.json')
@@ -45,14 +45,14 @@ t.create('resolve version')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('nexus'),
     value: Joi.string().regex(/^3(\.\d+)+$/)
-}));
+  }));
 
 t.create('resolve version with query')
   .get('/fs-public-snapshots/https/repository.jboss.org/nexus/com.progress.fuse/fusehq:c=agent-apple-osx:p=tar.gz.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('nexus'),
     value: Joi.string().regex(/^7(\.\d+)+-SNAPSHOT$/)
-}));
+  }));
 
 t.create('resolve version of an inexistent artifact')
   .get('/developer/https/repository.jboss.org/nexus/jboss/inexistent-artifact-id.json')
@@ -68,5 +68,5 @@ t.create('json parsing error')
   .intercept(nock => nock('https://repository.jboss.org')
     .get('/nexus/service/local/lucene/search')
     .query({g: 'jboss', a: 'jboss-client'})
-    .reply(200, "this should be a valid json"))
+    .reply(200, 'this should be a valid json'))
   .expectJSON({ name: 'nexus', value: 'invalid' });

--- a/service-tests/waffle.js
+++ b/service-tests/waffle.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
@@ -6,32 +8,32 @@ module.exports = t;
 
 
 const fakeData = [
-    {
-        githubMetadata: {
-            labels: [
-                { color: "c5def5", name: "feature" },
-                { color: "fbca04", name: "bug" },
-                { color: "e11d21", name: "bug" }
-            ]
-        }
-    },
-    {
-        githubMetadata: {
-            labels: [
-                { color: "c5def5", name: "feature" },
-                { color: "fbca04", name: "bug" },
-                { color: "e11d21", name: "feature" }
-            ]
-        }
-    },
-    {
-        githubMetadata: {
-            labels: [
-                { color: "c5def5", name: "bug" },
-                { color: "fbca04", name: "bug" }
-            ]
-        }
-    },
+  {
+    githubMetadata: {
+      labels: [
+                { color: 'c5def5', name: 'feature' },
+                { color: 'fbca04', name: 'bug' },
+                { color: 'e11d21', name: 'bug' }
+      ]
+    }
+  },
+  {
+    githubMetadata: {
+      labels: [
+                { color: 'c5def5', name: 'feature' },
+                { color: 'fbca04', name: 'bug' },
+                { color: 'e11d21', name: 'feature' }
+      ]
+    }
+  },
+  {
+    githubMetadata: {
+      labels: [
+                { color: 'c5def5', name: 'bug' },
+                { color: 'fbca04', name: 'bug' }
+      ]
+    }
+  },
 ];
 
 t.create('label should be `bug` & value should be exactly 5 as supplied in `fakeData`.  e.g: bug|5')
@@ -40,13 +42,13 @@ t.create('label should be `bug` & value should be exactly 5 as supplied in `fake
         .get('/userName/repoName/cards')
         .reply(200, fakeData))
     .expectJSONTypes(Joi.object().keys({
-        name: Joi.equal('bug'),
-        value: Joi.equal('5')
+      name: Joi.equal('bug'),
+      value: Joi.equal('5')
     }));
 
 t.create('label should be `Mybug` & value should be formated.  e.g: Mybug|25')
     .get('/label/ritwickdey/vscode-live-server/bug.json?label=Mybug')
     .expectJSONTypes(Joi.object().keys({
-        name: Joi.equal('Mybug'),
-        value: Joi.string().regex(/^\d+$/)
+      name: Joi.equal('Mybug'),
+      value: Joi.string().regex(/^\d+$/)
     }));


### PR DESCRIPTION
Because I despise nitpicking stuff like indentation and spacing in pull request comments, I'd like to nudge forward our automated style checking, at least for new files being added.

I don't want to totally rewrite server.js just to get automated style checking… the blame tracking is just too useful. So let's it's just take care of that when we start splitting it out.

More discussion in #948.