### PR TITLE
Add list of critical services

### DIFF
--- a/lib/project/critical-services.yml
+++ b/lib/project/critical-services.yml
@@ -1,0 +1,45 @@
+# Subjective prioritization of critical services. If you think some are
+# missing, open a PR to add your own list.
+
+paulmelnikow:
+  - cdnjs
+  - chocolatey
+  - circleci
+  - clojars
+  - cocoapods
+  - codeship
+  - david
+  - docker
+  - dotnet.myget
+  - myget
+  - nuget
+  - dub
+  - gem
+  - hackage
+  - homebrew
+  - itunes
+  - jira
+  - uptimerobot
+  - amo
+  - ansible
+  - appveyor
+  - bitbucket
+  - chrome-web-store
+  - codeclimate
+  - coveralls
+  - discord
+  - eclipse-marketplace
+  - elm-package
+  - github
+  - hexpm
+  - jenkins
+  - luarocks
+  - maven-central
+  - node
+  - nom
+  - packagist
+  - pypi
+  - suggest
+  - website
+  - vscode-marketplace
+  - wordpress

--- a/lib/project/critical-services.yml
+++ b/lib/project/critical-services.yml
@@ -40,6 +40,7 @@ paulmelnikow:
   - packagist
   - pypi
   - suggest
+  - twitter
   - website
   - vscode-marketplace
   - wordpress


### PR DESCRIPTION
I have a branch going to automatically generate stats on which services have tests, and make a line chart over time. I'm having a lot of fun with that so I'll keep at it.

Meanwhile, here is my list of critical services, for #1358.