### PR TITLE
Github admin endpoint: use basic auth password instead of username

### DIFF
--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -120,10 +120,14 @@ function setRoutes(server) {
   // - Ensure tokens have been propagated to all servers
   // - Debug GitHub badge failures
   //
-  // The admin can authenticate with HTTP Basic Auth, with the shields secret
-  // in the username and an empty/any password.
+  // The admin can authenticate with HTTP Basic Auth, with an empty/any
+  // username and the shields secret in the password and an empty/any
+  // password.
+  //
+  // e.g.
+  // curl -u ':very-very-secret' 'https://example.com/$github-auth/tokens'
   server.ajax.on('github-auth/tokens', (json, end, ask) => {
-    if (! constEq(ask.username, serverSecrets.shieldsSecret)) {
+    if (! constEq(ask.password, serverSecrets.shieldsSecret)) {
       // An unknown entity tries to connect. Let the connection linger for a minute.
       return setTimeout(function() { end('Invalid secret.'); }, 10000);
     }


### PR DESCRIPTION
c.f. https://github.com/badges/shields/issues/1314#issuecomment-348803814