### PR TITLE
[eclipse-marketplace] New last updated Eclipse badge

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1776,6 +1776,14 @@ const allBadgeExamples = [
           'eclipse',
           'marketplace'
         ]
+      },
+      {
+        title: 'Eclipse Marketplace',
+        previewUri: '/eclipse-marketplace/last-update/notepad4e.svg',
+        keywords: [
+          'eclipse',
+          'marketplace'
+        ]
       }
     ]
   },

--- a/server.js
+++ b/server.js
@@ -5392,7 +5392,7 @@ camp.route(/^\/vscode-marketplace\/(d|v|r)\/(.*)\.(svg|png|gif|jpg|json)$/,
 );
 
 // Eclipse Marketplace integration.
-camp.route(/^\/eclipse-marketplace\/(dt|dm|v|favorites|updated)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/eclipse-marketplace\/(dt|dm|v|favorites|last-update)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var project = match[2];
@@ -5436,7 +5436,7 @@ cache(function(data, match, sendBadge, request) {
             badgeData.text[1] = parseInt(projectNode.favorited[0]);
             badgeData.colorscheme = 'brightgreen';
             break;
-          case 'updated':
+          case 'last-update':
             var date = 1000 * parseInt(projectNode.changed[0]);
             badgeData.text[0] = 'updated';
             badgeData.text[1] = formatDate(date);

--- a/server.js
+++ b/server.js
@@ -5392,7 +5392,7 @@ camp.route(/^\/vscode-marketplace\/(d|v|r)\/(.*)\.(svg|png|gif|jpg|json)$/,
 );
 
 // Eclipse Marketplace integration.
-camp.route(/^\/eclipse-marketplace\/(dt|dm|v|favorites)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/eclipse-marketplace\/(dt|dm|v|favorites|updated)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var type = match[1];
   var project = match[2];
@@ -5435,6 +5435,12 @@ cache(function(data, match, sendBadge, request) {
             badgeData.text[0] = 'favorites';
             badgeData.text[1] = parseInt(projectNode.favorited[0]);
             badgeData.colorscheme = 'brightgreen';
+            break;
+          case 'updated':
+            var date = 1000 * parseInt(projectNode.changed[0]);
+            badgeData.text[0] = 'updated';
+            badgeData.text[1] = formatDate(date);
+            badgeData.colorscheme = ageColor(Date.parse(date));
             break;
           default:
             throw Error('Unreachable due to regex');

--- a/service-tests/eclipse-marketplace.js
+++ b/service-tests/eclipse-marketplace.js
@@ -40,8 +40,8 @@ t.create('favorites count')
     value: Joi.number().integer().positive(),
   }));
 
-t.create('last updated date')
-  .get('/updated/notepad4e.json')
+t.create('last update date')
+  .get('/last-update/notepad4e.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'updated',
     value: isFormattedDate,

--- a/service-tests/eclipse-marketplace.js
+++ b/service-tests/eclipse-marketplace.js
@@ -3,10 +3,10 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const {
+    isFormattedDate,
 	  isMetric,
 	  isMetricOverTimePeriod,
-	  isVPlusDottedVersionAtLeastOne,
-	  isFormattedDate
+	  isVPlusDottedVersionAtLeastOne
 } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'eclipse-marketplace', title: 'Eclipse' });

--- a/service-tests/eclipse-marketplace.js
+++ b/service-tests/eclipse-marketplace.js
@@ -5,7 +5,8 @@ const ServiceTester = require('./runner/service-tester');
 const {
 	  isMetric,
 	  isMetricOverTimePeriod,
-	  isVPlusDottedVersionAtLeastOne
+	  isVPlusDottedVersionAtLeastOne,
+	  isFormattedDate
 } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'eclipse-marketplace', title: 'Eclipse' });
@@ -37,4 +38,11 @@ t.create('favorites count')
   .expectJSONTypes(Joi.object().keys({
     name: 'favorites',
     value: Joi.number().integer().positive(),
+  }));
+
+t.create('last updated date')
+  .get('/updated/notepad4e.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'updated',
+    value: isFormattedDate,
   }));

--- a/try.html
+++ b/try.html
@@ -2089,11 +2089,18 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
           <td><code>https://img.shields.io/vscode-marketplace/r/ritwickdey.LiveServer.svg</code></td>
         </tr>
         <tr>
-          <th data-keywords="eclipse marketplace">Eclipse Marketplace:</th>
+          <th data-keywords="eclipse marketplace favorites">Eclipse Marketplace favorites:</th>
           <td>
             <img src="/eclipse-marketplace/favorites/notepad4e.svg" alt="" />
           </td>
           <td><code>https://img.shields.io/eclipse-marketplace/favorites/notepad4e.svg</code></td>
+        </tr>
+        <tr>
+          <th data-keywords="eclipse marketplace update">Eclipse Marketplace last update:</th>
+          <td>
+            <img src="/eclipse-marketplace/updated/notepad4e.svg" alt="" />
+          </td>
+          <td><code>https://img.shields.io/eclipse-marketplace/updated/notepad4e.svg</code></td>
         </tr>
       </tbody>
     </table>

--- a/try.html
+++ b/try.html
@@ -2089,18 +2089,11 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
           <td><code>https://img.shields.io/vscode-marketplace/r/ritwickdey.LiveServer.svg</code></td>
         </tr>
         <tr>
-          <th data-keywords="eclipse marketplace favorites">Eclipse Marketplace favorites:</th>
+          <th data-keywords="eclipse marketplace">Eclipse Marketplace:</th>
           <td>
             <img src="/eclipse-marketplace/favorites/notepad4e.svg" alt="" />
           </td>
           <td><code>https://img.shields.io/eclipse-marketplace/favorites/notepad4e.svg</code></td>
-        </tr>
-        <tr>
-          <th data-keywords="eclipse marketplace update">Eclipse Marketplace last update:</th>
-          <td>
-            <img src="/eclipse-marketplace/updated/notepad4e.svg" alt="" />
-          </td>
-          <td><code>https://img.shields.io/eclipse-marketplace/updated/notepad4e.svg</code></td>
         </tr>
       </tbody>
     </table>

--- a/try.html
+++ b/try.html
@@ -2095,6 +2095,13 @@ Pixel-perfect &nbsp; Retina-ready &nbsp; Fast &nbsp; Consistent &nbsp; Hackable 
           </td>
           <td><code>https://img.shields.io/eclipse-marketplace/favorites/notepad4e.svg</code></td>
         </tr>
+        <tr>
+          <th data-keywords="eclipse marketplace">Eclipse Marketplace:</th>
+          <td>
+            <img src="/eclipse-marketplace/last-update/notepad4e.svg" alt="" />
+          </td>
+          <td><code>https://img.shields.io/eclipse-marketplace/last-update/notepad4e.svg</code></td>
+        </tr>
       </tbody>
     </table>
   </div>


### PR DESCRIPTION
This pull request implements a fifth Eclipse Marketplace badge, which displays the "date" when the plugin was last updated on the marketplace. For instance:

![last updated](https://img.shields.io/badge/updated-september-yellowgreen.svg)

Cheers,

Pyves