### PR TITLE
Better test coverage of text formatters

### DIFF
--- a/lib/text-formatters.js
+++ b/lib/text-formatters.js
@@ -45,10 +45,14 @@ function metric(n) {
     const limit = metricPower[i];
     if (n >= limit) {
       n = Math.round(n / limit);
-      return ''+n + metricPrefix[i];
+      if (n < 1000) {
+        return '' + n + metricPrefix[i];
+      } else {
+        return '1' + metricPrefix[i + 1];
+      }
     }
   }
-  return ''+n;
+  return '' + n;
 }
 
 // Remove the starting v in a string.

--- a/lib/text-formatters.spec.js
+++ b/lib/text-formatters.spec.js
@@ -1,12 +1,58 @@
 'use strict';
 
 const assert = require('assert');
+const moment = require('moment');
 const {
- maybePluralize,
- starRating
+  starRating,
+  currencyFromCode,
+  ordinalNumber,
+  metric,
+  omitv,
+  maybePluralize,
+  formatDate
 } = require('./text-formatters');
 
 describe('text formatters', function() {
+  it('should format star rating', function () {
+    assert.equal(starRating(4.9), '★★★★★');
+    assert.equal(starRating(3.7), '★★★¾☆');
+    assert.equal(starRating(2.566), '★★½☆☆');
+    assert.equal(starRating(2.2), '★★¼☆☆');
+    assert.equal(starRating(3), '★★★☆☆');
+  });
+
+  it('should format currency from code', function() {
+    assert.equal(currencyFromCode('CNY'), '¥');
+    assert.equal(currencyFromCode('EUR'), '€');
+    assert.equal(currencyFromCode('GBP'), '₤');
+    assert.equal(currencyFromCode('USD'), '$');
+    assert.equal(currencyFromCode('AUD'), 'AUD');
+  });
+
+  it('should format ordinal number', function() {
+    assert.equal(ordinalNumber(2), '2ⁿᵈ');
+    assert.equal(ordinalNumber(11), '11ᵗʰ');
+    assert.equal(ordinalNumber(23), '23ʳᵈ');
+    assert.equal(ordinalNumber(131), '131ˢᵗ');
+  });
+
+  it('should format metric', function() {
+    assert.equal(metric(3), '3');
+    assert.equal(metric(998999), '999k');
+    assert.equal(metric(5000000), '5M');
+    assert.equal(metric(1578896212), '2G');
+    assert.equal(metric(80000000000000), '80T');
+    assert.equal(metric(4000000000000001), '4P');
+    assert.equal(metric(71007000100580002000), '71E');
+    assert.equal(metric(1000000000000000000000), '1Z');
+    assert.equal(metric(2222222222222222222222222), '2Y');
+  });
+
+  it('should omit leading v characters', function() {
+    assert.equal(omitv('hello'), 'hello');
+    assert.equal(omitv('v1.0.1'), '1.0.1');
+  });
+
   it('should pluralize', function() {
     assert.equal(maybePluralize('foo', []), 'foos');
     assert.equal(maybePluralize('foo', [123]), 'foo');
@@ -18,12 +64,9 @@ describe('text formatters', function() {
     assert.equal(maybePluralize('box', [123, 456], 'boxes'), 'boxes');
     assert.equal(maybePluralize('box', undefined, 'boxes'), 'boxes');
   });
-  
-  it('should format star rating', function () {
-    assert.equal(starRating(4.9), '★★★★★');
-    assert.equal(starRating(3.7), '★★★¾☆');
-    assert.equal(starRating(2.566), '★★½☆☆');
-    assert.equal(starRating(2.2), '★★¼☆☆');
-    assert.equal(starRating(3), '★★★☆☆');
-  })
+
+  it('should format date', function() {
+    assert.equal(formatDate(1465513200000), 'june 2016');
+    assert.equal(formatDate(moment().startOf('year')), 'january');
+  });
 });

--- a/lib/text-formatters.spec.js
+++ b/lib/text-formatters.spec.js
@@ -37,9 +37,10 @@ describe('text formatters', function() {
   });
 
   it('should format metric', function() {
-    assert.equal(metric(3), '3');
-    assert.equal(metric(998999), '999k');
-    assert.equal(metric(5000000), '5M');
+    assert.equal(metric(999), '999');
+    assert.equal(metric(1000), '1k');
+    assert.equal(metric(999499), '999k');
+    assert.equal(metric(999500), '1M');
     assert.equal(metric(1578896212), '2G');
     assert.equal(metric(80000000000000), '80T');
     assert.equal(metric(4000000000000001), '4P');


### PR DESCRIPTION
This pull request simply adds missing unit tests for the text formatter functions.

As a side note, I noticed something that may not be intended behaviour when writing the tests. The text formatter `metric` formats values such as 999998 to '1000k', because the value is rounded. Shouldn't this instead be formatted as '1M'? If so, I'm happy tweak the tests and the implementation to reflect this.

Cheers,

Pyves