### PR TITLE
Add standard npm start script + rm unnecessary make step

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -34,11 +34,9 @@ If you do not, install it and learn about the [Github workflow](http://try.githu
    `sudo apt-get install npm nodejs-legacy curl imagemagick`
 5. Install all packages  
    `npm install`
-6. Setup  
-   `make setup`
-7. Run the server  
-   `node server.js 8080`
-8. Visit the website to check the badges get loaded slowly:  
+6. Run the server  
+   `npm start`
+7. Visit the website to check the badges get loaded slowly:  
    [http://[::1]:8080/try.html](http://[::1]/try.html)
 
 (3) Open an Issue
@@ -88,9 +86,9 @@ To try out this custom badge do the following:
 1. Copy and paste these lines into [server.js][server].
    I did this at about line 5000.
 2. Quit the running server with `Control+C`.
-3. Start the server again.  
-   `node server.js 8080`
-4. Visit the badge at <http://[::1]:8080/test/subject/STATUS.svg>.
+3. Start the server again.
+   `npm start`
+4. Visit the badge at <http://[::]:8080/test/subject/STATUS.svg>.
    It should look like this: ![](https://img.shields.io/badge/subject-STATUS-blue.svg)
 
 ### (4.1) Querying an API

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "test:services:pr:prepare": "node service-tests/runner/pull-request-services-cli.js > pull-request-services.log",
     "test:services:pr:run": "mocha --delay service-tests/runner/cli.js --stdin < pull-request-services.log",
     "test:services:pr": "npm run test:services:pr:prepare && npm run test:services:pr:run",
-    "test": "npm run lint && npm run test:js"
+    "test": "npm run lint && npm run test:js",
+    "start": "node server 8080 ::"
   },
   "bin": {
     "badge": "./gh-badge.js"


### PR DESCRIPTION
- `make setup` (i.e. `make`) in the dev tutorial seems an unnecessary step. When I open try.html without running that first, badges load from my local server.