### PR TITLE
[github] Revert "github issue/pr support labels with spaces (#1240)"

### DIFF
--- a/server.js
+++ b/server.js
@@ -3512,7 +3512,7 @@ cache(function(data, match, sendBadge, request) {
   var isRaw = !!match[3];
   var user = match[4];  // eg, badges
   var repo = match[5];  // eg, shields
-  var ghLabel = decodeURI(match[6]);  // eg, website
+  var ghLabel = match[6];  // eg, website
   var format = match[7];
   var apiUrl = githubApiUrl + '/search/issues';
   var query = {};


### PR DESCRIPTION
This reverts #1240, which introduced this issue:

http://localhost:8080/github/issues-raw/badges/shields.json

0d1e4c0 (merge of #1240)

```
{
name: "open undefined issues",
value: "0"
}
```

ad4a8b4 (previous commit)

```
{
name: "open issues",
value: "114"
}
```

I believe the bug was already fixed in #1135.