### PR TITLE
fix "flat-square" example badge

### DIFF
--- a/frontend/fragments/try-footer.html
+++ b/frontend/fragments/try-footer.html
@@ -86,8 +86,8 @@ The following styles are available (flat is the default as of Feb 1st 2015):
   <td><code>https://img.shields.io/badge/style-flat-green.svg?style=flat</code></td>
   </tr>
   <tr>
-  <td><img src="/badge/style-flat--squared-green.svg?style=flat-square" alt=''/></td>
-  <td><code>https://img.shields.io/badge/style-flat--squared-green.svg?style=flat-square</code></td>
+  <td><img src="/badge/style-flat--square-green.svg?style=flat-square" alt=''/></td>
+  <td><code>https://img.shields.io/badge/style-flat--square-green.svg?style=flat-square</code></td>
   </tr>
   <tr>
   <td><img src="/badge/style-for--the--badge-green.svg?style=for-the-badge" alt=''/></td>


### PR DESCRIPTION
Logo wasn't matching the used parameter.