### PR TITLE
Fix Windows coverage errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "xml2js": "~0.4.16"
   },
   "scripts": {
-    "coverage:test:js": "istanbul cover _mocha '*.spec.js' 'lib/*.spec.js' --dir coverage/js",
-    "coverage:test:services": "istanbul cover _mocha service-tests/runner/cli.js --dir coverage/services -- --delay",
+    "coverage:test:js": "istanbul cover node_modules/mocha/bin/_mocha '*.spec.js' 'lib/*.spec.js' --dir coverage/js",
+    "coverage:test:services": "istanbul cover node_modules/mocha/bin/_mocha service-tests/runner/cli.js --dir coverage/services -- --delay",
     "coverage:test": "npm run coverage:test:js && npm run coverage:test:services",
     "coverage:report": "istanbul report",
     "coverage:report:reopen": "opn coverage/lcov-report/index.html",


### PR DESCRIPTION
Refer #1101 
Provide relative path to `_mocha` for `istanbul`
Currently creates errors on windows machines when trying to run a coverage test
closes #1101 