### PR TITLE
Broken Discord Link at Button

### DIFF
--- a/try.html
+++ b/try.html
@@ -1338,7 +1338,7 @@ And tell us, we might be able to bring it to you anyway!
 <iframe src="https://ghbtns.com/github-btn.html?user=badges&amp;repo=shields&amp;type=fork&amp;count=true"
   style="border:0; background-color:transparent"
   width="95" height="20"></iframe>
-<a href="https://discord.gg/HjJCwm5"><img src="/discord/308323056592486420.svg?style=social&label=Chat" alt="chat on Discord"></a>
+<a href="https://discord.gg/HjJCwm5"><img src='/discord/308323056592486420.svg?style=social&label=Chat' alt='chat on Discord'></a>
 </p>
 <p>
 <a href='https://github.com/h5bp/lazyweb-requests/issues/150'>This</a>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18099464/31294740-b853dab8-aaf9-11e7-8c57-5dc7c8aa13a3.png)


I think the link is not prefixed by `https://img.shield.io` because of double inverted comma `"`
[Sorry, I made that mistake #1096 ]

At `makefie`
https://github.com/badges/shields/blob/2d157b39281c692441b75e4325631b633af5072a/Makefile#L17-L18