### PR TITLE
Update Homepage - Styles

### DIFF
--- a/frontend/fragments/try-footer.html
+++ b/frontend/fragments/try-footer.html
@@ -90,7 +90,7 @@ The following styles are available (flat is the default as of Feb 1st 2015):
   <td><code>https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square</code></td>
   </tr>
   <tr>
-  <td><img src="/badge/style-for--the--badge-green.svg?style=for-the-badge" alt='' style='height:28px;'/></td>
+  <td><img src="/badge/style-for--the--badge-green.svg?style=for-the-badge" alt=''/></td>
   <td><code>https://img.shields.io/badge/style-for--the--badge-green.svg?style=for-the-badge</code></td>
   </tr>
   <tr>

--- a/frontend/fragments/try-footer.html
+++ b/frontend/fragments/try-footer.html
@@ -157,9 +157,11 @@ is where the current server got started.
   </p><p><label> Image <input type='url' name='img'/></label>
   </p><p><label> Style
     <select name='style'>
-      <option value='plastic'>          plastic
-      <option value='flat' selected>    flat
-      <option value='flat-square'>      flat-square
+      <option value='plastic'>plastic</option>
+      <option value='flat' selected>flat</option>
+      <option value='flat-square'>flat-square</option>
+      <option value='for-the-badge'>for-the-badge</option>
+      <option value='social'>social</option>
     </select>
   </label>
   </p><p> Markdown

--- a/frontend/fragments/try-footer.html
+++ b/frontend/fragments/try-footer.html
@@ -90,7 +90,7 @@ The following styles are available (flat is the default as of Feb 1st 2015):
   <td><code>https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square</code></td>
   </tr>
   <tr>
-  <td><img src="/badge/style-for--the--badge-green.svg?style=for-the-badge" alt=''/></td>
+  <td><img src="/badge/style-for--the--badge-green.svg?style=for-the-badge" alt='' style='height:28px;'/></td>
   <td><code>https://img.shields.io/badge/style-for--the--badge-green.svg?style=for-the-badge</code></td>
   </tr>
   <tr>

--- a/frontend/fragments/try-header.html
+++ b/frontend/fragments/try-header.html
@@ -48,7 +48,7 @@ table.badge > tbody > tr > th,
 table.badge > tbody > tr > td > img,
 table.badge > tbody > tr > td > code { cursor: pointer; }
 table.badge > tbody > tr > td > img, .badge-img img, #copyImg {
-  height: 20px;
+  min-height: 20px;
   vertical-align: middle;
 }
 </style>


### PR DESCRIPTION
Closes #1206 
![image](https://user-images.githubusercontent.com/7288322/32303225-2a4b5830-bfcc-11e7-8607-12f87e80d31a.png)
_IMO it looks a little strange, but makes sense to display it the real size_

Added `social` & `for-the-badge` style to badge creation dropdown list
& close `<option>` tags
![image](https://user-images.githubusercontent.com/7288322/32303295-7ec651bc-bfcc-11e7-86be-da0f504eecf9.png)