### PR TITLE
Removal of hasPrefix function in badge-data.js

### DIFF
--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -17,14 +17,10 @@ function isDataUri(s) {
   return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
 }
 
-function hasPrefix(s, prefix) {
-  return s !== undefined && s.slice(0, prefix.length) === prefix;
-}
-
 function prependPrefix(s, prefix) {
   if (s === undefined) {
     return undefined;
-  } else if (hasPrefix(s, prefix)) {
+  } else if (s.startsWith(prefix)) {
     return s;
   } else {
     return prefix + s;
@@ -102,7 +98,7 @@ function makeBadgeData(defaultLabel, overrides) {
 }
 
 module.exports = {
-  hasPrefix,
+  prependPrefix,
   isDataUri,
   isValidStyle,
   isSixHex,

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const { test, given, forCases } = require('sazerac');
 const {
   isDataUri,
-  hasPrefix,
+  prependPrefix,
   isSixHex,
   makeLabel,
   makeLogo,
@@ -13,12 +13,13 @@ const {
 } = require('./badge-data');
 
 describe('Badge data helpers', function() {
-  test(hasPrefix, () => {
+  test(prependPrefix, () => {
     forCases([
       given('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:'),
       given('data:foobar', 'data:'),
-    ]).expect(true);
-    given('foobar', 'data:').expect(false);
+    ]).expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
+    given('foobar', 'data:').expect('data:foobar');
+    given(undefined, 'data:').expect(undefined);
   });
 
   test(isDataUri, () => {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -14,10 +14,7 @@ const {
 
 describe('Badge data helpers', function() {
   test(prependPrefix, () => {
-    forCases([
-      given('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:'),
-      given('data:foobar', 'data:'),
-    ]).expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
+    given('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:').expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
     given('foobar', 'data:').expect('data:foobar');
     given(undefined, 'data:').expect(undefined);
   });


### PR DESCRIPTION
Hello there,

Nothing much going on here. I noticed that we were checking for string prefixes in a slightly odd way in _badge-data.js_, probably due to the lack of ECMA Script 6 at the time. Switched to using `startsWith` instead and reworked a few tests around the `prependPrefix` function.

Cheers,

Pyves