### PR TITLE
[github] Issues/PR support labels with spaces

### DIFF
--- a/server.js
+++ b/server.js
@@ -3512,7 +3512,7 @@ cache(function(data, match, sendBadge, request) {
   var isRaw = !!match[3];
   var user = match[4];  // eg, badges
   var repo = match[5];  // eg, shields
-  var ghLabel = match[6];  // eg, website
+  var ghLabel = decodeURI(match[6]);  // eg, website
   var format = match[7];
   var apiUrl = githubApiUrl + '/search/issues';
   var query = {};


### PR DESCRIPTION
Support showing PR's & Issues when searching for specific label containing spaces:
Example from README.md:

Currently: ![](https://img.shields.io/github/issues/badges/shields/good%20first%20issue.svg)
Should Be: ![](https://img.shields.io/badge/"good%20first%20issue"%20issues-52%20open-yellow.svg)