### PR TITLE
For-the-badge | Convert labels to string then uppercase

### DIFF
--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -95,8 +95,8 @@ function makeBadge (data) {
     data.template = 'flat';
   }
   if (data.template === 'for-the-badge'){
-    data.text[0] = data.text[0].toString().toUpperCase();
-    data.text[1] = data.text[1].toString().toUpperCase();
+    data.text[0] = ('' + data.text[0]).toUpperCase();
+    data.text[1] = ('' + data.text[1]).toUpperCase();
   }
   if (data.colorscheme) {
     let pickedColorscheme = colorscheme[data.colorscheme];

--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -95,8 +95,8 @@ function makeBadge (data) {
     data.template = 'flat';
   }
   if (data.template === 'for-the-badge'){
-    data.text[0] = data.text[0].toUpperCase();
-    data.text[1] = data.text[1].toUpperCase();
+    data.text[0] = data.text[0].toString().toUpperCase();
+    data.text[1] = data.text[1].toString().toUpperCase();
   }
   if (data.colorscheme) {
     let pickedColorscheme = colorscheme[data.colorscheme];

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -12,3 +12,18 @@ describe('The badge generator', function () {
     assert(svg.includes('grown'), 'grown');
   });
 });
+
+describe('"for-the-badge" template badge generation', function () {
+   // https://github.com/badges/shields/issues/1280
+  it('numbers should produce a string', function () {
+    const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
+    assert(svg.includes('1998'), `${svg} does not contain '1998'`);
+    assert(svg.includes('1999'), `${svg} does not contain '1999'`);
+  });
+
+  it('lowercase/mixedcase string should produce uppercase string', function () {
+    const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
+    assert(svg.includes('LABEL'), `${svg} does not contain 'LABEL'`);
+    assert(svg.includes('1 STRING'), `${svg} does not contain '1 TEST'`);
+  });
+});

--- a/templates/for-the-badge-template.svg
+++ b/templates/for-the-badge-template.svg
@@ -7,8 +7,8 @@
     {{?it.logo}}
       <image x="9" y="7" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
-    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="175" transform="scale(0.1)" textLength="{{=(it.widths[0]-(24+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0].toUpperCase())}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2)*10}}" y="175" font-weight="bold" transform="scale(0.1)" textLength="{{=(it.widths[1]-24)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1].toUpperCase())}}</text>
+    <text x="{{=((it.widths[0]+it.logoWidth+it.logoPadding)/2)*10}}" y="175" transform="scale(0.1)" textLength="{{=(it.widths[0]-(24+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[0])}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2)*10}}" y="175" font-weight="bold" transform="scale(0.1)" textLength="{{=(it.widths[1]-24)*10}}" lengthAdjust="spacing">{{=it.escapeXml(it.text[1])}}</text>
   </g>
   {{?(it.links[0] && it.links[0].length)}}
     <a xlink:href="{{=it.links[0]}}">


### PR DESCRIPTION
Closes #1280 

was previously trying to convert any numbers to uppercase,
![](http://img.shields.io/badge/COMMITS%20SINCE%202017--05--05--RELEASE--2.3.17-INVALID-blue.svg?style=for-the-badge)
will now convert the label to a string and then to uppercase.
![](http://img.shields.io/badge/COMMITS%20SINCE%202017--05--05--RELEASE--2.3.17-93-blue.svg?style=for-the-badge)

Also removed `.toUpperCase()` from the template as it shouldn't be needed.

Edit: Updated title as it was breaking the tests