### PR TITLE
Fix enlarged text when min-font-size is enabled

### DIFF
--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -3,11 +3,11 @@
     <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
     <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
   </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -7,7 +7,7 @@
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -14,13 +14,13 @@
     <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
   </g>
 
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="14">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="15" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[1])}}</text>
-    <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -18,9 +18,9 @@
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -17,9 +17,9 @@
   </g>
 
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
-    <text x="{{=(it.widths[0]/2+1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]/2+1)*10}}" y="130" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="130" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]/2+1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]/2+1)*10}}" y="130" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="130" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -16,10 +16,10 @@
     <rect width="{{=it.widths[0]+it.widths[1]}}" height="18" fill="url(#smooth)"/>
   </g>
 
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
-    <text x="{{=it.widths[0]/2+1}}" y="14" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=it.widths[0]/2+1}}" y="13">{{=it.escapeXml(it.text[0])}}</text>
-    <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="14" fill="#010101" fill-opacity=".3">{{=it.escapeXml(it.text[1])}}</text>
-    <text x="{{=it.widths[0]+it.widths[1]/2-1}}" y="13">{{=it.escapeXml(it.text[1])}}</text>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+    <text x="{{=(it.widths[0]/2+1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]/2+1)*10}}" y="130" transform="scale(0.1)">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="130" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
   </g>
 </svg>

--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -24,12 +24,12 @@
     <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
   {{?}}
   <g fill="#333" text-anchor="middle" font-family="Helvetica Neue,Helvetica,Arial,sans-serif" font-weight="700" font-size="110px" line-height="14px">
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#fff" transform="scale(0.1)">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#fff" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
     {{?(it.text[1] && it.text[1].length)}}
-    <text x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="150" fill="#fff" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="150" fill="#fff" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
     <a xlink:href="{{=it.links[1]}}">
-      <text id="rlink" x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
+      <text id="rlink" x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
     </a>
     {{?}}
   </g>

--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -23,13 +23,13 @@
   {{?it.logo}}
     <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
   {{?}}
-  <g fill="#333" text-anchor="middle" font-family="Helvetica Neue,Helvetica,Arial,sans-serif" font-weight="700" font-size="11px" line-height="14px">
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="15" fill="#fff">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
-    <text x="{{=(it.widths[0]+it.logoWidth+it.logoPadding)/2}}" y="14">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+  <g fill="#333" text-anchor="middle" font-family="Helvetica Neue,Helvetica,Arial,sans-serif" font-weight="700" font-size="110px" line-height="14px">
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#fff" transform="scale(0.1)">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
     {{?(it.text[1] && it.text[1].length)}}
-    <text x="{{=it.widths[0]+it.widths[1]/2+6}}" y="15" fill="#fff">{{=it.escapeXml(it.text[1])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="150" fill="#fff" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
     <a xlink:href="{{=it.links[1]}}">
-      <text id="rlink" x="{{=it.widths[0]+it.widths[1]/2+6}}" y="14">{{=it.escapeXml(it.text[1])}}</text>
+      <text id="rlink" x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="140" transform="scale(0.1)">{{=it.escapeXml(it.text[1])}}</text>
     </a>
     {{?}}
   </g>


### PR DESCRIPTION
Fixes #746 
Fixes #848 

Works by making the font-size `110px` instead of `11px` so the browser doesnt enforce the minimum font size and then scales the text down to 10%.

Also fixes the padding issue on Firefox

Tested on the following:

Browser | Version | Status
:-- | :-- | :--:
Chrome | 61.0 | working
Firefox | 56.0 | working
Edge | 25 | working
IE | 11 | working
Mobile Safari | 9.3 | working