### PR TITLE
Consistent overriding of labels set by the user

### DIFF
--- a/server.js
+++ b/server.js
@@ -1784,7 +1784,7 @@ cache(function(queryData, match, sendBadge, request) {
   const variants = {
     // default use `conda|{channelname}` as label
     '': function(queryData, badgeData) {
-      badgeData.text[0] = getLabel('conda|' + badgeData.text[0], queryData);
+      badgeData.text[0] = getLabel(`conda|${badgeData.text[0]}`, queryData);
     },
     // skip `conda|` prefix
     'n': function(queryData, badgeData) {
@@ -3342,7 +3342,7 @@ cache(function(query_data, match, sendBadge, request) {
           // falls through
         default:
           var value = typeof json_data[info] != 'undefined' && typeof json_data[info] != 'object' ? json_data[info] : Array.isArray(json_data[info]) ? json_data[info].join(", ") : 'invalid data';
-          badgeData.text[0] = getLabel(type + " " + info, query_data);
+          badgeData.text[0] = getLabel(`${type} ${info}`, query_data);
           badgeData.text[1] = value;
           badgeData.colorscheme = value != 'invalid data' ? 'blue' : 'lightgrey';
           break;
@@ -6208,7 +6208,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = floorCountColor(1000, 10000, 20000);
       } else if (info === 't') {
         var count = parsedData.items[0].count;
-        badgeData.text[0] = getLabel(site + ' ' + item + ' questions', data);
+        badgeData.text[0] = getLabel(`${site} ${item} questions`, data);
         badgeData.text[1] = metric(count);
         badgeData.colorscheme = floorCountColor(1000, 10000, 20000);
       }

--- a/server.js
+++ b/server.js
@@ -3342,7 +3342,7 @@ cache(function(query_data, match, sendBadge, request) {
           // falls through
         default:
           var value = typeof json_data[info] != 'undefined' && typeof json_data[info] != 'object' ? json_data[info] : Array.isArray(json_data[info]) ? json_data[info].join(", ") : 'invalid data';
-          badgeData.text[0] = getLabel(type + " " + info, data);
+          badgeData.text[0] = getLabel(type + " " + info, query_data);
           badgeData.text[1] = value;
           badgeData.colorscheme = value != 'invalid data' ? 'blue' : 'lightgrey';
           break;


### PR DESCRIPTION
Hello,

Quite a few badges were ignoring the override label set by the user (using `?label=healthinesses` in the URL for instance), and were just imposing their own value with calls such as `badgeData.text[0] = 'format';`. Admittedly, some of the badges submitted in my previous pull requests were also misbehaving like this! :sweat_smile:

This piece of work makes sure preference is given to the user defined value if any, by adding missing calls to `getLabel` when the value of `badgeData.text[0]` is reassigned.

Everything seems to still pass locally, nevertheless not sure what to put in the pull request title as the list of service tests to run would probably be a bit too long.

Cheers,

Pyves