### PR TITLE
[Jenkins] Support for Jenkins plugin version

### DIFF
--- a/server.js
+++ b/server.js
@@ -4353,6 +4353,39 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Jenkins Plugins version integration
+camp.route(/^\/jenkins\/plugin\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var pluginId = match[1];  // e.g. blueocean
+  var format = match[2];
+  var options = {
+    method: 'GET',
+    json: true,
+    uri: 'https://updates.jenkins-ci.org/current/update-center.actual.json'
+  };
+  var badgeData = getBadgeData('plugin', data);
+  request(options, function(err, res, json) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      var version = json.plugins[pluginId].version;
+      badgeData.text[1] = 'v' + version;
+      if (version === '0') {
+        badgeData.colorscheme = 'orange';
+      } else {
+        badgeData.colorscheme = 'blue';
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'not found';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Ansible integration
 camp.route(/^\/ansible\/role\/(?:(d)\/)?(\d+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -4360,7 +4360,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[2];
   var badgeData = getBadgeData('plugin', data);
   regularUpdate('https://updates.jenkins-ci.org/current/update-center.actual.json',
-    (3600 * 1000),
+    (4 * 3600 * 1000),
     function(json) {
       json = JSON.parse(json);
       return Object.keys(json.plugins).reduce(function(previous, current) {

--- a/service-tests/jenkins.js
+++ b/service-tests/jenkins.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'jenkins', title: 'Jenkins' });
+module.exports = t;
+
+t.create('latest version')
+  .get('/plugin/v/blueocean.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'plugin',
+    value: Joi.string().regex(/^v(.*)$/)
+  }));
+
+t.create('version 0')
+  .get('/plugin/v/blueocean.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/current/update-center.actual.json')
+    .reply(200, { plugins: { blueocean: { version: '0' } } })
+  )
+  .expectJSONTypes(Joi.object().keys({
+    name: 'plugin',
+    value: Joi.string().regex(/^v0$/)
+  }));
+
+t.create('inexistent artifact')
+  .get('/plugin/v/inexistent-artifact-id.json')
+  .expectJSON({ name: 'plugin', value: 'not found' });
+
+t.create('connection error')
+  .get('/plugin/v/blueocean.json')
+  .networkOff()
+  .expectJSON({ name: 'plugin', value: 'inaccessible' });

--- a/service-tests/jenkins.js
+++ b/service-tests/jenkins.js
@@ -8,6 +8,10 @@ module.exports = t;
 
 t.create('latest version')
   .get('/plugin/v/blueocean.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/current/update-center.actual.json')
+    .reply(200, { plugins: { blueocean: { version: '1.1.6' } } })
+  )
   .expectJSONTypes(Joi.object().keys({
     name: 'plugin',
     value: Joi.string().regex(/^v(.*)$/)
@@ -26,6 +30,10 @@ t.create('version 0')
 
 t.create('inexistent artifact')
   .get('/plugin/v/inexistent-artifact-id.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/current/update-center.actual.json')
+    .reply(200, { plugins: { blueocean: { version: '1.1.6' } } })
+  )
   .expectJSON({ name: 'plugin', value: 'not found' });
 
 t.create('connection error')

--- a/try.html
+++ b/try.html
@@ -714,6 +714,10 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/jitpack/v/jitpack/maven-simple.svg' alt=''/></td>
     <td><code>https://img.shields.io/jitpack/v/jitpack/maven-simple.svg</code></td>
   </tr>
+  <tr><th> Jenkins Plugins: </th>
+    <td><img src='/jenkins/plugin/v/blueocean.svg' alt=''/></td>
+    <td><code>https://img.shields.io/jenkins/plugin/v/blueocean.svg</code></td>
+  </tr>
 </tbody></table>
 
 <h3 id="social"> Social </h3>


### PR DESCRIPTION
Closes #622 

Added simple badge for Jenkins plugins: shows latest version published to Jenkins' repository (fetched from: <https://updates.jenkins.io/update-center.actual.json>).

This uses the URL format: `/jenkins/plugin/v/:pluginId.:format`

Created service-test cases and added under Version in `try.html`.

This is my first contribution here, so let me know if I need to change something.