### PR TITLE
[GitHub] badge for (pre-)release date

### DIFF
--- a/lib/github-provider.js
+++ b/lib/github-provider.js
@@ -76,16 +76,16 @@ function mapGithubCommitsSince(camp, githubApiUrl, githubAuth) {
     }));
 }
 
-//Github Release & Pre-Release Date Integration
+//Github Release & Pre-Release Date Integration release-date-pre (?:\/(all))?
 function mapGithubReleaseDate(camp, githubApiUrl, githubAuth) {
-  camp.route(/^\/github\/release-date\/([^\/]+)\/([^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
+  camp.route(/^\/github\/(release-date|release-date-pre)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
     cache(function (data, match, sendBadge, request) {
-      const user = match[1];  // eg, microsoft
-      const repo = match[2];  // eg, vscode
-      const allReleases = match[3]; //`all` for Release & Pre-Release OR undefined for latest Release
+      const releaseType = match[1]; // eg, release-date-pre / release-date
+      const user = match[2];  // eg, microsoft
+      const repo = match[3];  // eg, vscode
       const format = match[4];
       let apiUrl = `${githubApiUrl}/repos/${user}/${repo}/releases`;
-      if(!allReleases) {
+      if(releaseType === 'release-date') {
         apiUrl += '/latest';
       }
       const badgeData = getBadgeData('release date', data);
@@ -108,7 +108,7 @@ function mapGithubReleaseDate(camp, githubApiUrl, githubAuth) {
 
         try {
           let data = JSON.parse(buffer);
-          if(allReleases === 'all') {
+          if(releaseType === 'release-date-pre') {
             data = data[0];
           }
           const releaseDate = moment(data.created_at);

--- a/lib/github-provider.js
+++ b/lib/github-provider.js
@@ -107,7 +107,7 @@ function mapGithubReleaseDate(camp, githubApiUrl, githubAuth) {
         }
 
         try {
-          let data = JSON.parse(buffer);         
+          let data = JSON.parse(buffer);
           if(allReleases === 'all') {
             data = data[0];
           }

--- a/lib/github-provider.js
+++ b/lib/github-provider.js
@@ -76,14 +76,18 @@ function mapGithubCommitsSince(camp, githubApiUrl, githubAuth) {
     }));
 }
 
-//Github Release Date Integration
+//Github Release & Pre-Release Date Integration
 function mapGithubReleaseDate(camp, githubApiUrl, githubAuth) {
-  camp.route(/^\/github\/release-date\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+  camp.route(/^\/github\/release-date\/([^\/]+)\/([^\/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
     cache(function (data, match, sendBadge, request) {
       const user = match[1];  // eg, microsoft
       const repo = match[2];  // eg, vscode
-      const format = match[3];
-      const apiUrl = `${githubApiUrl}/repos/${user}/${repo}/releases/latest`;
+      const allReleases = match[3]; //`all` for Release & Pre-Release OR undefined for latest Release
+      const format = match[4];
+      let apiUrl = `${githubApiUrl}/repos/${user}/${repo}/releases`;
+      if(!allReleases) {
+        apiUrl += '/latest';
+      }
       const badgeData = getBadgeData('release date', data);
       if (badgeData.template === 'social') {
         badgeData.logo = getLogo('github', data);
@@ -103,7 +107,10 @@ function mapGithubReleaseDate(camp, githubApiUrl, githubAuth) {
         }
 
         try {
-          const data = JSON.parse(buffer);
+          let data = JSON.parse(buffer);         
+          if(allReleases === 'all') {
+            data = data[0];
+          }
           const releaseDate = moment(data.created_at);
           badgeData.text[1] = formatDate(releaseDate);
           badgeData.colorscheme = age(releaseDate);

--- a/server.js
+++ b/server.js
@@ -3324,7 +3324,7 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// GitHub release date integration.
+// GitHub release & pre-release date integration.
 mapGithubReleaseDate(camp, githubApiUrl, githubAuth);
 
 // GitHub commits since integration.

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -184,21 +184,21 @@ t.create('Release Date - Should return `no releases or repo not found` for inval
 .expectJSON({ name: 'release date', value: 'no releases or repo not found' });
 
 t.create('(Pre-)Release Date. e.g release date|today')
-.get('/release-date/microsoft/vscode/all.json')
+.get('/release-date-pre/microsoft/vscode.json')
 .expectJSONTypes(Joi.object().keys({
   name: 'release date',
   value: validDateString
 }));
 
 t.create('(Pre-)Release Date - Custom Label. e.g myRelease|today')
-.get('/release-date/microsoft/vscode/all.json?label=myRelease')
+.get('/release-date-pre/microsoft/vscode.json?label=myRelease')
 .expectJSONTypes(Joi.object().keys({
   name: 'myRelease',
   value: validDateString
 }));
 
 t.create('(Pre-)Release Date - Should return `no releases or repo not found` for invalid repo')
-.get('/release-date/not-valid-name/not-valid-repo/all.json')
+.get('/release-date-pre/not-valid-name/not-valid-repo.json')
 .expectJSON({ name: 'release date', value: 'no releases or repo not found' });
 
 

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -183,6 +183,24 @@ t.create('Release Date - Should return `no releases or repo not found` for inval
 .get('/release-date/not-valid-name/not-valid-repo.json')
 .expectJSON({ name: 'release date', value: 'no releases or repo not found' });
 
+t.create('(Pre-)Release Date. e.g release date|today')
+.get('/release-date/microsoft/vscode/all.json')
+.expectJSONTypes(Joi.object().keys({
+  name: 'release date',
+  value: validDateString
+}));
+
+t.create('(Pre-)Release Date - Custom Label. e.g myRelease|today')
+.get('/release-date/microsoft/vscode/all.json?label=myRelease')
+.expectJSONTypes(Joi.object().keys({
+  name: 'myRelease',
+  value: validDateString
+}));
+
+t.create('(Pre-)Release Date - Should return `no releases or repo not found` for invalid repo')
+.get('/release-date/not-valid-name/not-valid-repo/all.json')
+.expectJSON({ name: 'release date', value: 'no releases or repo not found' });
+
 
 t.create('Tag')
   .get('/tag/photonstorm/phaser.json')

--- a/try.html
+++ b/try.html
@@ -916,6 +916,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/release-date/SubtitleEdit/subtitleedit.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/release-date/SubtitleEdit/subtitleedit.svg</code></td>
   </tr>
+  <tr><th data-doc='githubDoc'data-keywords='GitHub release date'> GitHub (Pre-)Release Date: </th>
+    <td><img src='/github/release-date/Cockatrice/Cockatrice/all.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/release-date/Cockatrice/Cockatrice/all.svg</code></td>
+  </tr>
   <tr><th data-keywords='GitHub pullrequest detail check' data-doc='githubDoc'> GitHub pull request check state: </th>
     <td><img src='/github/status/s/pulls/badges/shields/1110.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/status/s/pulls/badges/shields/1110.svg</code></td>

--- a/try.html
+++ b/try.html
@@ -917,8 +917,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/github/release-date/SubtitleEdit/subtitleedit.svg</code></td>
   </tr>
   <tr><th data-doc='githubDoc'data-keywords='GitHub release date'> GitHub (Pre-)Release Date: </th>
-    <td><img src='/github/release-date/Cockatrice/Cockatrice/all.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/release-date/Cockatrice/Cockatrice/all.svg</code></td>
+    <td><img src='/github/release-date-pre/Cockatrice/Cockatrice.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/release-date-pre/Cockatrice/Cockatrice.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub pullrequest detail check' data-doc='githubDoc'> GitHub pull request check state: </th>
     <td><img src='/github/status/s/pulls/badges/shields/1110.svg' alt=''/></td>


### PR DESCRIPTION
URI : `github/release-date/:user/:repo/all.svg`

Actually, there has URI for *release version* badge like that -
[/github/release/Cockatrice/Cockatrice.svg](https://img.shields.io/github/release/Cockatrice/Cockatrice.svg) `full release`
[/github/release/Cockatrice/Cockatrice/all.svg](https://img.shields.io/github/release/Cockatrice/Cockatrice/all.svg) `included pre-release`

So, for consistency, I've done *release date* like that - 
[/github/release-date/Cockatrice/Cockatrice.svg](https://img.shields.io/github/release-date/Cockatrice/Cockatrice.svg) `full release` (Previously Merged #1122)
[/github/release-date/Cockatrice/Cockatrice/all.svg](https://img.shields.io/github/release-date/Cockatrice/Cockatrice/all.svg) `included pre-release` (This PR)

![image](https://user-images.githubusercontent.com/18099464/31214889-ddd5385c-a9ca-11e7-94c8-fe06b42325e9.png)

https://github.com/badges/shields/pull/1122#issuecomment-334113759