### PR TITLE
Fix downloads and commit activity badges showing zero

### DIFF
--- a/server.js
+++ b/server.js
@@ -3476,7 +3476,7 @@ cache(function(data, match, sendBadge, request) {
       }
       var downloads = 0;
 
-      const labelWords = [metric(downloads)];
+      const labelWords = [];
       if (total) {
         data.forEach(function (tagData) {
           tagData.assets.forEach(function (asset) {
@@ -3504,6 +3504,7 @@ cache(function(data, match, sendBadge, request) {
           labelWords.push(`[${asset_name}]`);
         }
       }
+      labelWords.unshift(metric(downloads));
       badgeData.text[1] = labelWords.join(' ');
       badgeData.colorscheme = 'brightgreen';
       sendBadge(format, badgeData);
@@ -3969,7 +3970,7 @@ cache(function(data, match, sendBadge, request) {
           intervalLabel = '/4 weeks';
           break;
         case 'w':
-          value = parsedData.slice(-1)[0].total;
+          value = parsedData.slice(-2)[0].total;
           intervalLabel = '/week';
           break;
         default:

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -99,16 +99,16 @@ t.create('GitHub open issues by label (raw)')
   }));
 
 t.create('GitHub open pull requests by label')
-  .get('/issues-pr/badges/shields/vendor-badge.json')
+  .get('/issues-pr/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'vendor-badge pull requests',
+    name: 'service-badge pull requests',
     value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
 t.create('GitHub open pull requests by label (raw)')
-  .get('/issues-pr-raw/badges/shields/vendor-badge.json')
+  .get('/issues-pr-raw/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'open vendor-badge pull requests',
+    name: 'open service-badge pull requests',
     value: isMetric
   }));
 

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -13,9 +13,10 @@ const isVPlusDottedVersionAtLeastOne = withRegex(/^v\d+(\.\d+)?(\.\d+)?$/);
 
 const isStarRating = withRegex(/^(?=.{5}$)(\u2605{0,5}[\u00BC\u00BD\u00BE]?\u2606{0,5})$/);
 
-const isMetric = withRegex(/^[0-9]+[kMGTPEZY]?$/);
+// Required to be > 0, beacuse accepting zero masks many problems.
+const isMetric = withRegex(/^[1-9][0-9]*[kMGTPEZY]?$/);
 
-const isMetricOverTimePeriod = withRegex(/^[0-9]+[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
+const isMetricOverTimePeriod = withRegex(/^[1-9][0-9]*[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
 
 const isPercentage = withRegex(/^[0-9]+%$/);
 


### PR DESCRIPTION
- `isMetric` tests must be > 0 to pass.
- Fix downloads badge bug introduced in #1140. (So much for [being clever](https://github.com/badges/shields/pull/1140#discussion_r143544396)!)
- Fix 1 week activity badge by returning the previous week instead of the current week.