### PR TITLE
Use shields.io for the fork badge & use objects for social badges

### DIFF
--- a/try.html
+++ b/try.html
@@ -1396,12 +1396,10 @@ Tell your favorite badge service to use it! <br/>
 And tell us, we might be able to bring it to you anyway!
 </p>
 <p>
-<a href='https://twitter.com/espadrine'><img src='/twitter/follow/espadrine.svg?style=social&label=Follow' alt='Follow @espadrine'></a>
-<a href='https://www.gratipay.com/Shields/'><img src='/gratipay/Shields.svg?style=social&label=Donate' alt='Donate to us!'/></a>
-<iframe src="https://ghbtns.com/github-btn.html?user=badges&amp;repo=shields&amp;type=fork&amp;count=true"
-  style="border:0; background-color:transparent"
-  width="95" height="20"></iframe>
-<a href="https://discord.gg/HjJCwm5"><img src='/discord/308323056592486420.svg?style=social&label=Chat' alt='chat on Discord'></a>
+<object data='/twitter/follow/espadrine.svg?style=social&label=Follow' alt='Follow @espadrine'></object>
+<object data='/gratipay/Shields.svg?style=social&label=Donate&link=https://www.gratipay.com/Shields/' alt='Donate to us!'></object>
+<object data='/github/forks/badges/shields.svg?style=social&label=Fork' alt='Fork on GitHub'></object>
+<object data='/discord/308323056592486420.svg?style=social&label=Chat&link=https://discord.gg/HjJCwm5' alt='chat on Discord'></object>
 </p>
 <p>
 <a href='https://github.com/h5bp/lazyweb-requests/issues/150'>This</a>

--- a/try.html
+++ b/try.html
@@ -1396,7 +1396,7 @@ Tell your favorite badge service to use it! <br/>
 And tell us, we might be able to bring it to you anyway!
 </p>
 <p>
-<object data='/twitter/follow/espadrine.svg?style=social&label=Follow' alt='Follow @espadrine'></object>
+<object data='/twitter/follow/shields_io.svg?style=social&label=Follow' alt='Follow @shields_io'></object>
 <object data='/gratipay/Shields.svg?style=social&label=Donate&link=https://www.gratipay.com/Shields/' alt='Donate to us!'></object>
 <object data='/github/forks/badges/shields.svg?style=social&label=Fork' alt='Fork on GitHub'></object>
 <object data='/discord/308323056592486420.svg?style=social&label=Chat&link=https://discord.gg/HjJCwm5' alt='chat on Discord'></object>


### PR DESCRIPTION
use `shields.io` for the github badge at bottom of page instead of `ghbtns.com`

change from `<a href='...'><img src='...'>` -> `<object data='...?link=...'>` for the social badges at the bottom of the page,
I didn't change any of the examples though not sure if they should be `img` or `object`?

_note: this slightly relies on #1172 being merged for the links to function correctly without adding a second `&link=`_