### PR TITLE
Add [Discourse] status/stats shield

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -312,43 +312,23 @@ const allBadgeExamples = [
       },
       {
         title: 'Discourse topics',
-        previewUri: '/discourse/meta.discourse.org/topics.svg',
-        exampleUri: '/discourse/DISCOURSE_HOST/topics.svg',
-        keywords: [
-          'discourse'
-        ]
+        previewUri: '/discourse/https/meta.discourse.org/topics.svg'
       },
       {
         title: 'Discourse posts',
-        previewUri: '/discourse/meta.discourse.org/posts.svg',
-        exampleUri: '/discourse/DISCOURSE_HOST/posts.svg',
-        keywords: [
-          'discourse'
-        ]
+        previewUri: '/discourse/https/meta.discourse.org/posts.svg'
       },
       {
         title: 'Discourse users',
-        previewUri: '/discourse/meta.discourse.org/users.svg',
-        exampleUri: '/discourse/DISCOURSE_HOST/users.svg',
-        keywords: [
-          'discourse'
-        ]
+        previewUri: '/discourse/https/meta.discourse.org/users.svg'
       },
       {
         title: 'Discourse likes',
-        previewUri: '/discourse/meta.discourse.org/likes.svg',
-        exampleUri: '/discourse/DISCOURSE_HOST/likes.svg',
-        keywords: [
-          'discourse'
-        ]
+        previewUri: '/discourse/https/meta.discourse.org/likes.svg'
       },
       {
         title: 'Discourse status',
-        previewUri: '/discourse/meta.discourse.org/status.svg',
-        exampleUri: '/discourse/DISCOURSE_HOST/status.svg',
-        keywords: [
-          'discourse'
-        ]
+        previewUri: '/discourse/https/meta.discourse.org/status.svg'
       },
       {
         title: 'Read the Docs',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -311,6 +311,46 @@ const allBadgeExamples = [
         previewUri: '/continuousphp/git-hub/doctrine/dbal/master.svg'
       },
       {
+        title: 'Discourse topics',
+        previewUri: '/discourse/meta.discourse.org/topics.svg',
+        exampleUri: '/discourse/DISCOURSE_HOST/topics.svg',
+        keywords: [
+          'discourse'
+        ]
+      },
+      {
+        title: 'Discourse posts',
+        previewUri: '/discourse/meta.discourse.org/posts.svg',
+        exampleUri: '/discourse/DISCOURSE_HOST/posts.svg',
+        keywords: [
+          'discourse'
+        ]
+      },
+      {
+        title: 'Discourse users',
+        previewUri: '/discourse/meta.discourse.org/users.svg',
+        exampleUri: '/discourse/DISCOURSE_HOST/users.svg',
+        keywords: [
+          'discourse'
+        ]
+      },
+      {
+        title: 'Discourse likes',
+        previewUri: '/discourse/meta.discourse.org/likes.svg',
+        exampleUri: '/discourse/DISCOURSE_HOST/likes.svg',
+        keywords: [
+          'discourse'
+        ]
+      },
+      {
+        title: 'Discourse status',
+        previewUri: '/discourse/meta.discourse.org/status.svg',
+        exampleUri: '/discourse/DISCOURSE_HOST/status.svg',
+        keywords: [
+          'discourse'
+        ]
+      },
+      {
         title: 'Read the Docs',
         previewUri: '/readthedocs/pip.svg',
         keywords: [

--- a/server.js
+++ b/server.js
@@ -3064,12 +3064,13 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Discourse integration
-camp.route(/^\/discourse\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/discourse\/(http(?:s)?)\/(.*)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  const host   = match[1]; // eg, meta.discourse.org
-  const stat   = match[2]; // eg, user_count
-  const format = match[3];
-  const url    = 'https://' + host + '/site/statistics.json';
+  const scheme = match[1]; // eg, https
+  const host   = match[2]; // eg, meta.discourse.org
+  const stat   = match[3]; // eg, user_count
+  const format = match[4];
+  const url    = scheme + '://' + host + '/site/statistics.json';
 
   const options = {
     method: 'GET',
@@ -3086,13 +3087,13 @@ cache(function(data, match, sendBadge, request) {
         console.error('' + res);
       }
 
-      badgeData.text[1] = 'invalid';
+      badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
       return;
     }
 
     if (res.statusCode !== 200) {
-      badgeData.text[1] = 'offline';
+      badgeData.text[1] = 'inaccessible';
       badgeData.colorscheme = 'red';
       sendBadge(format, badgeData);
       return;
@@ -3122,7 +3123,6 @@ cache(function(data, match, sendBadge, request) {
           badgeData.text[1] = metric(statCount) + ' likes';
           break;
         case 'status':
-          statCount = data.like_count;
           badgeData.text[1] = 'online';
           break;
         default:

--- a/service-tests/discourse.js
+++ b/service-tests/discourse.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
 const t = new ServiceTester({ id: 'discourse', title: 'Discourse' });

--- a/service-tests/discourse.js
+++ b/service-tests/discourse.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'discourse', title: 'Discourse' });
+module.exports = t;
+
+const data = {
+  topic_count: 22513,
+  post_count: 337719,
+  user_count: 31220,
+  topics_7_days: 143,
+  topics_30_days: 551,
+  posts_7_days: 2679,
+  posts_30_days: 10445,
+  users_7_days: 204,
+  users_30_days: 803,
+  active_users_7_days: 762,
+  active_users_30_days: 1495,
+  like_count: 308833,
+  likes_7_days: 3633,
+  likes_30_days: 13397
+};
+
+t.create('Topics')
+  .get('/meta.discourse.org/topics.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: '23k topics' });
+
+t.create('Posts')
+  .get('/meta.discourse.org/posts.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: '338k posts' });
+
+t.create('Users')
+  .get('/meta.discourse.org/users.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: '31k users' });
+
+t.create('Likes')
+  .get('/meta.discourse.org/likes.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: '309k likes' });
+
+t.create('Status')
+  .get('/meta.discourse.org/status.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: 'online' });
+
+t.create('Invalid Host')
+  .get('/some.host/status.json')
+  .intercept(nock => nock('https://some.host')
+    .get('/site/statistics.json')
+    .reply(404, "<h1>Not Found</h1>")
+  )
+  .expectJSON({ name: 'discourse', value: 'offline' });
+
+t.create('Invalid Stat')
+  .get('/meta.discourse.org/unknown.json')
+  .intercept(nock => nock('https://meta.discourse.org')
+    .get('/site/statistics.json')
+    .reply(200, data)
+  )
+  .expectJSON({ name: 'discourse', value: 'invalid' });
+
+t.create('Connection Error')
+  .get('/meta.discourse.org/status.json')
+  .networkOff()
+  .expectJSON({ name: 'discourse', value: 'invalid' });


### PR DESCRIPTION
References https://github.com/badges/shields/issues/1325

API:

`/discourse/SCHEME/DISCOURSE_HOST/topics.svg`
`/discourse/SCHEME/DISCOURSE_HOST/posts.svg`
`/discourse/SCHEME/DISCOURSE_HOST/users.svg`
`/discourse/SCHEME/DISCOURSE_HOST/likes.svg`
`/discourse/SCHEME/DISCOURSE_HOST/status.svg`

Preview:

<img width="927" alt="screen shot 2017-12-05 at 3 10 07 pm" src="https://user-images.githubusercontent.com/12481/33633536-7142c496-d9ce-11e7-866d-979319232fa5.png">

