### PR TITLE
Test on Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - 8
   - 6
 
 before_script:


### PR DESCRIPTION
We use Node 6 in production, but let's make sure we're ready to upgrade to Node 8, and that things keep working on both versions.

To keep forward progress, and enable things like async/await, let's drop Node 6 support once we're using Node 8 in production.