### PR TITLE
[GitHub] Top language, languages count and code size badges

### DIFF
--- a/server.js
+++ b/server.js
@@ -3907,7 +3907,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub languages integration.
-camp.route(/^\/github\/languages\/(top|count|bytes)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/languages\/(top|count|code-size)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var user = match[2];
@@ -3952,7 +3952,7 @@ cache(function(data, match, sendBadge, request) {
           badgeData.text[1] = Object.keys(parsedData).length;
           badgeData.colorscheme = 'blue';
           break;
-        case 'bytes':
+        case 'code-size':
           for (const language of Object.keys(parsedData)) {
             sumBytes += parseInt(parsedData[language]);
           }

--- a/server.js
+++ b/server.js
@@ -3957,7 +3957,7 @@ cache(function(data, match, sendBadge, request) {
             sumBytes += parseInt(parsedData[language]);
           }
           badgeData.text[0] = 'code size';
-          badgeData.text[1] = metric(sumBytes) + 'B';
+          badgeData.text[1] = prettyBytes(sumBytes);
           badgeData.colorscheme = 'blue';
           break;
         default:

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -467,7 +467,7 @@ t.create('language count')
 }));
 
 t.create('code size in bytes for all languages')
-.get('/languages/bytes/badges/shields.json')
+.get('/languages/code-size/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('code size'),
   value: isFileSize,

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -447,3 +447,31 @@ t.create('github pull request check state')
 t.create('github pull request check contexts')
   .get('/status/contexts/pulls/badges/shields/1110.json')
   .expectJSONTypes(Joi.object().keys({ name: 'checks', value: '1 failure' }));
+
+t.create('top language')
+.get('/languages/top/badges/shields.json')
+.expectJSONTypes(Joi.object().keys({
+  name: Joi.equal('JavaScript'),
+  value: Joi.string().regex(/^([1-9]?[0-9]\.[0-9]|100\.0)%$/),
+}));
+
+t.create('top language with empty repository')
+.get('/languages/top/pyvesb/emptyrepo.json')
+.expectJSONTypes(Joi.object().keys({
+  name: Joi.equal('language'),
+  value: Joi.equal('none'),
+}));
+
+t.create('language count')
+.get('/languages/count/badges/shields.json')
+.expectJSONTypes(Joi.object().keys({
+  name: Joi.equal('languages'),
+  value: Joi.string().regex(/^[0-9]*$/),
+}));
+
+t.create('code size in bytes for all languages')
+.get('/languages/bytes/badges/shields.json')
+.expectJSONTypes(Joi.object().keys({
+  name: Joi.equal('code size'),
+  value: Joi.string().regex(/^[0-9]*(k|M|G|T|P|E|Z|Y)B$/),
+}));

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -457,21 +457,18 @@ t.create('top language')
 
 t.create('top language with empty repository')
 .get('/languages/top/pyvesb/emptyrepo.json')
-.expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('language'),
-  value: Joi.equal('none'),
-}));
+.expectJSON({ name: 'language', value: 'none' });
 
 t.create('language count')
 .get('/languages/count/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('languages'),
-  value: Joi.string().regex(/^[0-9]*$/),
+  value: Joi.number().integer().positive(),
 }));
 
 t.create('code size in bytes for all languages')
 .get('/languages/bytes/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('code size'),
-  value: Joi.string().regex(/^[0-9]*(k|M|G|T|P|E|Z|Y)B$/),
+  value: isFileSize,
 }));

--- a/try.html
+++ b/try.html
@@ -955,6 +955,18 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><img src='/github/last-commit/google/skia/infra/config.svg' alt=''/></td>
     <td><code>https://img.shields.io/github/commits/google/skia/infra/config/last.svg</code></td>
   </tr>
+  <tr><th data-keywords='GitHub top language' data-doc='githubDoc'> GitHub top language: </th>
+    <td><img src='/github/languages/top/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/languages/top/badges/shields.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub language count' data-doc='githubDoc'> GitHub language count: </th>
+    <td><img src='/github/languages/count/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/languages/count/badges/shields.svg</code></td>
+  </tr>
+  <tr><th data-keywords='GitHub byte code size' data-doc='githubDoc'> GitHub code size in bytes: </th>
+    <td><img src='/github/languages/bytes/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/languages/bytes/badges/shields.svg</code></td>
+  </tr>
   <tr><th> Bitbucket issues: </th>
     <td><img src='/bitbucket/issues/atlassian/python-bitbucket.svg' alt=''/></td>
     <td><code>https://img.shields.io/bitbucket/issues/atlassian/python-bitbucket.svg</code></td>

--- a/try.html
+++ b/try.html
@@ -964,8 +964,8 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
     <td><code>https://img.shields.io/github/languages/count/badges/shields.svg</code></td>
   </tr>
   <tr><th data-keywords='GitHub byte code size' data-doc='githubDoc'> GitHub code size in bytes: </th>
-    <td><img src='/github/languages/bytes/badges/shields.svg' alt=''/></td>
-    <td><code>https://img.shields.io/github/languages/bytes/badges/shields.svg</code></td>
+    <td><img src='/github/languages/code-size/badges/shields.svg' alt=''/></td>
+    <td><code>https://img.shields.io/github/languages/code-size/badges/shields.svg</code></td>
   </tr>
   <tr><th> Bitbucket issues: </th>
     <td><img src='/bitbucket/issues/atlassian/python-bitbucket.svg' alt=''/></td>


### PR DESCRIPTION
This pull request is related to issue #1139 .

In addition to the main programming language badge discussed there, these commits also add two additional badges making use of the same [languages API endpoint](https://developer.github.com/v3/repos/#list-languages), but parsing the received data slightly differently.

The resulting badges should look similar to the following:
- top language ![top](https://img.shields.io/badge/JavaScript-68.1%25-blue.svg)
- count of languages ![count](https://img.shields.io/badge/languages-3-blue.svg)
- code size in bytes ![bytes](https://img.shields.io/badge/code%20size-547kB-blue.svg)

Hope I have followed the guidelines correctly and looking forward to any review comments and feedback! :thumbsup:

Cheers,

Pyves