### PR TITLE
Always allow overriding the label [hexpm cran conda]

### DIFF
--- a/lib/text-formatters.js
+++ b/lib/text-formatters.js
@@ -10,7 +10,6 @@ function starRating(rating) {
   while (stars.length < 5) { stars += '☆'; }
   return stars;
 }
-exports.starRating = starRating;
 
 // Convert ISO 4217 code to unicode string.
 function currencyFromCode(code) {
@@ -21,13 +20,11 @@ function currencyFromCode(code) {
     USD: '$',
   })[code] || code;
 }
-exports.currencyFromCode = currencyFromCode;
 
 function ordinalNumber(n) {
   var s=["ᵗʰ","ˢᵗ","ⁿᵈ","ʳᵈ"], v=n%100;
   return n+(s[(v-20)%10]||s[v]||s[0]);
 }
-exports.ordinalNumber = ordinalNumber;
 
 // Given a number, string with appropriate unit in the metric system, SI.
 // Note: numbers beyond the peta- cannot be represented as integers in JS.
@@ -44,7 +41,6 @@ function metric(n) {
   }
   return ''+n;
 }
-exports.metric = metric;
 
 // Remove the starting v in a string.
 function omitv(version) {
@@ -53,4 +49,22 @@ function omitv(version) {
   }
   return version;
 }
-exports.omitv = omitv;
+
+function maybePluralize(singular, countable, plural) {
+  plural = plural || `${singular}s`;
+
+  if (countable && countable.length === 1) {
+    return singular;
+  } else {
+    return plural;
+  }
+}
+
+module.exports = {
+  starRating,
+  currencyFromCode,
+  ordinalNumber,
+  metric,
+  omitv,
+  maybePluralize
+};

--- a/lib/text-formatters.spec.js
+++ b/lib/text-formatters.spec.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const assert = require('assert');
+const {
+ maybePluralize
+} = require('./text-formatters');
+
+describe('text formatters', function() {
+  it('should pluralize', function() {
+    assert.equal(maybePluralize('foo', []), 'foos');
+    assert.equal(maybePluralize('foo', [123]), 'foo');
+    assert.equal(maybePluralize('foo', [123, 456]), 'foos');
+    assert.equal(maybePluralize('foo', undefined), 'foos');
+
+    assert.equal(maybePluralize('box', [], 'boxes'), 'boxes');
+    assert.equal(maybePluralize('box', [123], 'boxes'), 'box');
+    assert.equal(maybePluralize('box', [123, 456], 'boxes'), 'boxes');
+    assert.equal(maybePluralize('box', undefined, 'boxes'), 'boxes');
+  });
+});

--- a/server.js
+++ b/server.js
@@ -1785,7 +1785,7 @@ cache(function(data, match, sendBadge, request) {
 
 // Anaconda Cloud / conda package manager integration
 camp.route(/^\/conda\/([dvp]n?)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
+cache(function(queryData, match, sendBadge, request) {
   const mode = match[1];
   const channel = match[2];
   const pkgname = match[3];
@@ -1818,29 +1818,29 @@ cache(function(data, match, sendBadge, request) {
   };
   const variants = {
     // default use `conda|{channelname}` as label
-    '': function(data, badgeData) {
-      badgeData.text[0] = (data && data.label) || 'conda|' + badgeData.text[0];
+    '': function(queryData, badgeData) {
+      badgeData.text[0] = (queryData && queryData.label) || 'conda|' + badgeData.text[0];
     },
     // skip `conda|` prefix
-    'n': function(data, badgeData) {
+    'n': function(queryData, badgeData) {
     }
   };
 
   const update = modes[mode.charAt(0)];
   const variant = variants[mode.charAt(1)];
 
-  var badgeData = getBadgeData(labels[mode.charAt(0)], data);
+  var badgeData = getBadgeData(labels[mode.charAt(0)], queryData);
   request(url, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
-      variant(data, badgeData);
+      variant(queryData, badgeData);
       sendBadge(format, badgeData);
       return;
     }
     try {
       var data = JSON.parse(buffer);
       update(data, badgeData);
-      variant(data, badgeData);
+      variant(queryData, badgeData);
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/service-tests/conda.js
+++ b/service-tests/conda.js
@@ -13,6 +13,13 @@ t.create('version')
     value: Joi.string().regex(/^v\d+\.\d+\.\d+$/)
   }));
 
+t.create('version (relabel)')
+  .get('/v/conda-forge/zlib.json?label=123')
+  .expectJSONTypes(Joi.object().keys({
+    name: Joi.equal('123'),
+    value: Joi.string().regex(/^v\d+\.\d+\.\d+$/)
+  }));
+
 t.create('version (skip prefix)')
   .get('/vn/conda-forge/zlib.json')
   .expectJSONTypes(Joi.object().keys({


### PR DESCRIPTION
This changeset audits all the badges with test coverage, looking for badges which assign `badgeData.text[0]`. The right hand of those assignments are replaced with a function which takes the query data `?label=` into account.