### PR TITLE
Update URL for Homebrew formula versions

### DIFF
--- a/server.js
+++ b/server.js
@@ -6609,7 +6609,7 @@ camp.route(/^\/homebrew\/v\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var pkg = match[1];  // eg. cake
   var format = match[2];
-  var apiUrl = 'http://braumeister.org/formula/' + pkg + '/version';
+  var apiUrl = 'http://formulae.brew.sh/formula/' + pkg + '/version';
 
   var badgeData = getBadgeData('homebrew', data);
   request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {


### PR DESCRIPTION
[braumeister.org](http://braumeister.org) is now part of Homebrew and available at [formulae.brew.sh](http://formulae.brew.sh).

formulae.brew.sh is the new canonical URL and braumeister.org is still available, but may vanish someday.