### PR TITLE
Set up Heroku review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,20 @@
+{
+  "name": "Shields",
+  "description": "Concise, consistent, and legible badges in SVG and raster format.",
+  "keywords": [
+    "badge",
+    "github",
+    "svg",
+    "status"
+  ],
+  "website": "https://shields.io/",
+  "repository": "https://github.com/badges/shields",
+  "logo": "http://shields.io/favicon.png",
+  "success_url": "/try.html",
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  }
+}


### PR DESCRIPTION
This will allow us to create a [review app](https://devcenter.heroku.com/articles/github-integration-review-apps) for a pull request. A review app is a transient deploy of Shields with a unique URI. We can use it to interactively test new PRs without needing to run the branch locally.

Review apps would be especially useful, in conjunction with something like Netlify (#960), to test issues affecting SVG badge rendering on different browsers (#1132).

I created a Heroku app and did a test deploy of Shields, which worked right out of the box!

https://shields-staging.herokuapp.com/try.html