### PR TITLE
Fix Github OAuth error again

### DIFF
--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -38,7 +38,7 @@ function cancelAutosaving() {
 }
 
 function setRoutes(server) {
-  const baseUrl = process.env.BASE_URL || 'https://shields.io';
+  const baseUrl = process.env.BASE_URL || 'https://img.shields.io';
 
   server.route(/^\/github-auth$/, function(data, match, end, ask) {
     if (!(serverSecrets && serverSecrets.gh_client_id)) {


### PR DESCRIPTION
This fix #1243, a merge error introduced in #1118.

This line went out:

```
const baseUrl = process.env.BASE_URL || 'https://img.shields.io';
```

And this one went in:

```
const baseUrl = process.env.BASE_URL || 'https://shields.io';
```