### PR TITLE
cursor style pointer on links

### DIFF
--- a/templates/social-template.svg
+++ b/templates/social-template.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+1 + (it.text[1] && it.text[1].length > 0 ? it.widths[1]+2 : 0)}}" height="20">
   {{it.widths[1]-=4;}}
   <style type="text/css"><![CDATA[
-    a #llink:hover { fill:url(#b); stroke:#ccc; }
-    a #rlink:hover { fill:#4183C4; }
+    a #llink:hover { fill:url(#b); stroke:#ccc; cursor: pointer; }
+    a #rlink:hover { fill:#4183C4; cursor: pointer; }
   ]]></style>
   <linearGradient id="a" x2="0" y2="100%">
     <stop offset="0" stop-color="#fcfcfc" stop-opacity="0"/>


### PR DESCRIPTION
Update cursor to `pointer` when hovering over links on social style badge.

[Current](https://img.shields.io/discord/308323056592486420.svg?style=social&label=Chat&link=https%3A%2F%2Fdiscord.gg%2FHjJCwm5): (cant seem to see it on the image, but usually just the text selector cursor)
![image](https://user-images.githubusercontent.com/7288322/34423982-e1b9a2a8-ec84-11e7-8c6e-838b9b7d185d.png)
This PR:
![image](https://user-images.githubusercontent.com/7288322/34423966-c86859c0-ec84-11e7-9d74-caaf4f8704de.png)
