### PR TITLE
[sonar] support new SonarQube api

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -137,11 +137,11 @@ const allBadgeExamples = [
         previewUri: '/sonar/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.svg'
       },
       {
-        title: 'SonarQube Coverage (depreciated API)',
+        title: 'SonarQube Coverage (legacy API)',
         previewUri: '/sonar/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.svg'
       },
       {
-        title: 'SonarQube Tech Debt (depreciated API)',
+        title: 'SonarQube Tech Debt (legacy API)',
         previewUri: '/sonar/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.svg'
       },
       {

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -130,11 +130,19 @@ const allBadgeExamples = [
       },
       {
         title: 'SonarQube Coverage',
-        previewUri: '/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/coverage.svg'
+        previewUri: '/sonar/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.svg'
       },
       {
         title: 'SonarQube Tech Debt',
-        previewUri: '/sonar/http/sonar.qatools.ru/ru.yandex.qatools.allure:allure-core/tech_debt.svg'
+        previewUri: '/sonar/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.svg'
+      },
+      {
+        title: 'SonarQube Coverage (depreciated API)',
+        previewUri: '/sonar/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.svg'
+      },
+      {
+        title: 'SonarQube Tech Debt (depreciated API)',
+        previewUri: '/sonar/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.svg'
       },
       {
         title: 'TeamCity CodeBetter Coverage',

--- a/server.js
+++ b/server.js
@@ -827,7 +827,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // SonarQube code coverage
-camp.route(/^\/sonar\/?(.*)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/sonar\/?([0-9.]+)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
     cache(function(data, match, sendBadge, request) {
       var version = parseFloat(match[1]);
       var scheme = match[2];
@@ -842,7 +842,9 @@ camp.route(/^\/sonar\/?(.*)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|j
         sonarMetricName = 'sqale_debt_ratio';
       }
 
-      var uri = (!!version && version < 5.4) ?
+      const useLegacyApi = !!version && version < 5.4;
+
+      var uri = useLegacyApi ?
           scheme + '://' + serverUrl + '/api/resources?resource=' + buildType + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true':
           scheme + '://' + serverUrl + '/api/measures/component?componentKey=' + buildType + '&metricKeys=' + encodeURIComponent(sonarMetricName);
 
@@ -869,7 +871,7 @@ camp.route(/^\/sonar\/?(.*)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|j
         try {
           var data = JSON.parse(buffer);
 
-          var value =  parseInt((!!version && version < 5.4) ? data[0].msr[0].val : data.component.measures[0].value);
+          var value =  parseInt(useLegacyApi ? data[0].msr[0].val : data.component.measures[0].value);
 
           if (value === undefined) {
             badgeData.text[1] = 'unknown';

--- a/server.js
+++ b/server.js
@@ -869,7 +869,7 @@ camp.route(/^\/sonar\/?(.*)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|j
         try {
           var data = JSON.parse(buffer);
 
-          var value =  (!!version && version < 5.4) ? data[0].msr[0].val : parseInt(data.component.measures[0].value);
+          var value =  parseInt((!!version && version < 5.4) ? data[0].msr[0].val : data.component.measures[0].value);
 
           if (value === undefined) {
             badgeData.text[1] = 'unknown';

--- a/server.js
+++ b/server.js
@@ -827,13 +827,14 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // SonarQube code coverage
-camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/sonar\/?(.*)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
     cache(function(data, match, sendBadge, request) {
-      var scheme = match[1];
-      var serverUrl = match[2];  // eg, `sonar.qatools.ru`.
-      var buildType = match[3];  // eg, `ru.yandex.qatools.allure:allure-core:master`.
-      var metricName = match[4];
-      var format = match[5];
+      var version = parseFloat(match[1]);
+      var scheme = match[2];
+      var serverUrl = match[3];
+      var buildType = match[4];
+      var metricName = match[5];
+      var format = match[6];
 
       var sonarMetricName = metricName;
       if (metricName === 'tech_debt') {
@@ -841,9 +842,12 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
         sonarMetricName = 'sqale_debt_ratio';
       }
 
+      var uri = (!!version && version < 5.4) ?
+          scheme + '://' + serverUrl + '/api/resources?resource=' + buildType + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true':
+          scheme + '://' + serverUrl + '/api/measures/component?componentKey=' + buildType + '&metricKeys=' + encodeURIComponent(sonarMetricName);
+
       var options = {
-        uri: scheme + '://' + serverUrl + '/api/resources?resource=' + buildType
-          + '&depth=0&metrics=' + encodeURIComponent(sonarMetricName) + '&includetrends=true',
+        uri,
         headers: {
           Accept: 'application/json'
         }
@@ -865,7 +869,7 @@ camp.route(/^\/sonar\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
         try {
           var data = JSON.parse(buffer);
 
-          var value = data[0].msr[0].val;
+          var value =  (!!version && version < 5.4) ? data[0].msr[0].val : parseInt(data.component.measures[0].value);
 
           if (value === undefined) {
             badgeData.text[1] = 'unknown';

--- a/service-tests/sonarqube.js
+++ b/service-tests/sonarqube.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'sonar', title: 'SonarQube' });
+module.exports = t;
+
+t.create('Tech Debt')
+  .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'tech debt',
+    value: Joi.string().regex(/^\d+\%$/)
+  }));
+
+t.create('Coverage')
+  .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.string().regex(/^\d+\%$/)
+  }));
+
+t.create('Tech Debt (old API supported)')
+  .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'tech debt',
+    value: Joi.string().regex(/^\d+\%$/)
+  }));
+
+t.create('Coverage (old API supported)')
+  .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.string().regex(/^\d+\%$/)
+  }));
+
+t.create('Tech Debt (old API unsupported)')
+  .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.json')
+  .expectJSON({ name: 'tech debt', value: 'invalid' });
+
+t.create('Coverage (old API unsupported)')
+  .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/coverage.json')
+  .expectJSON({ name: 'coverage', value: 'invalid' });

--- a/service-tests/sonarqube.js
+++ b/service-tests/sonarqube.js
@@ -10,28 +10,28 @@ t.create('Tech Debt')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: Joi.string().regex(/^\d+\%$/)
+    value: Joi.string().regex(/^\d+%$/)
   }));
 
 t.create('Coverage')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: Joi.string().regex(/^\d+\%$/)
+    value: Joi.string().regex(/^\d+%$/)
   }));
 
 t.create('Tech Debt (old API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: Joi.string().regex(/^\d+\%$/)
+    value: Joi.string().regex(/^\d+%$/)
   }));
 
 t.create('Coverage (old API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: Joi.string().regex(/^\d+\%$/)
+    value: Joi.string().regex(/^\d+%$/)
   }));
 
 t.create('Tech Debt (old API unsupported)')

--- a/service-tests/sonarqube.js
+++ b/service-tests/sonarqube.js
@@ -2,6 +2,9 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
+const {
+  isPercentage,
+} = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'sonar', title: 'SonarQube' });
 module.exports = t;
@@ -10,34 +13,34 @@ t.create('Tech Debt')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: Joi.string().regex(/^\d+%$/)
+    value: isPercentage
   }));
 
 t.create('Coverage')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: Joi.string().regex(/^\d+%$/)
+    value: isPercentage
   }));
 
-t.create('Tech Debt (old API supported)')
+t.create('Tech Debt (legacy API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: Joi.string().regex(/^\d+%$/)
+    value: isPercentage
   }));
 
-t.create('Coverage (old API supported)')
+t.create('Coverage (legacy API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: Joi.string().regex(/^\d+%$/)
+    value: isPercentage
   }));
 
-t.create('Tech Debt (old API unsupported)')
+t.create('Tech Debt (legacy API unsupported)')
   .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.json')
   .expectJSON({ name: 'tech debt', value: 'invalid' });
 
-t.create('Coverage (old API unsupported)')
+t.create('Coverage (legacy API unsupported)')
   .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/coverage.json')
   .expectJSON({ name: 'coverage', value: 'invalid' });


### PR DESCRIPTION
Update of #931 
Closes #877 

The depreciated api example does not seem to work, I suspect the project no longer exist.
If anyone has a badge which we could use that uses the old api for the example/tests would be great!

to-do's
- [x] Update Examples
  - [x] New API example
  - [x] Depreciated API example
- [x] Add Tests
  - [x] New API
  - [x] Depreciated API

_currently failing due to no tests_