### PR TITLE
readme: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ under their terms and license.
 
 ## Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/shields/contributors.svg?width=890" /></a>
+This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+<a href="https://github.com/badges/shields/graphs/contributors"><img src="https://opencollective.com/shields/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
- fixed link to github contributors from Open Collective template
- adjusted brackets around [contribute] to match style for backers and sponsors

(@asood123 you might want to double check your template, this is the second repo with a broken link on the nice contributors gallery)