### PR TITLE
Run service tests in a separate Travis job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,14 @@ node_js:
 before_script:
   - mkdir private && echo "{\"gh_token\":\"$GITHUB_TOKEN\"}" > private/secret.json
 
-script:
-  - npm run lint
-  - npm run test:js
-  - if [ "$TRAVIS_EVENT_TYPE" == cron ]; then npm run test:services; fi
-  - if [ "$TRAVIS_EVENT_TYPE" == pull_request ]; then npm run test:services:pr; fi
+jobs:
+  include:
+    - script:
+      - npm run lint
+      - npm run test:js
+    - script:
+      - if [ "$TRAVIS_EVENT_TYPE" == cron ]; then npm run test:services; fi
+      - if [ "$TRAVIS_EVENT_TYPE" == pull_request ]; then npm run test:services:pr; fi
 
 branches:
   except:


### PR DESCRIPTION
With this patch, the service tests run in a separate Travis job. That makes it easy to see whether a PR failure is resulting from unit tests/lint failures, or service tests, which are inherently flakier.

By running these in a single build stage, they will both run, even if the unit tests + lint fail. This is good, because it's helpful to see the result of a failed integration test, even when there's a lint or unit test failure.

I'm hoping this will appear as two separate jobs in Github… let's see!