### PR TITLE
Prettier updated to 1.9.2 in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10748,9 +10748,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.1.tgz",
-      "integrity": "sha512-oYpQsZk7/0o8+YJUB0LfjkTYQa79gUIF2ESeqvG23IzcgqqvmeOE4+lMG7E/UKX3q3RIj8JHSfhrXWhon1L+zA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
       "dev": true
     },
     "pretty": {


### PR DESCRIPTION
`package-lock.json` wasn't updated in https://github.com/badges/shields/pull/1367. This PR updates it to version from `package.json`