### PR TITLE
Default to not logging GitHub token debugging

### DIFF
--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -51,7 +51,7 @@ const config = {
     github: {
       baseUri: process.env.GITHUB_URL || 'https://api.github.com',
       debug: {
-        enabled: envFlag(process.env.GITHUB_DEBUG_ENABLED, true),
+        enabled: envFlag(process.env.GITHUB_DEBUG_ENABLED, false),
         intervalSeconds: process.env.GITHUB_DEBUG_INTERVAL_SECONDS || 300,
       },
     },


### PR DESCRIPTION
As argued for in
https://github.com/badges/shields/issues/1314#issuecomment-350564524.

It populates large quantities of text in the logs, where I wish to only
see errors.