### PR TITLE
[chrome-web-store] Add tests, update labels

### DIFF
--- a/server.js
+++ b/server.js
@@ -6109,6 +6109,7 @@ cache(function(data, match, sendBadge, request) {
     }
     chromeWebStore.convert(buffer)
       .then(function (value) {
+        var rating;
         switch (type) {
           case 'v':
             var vdata = versionColor(value.version);
@@ -6128,13 +6129,13 @@ cache(function(data, match, sendBadge, request) {
             badgeData.colorscheme = 'brightgreen';
             break;
           case 'rating':
-            var rating = Math.round(value.ratingValue * 100) / 100;
+            rating = Math.round(value.ratingValue * 100) / 100;
             badgeData.text[0] = data.label || 'rating';
             badgeData.text[1] = rating + '/5';
             badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
             break;
           case 'stars':
-            var rating = Math.round(value.ratingValue);
+            rating = Math.round(value.ratingValue);
             badgeData.text[0] = data.label || 'rating';
             badgeData.text[1] = starRating(rating);
             badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);

--- a/server.js
+++ b/server.js
@@ -6093,7 +6093,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Chrome web store integration
-camp.route(/^\/chrome-web-store\/(v|d|u|price|rating|stars|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/chrome-web-store\/(v|d|users|price|rating|stars|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var storeId = match[2];  // eg, nimelepbpejjlbmoobocpfnjhihnpked
@@ -6117,7 +6117,7 @@ cache(function(data, match, sendBadge, request) {
             badgeData.colorscheme = vdata.color;
             break;
           case 'd':
-          case 'u':
+          case 'users':
             var downloads = value.interactionCount.UserDownloads;
             badgeData.text[0] = data.label || 'users';
             badgeData.text[1] = metric(downloads);

--- a/server.js
+++ b/server.js
@@ -6093,7 +6093,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Chrome web store integration
-camp.route(/^\/chrome-web-store\/(v|d|price|rating|stars|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/chrome-web-store\/(v|d|u|price|rating|stars|rating-count)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var storeId = match[2];  // eg, nimelepbpejjlbmoobocpfnjhihnpked
@@ -6109,35 +6109,42 @@ cache(function(data, match, sendBadge, request) {
     }
     chromeWebStore.convert(buffer)
       .then(function (value) {
-        if (type === 'v') {
-          var vdata = versionColor(value.version);
-          badgeData.text[1] = vdata.version;
-          badgeData.colorscheme = vdata.color;
-        } else if (type === 'd') {
-          var downloads = value.interactionCount.UserDownloads;
-          badgeData.text[0] = data.label || 'downloads';
-          badgeData.text[1] = metric(downloads) + ' total';
-          badgeData.colorscheme = downloadCountColor(downloads);
-        } else if (type === 'price') {
-          badgeData.text[0] = data.label || 'price';
-          badgeData.text[1] = currencyFromCode(value.priceCurrency) +
-            value.price;
-          badgeData.colorscheme = 'brightgreen';
-        } else if (type === 'rating') {
-          let rating = Math.round(value.ratingValue * 100) / 100;
-          badgeData.text[0] = data.label || 'rating';
-          badgeData.text[1] = rating + '/5';
-          badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
-        } else if (type === 'stars') {
-          let rating = Math.round(value.ratingValue);
-          badgeData.text[0] = data.label || 'rating';
-          badgeData.text[1] = starRating(rating);
-          badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
-        } else if (type === 'rating-count') {
-          var ratingCount = value.ratingCount;
-          badgeData.text[0] = data.label || 'rating count';
-          badgeData.text[1] = metric(ratingCount) + ' total';
-          badgeData.colorscheme = floorCountColor(ratingCount, 5, 50, 500);
+        switch (type) {
+          case 'v':
+            var vdata = versionColor(value.version);
+            badgeData.text[1] = vdata.version;
+            badgeData.colorscheme = vdata.color;
+            break;
+          case 'd':
+          case 'u':
+            var downloads = value.interactionCount.UserDownloads;
+            badgeData.text[0] = data.label || 'users';
+            badgeData.text[1] = metric(downloads);
+            badgeData.colorscheme = downloadCountColor(downloads);
+            break;
+          case 'price':
+            badgeData.text[0] = data.label || 'price';
+            badgeData.text[1] = currencyFromCode(value.priceCurrency) + value.price;
+            badgeData.colorscheme = 'brightgreen';
+            break;
+          case 'rating':
+            var rating = Math.round(value.ratingValue * 100) / 100;
+            badgeData.text[0] = data.label || 'rating';
+            badgeData.text[1] = rating + '/5';
+            badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
+            break;
+          case 'stars':
+            var rating = Math.round(value.ratingValue);
+            badgeData.text[0] = data.label || 'rating';
+            badgeData.text[1] = starRating(rating);
+            badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
+            break;
+          case 'rating-count':
+            var ratingCount = value.ratingCount;
+            badgeData.text[0] = data.label || 'rating count';
+            badgeData.text[1] = metric(ratingCount) + ' total';
+            badgeData.colorscheme = floorCountColor(ratingCount, 5, 50, 500);
+            break;
         }
         sendBadge(format, badgeData);
       }).catch(function (err) {

--- a/service-tests/chrome-web-store.js
+++ b/service-tests/chrome-web-store.js
@@ -14,7 +14,7 @@ t.create('Downloads (now users)')
   }));
 
 t.create('Users')
-  .get('/u/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/users/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('users'),
     value: Joi.string().regex(/^\d+k?$/)

--- a/service-tests/chrome-web-store.js
+++ b/service-tests/chrome-web-store.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'chrome-web-store', title: 'Chrome Web Store' });
+module.exports = t;
+
+t.create('Downloads (now users)')
+  .get('/d/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('users'),
+    value: Joi.string().regex(/^\d+k?$/)
+  }));
+
+t.create('Users')
+  .get('/u/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('users'),
+    value: Joi.string().regex(/^\d+k?$/)
+  }));
+
+t.create('Version')
+  .get('/v/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('chrome web store'),
+    value: Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?$/)
+  }));
+
+t.create('Version - Custom label')
+  .get('/v/alhjnofcnnpeaphgeakdhkebafjcpeae.json?label=IndieGala Helper')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('IndieGala Helper'),
+    value: Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?$/)
+  }));
+
+t.create('Rating')
+  .get('/rating/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('rating'),
+    value: Joi.string().regex(/^\d\.?\d+?\/5$/)
+  }));
+
+t.create('Stars')
+  .get('/stars/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('rating'),
+    value: Joi.string().regex(/^[\u2605\u2606]{5}$/)
+  }));
+
+t.create('Invalid addon')
+  .get('/d/invalid-name-of-addon.json')
+  .expectJSON({ name: 'chrome web store', value: 'invalid' });
+
+t.create('No connection')
+  .get('/v/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .networkOff()
+  .expectJSON({ name: 'chrome web store', value: 'inaccessible' });

--- a/try.html
+++ b/try.html
@@ -986,8 +986,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/waffle/label/evancohen/smart-mirror/in%20progress.svg</code></td>
   </tr>
   <tr><th data-keywords='chrome'> Chrome Web Store: </th>
-    <td><img src='/chrome-web-store/u/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
-    <td><code>https://img.shields.io/chrome-web-store/u/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
+    <td><img src='/chrome-web-store/users/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/users/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
   <tr><th data-keywords='chrome'> Chrome Web Store: </th>
     <td><img src='/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>

--- a/try.html
+++ b/try.html
@@ -423,10 +423,6 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <td><img src='/packagecontrol/dt/GitGutter.svg' alt=''/></td>
   <td><code>https://img.shields.io/packagecontrol/dt/GitGutter.svg</code></td>
   </tr>
-  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
-    <td><img src='/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
-    <td><code>https://img.shields.io/chrome-web-store/d/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
-  </tr>
   <tr><th data-keywords='website' data-doc='websiteDoc'> Website: </th>
     <td><img src='/website-up-down-green-red/http/shields.io.svg?label=my-website' alt=''/></td>
     <td><code>https://img.shields.io/website-up-down-green-red/http/shields.io.svg?label=my-website</code></td>
@@ -988,6 +984,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   <tr><th> Waffle.io: </th>
     <td><img src='/waffle/label/evancohen/smart-mirror/in%20progress.svg' alt=''/></td>
     <td><code>https://img.shields.io/waffle/label/evancohen/smart-mirror/in%20progress.svg</code></td>
+  </tr>
+  <tr><th data-keywords='chrome'> Chrome Web Store: </th>
+    <td><img src='/chrome-web-store/u/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>
+    <td><code>https://img.shields.io/chrome-web-store/u/nimelepbpejjlbmoobocpfnjhihnpked.svg</code></td>
   </tr>
   <tr><th data-keywords='chrome'> Chrome Web Store: </th>
     <td><img src='/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg' alt=''/></td>


### PR DESCRIPTION
Update 'downloads'->'users' as label,
added `/users/` as option,
kept `/d/` as an option for backwards compatibility,
moved example from 'Downloads'->'Misc' section,
Removed 'total' from badge value (keep it consistent with amo badges).

example old badge: ![](https://img.shields.io/badge/downloads-1k%20total-brightgreen.svg)
example new badge: ![](https://img.shields.io/badge/users-1k-brightgreen.svg)


Closes #1016 