### PR TITLE
[BitBucket GitHub] fixes and tests for BitBucket service integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -4246,7 +4246,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var issues = data.count;
-      badgeData.text[1] = issues + (isRaw? '': ' open');
+      badgeData.text[1] = metric(issues) + (isRaw? '': ' open');
       badgeData.colorscheme = issues ? 'yellow' : 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -4246,6 +4246,9 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var issues = data.count;
+      if (typeof issues === 'undefined') {
+        throw Error('Failed to count issues.');
+      }
       badgeData.text[1] = metric(issues) + (isRaw? '': ' open');
       badgeData.colorscheme = issues ? 'yellow' : 'brightgreen';
       sendBadge(format, badgeData);
@@ -4277,6 +4280,9 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var pullrequests = data.size;
+      if (typeof pullrequests === 'undefined') {
+        throw Error('Failed to count pull requests.');
+      }
       badgeData.text[1] = metric(pullrequests) + (isRaw? '': ' open');
       badgeData.colorscheme = (pullrequests > 0)? 'yellow': 'brightgreen';
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -4253,7 +4253,11 @@ cache(function(data, match, sendBadge, request) {
       badgeData.colorscheme = issues ? 'yellow' : 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {
-      badgeData.text[1] = 'invalid';
+      if (res.statusCode === 404) {
+        badgeData.text[1] = 'not found';
+      } else {
+        badgeData.text[1] = 'invalid';
+      }
       sendBadge(format, badgeData);
     }
   });
@@ -4287,7 +4291,11 @@ cache(function(data, match, sendBadge, request) {
       badgeData.colorscheme = (pullrequests > 0)? 'yellow': 'brightgreen';
       sendBadge(format, badgeData);
     } catch(e) {
-      badgeData.text[1] = 'invalid';
+      if (res.statusCode === 404) {
+        badgeData.text[1] = 'not found';
+      } else {
+        badgeData.text[1] = 'invalid';
+      }
       sendBadge(format, badgeData);
     }
   });

--- a/server.js
+++ b/server.js
@@ -4246,7 +4246,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var issues = data.count;
-      if (typeof issues === 'undefined') {
+      if (res.statusCode !== 200) {
         throw Error('Failed to count issues.');
       }
       badgeData.text[1] = metric(issues) + (isRaw? '': ' open');
@@ -4280,7 +4280,7 @@ cache(function(data, match, sendBadge, request) {
     try {
       var data = JSON.parse(buffer);
       var pullrequests = data.size;
-      if (typeof pullrequests === 'undefined') {
+      if (res.statusCode !== 200) {
         throw Error('Failed to count pull requests.');
       }
       badgeData.text[1] = metric(pullrequests) + (isRaw? '': ' open');

--- a/service-tests/bitbucket.js
+++ b/service-tests/bitbucket.js
@@ -14,7 +14,7 @@ t.create('issues-raw (valid)')
   .get('/issues-raw/atlassian/python-bitbucket.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'issues',
-    value: Joi.number().integer()
+    value: isMetric
   }));
 
 t.create('issues-raw (invalid)')
@@ -30,7 +30,7 @@ t.create('issues (valid)')
   .get('/issues/atlassian/python-bitbucket.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'issues',
-    value: Joi.string().regex(/^\d+ open?$/)
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
 t.create('issues (invalid)')
@@ -65,7 +65,7 @@ t.create('pr-raw (connection error)')
   .get('/pr/atlassian/python-bitbucket.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'pull requests',
-    value:  Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
   }));
 
 t.create('pr (invalid)')

--- a/service-tests/bitbucket.js
+++ b/service-tests/bitbucket.js
@@ -2,7 +2,10 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const { isMetric } = require('./helpers/validators.js');
+const {
+  isMetric,
+  isMetricOpenIssues
+} = require('./helpers/validators.js');
 
 const t = new ServiceTester({ id: 'bitbucket', title: 'BitBucket badges' });
 module.exports = t;
@@ -30,7 +33,7 @@ t.create('issues (valid)')
   .get('/issues/atlassian/python-bitbucket.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'issues',
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('issues (invalid)')
@@ -65,7 +68,7 @@ t.create('pr-raw (connection error)')
   .get('/pr/atlassian/python-bitbucket.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'pull requests',
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('pr (invalid)')

--- a/service-tests/bitbucket.js
+++ b/service-tests/bitbucket.js
@@ -22,7 +22,7 @@ t.create('issues-raw (valid)')
 
 t.create('issues-raw (invalid)')
   .get('/issues-raw/atlassian/not-a-repo.json')
-  .expectJSON({ name: 'issues', value: 'undefined' });
+  .expectJSON({ name: 'issues', value: 'invalid' });
 
 t.create('issues-raw (connection error)')
   .get('/issues-raw/atlassian/python-bitbucket.json')
@@ -38,7 +38,7 @@ t.create('issues (valid)')
 
 t.create('issues (invalid)')
   .get('/issues/atlassian/not-a-repo.json')
-  .expectJSON({ name: 'issues', value: 'undefined open' });
+  .expectJSON({ name: 'issues', value: 'invalid' });
 
 t.create('issues (connection error)')
   .get('/issues/atlassian/python-bitbucket.json')
@@ -57,7 +57,7 @@ t.create('pr-raw (valid)')
 
 t.create('pr-raw (invalid)')
   .get('/pr-raw/atlassian/not-a-repo.json')
-  .expectJSON({ name: 'pull requests', value: 'undefined' });
+  .expectJSON({ name: 'pull requests', value: 'invalid' });
 
 t.create('pr-raw (connection error)')
   .get('/pr-raw/atlassian/python-bitbucket.json')
@@ -73,7 +73,7 @@ t.create('pr-raw (connection error)')
 
 t.create('pr (invalid)')
   .get('/pr/atlassian/not-a-repo.json')
-  .expectJSON({ name: 'pull requests', value: 'undefined open' });
+  .expectJSON({ name: 'pull requests', value: 'invalid' });
 
 t.create('pr (connection error)')
   .get('/pr/atlassian/python-bitbucket.json')

--- a/service-tests/bitbucket.js
+++ b/service-tests/bitbucket.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+const { isMetric } = require('./helpers/validators.js');
+
+const t = new ServiceTester({ id: 'bitbucket', title: 'BitBucket badges' });
+module.exports = t;
+
+
+// tests for issues endpoints
+
+t.create('issues-raw (valid)')
+  .get('/issues-raw/atlassian/python-bitbucket.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'issues',
+    value: Joi.number().integer()
+  }));
+
+t.create('issues-raw (invalid)')
+  .get('/issues-raw/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'issues', value: 'undefined' });
+
+t.create('issues-raw (connection error)')
+  .get('/issues-raw/atlassian/python-bitbucket.json')
+  .networkOff()
+  .expectJSON({ name: 'issues', value: 'inaccessible' });
+
+t.create('issues (valid)')
+  .get('/issues/atlassian/python-bitbucket.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'issues',
+    value: Joi.string().regex(/^\d+ open?$/)
+  }));
+
+t.create('issues (invalid)')
+  .get('/issues/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'issues', value: 'undefined open' });
+
+t.create('issues (connection error)')
+  .get('/issues/atlassian/python-bitbucket.json')
+  .networkOff()
+  .expectJSON({ name: 'issues', value: 'inaccessible' });
+
+
+// tests for pull requests endpoints
+
+t.create('pr-raw (valid)')
+  .get('/pr-raw/atlassian/python-bitbucket.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'pull requests',
+    value: isMetric
+  }));
+
+t.create('pr-raw (invalid)')
+  .get('/pr-raw/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'pull requests', value: 'undefined' });
+
+t.create('pr-raw (connection error)')
+  .get('/pr-raw/atlassian/python-bitbucket.json')
+  .networkOff()
+  .expectJSON({ name: 'pull requests', value: 'inaccessible' });
+
+  t.create('pr (valid)')
+  .get('/pr/atlassian/python-bitbucket.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'pull requests',
+    value:  Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+  }));
+
+t.create('pr (invalid)')
+  .get('/pr/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'pull requests', value: 'undefined open' });
+
+t.create('pr (connection error)')
+  .get('/pr/atlassian/python-bitbucket.json')
+  .networkOff()
+  .expectJSON({ name: 'pull requests', value: 'inaccessible' });

--- a/service-tests/bitbucket.js
+++ b/service-tests/bitbucket.js
@@ -20,8 +20,12 @@ t.create('issues-raw (valid)')
     value: isMetric
   }));
 
-t.create('issues-raw (invalid)')
+t.create('issues-raw (not found)')
   .get('/issues-raw/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'issues', value: 'not found' });
+
+t.create('issues-raw (invalid)')
+  .get('/issues-raw/chris48s/example-private-repo.json')
   .expectJSON({ name: 'issues', value: 'invalid' });
 
 t.create('issues-raw (connection error)')
@@ -36,8 +40,12 @@ t.create('issues (valid)')
     value: isMetricOpenIssues
   }));
 
-t.create('issues (invalid)')
+t.create('issues (not found)')
   .get('/issues/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'issues', value: 'not found' });
+
+t.create('issues (invalid)')
+  .get('/issues/chris48s/example-private-repo.json')
   .expectJSON({ name: 'issues', value: 'invalid' });
 
 t.create('issues (connection error)')
@@ -55,8 +63,12 @@ t.create('pr-raw (valid)')
     value: isMetric
   }));
 
-t.create('pr-raw (invalid)')
+t.create('pr-raw (not found)')
   .get('/pr-raw/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'pull requests', value: 'not found' });
+
+t.create('pr-raw (invalid)')
+  .get('/pr-raw/chris48s/example-private-repo.json')
   .expectJSON({ name: 'pull requests', value: 'invalid' });
 
 t.create('pr-raw (connection error)')
@@ -71,8 +83,12 @@ t.create('pr-raw (connection error)')
     value: isMetricOpenIssues
   }));
 
-t.create('pr (invalid)')
+t.create('pr (not found)')
   .get('/pr/atlassian/not-a-repo.json')
+  .expectJSON({ name: 'pull requests', value: 'not found' });
+
+t.create('pr (invalid)')
+  .get('/pr/chris48s/example-private-repo.json')
   .expectJSON({ name: 'pull requests', value: 'invalid' });
 
 t.create('pr (connection error)')

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -82,14 +82,14 @@ t.create('GitHub open issues by label is > zero')
   .get('/issues/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'service-badge issues',
-    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('GitHub open issues by multi-word label is > zero')
   .get('/issues/Cockatrice/Cockatrice/App%20-%20Cockatrice.json')
   .expectJSONTypes(Joi.object().keys({
     name: '"App - Cockatrice" issues',
-    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('GitHub open issues by label (raw)')

--- a/service-tests/github.js
+++ b/service-tests/github.js
@@ -4,6 +4,7 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const {
   isMetric,
+  isMetricOpenIssues,
   isMetricOverTimePeriod,
   isFileSize,
   isFormattedDate,
@@ -42,7 +43,7 @@ t.create('GitHub pull requests')
   .get('/issues-pr/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'pull requests',
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('GitHub pull requests raw')
@@ -70,7 +71,7 @@ t.create('GitHub open issues')
   .get('/issues/badges/shields.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'issues',
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('GitHub open issues raw')
@@ -102,7 +103,7 @@ t.create('GitHub open pull requests by label')
   .get('/issues-pr/badges/shields/service-badge.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'service-badge pull requests',
-    value: Joi.string().regex(/^[0-9]+[kMGTPEZY]? open$/)
+    value: isMetricOpenIssues
   }));
 
 t.create('GitHub open pull requests by label (raw)')

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -37,7 +37,7 @@ const isStarRating = withRegex(/^(?=.{5}$)(\u2605{0,5}[\u00BC\u00BD\u00BE]?\u260
 // Required to be > 0, beacuse accepting zero masks many problems.
 const isMetric = withRegex(/^[1-9][0-9]*[kMGTPEZY]?$/);
 
-const isMetricOpenIssues = withRegex(/^[0-9]+[kMGTPEZY]? open$/);
+const isMetricOpenIssues = withRegex(/^[1-9][0-9]*[kMGTPEZY]? open$/);
 
 const isMetricOverTimePeriod = withRegex(/^[1-9][0-9]*[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
 

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -37,6 +37,8 @@ const isStarRating = withRegex(/^(?=.{5}$)(\u2605{0,5}[\u00BC\u00BD\u00BE]?\u260
 // Required to be > 0, beacuse accepting zero masks many problems.
 const isMetric = withRegex(/^[1-9][0-9]*[kMGTPEZY]?$/);
 
+const isMetricOpenIssues = withRegex(/^[0-9]+[kMGTPEZY]? open$/);
+
 const isMetricOverTimePeriod = withRegex(/^[1-9][0-9]*[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
 
 const isPercentage = withRegex(/^[0-9]+%$/);
@@ -55,6 +57,7 @@ module.exports = {
   isComposerVersion,
   isStarRating,
   isMetric,
+  isMetricOpenIssues,
   isMetricOverTimePeriod,
   isPercentage,
   isFileSize,


### PR DESCRIPTION
* Add test suite for BitBucket service integration
* Present BitBucket issues as a metric (for consistency with BitBucket PR endpoint and GitHub endpoints)
* Factor out a shared regex
* Fail cleanly if count is `undefined`

i.e: do this: ![invalid](https://user-images.githubusercontent.com/6025893/33528467-b8d5f5a2-d858-11e7-9e9a-f9139f3769e3.png)
not this: ![undefined_open](https://user-images.githubusercontent.com/6025893/33528470-c5af2712-d858-11e7-98b1-6e289613cd09.png)

