### PR TITLE
[pypi] Add badge for django version support

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1300,6 +1300,14 @@ const allBadgeExamples = [
         ]
       },
       {
+        title: 'PyPI',
+        previewUri: '/pypi/djversions/djangorestframework.svg',
+        keywords: [
+          'python',
+          'django'
+        ]
+      },
+      {
         title: 'Hex.pm',
         previewUri: '/hexpm/l/plug.svg'
       },

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1258,52 +1258,59 @@ const allBadgeExamples = [
         previewUri: '/bower/l/bootstrap.svg'
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - License',
         previewUri: '/pypi/l/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Wheel',
         previewUri: '/pypi/wheel/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Format',
         previewUri: '/pypi/format/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Python Version',
         previewUri: '/pypi/pyversions/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Implementation',
         previewUri: '/pypi/implementation/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Status',
         previewUri: '/pypi/status/Django.svg',
         keywords: [
-          'python'
+          'python',
+          'pypi'
         ]
       },
       {
-        title: 'PyPI',
+        title: 'PyPI - Django Version',
         previewUri: '/pypi/djversions/djangorestframework.svg',
         keywords: [
           'python',
+          'pypi',
           'django'
         ]
       },

--- a/lib/pypi-helpers.js
+++ b/lib/pypi-helpers.js
@@ -30,6 +30,21 @@ const sortDjangoVersions = function(versions) {
   });
 };
 
+
+// extract classifiers from a pypi json response based on a regex
+const parseClassifiers = function(parsedData, pattern) {
+  const results = [];
+  for (let i = 0; i < parsedData.info.classifiers.length; i++) {
+    const matched = pattern.exec(parsedData.info.classifiers[i]);
+    if (matched && matched[1]) {
+      results.push(matched[1].toLowerCase());
+    }
+  }
+  return results;
+};
+
+
 module.exports = {
-  sortDjangoVersions
+  sortDjangoVersions,
+  parseClassifiers
 };

--- a/lib/pypi-helpers.js
+++ b/lib/pypi-helpers.js
@@ -45,6 +45,7 @@ const parseClassifiers = function(parsedData, pattern) {
 
 
 module.exports = {
-  sortDjangoVersions,
-  parseClassifiers
+  parseClassifiers,
+  parseDjangoVersionString,
+  sortDjangoVersions
 };

--- a/lib/pypi-helpers.js
+++ b/lib/pypi-helpers.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/*
+  Django versions will be specified in the form major.minor
+  trying to sort with `semver.compare` will throw e.g:
+  TypeError: Invalid Version: 1.11
+  because no patch release is specified, so we will define
+  our own functions to parse and sort django versions
+*/
+
+const parseDjangoVersionString = function(str) {
+  if (typeof(str) !== 'string') { return false; }
+  const x = str.split('.');
+  const maj = parseInt(x[0]) || 0;
+  const min = parseInt(x[1]) || 0;
+  return {
+      major: maj,
+      minor: min
+  };
+};
+
+// sort an array of django versions low to high
+const sortDjangoVersions = function(versions) {
+  return versions.sort(function(a, b) {
+    if (parseDjangoVersionString(a).major === parseDjangoVersionString(b).major) {
+      return parseDjangoVersionString(a).minor - parseDjangoVersionString(b).minor;
+    } else {
+      return parseDjangoVersionString(a).major - parseDjangoVersionString(b).major;
+    }
+  });
+};
+
+module.exports = {
+  sortDjangoVersions
+};

--- a/lib/pypi-helpers.spec.js
+++ b/lib/pypi-helpers.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const { test, given } = require('sazerac');
+const {
+  parseClassifiers,
+  parseDjangoVersionString,
+  sortDjangoVersions
+} = require('./pypi-helpers.js');
+
+const classifiersFixture = {
+  info: {
+    classifiers: [
+      "Development Status :: 5 - Production/Stable",
+      "Environment :: Web Environment",
+      "Framework :: Django",
+      "Framework :: Django :: 1.10",
+      "Framework :: Django :: 1.11",
+      "Intended Audience :: Developers",
+      "Intended Audience :: Developers",
+      "License :: OSI Approved :: BSD License",
+      "Operating System :: OS Independent",
+      "Natural Language :: English",
+      "Programming Language :: Python",
+      "Programming Language :: Python :: 2",
+      "Programming Language :: Python :: 2.7",
+      "Programming Language :: Python :: 3",
+      "Programming Language :: Python :: 3.4",
+      "Programming Language :: Python :: 3.5",
+      "Programming Language :: Python :: 3.6",
+      "Topic :: Internet :: WWW/HTTP",
+      "Programming Language :: Python :: Implementation :: CPython",
+      "Programming Language :: Python :: Implementation :: PyPy"
+    ]
+  }
+};
+
+describe('PyPI helpers', function() {
+  test(parseClassifiers, function() {
+    given(classifiersFixture, /^Programming Language :: Python :: ([\d.]+)$/)
+      .expect(["2","2.7","3","3.4","3.5","3.6"]);
+
+    given(classifiersFixture, /^Framework :: Django :: ([\d.]+)$/)
+      .expect(["1.10", "1.11"]);
+
+    given(classifiersFixture, /^Programming Language :: Python :: Implementation :: (\S+)$/)
+      .expect(["cpython", "pypy"]);
+
+    // regex that matches everything
+    given(classifiersFixture, /^([\S\s+]+)$/)
+      .expect(classifiersFixture.info.classifiers.map(function(e) {
+        return e.toLowerCase();
+      }));
+
+    // regex that matches nothing
+    given(classifiersFixture, /^(?!.*)*$/)
+      .expect([]);
+  });
+
+  test(parseDjangoVersionString, function() {
+    given("1").expect({ major: 1, minor: 0});
+    given("1.0").expect({ major: 1, minor: 0});
+    given("7.2").expect({ major: 7, minor: 2});
+    given("7.2derpderp").expect({ major: 7, minor: 2});
+    given("7.2.9.5.8.3").expect({ major: 7, minor: 2});
+    given("foo").expect({ major: 0, minor: 0});
+  });
+
+  test(sortDjangoVersions, function() {
+    given(["2.0", "1.9", "10", "1.11", "2.1", "2.11",])
+      .expect(["1.9", "1.11", "2.0", "2.1", "2.11", "10"]);
+
+    given(["2", "1.9", "10", "1.11", "2.1", "2.11",])
+      .expect(["1.9", "1.11", "2", "2.1", "2.11", "10"]);
+
+    given(["2.0rc1", "10", "1.9", "1.11", "2.1", "2.11",])
+      .expect(["1.9", "1.11", "2.0rc1", "2.1", "2.11", "10"]);
+  });
+});

--- a/server.js
+++ b/server.js
@@ -2094,7 +2094,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var parsedData = JSON.parse(buffer);
-      if ((info === 'dm') || (info === 'dw') || (info ==='dd')) {
+      if (info === 'dm' || info === 'dw' || info ==='dd') {
         // See #716 for the details of the loss of service.
         badgeData.text[0] = getLabel('downloads', data);
         badgeData.text[1] = 'no longer available';

--- a/server.js
+++ b/server.js
@@ -93,6 +93,7 @@ const {
   mapGithubCommitsSince,
   mapGithubReleaseDate
 } = require('./lib/github-provider');
+const { sortDjangoVersions } = require('./lib/pypi-helpers.js');
 
 const serverStartTime = new Date((new Date()).toGMTString());
 const githubApiUrl = config.services.github.baseUri;
@@ -2208,31 +2209,8 @@ cache(function(data, match, sendBadge, request) {
           versions.push('not found');
         }
 
-        /*
-          note: django versions will be specified in the form major.minor
-          trying to sort with `semver.compare` will throw e.g:
-          TypeError: Invalid Version: 1.11
-          because no patch release is specified, so we will define
-          our own function to sort django versions
-        */
-        const parseVersionString = function(str) {
-          if (typeof(str) != 'string') { return false; }
-          const x = str.split('.');
-          const maj = parseInt(x[0]) || 0;
-          const min = parseInt(x[1]) || 0;
-          return {
-              major: maj,
-              minor: min
-          };
-        };
         // sort low to high
-        versions = versions.sort(function(a, b) {
-          if (parseVersionString(a).major === parseVersionString(b).major) {
-            return parseVersionString(a).minor - parseVersionString(b).minor;
-          } else {
-            return parseVersionString(a).major - parseVersionString(b).major;
-          }
-        });
+        versions = sortDjangoVersions(versions);
 
         badgeData.text[0] = getLabel('django versions', data);
         badgeData.text[1] = versions.join(', ');

--- a/server.js
+++ b/server.js
@@ -93,7 +93,10 @@ const {
   mapGithubCommitsSince,
   mapGithubReleaseDate
 } = require('./lib/github-provider');
-const { sortDjangoVersions } = require('./lib/pypi-helpers.js');
+const {
+  sortDjangoVersions,
+  parseClassifiers
+} = require('./lib/pypi-helpers.js');
 
 const serverStartTime = new Date((new Date()).toGMTString());
 const githubApiUrl = config.services.github.baseUri;
@@ -2173,14 +2176,11 @@ cache(function(data, match, sendBadge, request) {
         }
         sendBadge(format, badgeData);
       } else if (info === 'pyversions') {
-        let versions = [];
-        let pattern = /^Programming Language :: Python :: ([\d.]+)$/;
-        for (let i = 0; i < parsedData.info.classifiers.length; i++) {
-          let matched = pattern.exec(parsedData.info.classifiers[i]);
-          if (matched && matched[1]) {
-            versions.push(matched[1]);
-          }
-        }
+        let versions = parseClassifiers(
+          parsedData,
+          /^Programming Language :: Python :: ([\d.]+)$/
+        );
+
         // We only show v2 if eg. v2.4 does not appear.
         // See https://github.com/badges/shields/pull/489 for more.
         ['2', '3'].forEach(function(version) {
@@ -2197,14 +2197,11 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'blue';
         sendBadge(format, badgeData);
       } else if (info === 'djversions') {
-        let versions = [];
-        let pattern = /^Framework :: Django :: ([\d.]+)$/;
-        for (let i = 0; i < parsedData.info.classifiers.length; i++) {
-          let matched = pattern.exec(parsedData.info.classifiers[i]);
-          if (matched && matched[1]) {
-            versions.push(matched[1]);
-          }
-        }
+        let versions = parseClassifiers(
+          parsedData,
+          /^Framework :: Django :: ([\d.]+)$/
+        );
+
         if (!versions.length) {
           versions.push('not found');
         }
@@ -2217,14 +2214,11 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'blue';
         sendBadge(format, badgeData);
       } else if (info === 'implementation') {
-        var implementations = [];
-        let pattern = /^Programming Language :: Python :: Implementation :: (\S+)$/;
-        for (let i = 0; i < parsedData.info.classifiers.length; i++) {
-          let matched = pattern.exec(parsedData.info.classifiers[i]);
-          if (matched && matched[1]) {
-            implementations.push(matched[1].toLowerCase());
-          }
-        }
+        let implementations = parseClassifiers(
+          parsedData,
+          /^Programming Language :: Python :: Implementation :: (\S+)$/
+        );
+
         if (!implementations.length) {
           implementations.push('cpython');  // assume CPython
         }

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { isSemver } = require('./helpers/validators');
 const isCommaSeperatedPythonVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
+const isCommaSeperatedDjangoVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
 const isPsycopg2Version = Joi.string().regex(/^v([0-9][.]?)+$/);
 
 const t = new ServiceTester({ id: 'pypi', title: 'PyPi badges' });
@@ -156,6 +157,31 @@ t.create('python versions (no versions specified)')
 
 t.create('python versions (invalid)')
   .get('/pyversions/not-a-package.json')
+  .expectJSON({ name: 'pypi', value: 'invalid' });
+
+
+// tests for django versions endpoint
+
+t.create('supported django versions (valid, package version in request)')
+  .get('/djversions/djangorestframework/3.7.3.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'django versions',
+    value: isCommaSeperatedDjangoVersions
+  }));
+
+t.create('supported django versions (valid, no package version specified)')
+  .get('/djversions/djangorestframework.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'django versions',
+    value: isCommaSeperatedDjangoVersions
+  }));
+
+t.create('supported django versions (no versions specified)')
+  .get('/djversions/django/1.11.json')
+  .expectJSON({ name: 'django versions', value: 'not found' });
+
+t.create('supported django versions (invalid)')
+  .get('/djversions/not-a-package.json')
   .expectJSON({ name: 'pypi', value: 'invalid' });
 
 

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -3,9 +3,12 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { isSemver } = require('./helpers/validators');
+
+const isPsycopg2Version = Joi.string().regex(/^v([0-9][.]?)+$/);
+
+// These regexes are the same, but defined separately for clarity.
 const isCommaSeperatedPythonVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
 const isCommaSeperatedDjangoVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
-const isPsycopg2Version = Joi.string().regex(/^v([0-9][.]?)+$/);
 
 const t = new ServiceTester({ id: 'pypi', title: 'PyPi badges' });
 module.exports = t;


### PR DESCRIPTION
This PR adds the django version support feature suggested in issue #1018

Having worked on this issue, I note that:

* There don't seem to be tests for the existing PyPi badges
* All the PyPi badges are defined in one big function (I am aware this PR makes this situation worse, not better)

As a further piece of work, I would also be interested in adding more tests to support refactoring this into a number of smaller functions and also having a go at some of that refactoring work. Would you be open to receiving some further PRs?

Closes #1018

