### PR TITLE
Added support for new Code Climate scores

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1043,6 +1043,14 @@ const allBadgeExamples = [
         previewUri: '/codeclimate/issues/github/me-and/mdf.svg'
       },
       {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/maintainability/Nickersoft/dql.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/tc/Nickersoft/dql.svg'
+      },
+      {
         title: 'bitHound',
         previewUri: '/bithound/code/github/rexxars/sse-channel.svg'
       },

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1048,7 +1048,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/tc/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/c/Nickersoft/dql.svg'
       },
       {
         title: 'bitHound',

--- a/server.js
+++ b/server.js
@@ -2568,7 +2568,146 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Code Climate integration
+// Code Climate coverage (new)
+camp.route(/^\/codeclimate\/tc\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var userRepo = match[1];  // eg, `kabisaict/flow`.
+  var format = match[2];
+  request({
+      method: 'GET',
+      uri: 'http://api.codeclimate.com/v1/repos?github_slug=' + userRepo,
+      json: true
+  }, function (err, res, body) {
+    var badgeData = getBadgeData('coverage', data);
+
+    if (err != null) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+      return;
+    }
+
+    if (!body.data || body.data.length == 0 || !body.data.hasOwnProperty('attributes')) {
+      badgeData.text[1] = 'unknown';
+      sendBadge(format, badgeData);
+      return;
+    }
+
+    var options = {
+      method: 'HEAD',
+      uri: 'https://api.codeclimate.com/v1/badges/' + body.data[0].attributes.badge_token + '/test_coverage',
+    };
+
+    request(options, function(err, res) {
+      if (err != null) {
+        badgeData.text[1] = 'invalid';
+        sendBadge(format, badgeData);
+        return;
+      }
+
+      try {
+        var statusMatch = res.headers['content-disposition']
+                             .match(/filename=".*test_coverage-(.+)\.svg"/);
+        if (!statusMatch) {
+          badgeData.text[1] = 'unknown';
+          sendBadge(format, badgeData);
+          return;
+        }
+
+        var score = statusMatch[1].replace('-', '.');
+        badgeData.text[1] = score;
+
+        if (score == 'A') {
+          badgeData.colorscheme = 'brightgreen';
+        } else if (score == 'B') {
+          badgeData.colorscheme = 'green';
+        } else if (score == 'C') {
+          badgeData.colorscheme = 'yellow';
+        } else if (score == 'D') {
+          badgeData.colorscheme = 'orange';
+        } else {
+          badgeData.colorscheme = 'red';
+        }
+        sendBadge(format, badgeData);
+      } catch(e) {
+        badgeData.text[1] = 'not found';
+        sendBadge(format, badgeData);
+      }
+    });
+
+  });
+}));
+
+
+// Code Climate maintainability
+camp.route(/^\/codeclimate\/maintainability\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var userRepo = match[1];  // eg, `kabisaict/flow`.
+  var format = match[2];
+  request({
+      method: 'GET',
+      uri: 'http://api.codeclimate.com/v1/repos?github_slug=' + userRepo,
+      json: true
+  }, function (err, res, body) {
+    var badgeData = getBadgeData('maintainability', data);
+
+    if (err != null) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+      return;
+    }
+
+    if (!body.data || body.data.length == 0 || !body.data.hasOwnProperty('attributes')) {
+      badgeData.text[1] = 'unknown';
+      sendBadge(format, badgeData);
+      return;
+    }
+
+    var options = {
+      method: 'HEAD',
+      uri: 'https://api.codeclimate.com/v1/badges/' + body.data[0].attributes.badge_token + '/maintainability',
+    };
+
+    request(options, function(err, res) {
+      if (err != null) {
+        badgeData.text[1] = 'invalid';
+        sendBadge(format, badgeData);
+        return;
+      }
+
+      try {
+        var statusMatch = res.headers['content-disposition']
+                             .match(/filename=".*maintainability-(.+)\.svg"/);
+        if (!statusMatch) {
+          badgeData.text[1] = 'unknown';
+          sendBadge(format, badgeData);
+          return;
+        }
+
+        var score = statusMatch[1].replace('-', '.');
+        badgeData.text[1] = score;
+
+        if (score == 'A') {
+          badgeData.colorscheme = 'brightgreen';
+        } else if (score == 'B') {
+          badgeData.colorscheme = 'green';
+        } else if (score == 'C') {
+          badgeData.colorscheme = 'yellowgreen';
+        } else if (score == 'D') {
+          badgeData.colorscheme = 'yellow';
+        } else {
+          badgeData.colorscheme = 'red';
+        }
+        sendBadge(format, badgeData);
+      } catch(e) {
+        badgeData.text[1] = 'not found';
+        sendBadge(format, badgeData);
+      }
+    });
+
+  });
+}));
+
+// // Code Climate integration
 camp.route(/^\/codeclimate\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var userRepo = match[1];  // eg, `github/kabisaict/flow`.
@@ -2600,9 +2739,9 @@ cache(function(data, match, sendBadge, request) {
       } else if (score > 3) {
         badgeData.colorscheme = 'green';
       } else if (score > 2) {
-        badgeData.colorscheme = 'yellowgreen';
-      } else if (score > 1) {
         badgeData.colorscheme = 'yellow';
+      } else if (score > 1) {
+        badgeData.colorscheme = 'orange';
       } else {
         badgeData.colorscheme = 'red';
       }

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
+
+t.create('maintainability score')
+  .get('/maintainability/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'maintainability',
+    value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
+  }));
+
+t.create('maintainability score for unknown repo')
+  .get('/maintainability/unknown/unknown.json')
+  .expectJSON({
+    name: 'maintainability',
+    value: 'unknown'
+  });
+
+t.create('test coverage score')
+  .get('/tc/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
+  }));
+
+t.create('test coverage score for unknown repo')
+  .get('/tc/unknown/unknown.json')
+  .expectJSON({
+    name: 'coverage',
+    value: 'unknown'
+  });
+
+
+module.exports = t;

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -12,25 +12,25 @@ t.create('maintainability score')
     value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
   }));
 
-t.create('maintainability score for unknown repo')
+t.create('maintainability score for non-existent repo')
   .get('/maintainability/unknown/unknown.json')
   .expectJSON({
     name: 'maintainability',
-    value: 'unknown'
+    value: 'not found'
   });
 
 t.create('test coverage score')
-  .get('/tc/Nickersoft/dql.json')
+  .get('/c/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
   }));
 
-t.create('test coverage score for unknown repo')
-  .get('/tc/unknown/unknown.json')
+t.create('test coverage score for non-existent repo')
+  .get('/c/unknown/unknown.json')
   .expectJSON({
     name: 'coverage',
-    value: 'unknown'
+    value: 'not found'
   });
 
 

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -19,6 +19,13 @@ t.create('maintainability score for non-existent repo')
     value: 'not found'
   });
 
+t.create('maintainability score without content-disposition')
+  .get('/maintainability/Nickersoft/dql.json')
+  .intercept(nock => nock('https://api.codeclimate.com/v1/badges')
+    .head('/78ac0fa85c83fea5213a/maintainability')
+    .reply(200))
+  .expectJSON({ name: 'maintainability', value: 'invalid' });
+
 t.create('test coverage score')
   .get('/c/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
@@ -32,6 +39,13 @@ t.create('test coverage score for non-existent repo')
     name: 'coverage',
     value: 'not found'
   });
+
+t.create('test coverage score without content-disposition')
+  .get('/c/Nickersoft/dql.json')
+  .intercept(nock => nock('https://api.codeclimate.com/v1/badges')
+    .head('/78ac0fa85c83fea5213a/test_coverage')
+    .reply(200))
+  .expectJSON({ name: 'coverage', value: 'invalid' });
 
 
 module.exports = t;


### PR DESCRIPTION
One think to note: unlike the previous CC badges, the new API uses badge tokens associated with repos to retrieve SVG badges for users (as opposed to just the repo name). As a result, the new badges have to first make a request to the CC API to get the token associated with the repo, then make another request to get information regarding the badge. Also due to this, it was difficult to write tests that test for invalid response headers. Everything else should be covered though.