### PR TITLE
Fix [Bower] service test

### DIFF
--- a/service-tests/bower.js
+++ b/service-tests/bower.js
@@ -4,64 +4,64 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { isVPlusDottedVersionAtLeastOne } = require('./helpers/validators');
 
-const isBowerPrereleaseVersion = Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?(-?\w)+?$/);
+const isBowerPrereleaseVersion = Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?(-?[.\w\d])+?$/);
 
 const t = new ServiceTester({ id: 'bower', title: 'Bower' });
 module.exports = t;
 
-t.create('licence. eg. bower|MIT')
+t.create('licence')
   .get('/l/bootstrap.json')
   .expectJSON({ name: 'bower', value: 'MIT' });
 
-t.create('custom label for licence. eg. my licence|MIT')
+t.create('custom label for licence')
   .get('/l/bootstrap.json?label="my licence"')
   .expectJSON({ name: 'my licence', value: 'MIT' });
 
-t.create('version. eg. bower|v0.2.5')
+t.create('version')
   .get('/v/bootstrap.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'bower',
     value: isVPlusDottedVersionAtLeastOne
   }));
 
-t.create('custom label for version. eg. my verison|v0.2.5')
+t.create('custom label for version')
   .get('/v/bootstrap.json?label="my version"')
   .expectJSONTypes(Joi.object().keys({
     name: 'my version',
     value: isVPlusDottedVersionAtLeastOne
   }));
 
-t.create('pre version. eg. bower|v0.2.5-alpha-rc-pre')
+t.create('pre version') // e.g. bower|v0.2.5-alpha-rc-pre
   .get('/vpre/bootstrap.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'bower',
     value: isBowerPrereleaseVersion
   }));
 
-t.create('custom label for pre version. eg. pre verison|v0.2.5-alpha-rc-pre')
-  .get('/vpre/bootstrap.json?label="pre verison"')
+t.create('custom label for pre version') // e.g. pre version|v0.2.5-alpha-rc-pre
+  .get('/vpre/bootstrap.json?label="pre version"')
   .expectJSONTypes(Joi.object().keys({
-    name: 'pre verison',
+    name: 'pre version',
     value: isBowerPrereleaseVersion
   }));
 
 
-t.create('Version for Invaild Package. eg. bower|invalid')
+t.create('Version for Invaild Package')
   .get('/v/it-is-a-invalid-package-should-error.json')
   .expectJSON({ name: 'bower', value: 'invalid' });
 
-t.create('Pre Version for Invaild Package. eg. bower|invalid')
+t.create('Pre Version for Invaild Package')
   .get('/vpre/it-is-a-invalid-package-should-error.json')
   .expectJSON({ name: 'bower', value: 'invalid' });
 
-t.create('licence for Invaild Package. eg. bower|invalid')
+t.create('licence for Invaild Package')
   .get('/l/it-is-a-invalid-package-should-error.json')
   .expectJSON({ name: 'bower', value: 'invalid' });
 
 
-t.create('Version label should be `no releases` if no offical version. eg. bower|no releases')
+t.create('Version label should be `no releases` if no offical version')
   .get('/v/bootstrap.json')
   .intercept(nock => nock('https://libraries.io')
     .get('/api/bower/bootstrap')
-    .reply(200, { latest_stable_release: { name: null } })) //or just `{}`
+    .reply(200, { latest_stable_release: { name: null } })) // or just `{}`
   .expectJSON({ name: 'bower', value: 'no releases' });


### PR DESCRIPTION
- Fix failing test
- Tidy up test titles (no need to repeat what is in the assertion)

```
  3) Bower
       custom label for pre version. eg. pre verison|v0.2.5-alpha-rc-pre

	[ GET http://localhost:1111/bower/vpre/bootstrap.json?label="pre verison" ]:
     ValidationError: child "value" fails because ["value" with value "v4.0.0-beta.2" fails to match the required pattern: /^v\d+(\.\d+)?(\.\d+)?(-?\w)+?$/]
```