### PR TITLE
expand documenation

### DIFF
--- a/try.html
+++ b/try.html
@@ -1363,7 +1363,7 @@ Here are a few other parameters you can use: (connecting several with "&" is pos
 </p>
 <table><tbody>
   <tr><td><code>?label=healthinesses</code></td><td>Override the default
-      left-hand-side text (<a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL-Encoding</a> needed for spaces or special characters!)</td>
+      left-hand-side text (<a href="https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding">URL-Encoding</a> needed for spaces or special characters!)</td>
   <tr><td><code>?logo=appveyor</code></td>
     <td>
       Insert one of the

--- a/try.html
+++ b/try.html
@@ -1363,8 +1363,7 @@ Here are a few other parameters you can use: (connecting several with "&" is pos
 </p>
 <table><tbody>
   <tr><td><code>?label=healthinesses</code></td><td>Override the default
-      left-hand-side text (<a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL-Encoding</a> 
-    needed for spaces or special characters!)</td>
+      left-hand-side text (<a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL-Encoding</a> needed for spaces or special characters!)</td>
   <tr><td><code>?logo=appveyor</code></td>
     <td>
       Insert one of the

--- a/try.html
+++ b/try.html
@@ -1359,11 +1359,12 @@ The following styles are available (flat is the default as of Feb 1st 2015):
 </tbody></table>
 
 <p>
-Here are a few other parameters you can use:
+Here are a few other parameters you can use: (connecting several with "&" is possible)
 </p>
 <table><tbody>
   <tr><td><code>?label=healthinesses</code></td><td>Override the default
-      left-hand-side text</td>
+      left-hand-side text (<a href="https://www.w3schools.com/tags/ref_urlencode.asp">URL-Encoding</a> 
+    needed for spaces or special characters!)</td>
   <tr><td><code>?logo=appveyor</code></td>
     <td>
       Insert one of the


### PR DESCRIPTION
This adds documentation for
- combining several custom parameters for one badge
- needed url-encoding

I went with a different link than you suggested.
My motivation to do so is that w3school provides more information and most likely never change.
Your proposal is more practical and might help quicker - [the tool](https://meyerweb.com/eric/tools/dencoder/) might not be available in the future though.
Other ideas?

Just saw your other link to https://developer.mozilla.org/en-US/docs/Glossary/percent-encoding, which one do we prefer?

(fixes https://github.com/badges/shields/issues/1170)