### PR TITLE
[BitBucket] check status code before parsing body

### DIFF
--- a/server.js
+++ b/server.js
@@ -4501,11 +4501,11 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var data = JSON.parse(buffer);
-      var issues = data.count;
       if (res.statusCode !== 200) {
         throw Error('Failed to count issues.');
       }
+      var data = JSON.parse(buffer);
+      var issues = data.count;
       badgeData.text[1] = metric(issues) + (isRaw? '': ' open');
       badgeData.colorscheme = issues ? 'yellow' : 'brightgreen';
       sendBadge(format, badgeData);
@@ -4539,11 +4539,11 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var data = JSON.parse(buffer);
-      var pullrequests = data.size;
       if (res.statusCode !== 200) {
         throw Error('Failed to count pull requests.');
       }
+      var data = JSON.parse(buffer);
+      var pullrequests = data.size;
       badgeData.text[1] = metric(pullrequests) + (isRaw? '': ' open');
       badgeData.colorscheme = (pullrequests > 0)? 'yellow': 'brightgreen';
       sendBadge(format, badgeData);


### PR DESCRIPTION
As @platan correctly notes in https://github.com/badges/shields/pull/1315#discussion_r155084514 we should check the status code first before attempting to parse the response body.