### PR TITLE
npm start | supported on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,11 @@
     "prebuild": "npm run frontend-depcheck",
     "build": "next build && next export -o build/",
     "heroku-postbuild": "npm run build",
-    "analyze": "ANALYZE=true LONG_CACHE=false BASE_URL=https://img.shields.io npm run build",
+    "analyze": "SET ANALYZE=true && SET LONG_CACHE=false && SET BASE_URL=https://img.shields.io && npm run build",
     "start:server": "node server 8080 ::",
     "now-start": "node server",
     "prestart": "npm run frontend-depcheck",
-    "start": "concurrently --names server,frontend \"ALLOWED_ORIGIN=http://localhost:3000 npm run start:server\" \"BASE_URL=http://[::]:8080 next dev\""
+    "start": "concurrently --names server,frontend \"SET ALLOWED_ORIGIN=http://localhost:3000 && npm run start:server\" \"SET BASE_URL=http://localhost:8080 && next dev\""
   },
   "bin": {
     "badge": "lib/badge-cli.js"


### PR DESCRIPTION
`npm start` currently fails to run on windows due to the way environment variables are set.

In order to merge this PR i would like to confirm this is also working on other operating systems.
If you are able to test on other OS please let me know.

- [x] Windows 10
- [x] Windows Server 2008
- [ ] OSX
- [ ] Linux

Alternative code if the current PR code doesn't work:
```json
    "analyze": "(ANALYZE=true || SET ANALYZE=true) && (LONG_CACHE=false || SET LONG_CACHE=false) && (BASE_URL=https://img.shields.io || SET BASE_URL=https://img.shields.io) && npm run build",
    "start": "concurrently --names server,frontend \"(ALLOWED_ORIGIN=http://localhost:3000 || SET ALLOWED_ORIGIN=http://localhost:3000) && npm run start:server\" \"(BASE_URL=http://localhost:8080 || SET BASE_URL=http://localhost:8080) && next dev\""
```