### PR TITLE
Add alternative static badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -7572,6 +7572,25 @@ camp.route(/^\/maven-metadata\/v\/(https?)\/(.+\.xml)\.(svg|png|gif|jpg|json)$/,
     });
 }));
 
+// User defined badge - Static
+camp.route(/^\/badge\/static\.(svg|png|gif|jpg|json)$/,
+cache({
+  queryParams: ['value', 'colorscheme'],
+  handler: function(query, match, sendBadge, request) {
+    const format = match[1];
+
+    var badgeData = getBadgeData(query.label, query);
+
+    try{
+      badgeData.text[1] = query.value || '';
+      badgeData.colorscheme = query.colorscheme || 'blue';
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+    }
+    sendBadge(format, badgeData);
+  }
+}));
+
 // User defined sources - JSON response
 camp.route(/^\/badge\/dynamic\/(json)\.(svg|png|gif|jpg|json)$/,
 cache({


### PR DESCRIPTION
Closes #815 
Add an alternative static badge similar to the `badge/dynamic/json` link,
Uses the uri `/badge/static.svg`

Examples:

Uri | Badge
:--: | :--:
`/badge/static.svg?label=Static&value=Badge` | ![](https://img.shields.io/badge/Static-Badge-blue.svg)
`/badge/static.svg?label=Static&value=Badge&colorscheme=brightgreen` | ![](https://img.shields.io/badge/Static-Badge-brightgreen.svg)
`/badge/static.svg?label=Static&value=Badge&colorB=FF00FF` | ![](https://img.shields.io/badge/Static-Badge-FF00FF.svg)

Still need to add tests