### PR TITLE
remove extra whitespace from social badge

### DIFF
--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+1 + (it.text[1] && it.text[1].length > 0 ? it.widths[1]+6 : 0)}}" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+1 + (it.text[1] && it.text[1].length > 0 ? it.widths[1]+2 : 0)}}" height="20">
   {{it.widths[1]-=4;}}
   <style type="text/css"><![CDATA[
     a #llink:hover { fill:url(#b); stroke:#ccc; }


### PR DESCRIPTION
Removes 4px from the width of the svg element on the social style badge

Current:
![image](https://user-images.githubusercontent.com/7288322/33643808-3414deb4-daa6-11e7-93cd-b39fc36d80be.png)
This PR:
![image](https://user-images.githubusercontent.com/7288322/33643781-15900dc4-daa6-11e7-8992-03f88f58850c.png)