### PR TITLE
Add link support for all badges

### DIFF
--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -10,4 +10,14 @@
     <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
     <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
+  {{?(it.links[0] && it.links[0].length)}}
+    <a xlink:href="{{=it.links[0]}}">
+      <rect width="{{=it.widths[0]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
+  {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}
+    <a xlink:href="{{=it.links[1] || it.links[0]}}">
+      <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
 </svg>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -23,4 +23,15 @@
     <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
     <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
+  
+  {{?(it.links[0] && it.links[0].length)}}
+    <a xlink:href="{{=it.links[0]}}">
+      <rect width="{{=it.widths[0]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
+  {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}
+    <a xlink:href="{{=it.links[1] || it.links[0]}}">
+      <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
 </svg>

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -25,4 +25,15 @@
     <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="140" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
     <text x="{{=(it.widths[0]+it.widths[1]/2-1)*10}}" y="130" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
+  
+  {{?(it.links[0] && it.links[0].length)}}
+    <a xlink:href="{{=it.links[0]}}">
+      <rect width="{{=it.widths[0]}}" height="18" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
+  {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}
+    <a xlink:href="{{=it.links[1] || it.links[0]}}">
+      <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="18" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
 </svg>

--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+1 + (it.text[1] && it.text[1].length > 0 ? it.widths[1]+6 : 0)}}" height="20">
   {{it.widths[1]-=4;}}
   <style type="text/css"><![CDATA[
-    #llink:hover { fill:url(#b); stroke:#ccc; }
-    #rlink:hover { fill:#4183C4; }
+    a #llink:hover { fill:url(#b); stroke:#ccc; }
+    a #rlink:hover { fill:#4183C4; }
   ]]></style>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-color="#fcfcfc" stop-opacity="0"/>
@@ -27,13 +27,13 @@
     <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="150" fill="#fff" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
     <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.capitalize(it.text[0]))}}</text>
     {{?(it.text[1] && it.text[1].length)}}
-    <text x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="150" fill="#fff" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
-    <a xlink:href="{{=it.links[1]}}">
-      <text id="rlink" x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
-    </a>
+      <text x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="150" fill="#fff" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
+      {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}<a xlink:href="{{=it.links[1] || it.links[0]}}">{{?}}
+        <text id="rlink" x="{{=(it.widths[0]+it.widths[1]/2+6)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-8)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
+      {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}</a>{{?}}
     {{?}}
   </g>
-  <a xlink:href="{{=it.links[0]}}">
-    <rect id="llink" stroke="#d5d5d5" fill="url(#a)" x="0.5" y="0.5" width="{{=it.widths[0]}}" height="19" rx="2"/>
-  </a>
+  {{?(it.links[0] && it.links[0].length)}}<a xlink:href="{{=it.links[0]}}">{{?}}
+      <rect id="llink" stroke="#d5d5d5" fill="url(#a)" x="0.5" y="0.5" width="{{=it.widths[0]}}" height="19" rx="2"/>
+  {{?(it.links[0] && it.links[0].length)}}</a>{{?}}
 </svg>


### PR DESCRIPTION
Relates to:
#852 
#598 
closes #1079 

Add link support to the following badges:
- flat
- flat-square
- plastic

Adjust social badge
- if only 1 link supplied the whole badge will use that link
- only use hover effects if badge contains a link
- remove link if no link specified (currently links to `undefined`)

For all badges if only 1 link is supplied the whole badge will use that link ~~(currently no way to manually specify a second link)~~ you can specify the second link using `link=//firstlink.com&link=//secondlink.com`

Also the only way i know of that a badge will show the links is if it is included via:
`<object data="linktobadge.svg"/>`