### PR TITLE
Enable node version for specific tag

### DIFF
--- a/try.html
+++ b/try.html
@@ -470,9 +470,21 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/npm/v/@cycle/core/canary.svg' alt=''/></td>
   <td><code>https://img.shields.io/npm/v/@cycle/core/canary.svg</code></td>
   </tr>
-  <tr><th> node: </th>
-  <td><img src='/node/v/gh-badges.svg' alt=''/></td>
-  <td><code>https://img.shields.io/node/v/gh-badges.svg</code></td>
+  <tr><th data-keywords='node'> node: </th>
+  <td><img src='/node/v/passport.svg' alt=''/></td>
+  <td><code>https://img.shields.io/node/v/passport.svg</code></td>
+  </tr>
+  <tr><th data-keywords='node'> node (scoped): </th>
+  <td><img src='/node/v/@stdlib/stdlib.svg' alt=''/></td>
+  <td><code>https://img.shields.io/node/v/@stdlib/stdlib.svg</code></td>
+  </tr>
+  <tr><th data-keywords='node'> node (tag): </th>
+  <td><img src='/node/v/passport/latest.svg' alt=''/></td>
+  <td><code>https://img.shields.io/node/v/passport/latest.svg</code></td>
+  </tr>
+  <tr><th data-keywords='node'> node (scoped with tag): </th>
+  <td><img src='/node/v/@stdlib/stdlib/latest.svg' alt=''/></td>
+  <td><code>https://img.shields.io/node/v/@stdlib/stdlib/latest.svg</code></td>
   </tr>
   <tr><th data-keywords='python'> PyPI: </th>
   <td><img src='/pypi/v/nine.svg' alt=''/></td>


### PR DESCRIPTION
This commit:

-   allows for getting the node version of a tag by appending `/<tag>` to the url.
-   allows for getting the node version for scoped packages.
-   adds node version examples

Builds on #926. Resolves #723.