### PR TITLE
[pypi] add test suite for PyPi service

### DIFF
--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -11,8 +11,6 @@ const isVPlusTripleDottedVersion = withRegex(/^v[0-9]+.[0-9]+.[0-9]+$/);
 
 const isVPlusDottedVersionAtLeastOne = withRegex(/^v\d+(\.\d+)?(\.\d+)?$/);
 
-const isCommaSeperatedPythonVersions = withRegex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
-
 // Simple regex for test Composer versions rule
 // https://getcomposer.org/doc/articles/versions.md
 // Examples:
@@ -47,7 +45,6 @@ module.exports = {
   isSemver,
   isVPlusTripleDottedVersion,
   isVPlusDottedVersionAtLeastOne,
-  isCommaSeperatedPythonVersions,
   isComposerVersion,
   isStarRating,
   isMetric,

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -11,6 +11,8 @@ const isVPlusTripleDottedVersion = withRegex(/^v[0-9]+.[0-9]+.[0-9]+$/);
 
 const isVPlusDottedVersionAtLeastOne = withRegex(/^v\d+(\.\d+)?(\.\d+)?$/);
 
+const isCommaSeperatedPythonVersions = withRegex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
+
 // Simple regex for test Composer versions rule
 // https://getcomposer.org/doc/articles/versions.md
 // Examples:
@@ -45,6 +47,7 @@ module.exports = {
   isSemver,
   isVPlusTripleDottedVersion,
   isVPlusDottedVersionAtLeastOne,
+  isCommaSeperatedPythonVersions,
   isComposerVersion,
   isStarRating,
   isMetric,

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -1,5 +1,12 @@
 'use strict';
 
+/*
+  Note:
+  Validators defined in this file are used by more than one service.
+  Validators which are only used by one service
+  should be declared in that service's test file.
+*/
+
 const Joi = require('joi');
 const semverRegex = require('semver-regex')();
 

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -2,10 +2,8 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const {
-  isCommaSeperatedPythonVersions,
-  isSemver,
-} = require('./helpers/validators');
+const { isSemver } = require('./helpers/validators');
+const isCommaSeperatedPythonVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
 
 const t = new ServiceTester({ id: 'pypi', title: 'PyPi badges' });
 module.exports = t;

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -20,27 +20,27 @@ module.exports = t;
 */
 t.create('daily downloads (expected failure)')
   .get('/dd/djangorestframework.json')
-  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
+  .expectJSON({ name: 'downloads', value: 'no longer available' });
 
 t.create('weekly downloads (expected failure)')
   .get('/dw/djangorestframework.json')
-  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
+  .expectJSON({ name: 'downloads', value: 'no longer available' });
 
 t.create('monthly downloads (expected failure)')
   .get('/dm/djangorestframework.json')
-  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
+  .expectJSON({ name: 'downloads', value: 'no longer available' });
 
 t.create('daily downloads (invalid)')
   .get('/dd/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 t.create('weekly downloads (invalid)')
   .get('/dw/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 t.create('monthly downloads (invalid)')
   .get('/dm/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 /*
@@ -74,64 +74,64 @@ t.create('version (not semver)')
 
 t.create('version (invalid)')
   .get('/v/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for license endpoint
 
 t.create('license (valid, package version in request)')
   .get('/l/requests/2.18.4.json')
-  .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
+  .expectJSON({ name: 'license', value: 'Apache 2.0' });
 
 t.create('license (valid, no package version specified)')
   .get('/l/requests.json')
-  .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
+  .expectJSON({ name: 'license', value: 'Apache 2.0' });
 
 t.create('license (invalid)')
   .get('/l/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for wheel endpoint
 
 t.create('wheel (has wheel, package version in request)')
   .get('/wheel/requests/2.18.4.json')
-  .expectJSONTypes({ name: 'wheel', value: 'yes' });
+  .expectJSON({ name: 'wheel', value: 'yes' });
 
 t.create('wheel (has wheel, no package version specified)')
   .get('/wheel/requests.json')
-  .expectJSONTypes({ name: 'wheel', value: 'yes' });
+  .expectJSON({ name: 'wheel', value: 'yes' });
 
 t.create('wheel (no wheel)')
   .get('/wheel/chai/1.1.2.json')
-  .expectJSONTypes({ name: 'wheel', value: 'no' });
+  .expectJSON({ name: 'wheel', value: 'no' });
 
 t.create('wheel (invalid)')
   .get('/wheel/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for format endpoint
 
 t.create('format (wheel, package version in request)')
   .get('/format/requests/2.18.4.json')
-  .expectJSONTypes({ name: 'format', value: 'wheel' });
+  .expectJSON({ name: 'format', value: 'wheel' });
 
 t.create('format (wheel, no package version specified)')
   .get('/format/requests.json')
-  .expectJSONTypes({ name: 'format', value: 'wheel' });
+  .expectJSON({ name: 'format', value: 'wheel' });
 
 t.create('format (source)')
   .get('/format/chai/1.1.2.json')
-  .expectJSONTypes({ name: 'format', value: 'source' });
+  .expectJSON({ name: 'format', value: 'source' });
 
 t.create('format (egg)')
   .get('/format/virtualenv/0.8.2.json')
-  .expectJSONTypes({ name: 'format', value: 'egg' });
+  .expectJSON({ name: 'format', value: 'egg' });
 
 t.create('format (invalid)')
   .get('/format/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for pyversions endpoint
@@ -152,46 +152,46 @@ t.create('python versions (valid, no package version specified)')
 
 t.create('python versions (no versions specified)')
   .get('/pyversions/pyshp/1.2.12.json')
-  .expectJSONTypes({ name: 'python', value: 'not found' });
+  .expectJSON({ name: 'python', value: 'not found' });
 
 t.create('python versions (invalid)')
   .get('/pyversions/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for implementation endpoint
 
 t.create('implementation (valid, package version in request)')
   .get('/implementation/beehive/1.0.json')
-  .expectJSONTypes({ name: 'implementation', value: 'cpython, jython, pypy' });
+  .expectJSON({ name: 'implementation', value: 'cpython, jython, pypy' });
 
 t.create('implementation (valid, no package version specified)')
   .get('/implementation/numpy.json')
-  .expectJSONTypes({ name: 'implementation', value: 'cpython' });
+  .expectJSON({ name: 'implementation', value: 'cpython' });
 
 t.create('implementation (not specified)')
   .get('/implementation/chai/1.1.2.json')
-  .expectJSONTypes({ name: 'implementation', value: 'cpython' });
+  .expectJSON({ name: 'implementation', value: 'cpython' });
 
 t.create('implementation (invalid)')
   .get('/implementation/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });
 
 
 // tests for status endpoint
 
 t.create('status (valid, stable, package version in request)')
   .get('/status/django/1.11.json')
-  .expectJSONTypes({name: 'status', value: 'stable' });
+  .expectJSON({name: 'status', value: 'stable' });
 
 t.create('status (valid, no package version specified)')
   .get('/status/typing.json')
-  .expectJSONTypes({name: 'status', value: 'stable' });
+  .expectJSON({name: 'status', value: 'stable' });
 
 t.create('status (valid, beta)')
   .get('/status/django/2.0rc1.json')
-  .expectJSONTypes({ name: 'status', value: 'beta' });
+  .expectJSON({ name: 'status', value: 'beta' });
 
 t.create('status (invalid)')
   .get('/status/not-a-package.json')
-  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+  .expectJSON({ name: 'pypi', value: 'invalid' });

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -12,6 +12,8 @@ module.exports = t;
 
 
 /*
+  tests for downloads endpoints
+
   Note:
   Download statistics are no longer available from pypi
   it is exptected that the download badges all show
@@ -41,7 +43,10 @@ t.create('monthly downloads (invalid)')
   .get('/dm/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
+
 /*
+  tests for version endpoint
+
   Note:
   Not all project on PyPi follow SemVer
 
@@ -75,6 +80,9 @@ t.create('version (invalid)')
   .get('/v/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
+
+// tests for licence endpoint
+
 t.create('licence (valid, package version in request)')
   .get('/l/requests/2.18.4.json')
   .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
@@ -86,6 +94,9 @@ t.create('licence (valid, no package version specified)')
 t.create('license (invalid)')
   .get('/l/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+
+
+// tests for wheel endpoint
 
 t.create('wheel (has wheel, package version in request)')
   .get('/wheel/requests/2.18.4.json')
@@ -102,6 +113,9 @@ t.create('wheel (no wheel)')
 t.create('wheel (invalid)')
   .get('/wheel/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+
+
+// tests for format endpoint
 
 t.create('format (wheel, package version in request)')
   .get('/format/requests/2.18.4.json')
@@ -122,6 +136,9 @@ t.create('format (egg)')
 t.create('format (invalid)')
   .get('/format/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+
+
+// tests for pyversions endpoint
 
 t.create('python versions (valid, package version in request)')
   .get('/pyversions/requests/2.18.4.json')
@@ -145,6 +162,9 @@ t.create('python versions (invalid)')
   .get('/pyversions/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
+
+// tests for implementation endpoint
+
 t.create('implementation (valid, package version in request)')
   .get('/implementation/beehive/1.0.json')
   .expectJSONTypes({ name: 'implementation', value: 'cpython, jython, pypy' });
@@ -160,6 +180,9 @@ t.create('implementation (not specified)')
 t.create('implementation (invalid)')
   .get('/implementation/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
+
+
+// tests for status endpoint
 
 t.create('status (valid, stable, package version in request)')
   .get('/status/django/1.11.json')

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -19,45 +19,27 @@ module.exports = t;
 */
 t.create('daily downloads (expected failure)')
   .get('/dd/djangorestframework.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads',
-    value: 'no longer available'
-  }));
+  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
 
 t.create('weekly downloads (expected failure)')
   .get('/dw/djangorestframework.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads',
-    value: 'no longer available'
-  }));
+  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
 
 t.create('monthly downloads (expected failure)')
   .get('/dm/djangorestframework.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads',
-    value: 'no longer available'
-  }));
+  .expectJSONTypes({ name: 'downloads', value: 'no longer available' });
 
 t.create('daily downloads (invalid)')
   .get('/dd/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('weekly downloads (invalid)')
   .get('/dw/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('monthly downloads (invalid)')
   .get('/dm/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 /*
   Note:
@@ -91,59 +73,35 @@ t.create('version (not semver)')
 
 t.create('version (invalid)')
   .get('/v/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('licence (valid)')
   .get('/l/requests/2.18.4.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'license',
-    value: 'Apache 2.0'
-  }));
+  .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
 
 t.create('license (invalid)')
   .get('/l/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('wheel (has wheel)')
   .get('/wheel/requests/2.18.4.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'wheel',
-    value: 'yes'
-  }));
+  .expectJSONTypes({ name: 'wheel', value: 'yes' });
 
 t.create('wheel (no wheel)')
   .get('/wheel/chai/1.1.2.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'wheel',
-    value: 'no'
-  }));
+  .expectJSONTypes({ name: 'wheel', value: 'no' });
 
 t.create('wheel (invalid)')
   .get('/wheel/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('format (wheel)')
   .get('/format/requests/2.18.4.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'format',
-    value: 'wheel'
-  }));
+  .expectJSONTypes({ name: 'format', value: 'wheel' });
 
 t.create('format (source)')
   .get('/format/chai/1.1.2.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'format',
-    value: 'source'
-  }));
+  .expectJSONTypes({ name: 'format', value: 'source' });
 
 /*
   TODO: add a test case for egg format
@@ -153,10 +111,7 @@ t.create('format (source)')
 
 t.create('format (invalid)')
   .get('/format/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('python versions (valid)')
   .get('/pyversions/requests/2.18.4.json')
@@ -167,56 +122,32 @@ t.create('python versions (valid)')
 
 t.create('python versions (no versions specified)')
   .get('/pyversions/pyshp/1.2.12.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'python',
-    value: 'not found'
-  }));
+  .expectJSONTypes({ name: 'python', value: 'not found' });
 
 t.create('python versions (invalid)')
   .get('/pyversions/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('implementation (valid)')
   .get('/implementation/beehive/1.0.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'implementation',
-    value: 'cpython, jython, pypy'
-  }));
+  .expectJSONTypes({ name: 'implementation', value: 'cpython, jython, pypy' });
 
 t.create('implementation (not specified)')
   .get('/implementation/chai/1.1.2.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'implementation',
-    value: 'cpython'
-  }));
+  .expectJSONTypes({ name: 'implementation', value: 'cpython' });
 
 t.create('implementation (invalid)')
   .get('/implementation/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 t.create('status (valid, stable)')
   .get('/status/django/1.11.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'status',
-    value: 'stable'
-  }));
+  .expectJSONTypes({name: 'status', value: 'stable' });
 
 t.create('status (valid, beta)')
   .get('/status/django/2.0rc1.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'status',
-    value: 'beta'
-  }));
+  .expectJSONTypes({ name: 'status', value: 'beta' });
 
 t.create('status (invalid)')
   .get('/status/not-a-package.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'pypi',
-    value: 'invalid'
-  }));
+  .expectJSONTypes({ name: 'pypi', value: 'invalid' });

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -75,16 +75,24 @@ t.create('version (invalid)')
   .get('/v/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('licence (valid)')
+t.create('licence (valid, package version in request)')
   .get('/l/requests/2.18.4.json')
+  .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
+
+t.create('licence (valid, no package version specified)')
+  .get('/l/requests.json')
   .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
 
 t.create('license (invalid)')
   .get('/l/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('wheel (has wheel)')
+t.create('wheel (has wheel, package version in request)')
   .get('/wheel/requests/2.18.4.json')
+  .expectJSONTypes({ name: 'wheel', value: 'yes' });
+
+t.create('wheel (has wheel, no package version specified)')
+  .get('/wheel/requests.json')
   .expectJSONTypes({ name: 'wheel', value: 'yes' });
 
 t.create('wheel (no wheel)')
@@ -95,8 +103,12 @@ t.create('wheel (invalid)')
   .get('/wheel/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('format (wheel)')
+t.create('format (wheel, package version in request)')
   .get('/format/requests/2.18.4.json')
+  .expectJSONTypes({ name: 'format', value: 'wheel' });
+
+t.create('format (wheel, no package version specified)')
+  .get('/format/requests.json')
   .expectJSONTypes({ name: 'format', value: 'wheel' });
 
 t.create('format (source)')
@@ -111,8 +123,15 @@ t.create('format (invalid)')
   .get('/format/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('python versions (valid)')
+t.create('python versions (valid, package version in request)')
   .get('/pyversions/requests/2.18.4.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'python',
+    value: isCommaSeperatedPythonVersions
+  }));
+
+t.create('python versions (valid, no package version specified)')
+  .get('/pyversions/requests.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'python',
     value: isCommaSeperatedPythonVersions
@@ -126,9 +145,13 @@ t.create('python versions (invalid)')
   .get('/pyversions/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('implementation (valid)')
+t.create('implementation (valid, package version in request)')
   .get('/implementation/beehive/1.0.json')
   .expectJSONTypes({ name: 'implementation', value: 'cpython, jython, pypy' });
+
+t.create('implementation (valid, no package version specified)')
+  .get('/implementation/numpy.json')
+  .expectJSONTypes({ name: 'implementation', value: 'cpython' });
 
 t.create('implementation (not specified)')
   .get('/implementation/chai/1.1.2.json')
@@ -138,8 +161,12 @@ t.create('implementation (invalid)')
   .get('/implementation/not-a-package.json')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
-t.create('status (valid, stable)')
+t.create('status (valid, stable, package version in request)')
   .get('/status/django/1.11.json')
+  .expectJSONTypes({name: 'status', value: 'stable' });
+
+t.create('status (valid, no package version specified)')
+  .get('/status/typing.json')
   .expectJSONTypes({name: 'status', value: 'stable' });
 
 t.create('status (valid, beta)')

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -103,11 +103,9 @@ t.create('format (source)')
   .get('/format/chai/1.1.2.json')
   .expectJSONTypes({ name: 'format', value: 'source' });
 
-/*
-  TODO: add a test case for egg format
-  It is quite hard to find a project on PyPi
-  which distributes an egg but not a whl
-*/
+t.create('format (egg)')
+  .get('/format/virtualenv/0.8.2.json')
+  .expectJSONTypes({ name: 'format', value: 'egg' });
 
 t.create('format (invalid)')
   .get('/format/not-a-package.json')

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { isSemver } = require('./helpers/validators');
 const isCommaSeperatedPythonVersions = Joi.string().regex(/^([0-9]+.[0-9]+[,]?[ ]?)+$/);
+const isPsycopg2Version = Joi.string().regex(/^v([0-9][.]?)+$/);
 
 const t = new ServiceTester({ id: 'pypi', title: 'PyPi badges' });
 module.exports = t;
@@ -63,15 +64,12 @@ t.create('version (semver)')
     value: isSemver
   }));
 
-/*
-  ..whereas this project uses version numbers that
-  should just be validated as an arbitary string
-*/
+// ..whereas this project does not folow SemVer
 t.create('version (not semver)')
   .get('/v/psycopg2.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'pypi',
-    value: Joi.string()
+    value: isPsycopg2Version
   }));
 
 t.create('version (invalid)')

--- a/service-tests/pypi.js
+++ b/service-tests/pypi.js
@@ -81,13 +81,13 @@ t.create('version (invalid)')
   .expectJSONTypes({ name: 'pypi', value: 'invalid' });
 
 
-// tests for licence endpoint
+// tests for license endpoint
 
-t.create('licence (valid, package version in request)')
+t.create('license (valid, package version in request)')
   .get('/l/requests/2.18.4.json')
   .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
 
-t.create('licence (valid, no package version specified)')
+t.create('license (valid, no package version specified)')
   .get('/l/requests.json')
   .expectJSONTypes({ name: 'license', value: 'Apache 2.0' });
 


### PR DESCRIPTION
This will create a merge conflict with #1286. I think it makes more sense to review this one ahead of #1286 so I can rebase the changes in 7c5937d onto this, rather than the other way around.

Suggestions for a suitable example to use for the missing `format (egg)` test welcome.