### PR TITLE
Fix [bower] service tests

### DIFF
--- a/service-tests/bower.js
+++ b/service-tests/bower.js
@@ -14,7 +14,7 @@ t.create('licence')
   .expectJSON({ name: 'bower', value: 'MIT' });
 
 t.create('custom label for licence')
-  .get('/l/bootstrap.json?label="my licence"')
+  .get('/l/bootstrap.json?label=my licence')
   .expectJSON({ name: 'my licence', value: 'MIT' });
 
 t.create('version')
@@ -25,7 +25,7 @@ t.create('version')
   }));
 
 t.create('custom label for version')
-  .get('/v/bootstrap.json?label="my version"')
+  .get('/v/bootstrap.json?label=my version')
   .expectJSONTypes(Joi.object().keys({
     name: 'my version',
     value: isVPlusDottedVersionAtLeastOne
@@ -39,7 +39,7 @@ t.create('pre version') // e.g. bower|v0.2.5-alpha-rc-pre
   }));
 
 t.create('custom label for pre version') // e.g. pre version|v0.2.5-alpha-rc-pre
-  .get('/vpre/bootstrap.json?label="pre version"')
+  .get('/vpre/bootstrap.json?label=pre version')
   .expectJSONTypes(Joi.object().keys({
     name: 'pre version',
     value: isBowerPrereleaseVersion


### PR DESCRIPTION
test was previously testing custom labels with `?label="my licence"` including the quote marks which is causing tests to fail.
Have updated to exclude the quote marks.

Though not sure why this is suddenly becoming an issue, as it previously has passed with quote marks.
And when i test it on the staging server or shields.io i get the [correct response](https://img.shields.io/bower/l/bootstrap.json?label=%22my%20licence%22): ![](https://img.shields.io/bower/l/bootstrap.svg?label=%22my%20licence%22)

But best to remove the quote marks as they are not needed.

```cmd
1) Bower
       custom label for licence
         
	[ GET http://localhost:1111/bower/l/bootstrap.json?label="my licence" ]:

      AssertionError: expected { name: '"my licence"', value: 'MIT' } to deeply equal { name: 'my licence', value: 'MIT' }
      + expected - actual

       {
      -  "name": "\"my licence\""
      +  "name": "my licence"
         "value": "MIT"
       }
      
      at Object.pathMatch.matchJSON (node_modules/icedfrisby/lib/pathMatch.js:138:38)
      at current.expects.push (node_modules/icedfrisby/lib/icedfrisby.js:724:10)
      at IcedFrisbyNock._invokeExpects (node_modules/icedfrisby/lib/icedfrisby.js:1294:33)
      at start (node_modules/icedfrisby/lib/icedfrisby.js:1274:12)
      at Request.runCallback [as _callback] (node_modules/icedfrisby/lib/icedfrisby.js:1232:16)
      at Request.self.callback (node_modules/request/request.js:186:22)
      at Request.<anonymous> (node_modules/request/request.js:1163:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1085:12)
      at endReadableNT (_stream_readable.js:1056:12)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickDomainCallback (internal/process/next_tick.js:218:9)
```