### PR TITLE
Attempt to show [Discord]-provided error message

### DIFF
--- a/server.js
+++ b/server.js
@@ -6668,6 +6668,15 @@ cache((data, match, sendBadge, request) => {
     }
     if (err != null || !res || res.statusCode !== 200) {
       badgeData.text[1] = 'inaccessible';
+      if (res && res.headers['content-type'] === 'application/json') {
+        try {
+          const data = JSON.parse(buffer);
+          if (data && typeof data.message === 'string') {
+            badgeData.text[1] = data.message.toLowerCase();
+          }
+        } catch(e) {
+        }
+      }
       sendBadge(format, badgeData);
       return;
     }

--- a/service-tests/discord.js
+++ b/service-tests/discord.js
@@ -17,6 +17,17 @@ t.create('invalid server ID')
   .get('/12345.json')
   .expectJSON({ name: 'chat', value: 'invalid server' });
 
+t.create('widget disabled')
+  .get('/12345.json')
+  .intercept(nock => nock('https://discordapp.com/')
+    .get('/api/guilds/12345/widget.json')
+    .reply(403, {
+      code: 50004,
+      message: 'Widget Disabled'
+    })
+  )
+  .expectJSON({ name: 'chat', value: 'widget disabled' });
+
 t.create('server error')
   .get('/12345.json')
   .intercept(nock => nock('https://discordapp.com/')


### PR DESCRIPTION
Implements #981.

The Discord API occasionally returns Cloudflare HTML errors or invalid JSON, so in those cases it will fallback to the standard `'inaccessible'` message. Some of the returned errors have uppercase letters, so `toLowerCase()` is used to stay consistent with the rest of shields.