### PR TITLE
Improve search performance

### DIFF
--- a/frontend/components/badge-examples.js
+++ b/frontend/components/badge-examples.js
@@ -50,9 +50,9 @@ const Category = ({ category, examples, baseUri, longCache, onClick }) => (
     <table className="badge">
       <tbody>
         {
-          examples.map((badgeData, i) => (
+          examples.map(badgeData => (
             <Badge
-              key={i}
+              key={badgeData.key}
               {...badgeData}
               baseUri={baseUri}
               longCache={longCache}

--- a/frontend/components/suggestion-and-search.js
+++ b/frontend/components/suggestion-and-search.js
@@ -15,7 +15,7 @@ export default class SuggestionAndSearch extends React.Component {
 
   constructor(props) {
     super(props);
-    this.queryChangedDebounced = debounce(props.queryChanged, 500, { leading: true });
+    this.queryChangedDebounced = debounce(props.queryChanged, 50, { leading: true });
   }
 
   state = {

--- a/frontend/lib/filter-examples.js
+++ b/frontend/lib/filter-examples.js
@@ -4,18 +4,34 @@ function exampleMatchesRegex(example, regex) {
   return regex.test(haystack);
 }
 
-export default function filterExamples(examples, query) {
-  if (! query) {
-    return examples;
+function predicateFromQuery(query) {
+  if (query) {
+    const regex = new RegExp(query, 'i'); // Case-insensitive.
+    return example => exampleMatchesRegex(example, regex);
+  } else {
+    return () => true;
   }
+}
 
-  const regex = new RegExp(query, 'i'); // Case-insensitive.
-
-  return examples
+export function mapExamples(categories, iteratee) {
+  return categories
     .map(({ category, examples }) => ({
       category,
-      examples: examples.filter(ex => exampleMatchesRegex(ex, regex)),
+      examples: iteratee(examples),
     }))
-    // Remove empty sections.
+    // Remove empty categories.
     .filter(({ category, examples }) => examples.length > 0);
+}
+
+// Assign each example a unique ID.
+export function prepareExamples(categories) {
+  let nextKey = 0;
+  return mapExamples(categories, examples => examples.map(example => Object.assign(example, {
+    key: nextKey++,
+  })));
+}
+
+export function filterExamples(categories, query) {
+  const predicate = predicateFromQuery(query);
+  return mapExamples(categories, examples => examples.filter(predicate));
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,10 +8,11 @@ import MarkupModal from '../frontend/components/markup-modal';
 import Usage from '../frontend/components/usage';
 import Footer from '../frontend/components/footer';
 import badgeExampleData from '../lib/all-badge-examples';
-import filterExamples from '../frontend/lib/filter-examples';
+import { prepareExamples, filterExamples } from '../frontend/lib/filter-examples';
 
 const baseUri = process.env.BASE_URL;
 const longCache = envFlag(process.env.LONG_CACHE, false);
+const preparedExamples = prepareExamples(badgeExampleData);
 
 export default class IndexPage extends React.Component {
   state = { query: null, example: null };
@@ -22,7 +23,7 @@ export default class IndexPage extends React.Component {
     // adjusting visibility of the elements rather than removing them from the
     // DOM and recreating them, as this does now. That's what the original
     // code did.
-    const filteredExamples = filterExamples(badgeExampleData, this.state.query);
+    const filteredExamples = filterExamples(preparedExamples, this.state.query);
 
     return (
       <div>


### PR DESCRIPTION
This change applies a unique ID to each badge example, and uses that to key the DOM.

Before this change, the key was the array index. While constant with the filter, it mutated as the filter changed, causing React to mutate the DOM very inefficiently. Badges were filtered out by mutating al the rows instead of simply removing the affected rows.

I first tried a version that applied a class with `display: none` to the hidden elements. That worked; however the implementation has a bunch of indirection, and this works nearly as well.

Fix #1314