### PR TITLE
fix(continuousphp) link badge example

### DIFF
--- a/try.html
+++ b/try.html
@@ -238,7 +238,7 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
   </tr>
   <tr><th> continuousphp: </th>
     <td><img src='/continuousphp/git-hub/doctrine/dbal/master.svg' alt=''/></td>
-    <td><code>https://img.shields.io/continuousphp/doctrine/dbal/master.svg</code></td>
+    <td><code>https://img.shields.io/continuousphp/git-hub/doctrine/dbal/master.svg</code></td>
   </tr>
 </tbody></table>
 <h3 id="downloads"> Downloads </h3>


### PR DESCRIPTION
Hello, this is a quick fix related to the implementation of continuousphp badge https://github.com/badges/shields/pull/1051

The provider are missing in the example link.
