### PR TITLE
[bountysource] tests and fixes for bountysource service integration

### DIFF
--- a/server.js
+++ b/server.js
@@ -1311,13 +1311,13 @@ cache(function(data, match, sendBadge, request) {
 // Bountysource integration.
 camp.route(/^\/bountysource\/team\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var team = match[1];  // eg, `mozilla-core`.
-  var type = match[2];  // eg, `activity`.
-  var format = match[3];
-  var url = 'https://api.bountysource.com/teams/' + team;
-  var options = {
+  const team = match[1];  // eg, `mozilla-core`.
+  const type = match[2];  // eg, `activity`.
+  const format = match[3];
+  const url = 'https://api.bountysource.com/teams/' + team;
+  const options = {
     headers: { 'Accept': 'application/vnd.bountysource+json; version=2' } };
-  var badgeData = getBadgeData('bounties', data);
+  let badgeData = getBadgeData('bounties', data);
   request(url, options, function dealWithData(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
@@ -1328,9 +1328,9 @@ cache(function(data, match, sendBadge, request) {
       if (res.statusCode !== 200) {
         throw Error('Bad response.');
       }
-      var data = JSON.parse(buffer);
+      const data = JSON.parse(buffer);
       if (type === 'activity') {
-        var activity = data.activity_total;
+        const activity = data.activity_total;
         badgeData.colorscheme = 'brightgreen';
         badgeData.text[1] = activity;
       }

--- a/server.js
+++ b/server.js
@@ -1325,6 +1325,9 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
+      if (res.statusCode !== 200) {
+        throw Error('Bad response.');
+      }
       var data = JSON.parse(buffer);
       if (type === 'activity') {
         var activity = data.activity_total;
@@ -1333,7 +1336,11 @@ cache(function(data, match, sendBadge, request) {
       }
       sendBadge(format, badgeData);
     } catch(e) {
-      badgeData.text[1] = 'invalid';
+      if (res.statusCode === 404) {
+        badgeData.text[1] = 'not found';
+      } else {
+        badgeData.text[1] = 'invalid';
+      }
       sendBadge(format, badgeData);
     }
   });

--- a/server.js
+++ b/server.js
@@ -1328,9 +1328,9 @@ cache(function(data, match, sendBadge, request) {
       if (res.statusCode !== 200) {
         throw Error('Bad response.');
       }
-      const data = JSON.parse(buffer);
+      const parsedData = JSON.parse(buffer);
       if (type === 'activity') {
-        const activity = data.activity_total;
+        const activity = parsedData.activity_total;
         badgeData.colorscheme = 'brightgreen';
         badgeData.text[1] = activity;
       }

--- a/server.js
+++ b/server.js
@@ -1309,11 +1309,10 @@ cache(function(data, match, sendBadge, request) {
 
 
 // Bountysource integration.
-camp.route(/^\/bountysource\/team\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/bountysource\/team\/([^/]+)\/activity\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   const team = match[1];  // eg, `mozilla-core`.
-  const type = match[2];  // eg, `activity`.
-  const format = match[3];
+  const format = match[2];
   const url = 'https://api.bountysource.com/teams/' + team;
   const options = {
     headers: { 'Accept': 'application/vnd.bountysource+json; version=2' } };
@@ -1329,11 +1328,9 @@ cache(function(data, match, sendBadge, request) {
         throw Error('Bad response.');
       }
       const parsedData = JSON.parse(buffer);
-      if (type === 'activity') {
-        const activity = parsedData.activity_total;
-        badgeData.colorscheme = 'brightgreen';
-        badgeData.text[1] = activity;
-      }
+      const activity = parsedData.activity_total;
+      badgeData.colorscheme = 'brightgreen';
+      badgeData.text[1] = activity;
       sendBadge(format, badgeData);
     } catch(e) {
       if (res.statusCode === 404) {

--- a/service-tests/bountysource.js
+++ b/service-tests/bountysource.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
-const t = new ServiceTester({ id: 'bountysource', title: 'Bountysource badges' });
+const t = new ServiceTester({ id: 'bountysource', title: 'Bountysource' });
 module.exports = t;
 
 
@@ -38,7 +38,7 @@ t.create('bounties (unexpected response)')
   )
   .expectJSON({name: 'bounties', value: 'invalid'});
 
-t.create('bounties (unexpected response)')
+t.create('bounties (error response)')
   .get('/team/mozilla-core/activity.json')
   .intercept(nock => nock('https://api.bountysource.com')
     .get('/teams/mozilla-core')

--- a/service-tests/bountysource.js
+++ b/service-tests/bountysource.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const t = new ServiceTester({ id: 'bountysource', title: 'Bountysource badges' });
+module.exports = t;
+
+
+t.create('bounties (valid)')
+  .get('/team/mozilla-core/activity.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'bounties',
+    value: Joi.number().integer().positive()
+  }));
+
+t.create('bounties (invalid team)')
+  .get('/team/not-a-real-team/activity.json')
+  .expectJSON({
+    name: 'bounties',
+    value: 'undefined' // FIXME!
+  });
+
+t.create('bounties (invalid type)')
+  .get('/team/mozilla-core/not-a-real-type.json')
+  .expectJSON({name: 'bounties', value: 'n/a'});
+
+t.create('bounties (connection error)')
+  .get('/team/mozilla-core/activity.json')
+  .networkOff()
+  .expectJSON({name: 'bounties', value: 'inaccessible'});
+
+t.create('bounties (unexpected response)')
+  .get('/team/mozilla-core/activity.json')
+  .intercept(nock => nock('https://api.bountysource.com')
+    .get('/teams/mozilla-core')
+    .reply(200, "{{{{{invalid json}}")
+  )
+  .expectJSON({name: 'bounties', value: 'invalid'});
+
+t.create('bounties (unexpected response)')
+  .get('/team/mozilla-core/activity.json')
+  .intercept(nock => nock('https://api.bountysource.com')
+    .get('/teams/mozilla-core')
+    .reply(500, '{"error":"oh noes!!"}')
+  )
+  .expectJSON({
+    name: 'bounties',
+    value: 'undefined' // FIXME!
+  });

--- a/service-tests/bountysource.js
+++ b/service-tests/bountysource.js
@@ -18,7 +18,7 @@ t.create('bounties (invalid team)')
   .get('/team/not-a-real-team/activity.json')
   .expectJSON({
     name: 'bounties',
-    value: 'undefined' // FIXME!
+    value: 'not found'
   });
 
 t.create('bounties (invalid type)')
@@ -46,5 +46,5 @@ t.create('bounties (unexpected response)')
   )
   .expectJSON({
     name: 'bounties',
-    value: 'undefined' // FIXME!
+    value: 'invalid'
   });

--- a/service-tests/bountysource.js
+++ b/service-tests/bountysource.js
@@ -21,10 +21,6 @@ t.create('bounties (invalid team)')
     value: 'not found'
   });
 
-t.create('bounties (invalid type)')
-  .get('/team/mozilla-core/not-a-real-type.json')
-  .expectJSON({name: 'bounties', value: 'n/a'});
-
 t.create('bounties (connection error)')
   .get('/team/mozilla-core/activity.json')
   .networkOff()


### PR DESCRIPTION
* Add service tests for bountysource badge
* switch to use ES6 style variable declarations
* Fail cleanly on bad responses.

i.e:
don't do this ![bad](https://user-images.githubusercontent.com/6025893/33736687-6f5fa478-db8b-11e7-929e-0a9c50b931f3.png)
do this ![good](https://user-images.githubusercontent.com/6025893/33736696-77ccb218-db8b-11e7-96ab-cf70d6d88f77.png)
or this ![good2](https://user-images.githubusercontent.com/6025893/33736702-7d2ca470-db8b-11e7-9736-27171db70cae.png)

I suspect there will be several more service badges with this class of error. I'll continue to look for them as I add tests.


@PyvesB - apologies again for our mixup yesterday. If you're in the mood to look at a PR please feel free to provide feedback. I'm sure your comments will be helpful :)