### PR TITLE
Exclude tests from coverage

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,2 +1,2 @@
 instrumentation:
-  excludes: ['lib/suggest.js', 'vendor/**/*.js']
+  excludes: ['**/*.spec.js', 'service-tests/']


### PR DESCRIPTION
Also, include `lib/suggest.js` which is part of the server, and rename `vendor` to `service-tests` to match the names the files got when they were merged