### PR TITLE
Upgrade IcedFrisby to version supporting only()

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "glob": "^7.1.1",
-    "icedfrisby": "^1.2.0",
+    "icedfrisby": "^1.4.0",
     "icedfrisby-nock": "^1.0.0",
     "is-png": "^1.1.0",
     "is-svg": "^2.1.0",


### PR DESCRIPTION
When debugging, it's often useful to run just one or two tests. With this change, it's possible to do that.

In this example, only the first and third tests will run:

```js
t.create('gets the package version of left-pad')
  .get('/v/left-pad.json')
  .only()
  .expectJSONTypes(Joi.object().keys({ name: 'npm', value: isSemver }));

t.create('gets the package version of @cycle/core')
  .get('/v/@cycle/core.json')
  .expectJSONTypes(Joi.object().keys({ name: 'npm', value: isSemver }));

t.create('gets the tagged package version of npm')
  .get('/v/npm/next.json')
  .only()
  .expectJSONTypes(Joi.object().keys({ name: 'npm@next', value: isSemver }));
```