### PR TITLE
On [Github] issues badge, add quotes around multi-word labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ When adding or changing a service [please add tests][service-tests].
 This project has quite a backlog of suggestions! If you're new to the project,
 maybe you'd like to open a pull request to address one of them:
 
-[![GitHub issues by-label](https://img.shields.io/github/issues/badges/shields/%22good%20first%20issue%22.svg)](https://github.com/badges/shields/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub issues by-label](https://img.shields.io/github/issues/badges/shields/good%20first%20issue.svg)](https://github.com/badges/shields/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 Or you can adopt one of these pull requests:
 
-[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr/badges/shields/%22good%20first%20issue%22.svg)](https://github.com/badges/shields/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr/badges/shields/good%20first%20issue.svg)](https://github.com/badges/shields/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22)
 
 You can read a [tutorial on how to add a badge][tutorial].
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ When adding or changing a service [please add tests][service-tests].
 This project has quite a backlog of suggestions! If you're new to the project,
 maybe you'd like to open a pull request to address one of them:
 
-[![GitHub issues by-label](https://img.shields.io/github/issues/badges/shields/good%20first%20issue.svg)](https://github.com/badges/shields/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub issues by-label](https://img.shields.io/github/issues/badges/shields/%22good%20first%20issue%22.svg)](https://github.com/badges/shields/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 Or you can adopt one of these pull requests:
 
-[![GitHub issues by-label](https://img.shields.io/github/issues-pr/badges/shields/good%20first%20issue.svg)](https://github.com/badges/shields/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22)
+[![GitHub pull requests by-label](https://img.shields.io/github/issues-pr/badges/shields/%22good%20first%20issue%22.svg)](https://github.com/badges/shields/pulls?q=is%3Apr+is%3Aopen+label%3A%22good+first+issue%22)
 
 You can read a [tutorial on how to add a badge][tutorial].
 

--- a/server.js
+++ b/server.js
@@ -3535,7 +3535,8 @@ cache(function(data, match, sendBadge, request) {
   var classText = isClosed? 'closed': 'open';
   var leftClassText = isRaw? classText + ' ': '';
   var rightClassText = !isRaw? ' ' + classText: '';
-  var labelText = hasLabel? ghLabel + ' ': '';
+  const isGhLabelMultiWord = hasLabel && ghLabel.includes(' ');
+  var labelText = hasLabel? (isGhLabelMultiWord? `"${ghLabel}"`: ghLabel) + ' ': '';
   var targetText = isPR? 'pull requests': 'issues';
   var badgeData = getBadgeData(leftClassText + labelText + targetText, data);
   if (badgeData.template === 'social') {

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -84,10 +84,10 @@ t.create('GitHub open issues by label is > zero')
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
   }));
 
-t.create('GitHub open issues by label is > zero')
-  .get('/issues/Cockatrice/Cockatrice/Easy%20Change.json')
+t.create('GitHub open issues by multi-word label is > zero')
+  .get('/issues/Cockatrice/Cockatrice/App%20-%20Cockatrice.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'Easy Change issues',
+    name: '"App - Cockatrice" issues',
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
   }));
 


### PR DESCRIPTION
Now "good first issue" badges in README works properly. 