### PR TITLE
[amo chrome-web-store wordpress] Enhanced star display

### DIFF
--- a/lib/text-formatters.js
+++ b/lib/text-formatters.js
@@ -8,8 +8,14 @@ const moment = require('moment');
 moment().format();
 
 function starRating(rating) {
+  const flooredRating =  Math.floor(rating);
   let stars = '';
-  while (stars.length < rating) { stars += '★'; }
+  while (stars.length < flooredRating) { stars += '★'; }
+  const decimal = rating - flooredRating;
+  if (decimal >= 0.875) { stars += '★'; }
+  else if (decimal >= 0.625) { stars += '¾'; }
+  else if (decimal >= 0.375) { stars += '½'; }
+  else if (decimal >= 0.125) { stars += '¼'; }
   while (stars.length < 5) { stars += '☆'; }
   return stars;
 }

--- a/lib/text-formatters.spec.js
+++ b/lib/text-formatters.spec.js
@@ -2,7 +2,8 @@
 
 const assert = require('assert');
 const {
- maybePluralize
+ maybePluralize,
+ starRating
 } = require('./text-formatters');
 
 describe('text formatters', function() {
@@ -17,4 +18,12 @@ describe('text formatters', function() {
     assert.equal(maybePluralize('box', [123, 456], 'boxes'), 'boxes');
     assert.equal(maybePluralize('box', undefined, 'boxes'), 'boxes');
   });
+  
+  it('should format star rating', function () {
+    assert.equal(starRating(4.9), '★★★★★');
+    assert.equal(starRating(3.7), '★★★¾☆');
+    assert.equal(starRating(2.566), '★★½☆☆');
+    assert.equal(starRating(2.2), '★★¼☆☆');
+    assert.equal(starRating(3), '★★★☆☆');
+  })
 });

--- a/server.js
+++ b/server.js
@@ -6385,7 +6385,7 @@ cache(function(data, match, sendBadge, request) {
             badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);
             break;
           case 'stars':
-            rating = Math.round(value.ratingValue);
+            rating = parseFloat(value.ratingValue);
             badgeData.text[0] = data.label || 'rating';
             badgeData.text[1] = starRating(rating);
             badgeData.colorscheme = floorCountColor(rating, 2, 3, 4);

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -11,7 +11,7 @@ const isVPlusTripleDottedVersion = withRegex(/^v[0-9]+.[0-9]+.[0-9]+$/);
 
 const isVPlusDottedVersionAtLeastOne = withRegex(/^v\d+(\.\d+)?(\.\d+)?$/);
 
-const isStarRating = withRegex(/^[\u2605\u2606]{5}$/);
+const isStarRating = withRegex(/^(?=.{5}$)(\u2605{0,5}[\u00BC\u00BD\u00BE]?\u2606{0,5})$/);
 
 const isMetric = withRegex(/^[0-9]+[kMGTPEZY]?$/);
 


### PR DESCRIPTION
This is another follow up pull request, related to some discussions in #1177.

Brief outline of the problem, for people who haven't read the previous comments. The `starRating` method was previously displaying stars floored to the nearest integer. If 4.99 was passed in as an argument, it would display ★★★★☆. Even if the value was rounded before passing it as an argument (this was done for the Chrome badges), values such as 4.49 would be brought down to ★★★★☆, which seems rough.

This pull request attempts to solve the problem by making use of three additional UTF-8 characters. Badges will now display ratings such as the following:
* ★★★¼☆
* ★★★★½
* ★★¾☆☆
* ...

Again, lacking UTF-8 characters such as half stars is not ideal, but this is a trade-off between having a badge that looks perfect and having a badge that actually conveys meaningful information. :star2:

Cheers,

Pyves