### PR TITLE
Latest tag with any prefix

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -15,7 +15,7 @@ function latest(versions) {
   let version = '';
   let origVersions = versions;
   versions = versions.filter(function(version) {
-    return (/v?[0-9]/).test(version);
+    return (/[0-9]/).test(version);
   });
   try {
     version = semver.maxSatisfying(versions, '');

--- a/lib/version.js
+++ b/lib/version.js
@@ -15,7 +15,7 @@ function latest(versions) {
   let version = '';
   let origVersions = versions;
   versions = versions.filter(function(version) {
-    return (/^v?[0-9]/).test(version);
+    return (/v?[0-9]/).test(version);
   });
   try {
     version = semver.maxSatisfying(versions, '');

--- a/lib/version.spec.js
+++ b/lib/version.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert');
+const {latest} = require('./version');
+
+describe('latest', function () {
+  it('should handle semver compatible versions', function () {
+    assert.equal(latest(['1.0.0', '1.0.2', '1.0.1']), '1.0.2');
+    assert.equal(latest(['1.0.0', '2.0.0', '3.0.0']), '3.0.0');
+    assert.equal(latest(['0.0.1', '0.0.10', '0.0.2', '0.0.20']), '0.0.20');
+  });
+
+  it('should handle simple dotted versions', function () {
+    assert.equal(latest(['0.1', '0.3', '0.2']), '0.3');
+    assert.equal(latest(['0.1', '0.5', '0.12', '0.21']), '0.21');
+    assert.equal(latest(['1.0', '2.0', '3.0']), '3.0');
+  });
+
+  it('should handle versions with "v" prefix', function () {
+    assert.equal(latest(['v1.0.0', 'v1.0.2', 'v1.0.1']), 'v1.0.2');
+    assert.equal(latest(['v1.0.0', 'v3.0.0', 'v2.0.0']), 'v3.0.0');
+  });
+
+  it('should handle versions with "-release" prefix', function () {
+    assert.equal(latest(['release-1.0.0', 'release-1.0.2', 'release-1.0.20', 'release-1.0.10']), 'release-1.0.20');
+  });
+
+  it('should handle simple (one number) versions', function () {
+    assert.equal(latest(['2', '10', '1']), '10');
+  });
+});

--- a/lib/version.spec.js
+++ b/lib/version.spec.js
@@ -10,6 +10,13 @@ describe('latest', function () {
     assert.equal(latest(['0.0.1', '0.0.10', '0.0.2', '0.0.20']), '0.0.20');
   });
 
+  it('should handle versions with and without prefix', function () {
+    assert.equal(latest(['1.0.0', 'v1.0.2', 'r1.0.1', 'release-2.0.0']), 'release-2.0.0');
+    assert.equal(latest(['1.0.0', 'v2.0.0', 'r1.0.1', 'release-1.0.3']), 'v2.0.0');
+    assert.equal(latest(['2.0.0', 'v1.0.3', 'r1.0.1', 'release-1.0.3']), '2.0.0');
+    assert.equal(latest(['1.0.0', 'v1.0.2', 'r2.0.0', 'release-1.0.3']), 'r2.0.0');
+  });
+
   it('should handle simple dotted versions', function () {
     assert.equal(latest(['0.1', '0.3', '0.2']), '0.3');
     assert.equal(latest(['0.1', '0.5', '0.12', '0.21']), '0.21');
@@ -22,7 +29,7 @@ describe('latest', function () {
   });
 
   it('should handle versions with "-release" prefix', function () {
-    assert.equal(latest(['release-1.0.0', 'release-1.0.2', 'release-1.0.20', 'release-1.0.10']), 'release-1.0.20');
+    assert.equal(latest(['release-1.0.0', 'release-1.0.2', 'release-1.0.20', 'release-1.0.3']), 'release-1.0.20');
   });
 
   it('should handle simple (one number) versions', function () {


### PR DESCRIPTION
Currently badge for latest GitHub tag does not support tags with prefix other than `v`. For projects with such custom prefix (https://github.com/mrdoob/three.js - "r" prefix, https://github.com/square/picasso - "picasso-parent-" prefix) we get "tag | none". This change solves this problem. 