### PR TITLE
Optimisation of makeBadge key width computation

### DIFF
--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -5,6 +5,10 @@ const path = require('path');
 const SVGO = require('svgo');
 const dot = require('dot');
 const measureTextWidth = require('./measure-text.js');
+const LruCache = require('./lru-cache');
+
+// Holds widths of badge keys (left hand side of badge).
+const badgeKeyWidthCache = new LruCache(1000);
 
 // cache templates.
 const templates = {};
@@ -119,10 +123,15 @@ function makeBadge (data) {
     data.logoPadding = 0;
   }
 
-  let textWidth1 = (measureTextWidth(data.text[0])|0);
+  let textWidth1 = badgeKeyWidthCache.get(data.text[0]);
+  if (textWidth1 === undefined) {
+    textWidth1 = (measureTextWidth(data.text[0])|0);
+    // Increase chances of pixel grid alignment.
+    if (textWidth1 % 2 === 0) { textWidth1++; }
+    badgeKeyWidthCache.set(data.text[0], textWidth1);
+  }
   let textWidth2 = (measureTextWidth(data.text[1])|0);
   // Increase chances of pixel grid alignment.
-  if (textWidth1 % 2 === 0) { textWidth1++; }
   if (textWidth2 % 2 === 0) { textWidth2++; }
   data.widths = [
     textWidth1 + 10 + data.logoWidth + data.logoPadding,
@@ -144,3 +153,5 @@ function makeBadge (data) {
 
 module.exports = makeBadge;
 module.exports.loadFont = measureTextWidth.loadFont;
+// Expose for testing.
+module.exports._badgeKeyWidthCache = badgeKeyWidthCache;

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -2,14 +2,26 @@
 
 const assert = require('assert');
 const makeBadge = require('./make-badge');
+const {
+  _badgeKeyWidthCache
+} = require('./make-badge');
 const isSvg = require('is-svg');
 
 describe('The badge generator', function () {
+  beforeEach(function () {
+    _badgeKeyTextWidthCache.clear();
+  });
+
   it('should produce SVG', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
     assert.ok(isSvg(svg));
     assert(svg.includes('cactus'), 'cactus');
     assert(svg.includes('grown'), 'grown');
+  });
+  
+  it('should cache width of badge key', function () {
+    makeBadge({ text: ['cached', 'not-cached'], format: 'svg' });
+    assert.deepEqual([..._badgeKeyWidthCache.cache.keys()], ['cached']);
   });
 });
 

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -9,7 +9,7 @@ const isSvg = require('is-svg');
 
 describe('The badge generator', function () {
   beforeEach(function () {
-    _badgeKeyTextWidthCache.clear();
+    _badgeKeyWidthCache.clear();
   });
 
   it('should produce SVG', function () {


### PR DESCRIPTION
Hello there,

This pull request follows up discussions in #358.

A quick look at shields.io's homepage shows that a lot of badges share the same key (left hand side of the badge). Words such as "downloads", "coverage", "build", "license" keep coming over and over again. Even for badges with a unique key (for instance "eclipse marketplace"), there may be many requests for the same badge type but for different projects within a period of time. The text width of these strings is therefore computed redundantly, which has a performance hit on badge creation time.

The proposed solution is to insert a cache layer, so that a given string width is only computed once. I used our existing `lru-cache` implementation.

Obviously, it would be interesting to benchmark this in a production-like environment. As this was not possible, I did write a very simple test that repeatedly called the `makeBadge` function on a number of different badges. Performance of that function was improved by around 10% on average on my local machine, which is quite encouraging.

I chose to exclude the badge values (right hand side of the badge), as these strings tend to be much more variable, and would therefore end up in cache misses most of the time.

As usual, looking forward to feedback! 👍 

Cheers,

Pyves
