### PR TITLE
add tests for [hackage]

### DIFF
--- a/server.js
+++ b/server.js
@@ -3426,11 +3426,11 @@ cache(function(data, match, sendBadge, request) {
 // Hackage dependencies version integration.
 camp.route(/^\/hackage-deps\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, `lens`.
-  var format = match[2];
+  const repo = match[1];  // eg, `lens`.
+  const format = match[2];
   const reverseUrl = 'http://packdeps.haskellers.com/reverse/' + repo;
   const feedUrl = 'http://packdeps.haskellers.com/feed/' + repo;
-  var badgeData = getBadgeData('hackage-deps', data);
+  const badgeData = getBadgeData('hackage-deps', data);
 
   // first call /reverse to check if the package exists
   // this will throw a 404 if it doesn't
@@ -3449,7 +3449,7 @@ cache(function(data, match, sendBadge, request) {
       }
 
       try {
-        var outdatedStr = "Outdated dependencies for " + repo + " ";
+        const outdatedStr = "Outdated dependencies for " + repo + " ";
         if (buffer.indexOf(outdatedStr) >= 0) {
           badgeData.text[1] = 'outdated';
           badgeData.colorscheme = 'orange';

--- a/server.js
+++ b/server.js
@@ -3399,11 +3399,11 @@ cache(function(data, match, sendBadge, request) {
   var apiUrl = 'https://hackage.haskell.org/package/' + repo + '/' + repo + '.cabal';
   var badgeData = getBadgeData('hackage', data);
   request(apiUrl, function(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }
+
     try {
       var lines = buffer.split("\n");
       var versionLines = lines.filter(function(e) {

--- a/server.js
+++ b/server.js
@@ -3428,29 +3428,43 @@ camp.route(/^\/hackage-deps\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var repo = match[1];  // eg, `lens`.
   var format = match[2];
-  var apiUrl = 'http://packdeps.haskellers.com/feed/' + repo;
+  const reverseUrl = 'http://packdeps.haskellers.com/reverse/' + repo;
+  const feedUrl = 'http://packdeps.haskellers.com/feed/' + repo;
   var badgeData = getBadgeData('hackage-deps', data);
-  request(apiUrl, function(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
+
+  // first call /reverse to check if the package exists
+  // this will throw a 404 if it doesn't
+  request(reverseUrl, function(err, res, buffer) {
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }
 
-    try {
-      var outdatedStr = "Outdated dependencies for " + repo + " ";
-      if (buffer.indexOf(outdatedStr) >= 0) {
-        badgeData.text[1] = 'outdated';
-        badgeData.colorscheme = 'orange';
-      } else {
-        badgeData.text[1] = 'up to date';
-        badgeData.colorscheme = 'brightgreen';
+    // if the package exists, then query /feed to check the dependencies
+    request(feedUrl, function(err, res, buffer) {
+      if (err != null) {
+        badgeData.text[1] = 'inaccessible';
+        sendBadge(format, badgeData);
+        return;
       }
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-    }
-    sendBadge(format, badgeData);
+
+      try {
+        var outdatedStr = "Outdated dependencies for " + repo + " ";
+        if (buffer.indexOf(outdatedStr) >= 0) {
+          badgeData.text[1] = 'outdated';
+          badgeData.colorscheme = 'orange';
+        } else {
+          badgeData.text[1] = 'up to date';
+          badgeData.colorscheme = 'brightgreen';
+        }
+      } catch(e) {
+        badgeData.text[1] = 'invalid';
+      }
+      sendBadge(format, badgeData);
+    });
+
   });
+
 }));
 
 // Elm package version integration.

--- a/server.js
+++ b/server.js
@@ -3430,7 +3430,7 @@ cache(function(data, match, sendBadge, request) {
   const format = match[2];
   const reverseUrl = 'http://packdeps.haskellers.com/reverse/' + repo;
   const feedUrl = 'http://packdeps.haskellers.com/feed/' + repo;
-  const badgeData = getBadgeData('hackage-deps', data);
+  const badgeData = getBadgeData('dependencies', data);
 
   // first call /reverse to check if the package exists
   // this will throw a 404 if it doesn't

--- a/service-tests/hackage.js
+++ b/service-tests/hackage.js
@@ -27,6 +27,10 @@ t.create('hackage version (not found)')
   .get('/v/not-a-package.json')
   .expectJSON({name: 'hackage', value: 'not found'});
 
+t.create('hackage version (not found)')
+  .get('-deps/v/not-a-package.json')
+  .expectJSON({name: 'hackage-deps', value: 'not found'});
+
 t.create('hackage version (connection error)')
   .get('/v/lens.json')
   .networkOff()

--- a/service-tests/hackage.js
+++ b/service-tests/hackage.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const { isVPlusDottedVersionAtLeastOne } = require('./helpers/validators');
+
+const t = new ServiceTester({ id: 'hackage', title: 'Hackage' });
+module.exports = t;
+
+
+t.create('hackage version (valid)')
+  .get('/v/lens.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'hackage',
+    value: isVPlusDottedVersionAtLeastOne,
+  }));
+
+t.create('hackage deps (valid)')
+  .get('-deps/v/lens.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'hackage-deps',
+    value: Joi.string().regex(/^(up to date|outdated)$/),
+  }));
+
+t.create('hackage version (not found)')
+  .get('/v/not-a-package.json')
+  .expectJSON({name: 'hackage', value: 'not found'});
+
+t.create('hackage version (connection error)')
+  .get('/v/lens.json')
+  .networkOff()
+  .expectJSON({name: 'hackage', value: 'inaccessible'});
+
+t.create('hackage deps (connection error)')
+  .get('-deps/v/lens.json')
+  .networkOff()
+  .expectJSON({name: 'hackage-deps', value: 'inaccessible'});
+
+t.create('hackage version (unexpected response)')
+  .get('/v/lens.json')
+  .intercept(nock => nock('https://hackage.haskell.org')
+    .get('/package/lens/lens.cabal')
+    .reply(200, "")
+  )
+  .expectJSON({name: 'hackage', value: 'invalid'});

--- a/service-tests/hackage.js
+++ b/service-tests/hackage.js
@@ -19,7 +19,7 @@ t.create('hackage version (valid)')
 t.create('hackage deps (valid)')
   .get('-deps/v/lens.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'hackage-deps',
+    name: 'dependencies',
     value: Joi.string().regex(/^(up to date|outdated)$/),
   }));
 
@@ -29,7 +29,7 @@ t.create('hackage version (not found)')
 
 t.create('hackage version (not found)')
   .get('-deps/v/not-a-package.json')
-  .expectJSON({name: 'hackage-deps', value: 'not found'});
+  .expectJSON({name: 'dependencies', value: 'not found'});
 
 t.create('hackage version (connection error)')
   .get('/v/lens.json')
@@ -39,7 +39,7 @@ t.create('hackage version (connection error)')
 t.create('hackage deps (connection error)')
   .get('-deps/v/lens.json')
   .networkOff()
-  .expectJSON({name: 'hackage-deps', value: 'inaccessible'});
+  .expectJSON({name: 'dependencies', value: 'inaccessible'});
 
 t.create('hackage version (unexpected response)')
   .get('/v/lens.json')


### PR DESCRIPTION
Note there is no check for the 'not found' case on the `hackage-deps` endpoint.

* A package where all the dependencies are up-to-date returns an empty feed: http://packdeps.haskellers.com/feed/AbortT-mtl
* ..and a package that doesn't exist returns an empty feed: http://packdeps.haskellers.com/feed/not-a-package

In order to add a not found case, we'd have to add a second API call so that the `hackage-deps` endpoint calls https://hackage.haskell.org/ first to check if the package exists and then makes a subsequent call to http://packdeps.haskellers.com if it does. Is it worth adding that additional overhead to cover the not found case?