### PR TITLE
[CodeClimate] Fix remaining badges

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1222,11 +1222,11 @@ const allBadgeExamples = [
     examples: [
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/c/Nickersoft/dql.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/coverage/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/c-letter/Nickersoft/dql.svg'
       },
       {
         title: 'Code Climate',
@@ -1238,7 +1238,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/c/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/maintainability-letter/Nickersoft/dql.svg'
       },
       {
         title: 'bitHound',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1222,23 +1222,27 @@ const allBadgeExamples = [
     examples: [
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/c/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/issues/twbs/bootstrap.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/c-letter/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/maintainability/angular/angular.js.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/issues/github/me-and/mdf.svg'
+        previewUri: '/codeclimate/maintainability-percentage/angular/angular.js.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/maintainability/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/coverage/jekyll/jekyll.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/maintainability-letter/Nickersoft/dql.svg'
+        previewUri: '/codeclimate/coverage-letter/jekyll/jekyll.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/tech-debt/jekyll/jekyll.svg'
       },
       {
         title: 'bitHound',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1222,11 +1222,11 @@ const allBadgeExamples = [
     examples: [
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/github/kabisaict/flow.svg'
+        previewUri: '/codeclimate/Nickersoft/dql.svg'
       },
       {
         title: 'Code Climate',
-        previewUri: '/codeclimate/coverage/github/triAGENS/ashikawa-core.svg'
+        previewUri: '/codeclimate/coverage/Nickersoft/dql.svg'
       },
       {
         title: 'Code Climate',

--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -40,6 +40,22 @@ function floorCount(value, yellow, yellowgreen, green) {
   }
 }
 
+function letterScore(score) {
+  if (score === 'A') {
+    return 'brightgreen';
+  } else if (score === 'B') {
+    return 'green';
+  } else if (score === 'C') {
+    return 'yellowgreen';
+  } else if (score === 'D') {
+    return 'yellow';
+  } else if (score === 'E') {
+    return 'orange';
+  } else {
+    return 'red';
+  }
+}
+
 function colorScale(steps, colors, reversed) {
   if (steps === undefined) {
     throw Error('When invoking colorScale, steps should be provided.');
@@ -89,6 +105,7 @@ module.exports = {
   downloadCount,
   coveragePercentage,
   floorCount,
+  letterScore,
   colorScale,
   age
 };

--- a/lib/color-formatters.spec.js
+++ b/lib/color-formatters.spec.js
@@ -4,6 +4,7 @@ const { test, given, forCases } = require('sazerac');
 const {
   coveragePercentage,
   colorScale,
+  letterScore,
   age,
   version
 } = require('./color-formatters');
@@ -38,6 +39,16 @@ describe('Color formatters', function() {
       given(400).expect('orange');
       given(800).expect('red');
     });
+  });
+
+  test(letterScore, () => {
+    given('A').expect('brightgreen');
+    given('B').expect('green');
+    given('C').expect('yellowgreen');
+    given('D').expect('yellow');
+    given('E').expect('orange');
+    given('F').expect('red');
+    given('Z').expect('red');
   });
 
   const monthsAgo = months => {

--- a/server.js
+++ b/server.js
@@ -2691,10 +2691,10 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Code Climate test reports integration
+// Code Climate integration.
 camp.route(/^\/codeclimate(\/(c|coverage|maintainability|issues)(-letter)?)?\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  // c and coverage are both equivalent. Top-level URL still supported for backwards compatibility. See #1387. 
+  // Top-level and /coverage URLs equivalent to /c, still supported for backwards compatibility. See #1387. 
   const type = match[2] === 'c' || !match[2] ? 'coverage' : match[2];
   const isLetter = match[3];
   const userRepo = match[4];  // eg, `Nickersoft/dql`.
@@ -2718,12 +2718,9 @@ cache(function(data, match, sendBadge, request) {
         return;
       }
 
-      let branchData;
-      if (type === 'coverage') {
-        branchData = body.data[0].relationships.latest_default_branch_test_report.data;
-      } else {
-        branchData = body.data[0].relationships.latest_default_branch_snapshot.data;
-      }
+      const branchData = type === 'coverage'
+        ? body.data[0].relationships.latest_default_branch_test_report.data
+        : body.data[0].relationships.latest_default_branch_snapshot.data;
       if (branchData == null) {
         badgeData.text[1] = 'unknown';
         sendBadge(format, badgeData);
@@ -2756,7 +2753,7 @@ cache(function(data, match, sendBadge, request) {
           badgeData.text[1] = score;
           badgeData.colorscheme = letterScoreColor(score);
         } else if (type === 'maintainability') {
-          const percentage = parseFloat(parsedData.data.meta.measures.technical_debt_ratio.value);
+          const percentage = parseFloat(parsedData.data.attributes.ratings[0].measure.value);
           badgeData.text[1] = percentage.toFixed(0) + '%';
           badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
         }

--- a/server.js
+++ b/server.js
@@ -2692,13 +2692,13 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Code Climate test reports integration
-camp.route(/^\/codeclimate\/(c|coverage|maintainability|issues)(-percentage)?\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codeclimate(\/(c|coverage|maintainability|issues)(-percentage)?)?\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  // c and coverage are both equivalent, see #1387.
-  const type = match[1] === 'c' ? 'coverage' : match[1];
-  const isPercentage = match[2];
-  const userRepo = match[3];  // eg, `Nickersoft/dql`.
-  const format = match[4];
+  // c and coverage are both equivalent. Top-level URL still supported for backwards compatibility. See #1387. 
+  const type = match[2] === 'c' || !match[2] ? 'coverage' : match[2];
+  const isPercentage = match[3];
+  const userRepo = match[4];  // eg, `Nickersoft/dql`.
+  const format = match[5];
   request({
       method: 'GET',
       uri: `https://api.codeclimate.com/v1/repos?github_slug=${userRepo}`,

--- a/server.js
+++ b/server.js
@@ -2754,6 +2754,7 @@ cache(function(data, match, sendBadge, request) {
           badgeData.colorscheme = letterScoreColor(score);
         } else if (type === 'maintainability') {
           const percentage = parseFloat(parsedData.data.attributes.ratings[0].measure.value);
+          badgeData.text[0] = getLabel('technical debt', data);
           badgeData.text[1] = percentage.toFixed(0) + '%';
           badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
         }

--- a/server.js
+++ b/server.js
@@ -2692,11 +2692,11 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Code Climate test reports integration
-camp.route(/^\/codeclimate(\/(c|coverage|maintainability|issues)(-percentage)?)?\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codeclimate(\/(c|coverage|maintainability|issues)(-letter)?)?\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   // c and coverage are both equivalent. Top-level URL still supported for backwards compatibility. See #1387. 
   const type = match[2] === 'c' || !match[2] ? 'coverage' : match[2];
-  const isPercentage = match[3];
+  const isLetter = match[3];
   const userRepo = match[4];  // eg, `Nickersoft/dql`.
   const format = match[5];
   request({
@@ -2739,26 +2739,26 @@ cache(function(data, match, sendBadge, request) {
         }
 
         const parsedData = JSON.parse(buffer);
-        if (type === 'coverage' && isPercentage) {
-          const percentage = parseFloat(parsedData.data.attributes.covered_percent);
-          badgeData.text[1] = percentage.toFixed(0) + '%';
-          badgeData.colorscheme = coveragePercentageColor(percentage);
-        } else if (type === 'coverage') {
+        if (type === 'coverage' && isLetter) {
           const score = parsedData.data.attributes.rating.letter;
           badgeData.text[1] = score;
           badgeData.colorscheme = letterScoreColor(score);
+        } else if (type === 'coverage') {
+          const percentage = parseFloat(parsedData.data.attributes.covered_percent);
+          badgeData.text[1] = percentage.toFixed(0) + '%';
+          badgeData.colorscheme = coveragePercentageColor(percentage);
         } else if (type === 'issues') {
           const count = parsedData.data.meta.issues_count;
           badgeData.text[1] = count;
           badgeData.colorscheme = colorScale([1, 5, 10, 20], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(count);
-        } else if (type === 'maintainability' && isPercentage) {
-          const percentage = parseFloat(parsedData.data.meta.measures.technical_debt_ratio.value);
-          badgeData.text[1] = percentage.toFixed(0) + '%';
-          badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
-        } else if (type === 'maintainability') {
+        } else if (type === 'maintainability' && isLetter) {
           const score = parsedData.data.attributes.ratings[0].letter;
           badgeData.text[1] = score;
           badgeData.colorscheme = letterScoreColor(score);
+        } else if (type === 'maintainability') {
+          const percentage = parseFloat(parsedData.data.meta.measures.technical_debt_ratio.value);
+          badgeData.text[1] = percentage.toFixed(0) + '%';
+          badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
         }
         sendBadge(format, badgeData);
       });

--- a/server.js
+++ b/server.js
@@ -2697,7 +2697,7 @@ cache(function(data, match, sendBadge, request) {
   // Top-level and /coverage URLs equivalent to /c, still supported for backwards compatibility. See #1387. 
   const type = match[2] === 'c' || !match[2] ? 'coverage' : match[2];
   const isLetter = match[3];
-  const userRepo = match[4];  // eg, `Nickersoft/dql`.
+  const userRepo = match[4];  // eg, `twbs/bootstrap`.
   const format = match[5];
   request({
       method: 'GET',

--- a/server.js
+++ b/server.js
@@ -2692,7 +2692,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Code Climate test reports integration
-camp.route(/^\/codeclimate\/(c|coverage|maintainability|issues)(\/percentage)?\/(.+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/codeclimate\/(c|coverage|maintainability|issues)(-percentage)?\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   // c and coverage are both equivalent, see #1387.
   const type = match[1] === 'c' ? 'coverage' : match[1];

--- a/server.js
+++ b/server.js
@@ -2717,7 +2717,7 @@ cache(function(data, match, sendBadge, request) {
         sendBadge(format, badgeData);
         return;
       }
-      
+
       let branchData;
       if (type === 'coverage') {
         branchData = body.data[0].relationships.latest_default_branch_test_report.data;

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -24,7 +24,7 @@ t.create('test coverage score alternative URL')
   }));
 
 t.create('test coverage percentage')
-  .get('/coverage/percentage/Nickersoft/dql.json')
+  .get('/coverage-percentage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
@@ -60,7 +60,7 @@ t.create('maintainability score')
   }));
 
 t.create('maintainability percentage')
-  .get('/maintainability/percentage/Nickersoft/dql.json')
+  .get('/maintainability-percentage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
     value: isPercentage

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -59,10 +59,10 @@ t.create('issues count')
     value: Joi.number().integer().positive()
   }));
 
-t.create('maintainability percentage')
+t.create('maintainability percentage (technical debt)')
   .get('/maintainability/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'maintainability',
+    name: 'technical debt',
     value: isPercentage
   }));
 

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -9,42 +9,42 @@ const {
 const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
 
 // Tests based on Code Climate's test reports endpoint.
-t.create('test coverage score')
-  .get('/coverage/Nickersoft/dql.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'coverage',
-    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
-  }));
-
-t.create('test coverage score alternative URL')
-  .get('/c/Nickersoft/dql.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'coverage',
-    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
-  }));
-
-t.create('test coverage score alternative top-level URL')
-  .get('/Nickersoft/dql.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'coverage',
-    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
-  }));
-
 t.create('test coverage percentage')
-  .get('/coverage-percentage/Nickersoft/dql.json')
+  .get('/coverage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
   }));
 
-t.create('test coverage score for non-existent repo')
+t.create('test coverage percentage alternative URL')
+  .get('/c/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: isPercentage
+  }));
+
+t.create('test coverage percentage alternative top-level URL')
+  .get('/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: isPercentage
+  }));
+
+t.create('test coverage letter')
+  .get('/coverage-letter/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
+t.create('test coverage percentage for non-existent repo')
   .get('/coverage/unknown/unknown.json')
   .expectJSON({
     name: 'coverage',
     value: 'not found'
   });
 
-t.create('test coverage score for repo without test reports')
+t.create('test coverage percentage for repo without test reports')
   .get('/coverage/kabisaict/flow.json')
   .expectJSON({
     name: 'coverage',
@@ -59,28 +59,28 @@ t.create('issues count')
     value: Joi.number().integer().positive()
   }));
 
-t.create('maintainability score')
-  .get('/maintainability/Nickersoft/dql.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'maintainability',
-    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
-  }));
-
 t.create('maintainability percentage')
-  .get('/maintainability-percentage/Nickersoft/dql.json')
+  .get('/maintainability/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
     value: isPercentage
   }));
 
-t.create('maintainability score for non-existent repo')
+t.create('maintainability letter')
+  .get('/maintainability-letter/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'maintainability',
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
+t.create('maintainability percentage for non-existent repo')
   .get('/maintainability/unknown/unknown.json')
   .expectJSON({
     name: 'maintainability',
     value: 'not found'
   });
 
-t.create('maintainability score for repo without snapshots')
+t.create('maintainability percentage for repo without snapshots')
   .get('/maintainability/kabisaict/flow.json')
   .expectJSON({
     name: 'maintainability',

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -9,42 +9,42 @@ const {
 const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
 
 // Tests based on Code Climate's test reports endpoint.
-t.create('test coverage percentage')
-.get('/coverage/Nickersoft/dql.json')
-.expectJSONTypes(Joi.object().keys({
-  name: 'coverage',
-  value: isPercentage
-}));
-
 t.create('test coverage score')
-.get('/c/Nickersoft/dql.json')
-.expectJSONTypes(Joi.object().keys({
-  name: 'coverage',
-  value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
-}));
-
-t.create('test coverage score for non-existent repo')
-.get('/c/unknown/unknown.json')
-.expectJSON({
-  name: 'coverage',
-  value: 'not found'
-});
-
-t.create('test coverage score for repo without test reports')
-.get('/c/kabisaict/flow.json')
-.expectJSON({
-  name: 'coverage',
-  value: 'unknown'
-});
-
-// Tests based on Code Climate's snapshots endpoint.
-t.create('technical debt percentage')
-  .get('/Nickersoft/dql.json')
+  .get('/coverage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'technical debt',
+    name: 'coverage',
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
+t.create('test coverage score alternative URL')
+  .get('/c/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
+t.create('test coverage percentage')
+  .get('/coverage/percentage/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
     value: isPercentage
   }));
 
+t.create('test coverage score for non-existent repo')
+  .get('/coverage/unknown/unknown.json')
+  .expectJSON({
+    name: 'coverage',
+    value: 'not found'
+  });
+
+t.create('test coverage score for repo without test reports')
+  .get('/coverage/kabisaict/flow.json')
+  .expectJSON({
+    name: 'coverage',
+    value: 'unknown'
+  });
+
+// Tests based on Code Climate's snapshots endpoint.
 t.create('issues count')
   .get('/issues/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
@@ -57,6 +57,13 @@ t.create('maintainability score')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
+t.create('maintainability percentage')
+  .get('/maintainability/percentage/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'maintainability',
+    value: isPercentage
   }));
 
 t.create('maintainability score for non-existent repo')

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -23,6 +23,13 @@ t.create('test coverage score alternative URL')
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
   }));
 
+t.create('test coverage score alternative top-level URL')
+  .get('/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+  }));
+
 t.create('test coverage percentage')
   .get('/coverage-percentage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -10,14 +10,14 @@ const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
 
 // Tests based on Code Climate's test reports endpoint.
 t.create('test coverage percentage')
-  .get('/coverage/Nickersoft/dql.json')
+  .get('/c/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
   }));
 
-t.create('test coverage percentage alternative URL')
-  .get('/c/Nickersoft/dql.json')
+t.create('test coverage percentage alternative coverage URL')
+  .get('/coverage/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
@@ -31,21 +31,21 @@ t.create('test coverage percentage alternative top-level URL')
   }));
 
 t.create('test coverage letter')
-  .get('/coverage-letter/Nickersoft/dql.json')
+  .get('/c-letter/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
   }));
 
 t.create('test coverage percentage for non-existent repo')
-  .get('/coverage/unknown/unknown.json')
+  .get('/c/unknown/unknown.json')
   .expectJSON({
     name: 'coverage',
     value: 'not found'
   });
 
 t.create('test coverage percentage for repo without test reports')
-  .get('/coverage/kabisaict/flow.json')
+  .get('/c/kabisaict/flow.json')
   .expectJSON({
     name: 'coverage',
     value: 'unknown'

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -2,14 +2,61 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
+const {
+  isPercentage,
+} = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
+
+// Tests based on Code Climate's test reports endpoint.
+t.create('test coverage percentage')
+.get('/coverage/Nickersoft/dql.json')
+.expectJSONTypes(Joi.object().keys({
+  name: 'coverage',
+  value: isPercentage
+}));
+
+t.create('test coverage score')
+.get('/c/Nickersoft/dql.json')
+.expectJSONTypes(Joi.object().keys({
+  name: 'coverage',
+  value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
+}));
+
+t.create('test coverage score for non-existent repo')
+.get('/c/unknown/unknown.json')
+.expectJSON({
+  name: 'coverage',
+  value: 'not found'
+});
+
+t.create('test coverage score for repo without test reports')
+.get('/c/kabisaict/flow.json')
+.expectJSON({
+  name: 'coverage',
+  value: 'unknown'
+});
+
+// Tests based on Code Climate's snapshots endpoint.
+t.create('technical debt percentage')
+  .get('/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'technical debt',
+    value: isPercentage
+  }));
+
+t.create('issues count')
+  .get('/issues/Nickersoft/dql.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'issues',
+    value: Joi.number().integer().positive()
+  }));
 
 t.create('maintainability score')
   .get('/maintainability/Nickersoft/dql.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
-    value: Joi.equal('A', 'B', 'C', 'D', 'F')
+    value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
   }));
 
 t.create('maintainability score for non-existent repo')
@@ -19,24 +66,10 @@ t.create('maintainability score for non-existent repo')
     value: 'not found'
   });
 
-t.create('test coverage score')
-  .get('/c/Nickersoft/dql.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'coverage',
-    value: Joi.equal('A', 'B', 'C', 'D', 'F')
-  }));
-
-t.create('test coverage score for non-existent repo')
-  .get('/c/unknown/unknown.json')
+t.create('maintainability score for repo without snapshots')
+  .get('/maintainability/kabisaict/flow.json')
   .expectJSON({
-    name: 'coverage',
-    value: 'not found'
-  });
-
-t.create('test coverage score for repo without test reports')
-  .get('/c/kabisaict/flow.json')
-  .expectJSON({
-    name: 'coverage',
+    name: 'maintainability',
     value: 'unknown'
   });
 

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -10,28 +10,28 @@ const t = new ServiceTester({ id: 'codeclimate', title: 'Code Climate' })
 
 // Tests based on Code Climate's test reports endpoint.
 t.create('test coverage percentage')
-  .get('/c/Nickersoft/dql.json')
+  .get('/c/jekyll/jekyll.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
   }));
 
 t.create('test coverage percentage alternative coverage URL')
-  .get('/coverage/Nickersoft/dql.json')
+  .get('/coverage/jekyll/jekyll.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
   }));
 
 t.create('test coverage percentage alternative top-level URL')
-  .get('/Nickersoft/dql.json')
+  .get('/jekyll/jekyll.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isPercentage
   }));
 
 t.create('test coverage letter')
-  .get('/c-letter/Nickersoft/dql.json')
+  .get('/c-letter/jekyll/jekyll.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
@@ -45,7 +45,7 @@ t.create('test coverage percentage for non-existent repo')
   });
 
 t.create('test coverage percentage for repo without test reports')
-  .get('/c/kabisaict/flow.json')
+  .get('/c/angular/angular.js.json')
   .expectJSON({
     name: 'coverage',
     value: 'unknown'
@@ -53,21 +53,21 @@ t.create('test coverage percentage for repo without test reports')
 
 // Tests based on Code Climate's snapshots endpoint.
 t.create('issues count')
-  .get('/issues/Nickersoft/dql.json')
+  .get('/issues/angular/angular.js.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'issues',
     value: Joi.number().integer().positive()
   }));
 
 t.create('maintainability percentage (technical debt)')
-  .get('/maintainability/Nickersoft/dql.json')
+  .get('/maintainability/angular/angular.js.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'technical debt',
     value: isPercentage
   }));
 
 t.create('maintainability letter')
-  .get('/maintainability-letter/Nickersoft/dql.json')
+  .get('/maintainability-letter/angular/angular.js.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')

--- a/service-tests/codeclimate.js
+++ b/service-tests/codeclimate.js
@@ -59,28 +59,36 @@ t.create('issues count')
     value: Joi.number().integer().positive()
   }));
 
-t.create('maintainability percentage (technical debt)')
-  .get('/maintainability/angular/angular.js.json')
+t.create('technical debt percentage')
+  .get('/tech-debt/angular/angular.js.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'technical debt',
     value: isPercentage
   }));
 
+t.create('maintainability percentage')
+  .get('/maintainability-percentage/angular/angular.js.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'maintainability',
+    value: isPercentage
+  }));
+
+
 t.create('maintainability letter')
-  .get('/maintainability-letter/angular/angular.js.json')
+  .get('/maintainability/angular/angular.js.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'maintainability',
     value: Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
   }));
 
-t.create('maintainability percentage for non-existent repo')
+t.create('maintainability letter for non-existent repo')
   .get('/maintainability/unknown/unknown.json')
   .expectJSON({
     name: 'maintainability',
     value: 'not found'
   });
 
-t.create('maintainability percentage for repo without snapshots')
+t.create('maintainability letter for repo without snapshots')
   .get('/maintainability/kabisaict/flow.json')
   .expectJSON({
     name: 'maintainability',


### PR DESCRIPTION
Hello there,

This pull request is related to discussions in #1368 and #1329. @RedSparr0w would probably be the ideal person to review this as he has been involved in the discussions and the previous pull request. 😉 

We should now have five functional Code Climate badges, with tests:
* `/codeclimate/c`: coverage score (letter).
* `/codeclimate/coverage`: coverage percentage.
* `/codeclimate`: technical debt percentage (related to the maintainability of the project).
* `/codeclimate/maintainability`:  maintainability score (letter).
* `/codeclimate/issues`:  number of issues.

Nevertheless, I'm still unhappy with the current state of our code for several reasons:
- the distinction between `/codeclimate/coverage` and `/codeclimate/c` is confusing for both users and developers. One is a percentage, the other is just a letter related to the percentage. `/codeclimate/coverage_score` and `/codeclimate/coverage_percentage` would have been more consistent in my opinion.
- the URL of the technical debt badge suggests this is a top level metric. This is not the case. Similarly to the two test coverage badges, the technical debt is a percentage, `/codeclimate/maintainability` is just a letter related to the percentage. The two URLs should be along the lines of `/codeclimate/maintainability_score` and `/codeclimate/maintainability_percentage`. Previously `/codeclimate` probably corresponded to the global GPA metric, which was deprecated in favour of  two top-level ratings, maintainability and test coverage (see [blog post](https://codeclimate.com/blog/a-new-clearer-way-to-understand-code-quality/)). In addition to the naming inconsistency, we have something that looks top-level, but actually isn't.

Unfortunately, I don't see how to resolve these problems without impacting users of the existing badge URLs. My approach in this PR was to match the 5 existing shields URLs to metrics that seemed to reflect as closely as possible the old badges, and make sure we have tests for all badges.

As a side note, there is a bit of code duplication in _server.js_ (~15-20 lines), as both the badges who call the `snapshots` and `test_reports` endpoints have to make the same first call to the `repos` parent endpoint. Merging the two was too messy, so I broke things down and hope that we can get rid of the code duplication nicely once we have neat separate services.

Cheers,

Pyves