### PR TITLE
[dotnetstatus github gratipay hexpm wordpress] General test improvements

### DIFF
--- a/server.js
+++ b/server.js
@@ -4977,10 +4977,9 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var rating = JSON.parse(buffer).rating;
-      rating = (rating/100)*5;
-      // round to the nearest half-star
-      badgeData.text[1] = metric(Math.round(rating * 2) / 2) + ' stars';
+      var rating = parseInt(JSON.parse(buffer).rating);
+      rating = rating / 100 * 5;
+      badgeData.text[1] = starRating(rating);
       if (rating === 0) {
         badgeData.colorscheme = 'red';
       } else if (rating < 2) {
@@ -5069,10 +5068,9 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var rating = JSON.parse(buffer).rating;
-      rating = (rating/100)*5;
-      // round to the nearest half-star
-      badgeData.text[1] = metric(Math.round(rating * 2) / 2) + ' stars';
+      var rating = parseInt(JSON.parse(buffer).rating);
+      rating = rating / 100 * 5;
+      badgeData.text[1] = starRating(rating);
       if (rating === 0) {
         badgeData.colorscheme = 'red';
       } else if (rating < 2) {

--- a/service-tests/README.md
+++ b/service-tests/README.md
@@ -191,7 +191,7 @@ Next we'll add a second test for a branch build.
 t.create('build status on named branch')
   .get('/rust-lang/rust/stable.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('build'),
+    name: 'build',
     value: Joi.equal('failing', 'passing', 'unknown')
   }));
 ```
@@ -313,14 +313,14 @@ module.exports = t;
 t.create('build status on default branch')
   .get('/rust-lang/rust.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('build'),
+    name: 'build',
     value: Joi.equal('failing', 'passing', 'unknown')
   }));
 
 t.create('build status on named branch')
   .get('/rust-lang/rust/stable.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('build'),
+    name: 'build',
     value: Joi.equal('failing', 'passing', 'unknown')
   }));
 

--- a/service-tests/dotnetstatus.js
+++ b/service-tests/dotnetstatus.js
@@ -14,7 +14,7 @@ t
   .get("/gh/jaredcnance/dotnet-status/API.json")
   .expectJSONTypes(
     Joi.object().keys({
-      name: Joi.equal("dependencies"),
+      name: "dependencies",
       value: Joi.equal("up to date", "out of date", "processing")
     })
   );

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -86,7 +86,6 @@ t.create('GitHub open issues by label is > zero')
 
 t.create('GitHub open issues by label is > zero')
   .get('/issues/Cockatrice/Cockatrice/Easy%20Change.json')
-  .inspectJSON()
   .expectJSONTypes(Joi.object().keys({
     name: 'Easy Change issues',
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -55,21 +55,21 @@ t.create('GitHub pull requests raw')
 t.create('GitHub closed issues')
   .get('/issues-closed/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
+    name: 'issues',
     value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? closed$/)
   }));
 
 t.create('GitHub closed issues raw')
   .get('/issues-closed-raw/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('closed issues'),
+    name: 'closed issues',
     value: Joi.string().regex(/^\w+\+?$/)
   }));
 
 t.create('GitHub open issues')
   .get('/issues/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('issues'),
+    name: 'issues',
     value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
@@ -80,7 +80,7 @@ t.create('GitHub open issues raw')
 t.create('GitHub open issues by label is > zero')
   .get('/issues/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('service-badge issues'),
+    name: 'service-badge issues',
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
   }));
 
@@ -88,21 +88,21 @@ t.create('GitHub open issues by label is > zero')
   .get('/issues/Cockatrice/Cockatrice/Easy%20Change.json')
   .inspectJSON()
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('Easy Change issues'),
+    name: 'Easy Change issues',
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
   }));
 
 t.create('GitHub open issues by label (raw)')
   .get('/issues-raw/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('open service-badge issues'),
+    name: 'open service-badge issues',
     value: isMetric
   }));
 
 t.create('GitHub open pull requests by label')
   .get('/issues-pr/badges/shields/vendor-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('vendor-badge pull requests'),
+    name: 'vendor-badge pull requests',
     value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
@@ -222,7 +222,7 @@ t.create('Package name - Custom label')
 t.create('Package array')
   .get('/package-json/keywords/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('package keywords'),
+    name: 'package keywords',
     value: Joi.string().regex(/.*?,/)
   }));
 
@@ -345,21 +345,21 @@ t.create('hit counter for nonexistent repo')
 t.create('commit activity (1 year)')
   .get('/commit-activity/y/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('commit activity'),
+    name: 'commit activity',
     value: isMetricOverTimePeriod,
   }));
 
 t.create('commit activity (4 weeks)')
   .get('/commit-activity/4w/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('commit activity'),
+    name: 'commit activity',
     value: isMetricOverTimePeriod,
   }));
 
 t.create('commit activity (1 week)')
   .get('/commit-activity/w/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('commit activity'),
+    name: 'commit activity',
     value: isMetricOverTimePeriod,
   }));
 
@@ -426,7 +426,7 @@ t.create('github pull request check contexts')
 t.create('top language')
 .get('/languages/top/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('JavaScript'),
+  name: 'JavaScript',
   value: Joi.string().regex(/^([1-9]?[0-9]\.[0-9]|100\.0)%$/),
 }));
 
@@ -437,20 +437,20 @@ t.create('top language with empty repository')
 t.create('language count')
 .get('/languages/count/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('languages'),
+  name: 'languages',
   value: Joi.number().integer().positive(),
 }));
 
 t.create('code size in bytes for all languages')
 .get('/languages/code-size/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('code size'),
+  name: 'code size',
   value: isFileSize,
 }));
 
 t.create('repository size')
 .get('/repo-size/badges/shields.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('repo size'),
+  name: 'repo size',
   value: isFileSize,
 }));

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const {
   isMetric,
+  isMetricOverTimePeriod,
   isFileSize,
   isFormattedDate,
   isVPlusDottedVersionAtLeastOne
@@ -345,21 +346,21 @@ t.create('commit activity (1 year)')
   .get('/commit-activity/y/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('commit activity'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?\/year$/),
+    value: isMetricOverTimePeriod,
   }));
 
 t.create('commit activity (4 weeks)')
   .get('/commit-activity/4w/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('commit activity'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?\/4 weeks$/),
+    value: isMetricOverTimePeriod,
   }));
 
 t.create('commit activity (1 week)')
   .get('/commit-activity/w/eslint/eslint.json')
   .expectJSONTypes(Joi.object().keys({
     name: Joi.equal('commit activity'),
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]?\/week$/),
+    value: isMetricOverTimePeriod,
   }));
 
 t.create('last commit (recent)')

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -9,7 +9,7 @@ module.exports = t;
 t.create('Receiving')
   .get('/Gratipay.json')
   .expectJSONTypes(Joi.object().keys({
-    name: Joi.equal('receives'),
+    name: 'receives',
     value: Joi.string().regex(/^\$[0-9]+(\.[0-9]{2})?\/week/)
   }));
 

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -15,7 +15,7 @@ const isStarRating = withRegex(/^[\u2605\u2606]{5}$/);
 
 const isMetric = withRegex(/^[0-9]+[kMGTPEZY]?$/);
 
-const isMetricOverTimePeriod = withRegex(/^[0-9]+[kMGTPEZY]?\/(year|month|week|day)$/);
+const isMetricOverTimePeriod = withRegex(/^[0-9]+[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
 
 const isPercentage = withRegex(/^[0-9]+%$/);
 

--- a/service-tests/hexpm.js
+++ b/service-tests/hexpm.js
@@ -2,7 +2,10 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const { isMetric } = require('./helpers/validators');
+const {
+  isMetric,
+  isMetricOverTimePeriod
+} = require('./helpers/validators');
 
 const isHexpmVersion = Joi.string().regex(/^v\d+.\d+.?\d?$/);
 
@@ -11,17 +14,11 @@ module.exports = t;
 
 t.create('downloads per week')
   .get('/dw/cowboy.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads',
-    value: Joi.string().regex(/^\d+[a-z]?\/week$/)
-  }));
+  .expectJSONTypes(Joi.object().keys({ name: 'downloads', value: isMetricOverTimePeriod }));
 
 t.create('downloads per day')
   .get('/dd/cowboy.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads',
-    value: Joi.string().regex(/^\d+[a-z]?\/day$/)
-  }));
+  .expectJSONTypes(Joi.object().keys({ name: 'downloads', value: isMetricOverTimePeriod }));
 
 t.create('downloads in total')
   .get('/dt/cowboy.json')

--- a/service-tests/wordpress.js
+++ b/service-tests/wordpress.js
@@ -10,41 +10,41 @@ module.exports = t;
 t.create('supported version')
 .get('/v/akismet.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('wordpress'),
+  name: 'wordpress',
   value: Joi.string()
 }));
 
 t.create('plugin version')
 .get('/plugin/v/akismet.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('plugin'),
+  name: 'plugin',
   value: Joi.string()
 }));
 
 t.create('plugin rating')
 .get('/plugin/r/akismet.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('rating'),
+  name: 'rating',
   value: Joi.string()
 }));
 
 t.create('plugin downloads')
 .get('/plugin/dt/akismet.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('downloads'),
+  name: 'downloads',
   value: isMetric
 }));
 
 t.create('theme rating')
 .get('/theme/r/hestia.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('rating'),
+  name: 'rating',
   value: Joi.string()
 }));
 
 t.create('theme downloads')
 .get('/theme/dt/hestia.json')
 .expectJSONTypes(Joi.object().keys({
-  name: Joi.equal('downloads'),
+  name: 'downloads',
   value: isMetric
 }));

--- a/service-tests/wordpress.js
+++ b/service-tests/wordpress.js
@@ -2,6 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
+const { isMetric } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'wordpress', title: 'Wordpress' });
 module.exports = t;
@@ -31,7 +32,7 @@ t.create('plugin downloads')
 .get('/plugin/dt/hestia.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('downloads'),
-  value: Joi.string()
+  value: isMetric
 }));
 
 t.create('theme rating')
@@ -45,5 +46,5 @@ t.create('theme downloads')
 .get('/theme/dt/hestia.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('downloads'),
-  value: Joi.string()
+  value: isMetric
 }));

--- a/service-tests/wordpress.js
+++ b/service-tests/wordpress.js
@@ -22,14 +22,14 @@ t.create('plugin version')
 }));
 
 t.create('plugin rating')
-.get('/plugin/r/hestia.json')
+.get('/plugin/r/akismet.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('rating'),
   value: Joi.string()
 }));
 
 t.create('plugin downloads')
-.get('/plugin/dt/hestia.json')
+.get('/plugin/dt/akismet.json')
 .expectJSONTypes(Joi.object().keys({
   name: Joi.equal('downloads'),
   value: isMetric

--- a/service-tests/wordpress.js
+++ b/service-tests/wordpress.js
@@ -2,7 +2,11 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const { isMetric } = require('./helpers/validators');
+const {
+  isMetric,
+  isStarRating,
+  isVPlusDottedVersionAtLeastOne
+} = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'wordpress', title: 'Wordpress' });
 module.exports = t;
@@ -11,21 +15,21 @@ t.create('supported version')
 .get('/v/akismet.json')
 .expectJSONTypes(Joi.object().keys({
   name: 'wordpress',
-  value: Joi.string()
+  value: Joi.string().regex(/^\d+(\.\d+)?(\.\d+)? tested$/)
 }));
 
 t.create('plugin version')
 .get('/plugin/v/akismet.json')
 .expectJSONTypes(Joi.object().keys({
   name: 'plugin',
-  value: Joi.string()
+  value: isVPlusDottedVersionAtLeastOne
 }));
 
 t.create('plugin rating')
 .get('/plugin/r/akismet.json')
 .expectJSONTypes(Joi.object().keys({
   name: 'rating',
-  value: Joi.string()
+  value: isStarRating
 }));
 
 t.create('plugin downloads')
@@ -39,7 +43,7 @@ t.create('theme rating')
 .get('/theme/r/hestia.json')
 .expectJSONTypes(Joi.object().keys({
   name: 'rating',
-  value: Joi.string()
+  value: isStarRating
 }));
 
 t.create('theme downloads')


### PR DESCRIPTION
This is a follow up pull request, related to some discussions in #1175.

It covers the following aspects:
* extended the usage of the `isMetric` and `isMetricOverTimePeriod` validators where possible.
* removed calls to `Joi.equal` for bare string literals. The service-test documentation was also updated accordingly.
* fixed some Wordpress tests. A couple of tests for plugins were actually using a theme project instead. The mistake became apparent when switching from a catch all `Joi.string` to a more specific metric validator.

Cheers,

Pyves