### PR TITLE
[CodeClimate] Fix coverage and maintainability score badges

### DIFF
--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -9,7 +9,7 @@ t.create('maintainability score')
   .get('/maintainability/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
-    value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
+    value: Joi.equal('A', 'B', 'C', 'D', 'F')
   }));
 
 t.create('maintainability score for non-existent repo')
@@ -19,21 +19,11 @@ t.create('maintainability score for non-existent repo')
     value: 'not found'
   });
 
-t.create('maintainability score without content-disposition')
-  .get('/maintainability/Nickersoft/dql.json')
-  .intercept(nock => nock('https://api.codeclimate.com')
-    .get('/v1/repos')
-    .query({ github_slug: 'Nickersoft/dql' })
-    .reply(200, { data: [{ attributes: { badge_token: '78ac0fa85c83fea5213a' } }] })
-    .head('/v1/badges/78ac0fa85c83fea5213a/maintainability')
-    .reply(200))
-  .expectJSON({ name: 'maintainability', value: 'invalid' });
-
 t.create('test coverage score')
   .get('/c/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: Joi.equal('A', 'B', 'C', 'D', 'F', 'unknown')
+    value: Joi.equal('A', 'B', 'C', 'D', 'F')
   }));
 
 t.create('test coverage score for non-existent repo')
@@ -43,15 +33,11 @@ t.create('test coverage score for non-existent repo')
     value: 'not found'
   });
 
-t.create('test coverage score without content-disposition')
-  .get('/c/Nickersoft/dql.json')
-  .intercept(nock => nock('https://api.codeclimate.com')
-    .get('/v1/repos')
-    .query({ github_slug: 'Nickersoft/dql' })
-    .reply(200, { data: [{ attributes: { badge_token: '78ac0fa85c83fea5213a' } }] })
-    .head('/v1/badges/78ac0fa85c83fea5213a/test_coverage')
-    .reply(200))
-  .expectJSON({ name: 'coverage', value: 'invalid' });
-
+t.create('test coverage score for repo without test reports')
+  .get('/c/kabisaict/flow.json')
+  .expectJSON({
+    name: 'coverage',
+    value: 'unknown'
+  });
 
 module.exports = t;


### PR DESCRIPTION
Hello there,

This pull request takes care of issue #1329. 

I had a closer look at the API documentation and managed to find a way to retrieve the now missing code coverage score in a different way. As before, the code is making a call to the [get repository](https://developer.codeclimate.com/#get-repository) endpoint, but instead of firing a second call to retrieve the headers of Code Climate's own badges, it's now calling the [get snapshot](https://developer.codeclimate.com/#get-snapshot) or [get test coverage reports](https://developer.codeclimate.com/#get-test-coverage-reports) endpoint to get the scores. In essence the coverage and maintainability badges are now generated only via API body responses rather than trying to do pattern matching on returned headers, which should hopefully be cleaner and more reliable. 👍 

Cheers,

Pyves