### PR TITLE
Support named logos and omit logos by default

### DIFF
--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -28,13 +28,13 @@ function prependPrefix (s, prefix) {
   }
 }
 
-function isSixHex (s) {
-  return s !== undefined && /^[0-9a-fA-F]{6}$/.test(s);
-}
-
 function isValidStyle (style) {
   const validStyles = ['default', 'plastic', 'flat', 'flat-square', 'social'];
   return style ? validStyles.indexOf(style) >= 0 : false;
+}
+
+function isSixHex (s) {
+  return s !== undefined && /^[0-9a-fA-F]{6}$/.test(s);
 }
 
 function makeColor (color) {

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -1,3 +1,5 @@
+const logos = require('./load-logos')();
+
 function toArray (val) {
   if (val === undefined) {
     return [];
@@ -8,12 +10,20 @@ function toArray (val) {
   }
 }
 
-function prependDataScheme (s) {
-  if (/^data:/.test(s)) {
-    return s;
-  } else {
-    return 'data:' + s;
+function isDataUri(s) {
+  return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
+}
+
+function hasPrefix (s, prefix) {
+  return s !== undefined && s.slice(0, prefix.length) === prefix;
+}
+
+function prependPrefix (s, prefix) {
+  if (s === undefined) {
+    return undefined;
   }
+
+  return hasPrefix(s, prefix) ? s : prefix + s;
 }
 
 function isSixHex (s) {
@@ -42,6 +52,17 @@ function makeLabel (defaultLabel, overrides) {
   return overrides.label || defaultLabel;
 }
 
+function makeLogo (defaultNamedLogo, overrides) {
+  const maybeDataUri = prependPrefix(overrides.logo, 'data:');
+  const maybeNamedLogo = overrides.logo === undefined ? defaultNamedLogo : overrides.logo;
+
+  if (isDataUri(maybeDataUri)) {
+    return maybeDataUri;
+  } else {
+    return logos[maybeNamedLogo];
+  }
+}
+
 // Generate the initial badge data. Pass the URL query parameters, which
 // override the default label.
 //
@@ -62,7 +83,7 @@ function makeBadgeData (defaultLabel, overrides) {
     text: [makeLabel(defaultLabel, overrides), 'n/a'],
     colorscheme: 'lightgrey',
     template: isValidStyle(overrides.style) ? overrides.style : 'default',
-    logo: overrides.logo === undefined ? undefined : prependDataScheme(overrides.logo),
+    logo: makeLogo(undefined, overrides),
     logoWidth: +overrides.logoWidth,
     links: toArray(overrides.link),
     colorA: makeColor(overrides.colorA),
@@ -71,9 +92,12 @@ function makeBadgeData (defaultLabel, overrides) {
 }
 
 module.exports = {
+  hasPrefix,
+  isDataUri,
   isValidStyle,
   isDarkBackgroundStyle,
   isSixHex,
   makeLabel,
+  makeLogo,
   makeBadgeData,
 };

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -1,0 +1,79 @@
+function toArray (val) {
+  if (val === undefined) {
+    return [];
+  } else if (Object(val) instanceof Array) {
+    return val;
+  } else {
+    return [val];
+  }
+}
+
+function prependDataScheme (s) {
+  if (/^data:/.test(s)) {
+    return s;
+  } else {
+    return 'data:' + s;
+  }
+}
+
+function isSixHex (s) {
+  return s !== undefined && /^[0-9a-fA-F]{6}$/.test(s);
+}
+
+function isValidStyle (style) {
+  const validStyles = ['default', 'plastic', 'flat', 'flat-square', 'social'];
+  return style ? validStyles.indexOf(style) >= 0 : false;
+}
+
+function isDarkBackgroundStyle (style) {
+  const darkBackgroundTemplates = ['default', 'flat', 'flat-square'];
+  return style ? darkBackgroundTemplates.indexOf(style) >= 0 : false;
+}
+
+function makeColor (color) {
+  if (isSixHex(color)) {
+    return '#' + color;
+  } else {
+    return color;
+  }
+}
+
+function makeLabel (defaultLabel, overrides) {
+  return overrides.label || defaultLabel;
+}
+
+// Generate the initial badge data. Pass the URL query parameters, which
+// override the default label.
+//
+// The following parameters are supported:
+//
+//   - label
+//   - style
+//   - logo
+//   - logoWidth
+//   - link
+//   - colorA
+//   - colorB
+//   - maxAge
+//
+// Note: maxAge is handled by cache(), not this function.
+function makeBadgeData (defaultLabel, overrides) {
+  return {
+    text: [makeLabel(defaultLabel, overrides), 'n/a'],
+    colorscheme: 'lightgrey',
+    template: isValidStyle(overrides.style) ? overrides.style : 'default',
+    logo: overrides.logo === undefined ? undefined : prependDataScheme(overrides.logo),
+    logoWidth: +overrides.logoWidth,
+    links: toArray(overrides.link),
+    colorA: makeColor(overrides.colorA),
+    colorB: makeColor(overrides.colorB),
+  };
+}
+
+module.exports = {
+  isValidStyle,
+  isDarkBackgroundStyle,
+  isSixHex,
+  makeLabel,
+  makeBadgeData,
+};

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -1,6 +1,6 @@
 const logos = require('./load-logos')();
 
-function toArray (val) {
+function toArray(val) {
   if (val === undefined) {
     return [];
   } else if (Object(val) instanceof Array) {
@@ -14,11 +14,11 @@ function isDataUri(s) {
   return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
 }
 
-function hasPrefix (s, prefix) {
+function hasPrefix(s, prefix) {
   return s !== undefined && s.slice(0, prefix.length) === prefix;
 }
 
-function prependPrefix (s, prefix) {
+function prependPrefix(s, prefix) {
   if (s === undefined) {
     return undefined;
   } else if (hasPrefix(s, prefix)) {
@@ -28,16 +28,16 @@ function prependPrefix (s, prefix) {
   }
 }
 
-function isValidStyle (style) {
+function isValidStyle(style) {
   const validStyles = ['default', 'plastic', 'flat', 'flat-square', 'social'];
   return style ? validStyles.indexOf(style) >= 0 : false;
 }
 
-function isSixHex (s) {
+function isSixHex (s){
   return s !== undefined && /^[0-9a-fA-F]{6}$/.test(s);
 }
 
-function makeColor (color) {
+function makeColor(color) {
   if (isSixHex(color)) {
     return '#' + color;
   } else {
@@ -45,11 +45,11 @@ function makeColor (color) {
   }
 }
 
-function makeLabel (defaultLabel, overrides) {
+function makeLabel(defaultLabel, overrides) {
   return overrides.label || defaultLabel;
 }
 
-function makeLogo (defaultNamedLogo, overrides) {
+function makeLogo(defaultNamedLogo, overrides) {
   const maybeDataUri = prependPrefix(overrides.logo, 'data:');
   const maybeNamedLogo = overrides.logo === undefined ? defaultNamedLogo : overrides.logo;
 
@@ -75,7 +75,7 @@ function makeLogo (defaultNamedLogo, overrides) {
 //   - maxAge
 //
 // Note: maxAge is handled by cache(), not this function.
-function makeBadgeData (defaultLabel, overrides) {
+function makeBadgeData(defaultLabel, overrides) {
   return {
     text: [makeLabel(defaultLabel, overrides), 'n/a'],
     colorscheme: 'lightgrey',

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -21,9 +21,11 @@ function hasPrefix (s, prefix) {
 function prependPrefix (s, prefix) {
   if (s === undefined) {
     return undefined;
+  } else if (hasPrefix(s, prefix)) {
+    return s;
+  } else {
+    return prefix + s;
   }
-
-  return hasPrefix(s, prefix) ? s : prefix + s;
 }
 
 function isSixHex (s) {
@@ -33,11 +35,6 @@ function isSixHex (s) {
 function isValidStyle (style) {
   const validStyles = ['default', 'plastic', 'flat', 'flat-square', 'social'];
   return style ? validStyles.indexOf(style) >= 0 : false;
-}
-
-function isDarkBackgroundStyle (style) {
-  const darkBackgroundTemplates = ['default', 'flat', 'flat-square'];
-  return style ? darkBackgroundTemplates.indexOf(style) >= 0 : false;
 }
 
 function makeColor (color) {
@@ -95,7 +92,6 @@ module.exports = {
   hasPrefix,
   isDataUri,
   isValidStyle,
-  isDarkBackgroundStyle,
   isSixHex,
   makeLabel,
   makeLogo,

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -1,0 +1,62 @@
+const assert = require('assert');
+const {
+  isValidStyle,
+  isDarkBackgroundStyle,
+  isSixHex,
+  makeLabel,
+  makeBadgeData,
+} = require('./badge-data');
+
+describe('Badge data helpers', function () {
+  it('should detect valid styles', function () {
+    assert.equal(isValidStyle('flat'), true);
+    assert.equal(isValidStyle('flattery'), false);
+    assert.equal(isValidStyle(''), false);
+    assert.equal(isValidStyle(undefined), false);
+
+    assert.equal(isDarkBackgroundStyle('flat'), true);
+    assert.equal(isDarkBackgroundStyle('social'), false);
+    assert.equal(isDarkBackgroundStyle(''), false);
+    assert.equal(isDarkBackgroundStyle(undefined), false);
+  });
+
+  it('should detect valid six-hex strings', function () {
+    assert.equal(isSixHex('f00bae'), true);
+    assert.equal(isSixHex('f00bar'), false);
+    assert.equal(isSixHex(''), false);
+    assert.equal(isSixHex(undefined), false);
+  });
+
+  it('should make labels', function () {
+    assert.equal(makeLabel('my badge', {}), 'my badge');
+    assert.equal(makeLabel('my badge', { label: 'no, my badge' }), 'no, my badge');
+  });
+
+  it('should make badge data', function () {
+    const overrides = {
+      style: 'flat-square',
+      logo: '<rect></rect>',
+      logoWidth: '25',
+      link: 'https://example.com/',
+      colorA: 'blue',
+      colorB: 'f00bae',
+    };
+
+    const expected = {
+      text: ['my badge', 'n/a'],
+      colorscheme: 'lightgrey',
+      template: 'flat-square',
+      logo: 'data:<rect></rect>',
+      logoWidth: 25,
+      links: ['https://example.com/'],
+      colorA: 'blue',
+      colorB: '#f00bae',
+    };
+
+    assert.deepEqual(makeBadgeData('my badge', overrides), expected);
+
+    expected.text[0] = overrides.label = 'no, my badge';
+
+    assert.deepEqual(makeBadgeData('my badge', overrides), expected);
+  });
+});

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -9,8 +9,6 @@ const {
   makeBadgeData,
 } = require('./badge-data');
 
-
-
 describe('Badge data helpers', function () {
   it('should detect prefixes', function () {
     assert.equal(hasPrefix('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:'), true);
@@ -50,9 +48,13 @@ describe('Badge data helpers', function () {
     assert.equal(
       makeLogo('gratipay', { logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu' }),
       'data:image/svg+xml;base64,PHN2ZyB4bWxu');
-    assert.equal(makeLogo('gratipay', { logo: '' }), undefined);
+    assert.equal(
+      makeLogo('gratipay', { logo: '' }),
+      undefined);
+    assert.equal(
+      makeLogo(undefined, {}),
+      undefined);
     assert.ok(isDataUri(makeLogo('gratipay', {})));
-    assert.equal(makeLogo(undefined, {}), undefined);
   });
 
   it('should make badge data', function () {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -1,13 +1,31 @@
 const assert = require('assert');
+const isSvg = require('is-svg');
 const {
+  isDataUri,
+  hasPrefix,
   isValidStyle,
   isDarkBackgroundStyle,
   isSixHex,
   makeLabel,
+  makeLogo,
   makeBadgeData,
 } = require('./badge-data');
 
+
+
 describe('Badge data helpers', function () {
+  it('should detect prefixes', function () {
+    assert.equal(hasPrefix('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:'), true);
+    assert.equal(hasPrefix('data:foobar', 'data:'), true);
+    assert.equal(hasPrefix('foobar', 'data:'), false);
+  });
+
+  it('should detect valid image data URIs', function () {
+    assert.equal(isDataUri('data:image/svg+xml;base64,PHN2ZyB4bWxu'), true);
+    assert.equal(isDataUri('data:foobar'), false);
+    assert.equal(isDataUri('foobar'), false);
+  });
+
   it('should detect valid styles', function () {
     assert.equal(isValidStyle('flat'), true);
     assert.equal(isValidStyle('flattery'), false);
@@ -32,10 +50,23 @@ describe('Badge data helpers', function () {
     assert.equal(makeLabel('my badge', { label: 'no, my badge' }), 'no, my badge');
   });
 
+  it('should make logos', function () {
+    assert.equal(
+      makeLogo('gratipay', { logo: 'image/svg+xml;base64,PHN2ZyB4bWxu' }),
+      'data:image/svg+xml;base64,PHN2ZyB4bWxu');
+    assert.equal(
+      makeLogo('gratipay', { logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu' }),
+      'data:image/svg+xml;base64,PHN2ZyB4bWxu');
+    assert.equal(makeLogo('gratipay', { logo: '' }), undefined);
+    assert.ok(isDataUri(makeLogo('gratipay', {})));
+    assert.equal(makeLogo(undefined, {}), undefined);
+  });
+
   it('should make badge data', function () {
     const overrides = {
+      label: 'no, my badge',
       style: 'flat-square',
-      logo: '<rect></rect>',
+      logo: 'image/svg+xml;base64,PHN2ZyB4bWxu',
       logoWidth: '25',
       link: 'https://example.com/',
       colorA: 'blue',
@@ -43,19 +74,15 @@ describe('Badge data helpers', function () {
     };
 
     const expected = {
-      text: ['my badge', 'n/a'],
+      text: ['no, my badge', 'n/a'],
       colorscheme: 'lightgrey',
       template: 'flat-square',
-      logo: 'data:<rect></rect>',
+      logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
       logoWidth: 25,
       links: ['https://example.com/'],
       colorA: 'blue',
       colorB: '#f00bae',
     };
-
-    assert.deepEqual(makeBadgeData('my badge', overrides), expected);
-
-    expected.text[0] = overrides.label = 'no, my badge';
 
     assert.deepEqual(makeBadgeData('my badge', overrides), expected);
   });

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -9,39 +9,39 @@ const {
   makeBadgeData,
 } = require('./badge-data');
 
-describe('Badge data helpers', function () {
-  it('should detect prefixes', function () {
+describe('Badge data helpers', function() {
+  it('should detect prefixes', function() {
     assert.equal(hasPrefix('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:'), true);
     assert.equal(hasPrefix('data:foobar', 'data:'), true);
     assert.equal(hasPrefix('foobar', 'data:'), false);
   });
 
-  it('should detect valid image data URIs', function () {
+  it('should detect valid image data URIs', function() {
     assert.equal(isDataUri('data:image/svg+xml;base64,PHN2ZyB4bWxu'), true);
     assert.equal(isDataUri('data:foobar'), false);
     assert.equal(isDataUri('foobar'), false);
   });
 
-  it('should detect valid styles', function () {
+  it('should detect valid styles', function() {
     assert.equal(isValidStyle('flat'), true);
     assert.equal(isValidStyle('flattery'), false);
     assert.equal(isValidStyle(''), false);
     assert.equal(isValidStyle(undefined), false);
   });
 
-  it('should detect valid six-hex strings', function () {
+  it('should detect valid six-hex strings', function() {
     assert.equal(isSixHex('f00bae'), true);
     assert.equal(isSixHex('f00bar'), false);
     assert.equal(isSixHex(''), false);
     assert.equal(isSixHex(undefined), false);
   });
 
-  it('should make labels', function () {
+  it('should make labels', function() {
     assert.equal(makeLabel('my badge', {}), 'my badge');
     assert.equal(makeLabel('my badge', { label: 'no, my badge' }), 'no, my badge');
   });
 
-  it('should make logos', function () {
+  it('should make logos', function() {
     assert.equal(
       makeLogo('gratipay', { logo: 'image/svg+xml;base64,PHN2ZyB4bWxu' }),
       'data:image/svg+xml;base64,PHN2ZyB4bWxu');
@@ -57,7 +57,7 @@ describe('Badge data helpers', function () {
     assert.ok(isDataUri(makeLogo('gratipay', {})));
   });
 
-  it('should make badge data', function () {
+  it('should make badge data', function() {
     const overrides = {
       label: 'no, my badge',
       style: 'flat-square',

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -1,10 +1,8 @@
 const assert = require('assert');
-const isSvg = require('is-svg');
 const {
   isDataUri,
   hasPrefix,
   isValidStyle,
-  isDarkBackgroundStyle,
   isSixHex,
   makeLabel,
   makeLogo,
@@ -31,11 +29,6 @@ describe('Badge data helpers', function () {
     assert.equal(isValidStyle('flattery'), false);
     assert.equal(isValidStyle(''), false);
     assert.equal(isValidStyle(undefined), false);
-
-    assert.equal(isDarkBackgroundStyle('flat'), true);
-    assert.equal(isDarkBackgroundStyle('social'), false);
-    assert.equal(isDarkBackgroundStyle(''), false);
-    assert.equal(isDarkBackgroundStyle(undefined), false);
   });
 
   it('should detect valid six-hex strings', function () {

--- a/server.js
+++ b/server.js
@@ -60,12 +60,17 @@ const {
   incrMonthlyAnalytics,
   getAnalytics
 } = require('./lib/analytics');
+const {
+  isValidStyle,
+  isDarkBackgroundStyle,
+  isSixHex: sixHex,
+  makeLabel: getLabel,
+  makeBadgeData: getBadgeData,
+} = require('./lib/badge-data');
 
 var semver = require('semver');
 var serverStartTime = new Date((new Date()).toGMTString());
 
-var validTemplates = ['default', 'plastic', 'flat', 'flat-square', 'social'];
-var darkBackgroundTemplates = ['default', 'flat', 'flat-square'];
 var logos = loadLogos();
 
 analyticsAutoLoad();
@@ -5691,7 +5696,7 @@ cache(function(data, match, sendBadge, request) {
   var badgeData = getBadgeData('chat', data);
   badgeData.text[1] = 'on gitter';
   badgeData.colorscheme = 'brightgreen';
-  if (darkBackgroundTemplates.some(function(t) { return t === badgeData.template; })) {
+  if (isDarkBackgroundStyle(badgeData.template)) {
     badgeData.logo = badgeData.logo || logos['gitter-white'];
     badgeData.logoWidth = 9;
   }
@@ -6601,7 +6606,7 @@ function(data, match, end, ask) {
         badgeData.colorscheme = color;
       }
     }
-    if (data.style && validTemplates.indexOf(data.style) > -1) {
+    if (isValidStyle(data.style)) {
       badgeData.template = data.style;
     }
     badge(badgeData, makeSend(format, ask.res, end));
@@ -6681,53 +6686,6 @@ function escapeFormatSlashes(t) {
 }
 
 
-function sixHex(s) { return /^[0-9a-fA-F]{6}$/.test(s); }
-
-function getLabel(label, data) {
-  return data.label || label;
-}
-
-function colorParam(color) { return (sixHex(color) ? '#' : '') + color; }
-
-// data (URL query) can include `label`, `style`, `logo`, `logoWidth`, `link`,
-// `colorA`, `colorB`.
-// It can also include `maxAge`.
-function getBadgeData(defaultLabel, data) {
-  var label = getLabel(defaultLabel, data);
-  var template = data.style || 'default';
-  if (data.style && validTemplates.indexOf(data.style) > -1) {
-    template = data.style;
-  }
-  if (!(Object(data.link) instanceof Array)) {
-    if (data.link === undefined) {
-      data.link = [];
-    } else {
-      data.link = [data.link];
-    }
-  }
-
-  if (data.logo !== undefined && !/^data:/.test(data.logo)) {
-    data.logo = 'data:' + data.logo;
-  }
-
-  if (data.colorA !== undefined) {
-    data.colorA = colorParam(data.colorA);
-  }
-  if (data.colorB !== undefined) {
-    data.colorB = colorParam(data.colorB);
-  }
-
-  return {
-    text: [label, 'n/a'],
-    colorscheme: 'lightgrey',
-    template: template,
-    logo: data.logo,
-    logoWidth: +data.logoWidth,
-    links: data.link,
-    colorA: data.colorA,
-    colorB: data.colorB
-  };
-}
 
 function makeSend(format, askres, end) {
   if (format === 'svg') {


### PR DESCRIPTION
- Except for social badges, omit logos by default (#983)
- Omit the logo from a social badge using the query string: `?logo=` (#983)
- Opt in to named logos using the query string: `?logo=appveyor`
- Provide custom logo data as before: `?logo=data:image/png;base64,...`
- Rewrite badge data functions, with unit tests

Unit tests are covering the new code very well, though the underlying functionality (logos) is untested.