### PR TITLE
[npm node] support for custom npm registry

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -641,6 +641,13 @@ const allBadgeExamples = [
         ]
       },
       {
+        title: 'npm (custom registry)',
+        previewUri: '/npm/v/npm.svg?registry_uri=https://registry.npm.taobao.org',
+        keywords: [
+          'node'
+        ]
+      },
+      {
         title: 'npm (scoped with tag)',
         previewUri: '/npm/v/@cycle/core/canary.svg',
         keywords: [
@@ -648,29 +655,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'custom registry :: npm',
-        previewUri: '/npm/https/registry.npm.taobao.org/v/npm.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: npm (scoped)',
-        previewUri: '/npm/https/registry.npm.taobao.org/v/@cycle/core.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: npm (tag)',
-        previewUri: '/npm/https/registry.npm.taobao.org/v/npm/next.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: npm (scoped with tag)',
-        previewUri: '/npm/https/registry.npm.taobao.org/v/@cycle/core/canary.svg',
+        title: 'npm (scoped with tag, custom registry)',
+        previewUri: '/npm/v/@cycle/core/canary.svg?registry_uri=https://registry.npm.taobao.org',
         keywords: [
           'node'
         ]
@@ -704,29 +690,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'custom registry :: node',
-        previewUri: '/node/https/registry.npm.taobao.org/v/passport.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: node (scoped)',
-        previewUri: '/node/https/registry.npm.taobao.org/v/@stdlib/stdlib.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: node (tag)',
-        previewUri: '/node/https/registry.npm.taobao.org/v/passport/latest.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'custom registry :: node (scoped with tag)',
-        previewUri: '/node/https/registry.npm.taobao.org/v/@stdlib/stdlib/latest.svg',
+        title: 'node (scoped with tag, custom registry)',
+        previewUri: '/node/v/@stdlib/stdlib/latest.svg?registry_uri=https://registry.npm.taobao.org',
         keywords: [
           'node'
         ]
@@ -1173,8 +1138,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'custom registry :: npm',
-        previewUri: '/npm/https/registry.npm.taobao.org/l/express.svg',
+        title: 'npm (custom registry)',
+        previewUri: '/npm/l/express.svg?registry_uri=https://registry.npm.taobao.org',
         keywords: [
           'node'
         ]

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -642,7 +642,7 @@ const allBadgeExamples = [
       },
       {
         title: 'npm (custom registry)',
-        previewUri: '/npm/v/npm.svg?registry_uri=https://registry.npm.taobao.org',
+        previewUri: '/npm/v/npm.svg?registry_uri=https://registry.npmjs.com',
         keywords: [
           'node'
         ]
@@ -656,7 +656,7 @@ const allBadgeExamples = [
       },
       {
         title: 'npm (scoped with tag, custom registry)',
-        previewUri: '/npm/v/@cycle/core/canary.svg?registry_uri=https://registry.npm.taobao.org',
+        previewUri: '/npm/v/@cycle/core/canary.svg?registry_uri=https://registry.npmjs.com',
         keywords: [
           'node'
         ]
@@ -691,7 +691,7 @@ const allBadgeExamples = [
       },
       {
         title: 'node (scoped with tag, custom registry)',
-        previewUri: '/node/v/@stdlib/stdlib/latest.svg?registry_uri=https://registry.npm.taobao.org',
+        previewUri: '/node/v/@stdlib/stdlib/latest.svg?registry_uri=https://registry.npmjs.com',
         keywords: [
           'node'
         ]
@@ -1139,7 +1139,7 @@ const allBadgeExamples = [
       },
       {
         title: 'npm (custom registry)',
-        previewUri: '/npm/l/express.svg?registry_uri=https://registry.npm.taobao.org',
+        previewUri: '/npm/l/express.svg?registry_uri=https://registry.npmjs.com',
         keywords: [
           'node'
         ]

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -648,6 +648,34 @@ const allBadgeExamples = [
         ]
       },
       {
+        title: 'custom registry :: npm',
+        previewUri: '/npm/https/registry.npm.taobao.org/v/npm.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: npm (scoped)',
+        previewUri: '/npm/https/registry.npm.taobao.org/v/@cycle/core.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: npm (tag)',
+        previewUri: '/npm/https/registry.npm.taobao.org/v/npm/next.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: npm (scoped with tag)',
+        previewUri: '/npm/https/registry.npm.taobao.org/v/@cycle/core/canary.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
         title: 'node',
         previewUri: '/node/v/passport.svg',
         keywords: [
@@ -671,6 +699,34 @@ const allBadgeExamples = [
       {
         title: 'node (scoped with tag)',
         previewUri: '/node/v/@stdlib/stdlib/latest.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: node',
+        previewUri: '/node/https/registry.npm.taobao.org/v/passport.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: node (scoped)',
+        previewUri: '/node/https/registry.npm.taobao.org/v/@stdlib/stdlib.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: node (tag)',
+        previewUri: '/node/https/registry.npm.taobao.org/v/passport/latest.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: node (scoped with tag)',
+        previewUri: '/node/https/registry.npm.taobao.org/v/@stdlib/stdlib/latest.svg',
         keywords: [
           'node'
         ]
@@ -1112,6 +1168,13 @@ const allBadgeExamples = [
       {
         title: 'npm',
         previewUri: '/npm/l/express.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'custom registry :: npm',
+        previewUri: '/npm/https/registry.npm.taobao.org/l/express.svg',
         keywords: [
           'node'
         ]

--- a/lib/npm-badge-helpers.js
+++ b/lib/npm-badge-helpers.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const defaultRegistryUrl = 'https://registry.npmjs.org';
+
+function getNpmRegistryUrl(maybeRegistryUrl) {
+  const registryUrl = maybeRegistryUrl || defaultRegistryUrl;
+  return registryUrl;
+}
+
+module.exports = {
+  getNpmRegistryUrl
+};

--- a/lib/npm-badge-helpers.js
+++ b/lib/npm-badge-helpers.js
@@ -1,12 +1,7 @@
 'use strict';
 
-const defaultRegistryUrl = 'https://registry.npmjs.org';
-
-function getNpmRegistryUrl(maybeRegistryUrl) {
-  const registryUrl = maybeRegistryUrl || defaultRegistryUrl;
-  return registryUrl;
-}
+const defaultNpmRegistryUri = 'https://registry.npmjs.org';
 
 module.exports = {
-  getNpmRegistryUrl
+  defaultNpmRegistryUri,
 };

--- a/lib/npm-provider.js
+++ b/lib/npm-provider.js
@@ -36,15 +36,6 @@ function mapNpmDownloads(camp, urlComponent, apiUriComponent) {
   }));
 }
 
-// npm registry url
-function getNpmRegistryUrl(maybeProtocol, maybeHost) {
-  const protocol = maybeProtocol || 'https';
-  const host = maybeHost || 'registry.npmjs.org';
-  const url = `${protocol}://${host}`;
-  return url;
-}
-
 module.exports = {
-  mapNpmDownloads,
-  getNpmRegistryUrl
+  mapNpmDownloads
 };

--- a/lib/npm-provider.js
+++ b/lib/npm-provider.js
@@ -36,6 +36,15 @@ function mapNpmDownloads(camp, urlComponent, apiUriComponent) {
   }));
 }
 
+// npm registry url
+function getNpmRegistryUrl(maybeProtocol, maybeHost) {
+  const protocol = maybeProtocol || 'https';
+  const host = maybeHost || 'registry.npmjs.org';
+  const url = `${protocol}://${host}`;
+  return url;
+}
+
 module.exports = {
-  mapNpmDownloads
+  mapNpmDownloads,
+  getNpmRegistryUrl
 };

--- a/server.js
+++ b/server.js
@@ -68,9 +68,11 @@ const {
   isSnapshotVersion: isNexusSnapshotVersion
 } = require('./lib/nexus-version');
 const {
-  mapNpmDownloads,
-  getNpmRegistryUrl
+  mapNpmDownloads
 } = require('./lib/npm-provider');
+const {
+  getNpmRegistryUrl
+} = require('./lib/npm-badge-helpers');
 const {
   teamcityBadge
 } = require('./lib/teamcity-badge-helpers');

--- a/service-tests/node.js
+++ b/service-tests/node.js
@@ -31,7 +31,7 @@ t.create("gets the tagged release's node version version of ionic")
   .afterJSON(json => { assertIsSemverRange(json.value); });
 
 t.create('gets the node version of passport from a custom registry')
-  .get('/v/passport.json?registry_uri=https://registry.npm.taobao.org')
+  .get('/v/passport.json?registry_uri=https://registry.npmjs.com')
   .expectJSONTypes(Joi.object({ name: 'node' }).unknown())
   .afterJSON(json => { assertIsSemverRange(json.value); });
 

--- a/service-tests/node.js
+++ b/service-tests/node.js
@@ -30,6 +30,11 @@ t.create("gets the tagged release's node version version of ionic")
   .expectJSONTypes(Joi.object({ name: 'node@next' }).unknown())
   .afterJSON(json => { assertIsSemverRange(json.value); });
 
+t.create('gets the node version of passport from a custom registry')
+  .get('/v/passport.json?registry_uri=https://registry.npm.taobao.org')
+  .expectJSONTypes(Joi.object({ name: 'node' }).unknown())
+  .afterJSON(json => { assertIsSemverRange(json.value); });
+
 t.create("gets the tagged release's node version of @cycle/core")
   .get('/v/@cycle/core/canary.json')
   .expectJSONTypes(Joi.object({ name: 'node@canary' }).unknown())

--- a/service-tests/npm.js
+++ b/service-tests/npm.js
@@ -19,8 +19,16 @@ t.create('gets the tagged package version of npm')
   .get('/v/npm/next.json')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@next', value: isSemver }));
 
+t.create('gets the package version of left-pad from a custom registry')
+  .get('/v/left-pad.json?registry_uri=https://registry.npm.taobao.org')
+  .expectJSONTypes(Joi.object().keys({ name: 'npm', value: isSemver }));
+
 t.create('gets the tagged package version of @cycle/core')
   .get('/v/@cycle/core/canary.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'npm@canary', value: isSemver }));
+
+t.create('gets the tagged package version of @cycle/core from a custom registry')
+  .get('/v/@cycle/core/canary.json?registry_uri=https://registry.npm.taobao.org')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@canary', value: isSemver }));
 
 t.create('invalid package name')

--- a/service-tests/npm.js
+++ b/service-tests/npm.js
@@ -31,6 +31,14 @@ t.create('gets the tagged package version of @cycle/core from a custom registry'
   .get('/v/@cycle/core/canary.json?registry_uri=https://registry.npmjs.com')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@canary', value: isSemver }));
 
+t.create('gets the license of express')
+  .get('/l/express.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'license', value: 'MIT' }));
+
+t.create('gets the license of express from a custom registry')
+  .get('/l/express.json?registry_uri=https://registry.npmjs.com')
+  .expectJSONTypes(Joi.object().keys({ name: 'license', value: 'MIT' }));
+
 t.create('invalid package name')
   .get('/v/frodo-is-not-a-package.json')
   .expectJSON({ name: 'npm', value: 'invalid' });

--- a/service-tests/npm.js
+++ b/service-tests/npm.js
@@ -20,7 +20,7 @@ t.create('gets the tagged package version of npm')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@next', value: isSemver }));
 
 t.create('gets the package version of left-pad from a custom registry')
-  .get('/v/left-pad.json?registry_uri=https://registry.npm.taobao.org')
+  .get('/v/left-pad.json?registry_uri=https://registry.npmjs.com')
   .expectJSONTypes(Joi.object().keys({ name: 'npm', value: isSemver }));
 
 t.create('gets the tagged package version of @cycle/core')
@@ -28,7 +28,7 @@ t.create('gets the tagged package version of @cycle/core')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@canary', value: isSemver }));
 
 t.create('gets the tagged package version of @cycle/core from a custom registry')
-  .get('/v/@cycle/core/canary.json?registry_uri=https://registry.npm.taobao.org')
+  .get('/v/@cycle/core/canary.json?registry_uri=https://registry.npmjs.com')
   .expectJSONTypes(Joi.object().keys({ name: 'npm@canary', value: isSemver }));
 
 t.create('invalid package name')


### PR DESCRIPTION
there are two types of custom npm registries:
* public: due to geographical or maybe political reasons https://registry.npm.taobao.org/—essentially copy of https://registry.npmjs.org/
* private: due to legal requirements (my case) or redundancy reasoning—either npm enterprise or sinopia

affected endpoints:
* _npm node version integration_ now supports `/npm/https/registry.npm.taobao.org/v/express.svg`:
  ```diff
  -/^\/npm\/v\/(?:@([^/]+))?\/?([^/]*)\/?([^/]*)\.(svg|png|gif|jpg|json)$/
  +/^\/npm(?:\/(http(?:s)?)\/([^/]+))?\/v\/(?:@([^/]+))?\/?([^/]*)\/?([^/]*)\.(svg|png|gif|jpg|json)$/
  ```
* _npm license integration_ now supports `/npm/https/registry.npm.taobao.org/l/express.svg`:
  ```diff
  -/^\/npm\/l\/(?:@([^/]+)\/)?([^/]+)\.(svg|png|gif|jpg|json)$/
  +/^\/npm(?:\/(http(?:s)?)\/([^/]+))?\/l\/(?:@([^/]+)\/)?([^/]+)\.(svg|png|gif|jpg|json)$/
  ```
* _npm node version integration_ now supports `/node/https/registry.npm.taobao.org/v/express.svg`:
  ```diff
  -/^\/npm\/l\/(?:@([^/]+)\/)?([^/]+)\.(svg|png|gif|jpg|json)$/
  +/^\/npm(?:\/(http(?:s)?)\/([^/]+))?\/l\/(?:@([^/]+)\/)?([^/]+)\.(svg|png|gif|jpg|json)$/
  ```

downloads related endpoints are not affected due to custom https://api.npmjs.org/ server, which complicates stuff. But apart from complexity, there are several reasons not to modify these endpoints:
  * for public registries its (maybe) okay to use default registry
  * for private registries this downloads metric is (maybe) unnecessary

P.S. inspiration for `/npm(/:protocol/:host)/…` is jenkins endpoint