### PR TITLE
Adopt Chai for assertions

### DIFF
--- a/.eslintrc-preferred.yml
+++ b/.eslintrc-preferred.yml
@@ -1,5 +1,6 @@
-# plugins:
+plugins:
 #   - "prettier"
+  - "chai-friendly"
 
 extends:
   - "standard"
@@ -22,3 +23,7 @@ rules:
   no-var: "error"
   prefer-const: "error"
   strict: "error"
+
+  # Chai friendly.
+  no-unused-expressions: "off"
+  chai-friendly/no-unused-expressions: "error"

--- a/lib/badge-cli.spec.js
+++ b/lib/badge-cli.spec.js
@@ -21,8 +21,8 @@ describe('The CLI', function () {
     return runCli(['cactus', 'grown']).then(stdout => {
       expect(stdout)
         .to.satisfy(isSvg)
-        .and.to.contain('cactus')
-        .and.to.contain('grown');
+        .and.to.include('cactus')
+        .and.to.include('grown');
     });
   });
 

--- a/lib/badge-cli.spec.js
+++ b/lib/badge-cli.spec.js
@@ -19,8 +19,10 @@ describe('The CLI', function () {
 
   it('should produce default badges', function () {
     return runCli(['cactus', 'grown']).then(stdout => {
-      expect(stdout).to.satisfy(isSvg);
-      expect(stdout).to.contain('cactus').and.to.contain('grown');
+      expect(stdout)
+        .to.satisfy(isSvg)
+        .and.to.contain('cactus')
+        .and.to.contain('grown');
     });
   });
 
@@ -32,8 +34,9 @@ describe('The CLI', function () {
 
   it('should produce right-color badges', function () {
     return runCli(['cactus', 'grown', '#abcdef']).then(stdout => {
-      expect(stdout).to.satisfy(isSvg);
-      expect(stdout).to.include('#abcdef');
+      expect(stdout)
+        .to.satisfy(isSvg)
+        .and.to.include('#abcdef');
     });
   });
 

--- a/lib/badge-cli.spec.js
+++ b/lib/badge-cli.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const isPng = require('is-png');
 const isSvg = require('is-svg');
 const {spawn} = require('child-process-promise');
@@ -13,28 +13,27 @@ function runCli (args) {
 describe('The CLI', function () {
   it('should provide a help message', function () {
     return runCli([]).then(stdout => {
-      assert(stdout.startsWith('Usage'));
+      expect(stdout).to.startWith('Usage');
     });
   });
 
   it('should produce default badges', function () {
     return runCli(['cactus', 'grown']).then(stdout => {
-      assert.ok(isSvg(stdout));
-      assert.ok(stdout.includes('cactus'), 'cactus');
-      assert.ok(stdout.includes('grown'), 'grown');
+      expect(stdout).to.satisfy(isSvg);
+      expect(stdout).to.contain('cactus').and.to.contain('grown');
     });
   });
 
   it('should produce colorschemed badges', function () {
     return runCli(['cactus', 'grown', ':green']).then(stdout => {
-      assert.ok(isSvg(stdout));
+      expect(stdout).to.satisfy(isSvg);
     });
   });
 
   it('should produce right-color badges', function () {
     return runCli(['cactus', 'grown', '#abcdef']).then(stdout => {
-      assert.ok(isSvg(stdout));
-      assert.ok(stdout.includes('#abcdef'), '#abcdef');
+      expect(stdout).to.satisfy(isSvg);
+      expect(stdout).to.include('#abcdef');
     });
   });
 
@@ -46,6 +45,6 @@ describe('The CLI', function () {
     let chunk;
     child.childProcess.stdout.once('data', data => { chunk = data; });
 
-    return child.then(() => { assert.ok(isPng(chunk)); });
+    return child.then(() => { expect(chunk).to.satisfy(isPng); });
   });
 });

--- a/lib/badge-cli.spec.js
+++ b/lib/badge-cli.spec.js
@@ -5,6 +5,9 @@ const isPng = require('is-png');
 const isSvg = require('is-svg');
 const {spawn} = require('child-process-promise');
 
+// https://github.com/badges/shields/pull/1419#discussion_r159957055
+require('./register-chai-plugins.spec');
+
 function runCli (args) {
   return spawn('node', ['lib/badge-cli.js', ...args], { capture: ['stdout'] })
     .then(result => result.stdout);

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -51,7 +51,7 @@ describe('Badge data helpers', function() {
       given(undefined, {}),
     ]).expect(undefined);
     given('gratipay', {})
-      .assert('should be truthy', v => expect(v).to.have.lengthOf.at.least(1));
+      .assert('should not be empty', v => expect(v).not.to.be.empty);
   });
 
   test(makeBadgeData, () => {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const { test, given, forCases } = require('sazerac');
 const {
   isDataUri,
@@ -50,7 +50,8 @@ describe('Badge data helpers', function() {
       given('gratipay', { logo: '' }),
       given(undefined, {}),
     ]).expect(undefined);
-    given('gratipay', {}).assert('should be truthy', assert.ok);
+    given('gratipay', {})
+      .assert('should be truthy', v => expect(v).to.have.lengthOf.at.least(1));
   });
 
   test(makeBadgeData, () => {

--- a/lib/lru-cache.spec.js
+++ b/lib/lru-cache.spec.js
@@ -1,51 +1,32 @@
 'use strict';
 
-const { expect } = require('chai');
+const assert = require('assert');
 const LRU = require('./lru-cache');
-
-function expectCacheSlots(cache, slots) {
-  expect(cache.cache.size).to.equal(slots.length);
-
-  const first = slots[0];
-  const last = slots.slice(-1)[0];
-
-  expect(cache.oldest).to.equal(first);
-  expect(cache.newest).to.equal(last);
-
-  expect(first.older).to.be.null;
-  expect(last.newer).to.be.null;
-
-  for (let i = 0; i + 1 < slots.length; ++i) {
-    const current = slots[i];
-    const next = slots[i+1];
-    expect(current.newer).to.equal(next);
-    expect(next.older).to.equal(current);
-  }
-}
 
 describe('The LRU cache', function () {
   it('should support being called without new', function () {
     const cache = LRU(1);
-    expect(cache).to.be.an.instanceof(LRU);
+    assert(cache instanceof LRU);
   });
 
   it('should support a zero capacity', function () {
     const cache = new LRU(0);
     cache.set('key', 'value');
-    expect(cache.cache.size).to.equal(0);
+    assert.equal(cache.cache.size, 0);
   });
 
   it('should support a one capacity', function () {
     const cache = new LRU(1);
     cache.set('key1', 'value1');
-    expect(cache.cache.size).to.equal(1);
-    expect(cache.newest).to.equal(cache.cache.get('key1'));
-    expect(cache.oldest).to.equal(cache.cache.get('key1'));
+    assert.equal(cache.cache.size, 1);
+    assert.equal(cache.newest, cache.cache.get('key1'));
+    assert.equal(cache.oldest, cache.cache.get('key1'));
     cache.set('key2', 'value2');
-    const slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot2]);
-    expect(cache.get('key1')).to.be.undefined;
-    expect(cache.get('key2')).to.equal('value2');
+    assert.equal(cache.cache.size, 1);
+    assert.equal(cache.newest, cache.cache.get('key2'));
+    assert.equal(cache.oldest, cache.cache.get('key2'));
+    assert.equal(cache.get('key1'), undefined);
+    assert.equal(cache.get('key2'), 'value2');
   });
 
   it('should remove the oldest element when reaching capacity', function () {
@@ -56,25 +37,28 @@ describe('The LRU cache', function () {
     cache.cache.get('key1');
     const slot2 = cache.cache.get('key2');
     const slot3 = cache.cache.get('key3');
-    expectCacheSlots(cache, [slot2, slot3]);
-    expect(cache.cache.get('key1')).to.be.undefined;
-    expect(cache.get('key1')).to.be.undefined;
-    expect(cache.get('key2')).to.equal('value2');
-    expect(cache.get('key3')).to.equal('value3');
+    assert.equal(cache.cache.size, 2);
+    assert.equal(cache.oldest, slot2);
+    assert.equal(cache.newest, slot3);
+    assert.equal(slot2.older, null);
+    assert.equal(slot2.newer, slot3);
+    assert.equal(slot3.older, slot2);
+    assert.equal(slot3.newer, null);
+    assert.equal(cache.cache.get('key1'), undefined);
+    assert.equal(cache.get('key1'), undefined);
+    assert.equal(cache.get('key2'), 'value2');
+    assert.equal(cache.get('key3'), 'value3');
   });
 
   it('should make sure that resetting a key in cache makes it newest', function () {
     const cache = new LRU(2);
     cache.set('key', 'value');
     cache.set('key2', 'value2');
-
-    let slot1 = cache.cache.get('key');
-    let slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot1, slot2]);
+    assert.equal(cache.oldest, cache.cache.get('key'));
+    assert.equal(cache.newest, cache.cache.get('key2'));
     cache.set('key', 'value');
-    slot1 = cache.cache.get('key');
-    slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot2, slot1]);
+    assert.equal(cache.oldest, cache.cache.get('key2'));
+    assert.equal(cache.newest, cache.cache.get('key'));
   });
 
   it('should make sure that getting a key in cache makes it newest', function () {
@@ -86,24 +70,40 @@ describe('The LRU cache', function () {
     cache.set('key2', 'value2');
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot1, slot2]);
+    assert.equal(cache.oldest, slot1);
+    assert.equal(cache.newest, slot2);
+    assert.equal(slot1.older, null);
+    assert.equal(slot1.newer, slot2);
+    assert.equal(slot2.older, slot1);
+    assert.equal(slot2.newer, null);
 
-    expect(cache.get('key1')).to.equal('value1');
+    assert.equal(cache.get('key1'), 'value1');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot2, slot1]);
+    assert.equal(cache.oldest, slot2);
+    assert.equal(cache.newest, slot1);
+    assert.equal(slot2.older, null);
+    assert.equal(slot2.newer, slot1);
+    assert.equal(slot1.older, slot2);
+    assert.equal(slot1.newer, null);
+
 
     // When the key is newest.
     cache = new LRU(2);
     cache.set('key1', 'value1');
     cache.set('key2', 'value2');
 
-    expect(cache.get('key2')).to.equal('value2');
+    assert.equal(cache.get('key2'), 'value2');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    expectCacheSlots(cache, [slot1, slot2]);
+    assert.equal(cache.oldest, slot1);
+    assert.equal(cache.newest, slot2);
+    assert.equal(slot1.older, null);
+    assert.equal(slot1.newer, slot2);
+    assert.equal(slot2.older, slot1);
+    assert.equal(slot2.newer, null);
 
     // When the key is in the middle.
     cache = new LRU(3);
@@ -113,14 +113,28 @@ describe('The LRU cache', function () {
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
     slot3 = cache.cache.get('key3');
-    expectCacheSlots(cache, [slot1, slot2, slot3]);
+    assert.equal(cache.oldest, slot1);
+    assert.equal(cache.newest, slot3);
+    assert.equal(slot1.older, null);
+    assert.equal(slot1.newer, slot2);
+    assert.equal(slot2.older, slot1);
+    assert.equal(slot2.newer, slot3);
+    assert.equal(slot3.older, slot2);
+    assert.equal(slot3.newer, null);
 
-    expect(cache.get('key2')).to.equal('value2');
+    assert.equal(cache.get('key2'), 'value2');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
     slot3 = cache.cache.get('key3');
-    expectCacheSlots(cache, [slot1, slot3, slot2]);
+    assert.equal(cache.oldest, slot1);
+    assert.equal(cache.newest, slot2);
+    assert.equal(slot1.older, null);
+    assert.equal(slot1.newer, slot3);
+    assert.equal(slot3.older, slot1);
+    assert.equal(slot3.newer, slot2);
+    assert.equal(slot2.older, slot3);
+    assert.equal(slot2.newer, null);
   });
 
   it('should clear', function () {
@@ -130,15 +144,15 @@ describe('The LRU cache', function () {
     cache.set('key2', 'value2');
 
     // Confidence check.
-    expect(cache.get('key1')).to.equal('value1');
-    expect(cache.get('key2')).to.equal('value2');
+    assert.equal(cache.get('key1'), 'value1');
+    assert.equal(cache.get('key2'), 'value2');
 
     // Run.
     cache.clear();
 
     // Test.
-    expect(cache.get('key1')).to.be.undefined;
-    expect(cache.get('key2')).to.be.undefined;
-    expect(cache.cache.size).to.equal(0);
+    assert.equal(cache.get('key1'), null);
+    assert.equal(cache.get('key2'), null);
+    assert.equal(cache.cache.size, 0);
   });
 });

--- a/lib/lru-cache.spec.js
+++ b/lib/lru-cache.spec.js
@@ -1,32 +1,51 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const LRU = require('./lru-cache');
+
+function expectCacheSlots(cache, slots) {
+  expect(cache.cache.size).to.equal(slots.length);
+
+  const first = slots[0];
+  const last = slots.slice(-1)[0];
+
+  expect(cache.oldest).to.equal(first);
+  expect(cache.newest).to.equal(last);
+
+  expect(first.older).to.be.null;
+  expect(last.newer).to.be.null;
+
+  for (let i = 0; i + 1 < slots.length; ++i) {
+    const current = slots[i];
+    const next = slots[i+1];
+    expect(current.newer).to.equal(next);
+    expect(next.older).to.equal(current);
+  }
+}
 
 describe('The LRU cache', function () {
   it('should support being called without new', function () {
     const cache = LRU(1);
-    assert(cache instanceof LRU);
+    expect(cache).to.be.an.instanceof(LRU);
   });
 
   it('should support a zero capacity', function () {
     const cache = new LRU(0);
     cache.set('key', 'value');
-    assert.equal(cache.cache.size, 0);
+    expect(cache.cache.size).to.equal(0);
   });
 
   it('should support a one capacity', function () {
     const cache = new LRU(1);
     cache.set('key1', 'value1');
-    assert.equal(cache.cache.size, 1);
-    assert.equal(cache.newest, cache.cache.get('key1'));
-    assert.equal(cache.oldest, cache.cache.get('key1'));
+    expect(cache.cache.size).to.equal(1);
+    expect(cache.newest).to.equal(cache.cache.get('key1'));
+    expect(cache.oldest).to.equal(cache.cache.get('key1'));
     cache.set('key2', 'value2');
-    assert.equal(cache.cache.size, 1);
-    assert.equal(cache.newest, cache.cache.get('key2'));
-    assert.equal(cache.oldest, cache.cache.get('key2'));
-    assert.equal(cache.get('key1'), undefined);
-    assert.equal(cache.get('key2'), 'value2');
+    const slot2 = cache.cache.get('key2');
+    expectCacheSlots(cache, [slot2]);
+    expect(cache.get('key1')).to.be.undefined;
+    expect(cache.get('key2')).to.equal('value2');
   });
 
   it('should remove the oldest element when reaching capacity', function () {
@@ -37,28 +56,25 @@ describe('The LRU cache', function () {
     cache.cache.get('key1');
     const slot2 = cache.cache.get('key2');
     const slot3 = cache.cache.get('key3');
-    assert.equal(cache.cache.size, 2);
-    assert.equal(cache.oldest, slot2);
-    assert.equal(cache.newest, slot3);
-    assert.equal(slot2.older, null);
-    assert.equal(slot2.newer, slot3);
-    assert.equal(slot3.older, slot2);
-    assert.equal(slot3.newer, null);
-    assert.equal(cache.cache.get('key1'), undefined);
-    assert.equal(cache.get('key1'), undefined);
-    assert.equal(cache.get('key2'), 'value2');
-    assert.equal(cache.get('key3'), 'value3');
+    expectCacheSlots(cache, [slot2, slot3]);
+    expect(cache.cache.get('key1')).to.be.undefined;
+    expect(cache.get('key1')).to.be.undefined;
+    expect(cache.get('key2')).to.equal('value2');
+    expect(cache.get('key3')).to.equal('value3');
   });
 
   it('should make sure that resetting a key in cache makes it newest', function () {
     const cache = new LRU(2);
     cache.set('key', 'value');
     cache.set('key2', 'value2');
-    assert.equal(cache.oldest, cache.cache.get('key'));
-    assert.equal(cache.newest, cache.cache.get('key2'));
+
+    let slot1 = cache.cache.get('key');
+    let slot2 = cache.cache.get('key2');
+    expectCacheSlots(cache, [slot1, slot2]);
     cache.set('key', 'value');
-    assert.equal(cache.oldest, cache.cache.get('key2'));
-    assert.equal(cache.newest, cache.cache.get('key'));
+    slot1 = cache.cache.get('key');
+    slot2 = cache.cache.get('key2');
+    expectCacheSlots(cache, [slot2, slot1]);
   });
 
   it('should make sure that getting a key in cache makes it newest', function () {
@@ -70,40 +86,24 @@ describe('The LRU cache', function () {
     cache.set('key2', 'value2');
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    assert.equal(cache.oldest, slot1);
-    assert.equal(cache.newest, slot2);
-    assert.equal(slot1.older, null);
-    assert.equal(slot1.newer, slot2);
-    assert.equal(slot2.older, slot1);
-    assert.equal(slot2.newer, null);
+    expectCacheSlots(cache, [slot1, slot2]);
 
-    assert.equal(cache.get('key1'), 'value1');
+    expect(cache.get('key1')).to.equal('value1');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    assert.equal(cache.oldest, slot2);
-    assert.equal(cache.newest, slot1);
-    assert.equal(slot2.older, null);
-    assert.equal(slot2.newer, slot1);
-    assert.equal(slot1.older, slot2);
-    assert.equal(slot1.newer, null);
-
+    expectCacheSlots(cache, [slot2, slot1]);
 
     // When the key is newest.
     cache = new LRU(2);
     cache.set('key1', 'value1');
     cache.set('key2', 'value2');
 
-    assert.equal(cache.get('key2'), 'value2');
+    expect(cache.get('key2')).to.equal('value2');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
-    assert.equal(cache.oldest, slot1);
-    assert.equal(cache.newest, slot2);
-    assert.equal(slot1.older, null);
-    assert.equal(slot1.newer, slot2);
-    assert.equal(slot2.older, slot1);
-    assert.equal(slot2.newer, null);
+    expectCacheSlots(cache, [slot1, slot2]);
 
     // When the key is in the middle.
     cache = new LRU(3);
@@ -113,28 +113,14 @@ describe('The LRU cache', function () {
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
     slot3 = cache.cache.get('key3');
-    assert.equal(cache.oldest, slot1);
-    assert.equal(cache.newest, slot3);
-    assert.equal(slot1.older, null);
-    assert.equal(slot1.newer, slot2);
-    assert.equal(slot2.older, slot1);
-    assert.equal(slot2.newer, slot3);
-    assert.equal(slot3.older, slot2);
-    assert.equal(slot3.newer, null);
+    expectCacheSlots(cache, [slot1, slot2, slot3]);
 
-    assert.equal(cache.get('key2'), 'value2');
+    expect(cache.get('key2')).to.equal('value2');
 
     slot1 = cache.cache.get('key1');
     slot2 = cache.cache.get('key2');
     slot3 = cache.cache.get('key3');
-    assert.equal(cache.oldest, slot1);
-    assert.equal(cache.newest, slot2);
-    assert.equal(slot1.older, null);
-    assert.equal(slot1.newer, slot3);
-    assert.equal(slot3.older, slot1);
-    assert.equal(slot3.newer, slot2);
-    assert.equal(slot2.older, slot3);
-    assert.equal(slot2.newer, null);
+    expectCacheSlots(cache, [slot1, slot3, slot2]);
   });
 
   it('should clear', function () {
@@ -144,15 +130,15 @@ describe('The LRU cache', function () {
     cache.set('key2', 'value2');
 
     // Confidence check.
-    assert.equal(cache.get('key1'), 'value1');
-    assert.equal(cache.get('key2'), 'value2');
+    expect(cache.get('key1')).to.equal('value1');
+    expect(cache.get('key2')).to.equal('value2');
 
     // Run.
     cache.clear();
 
     // Test.
-    assert.equal(cache.get('key1'), null);
-    assert.equal(cache.get('key2'), null);
-    assert.equal(cache.cache.size, 0);
+    expect(cache.get('key1')).to.be.undefined;
+    expect(cache.get('key2')).to.be.undefined;
+    expect(cache.cache.size).to.equal(0);
   });
 });

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const { _badgeKeyWidthCache } = require('./make-badge');
 const isSvg = require('is-svg');
 const testHelpers = require('./make-badge-test-helpers');
@@ -14,14 +14,14 @@ describe('The badge generator', function () {
 
   it('should produce SVG', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
-    assert.ok(isSvg(svg));
-    assert(svg.includes('cactus'), 'cactus');
-    assert(svg.includes('grown'), 'grown');
+    expect(svg).to.satisfy(isSvg);
+    expect(svg).to.contain('cactus');
+    expect(svg).to.contain('grown');
   });
 
   it('should cache width of badge key', function () {
     makeBadge({ text: ['cached', 'not-cached'], format: 'svg' });
-    assert.deepEqual([..._badgeKeyWidthCache.cache.keys()], ['cached']);
+    expect([..._badgeKeyWidthCache.cache.keys()]).to.have.members(['cached']);
   });
 });
 
@@ -29,13 +29,13 @@ describe('"for-the-badge" template badge generation', function () {
    // https://github.com/badges/shields/issues/1280
   it('numbers should produce a string', function () {
     const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
-    assert(svg.includes('1998'), `${svg} does not contain '1998'`);
-    assert(svg.includes('1999'), `${svg} does not contain '1999'`);
+    expect(svg).to.contain('1998');
+    expect(svg).to.contain('1999');
   });
 
   it('lowercase/mixedcase string should produce uppercase string', function () {
     const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
-    assert(svg.includes('LABEL'), `${svg} does not contain 'LABEL'`);
-    assert(svg.includes('1 STRING'), `${svg} does not contain '1 TEST'`);
+    expect(svg).to.contain('LABEL');
+    expect(svg).to.contain('1 STRING');
   });
 });

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -15,7 +15,7 @@ describe('The badge generator', function () {
   it('should produce SVG', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
     expect(svg)
-      .to.satisfy(isSvg);
+      .to.satisfy(isSvg)
       .and.to.include('cactus')
       .and.to.include('grown');
   });

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -15,13 +15,12 @@ describe('The badge generator', function () {
   it('should produce SVG', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
     expect(svg).to.satisfy(isSvg);
-    expect(svg).to.contain('cactus');
-    expect(svg).to.contain('grown');
+    expect(svg).to.contain('cactus').and.to.contain('grown');
   });
 
   it('should cache width of badge key', function () {
     makeBadge({ text: ['cached', 'not-cached'], format: 'svg' });
-    expect([..._badgeKeyWidthCache.cache.keys()]).to.have.members(['cached']);
+    expect(_badgeKeyWidthCache.cache).to.have.keys('cached');
   });
 });
 
@@ -29,13 +28,11 @@ describe('"for-the-badge" template badge generation', function () {
    // https://github.com/badges/shields/issues/1280
   it('numbers should produce a string', function () {
     const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.contain('1998');
-    expect(svg).to.contain('1999');
+    expect(svg).to.contain('1998').and.to.contain('1999');
   });
 
   it('lowercase/mixedcase string should produce uppercase string', function () {
     const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.contain('LABEL');
-    expect(svg).to.contain('1 STRING');
+    expect(svg).to.contain('LABEL').and.to.contain('1 STRING');
   });
 });

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -14,8 +14,10 @@ describe('The badge generator', function () {
 
   it('should produce SVG', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
-    expect(svg).to.satisfy(isSvg);
-    expect(svg).to.contain('cactus').and.to.contain('grown');
+    expect(svg)
+      .to.satisfy(isSvg);
+      .and.to.include('cactus')
+      .and.to.include('grown');
   });
 
   it('should cache width of badge key', function () {
@@ -28,11 +30,11 @@ describe('"for-the-badge" template badge generation', function () {
    // https://github.com/badges/shields/issues/1280
   it('numbers should produce a string', function () {
     const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.contain('1998').and.to.contain('1999');
+    expect(svg).to.include('1998').and.to.include('1999');
   });
 
   it('lowercase/mixedcase string should produce uppercase string', function () {
     const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.contain('LABEL').and.to.contain('1 STRING');
+    expect(svg).to.include('LABEL').and.to.include('1 STRING');
   });
 });

--- a/lib/nodeify-sync.spec.js
+++ b/lib/nodeify-sync.spec.js
@@ -1,14 +1,14 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const nodeifySync = require('./nodeify-sync');
 
 describe('nodeifySync()', function() {
   it('Should return the result via the callback', function(done) {
     const exampleValue = {};
     nodeifySync(() => exampleValue, (err, result) => {
-      assert.equal(err, undefined);
-      assert.strictEqual(result, exampleValue);
+      expect(err).to.be.undefined;
+      expect(result).to.equal(exampleValue);
       done();
     });
   });
@@ -16,8 +16,8 @@ describe('nodeifySync()', function() {
   it('Should catch an error and return it via the callback', function(done) {
     const exampleError = Error('This is my error!');
     nodeifySync(() => { throw exampleError; }, (err, result) => {
-      assert.strictEqual(err, exampleError);
-      assert.equal(result, undefined);
+      expect(err).to.equal(exampleError);
+      expect(result).to.be.undefined;
       done();
     });
   });

--- a/lib/register-chai-plugins.spec.js
+++ b/lib/register-chai-plugins.spec.js
@@ -1,0 +1,6 @@
+'use strict';
+
+const { use } = require('chai');
+
+use(require('chai-string'));
+use(require('sinon-chai'));

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const fetch = require('node-fetch');
 const config = require('./test-config');
 const Camp = require('camp');
@@ -20,10 +20,10 @@ const baseUri = `http://127.0.0.1:${config.port}`;
 function performTwoRequests (first, second) {
   return fetch(`${baseUri}${first}`)
     .then(res => {
-      assert.ok(res.ok);
+      expect(res.ok).to.equal(true);
       return fetch(`${baseUri}${second}`)
         .then(res => {
-          assert.ok(res.ok);
+          expect(res.ok).to.equal(true);
         })
     });
 }
@@ -60,10 +60,10 @@ describe('The request handler', function() {
     it('should return the expected response', function () {
       return fetch(`${baseUri}/testing/123.json`)
         .then(res => {
-          assert.ok(res.ok);
+          expect(res.ok).to.equal(true);
           return res.json();
         }).then(json => {
-          assert.deepEqual(json, { name: 'testing', value: '123' });
+          expect(json).to.deep.equal({ name: 'testing', value: '123' });
         });
     });
   });
@@ -77,10 +77,10 @@ describe('The request handler', function() {
     it('should return the expected response', function () {
       return fetch(`${baseUri}/testing/123.json`)
         .then(res => {
-          assert.ok(res.ok);
+          expect(res.ok).to.equal(true);
           return res.json();
         }).then(json => {
-          assert.deepEqual(json, { name: 'testing', value: '123' });
+          expect(json).to.deep.equal({ name: 'testing', value: '123' });
         });
     });
   });
@@ -100,7 +100,7 @@ describe('The request handler', function() {
 
       it('should cache identical requests', function () {
         return performTwoRequests('/testing/123.svg', '/testing/123.svg').then(() => {
-          assert.equal(handlerCallCount, 1);
+          expect(handlerCallCount).to.equal(1);
         });
       });
 
@@ -108,14 +108,14 @@ describe('The request handler', function() {
         return performTwoRequests(
           '/testing/123.svg?label=foo',
           '/testing/123.svg?label=bar'
-        ).then(() => { assert.equal(handlerCallCount, 2); });
+        ).then(() => { expect(handlerCallCount).to.equal(2); });
       });
 
       it('should ignore unknown query parameters', function () {
         return performTwoRequests(
           '/testing/123.svg?foo=1',
           '/testing/123.svg?foo=2'
-        ).then(() => { assert.equal(handlerCallCount, 1); });
+        ).then(() => { expect(handlerCallCount).to.equal(1); });
       });
 
       describe('the cache key', function () {
@@ -123,15 +123,15 @@ describe('The request handler', function() {
         it('should match expected and use canonical order - 1', function () {
           return fetch(`${baseUri}/testing/123.json?colorB=123&label=foo`)
             .then(res => {
-              assert.ok(res.ok);
-              assert.deepEqual([..._requestCache.cache.keys()], [expectedCacheKey]);
+              expect(res.ok).to.equal(true);
+              expect([..._requestCache.cache.keys()]).to.have.members([expectedCacheKey]);
             });
         });
         it('should match expected and use canonical order - 2', function () {
           return fetch(`${baseUri}/testing/123.json?label=foo&colorB=123`)
             .then(res => {
-              assert.ok(res.ok);
-              assert.deepEqual([..._requestCache.cache.keys()], [expectedCacheKey]);
+              expect(res.ok).to.equal(true);
+              expect([..._requestCache.cache.keys()]).to.have.members([expectedCacheKey]);
             });
         });
       });
@@ -155,7 +155,7 @@ describe('The request handler', function() {
         return performTwoRequests(
           '/testing/123.svg?foo=1',
           '/testing/123.svg?foo=2'
-        ).then(() => { assert.equal(handlerCallCount, 2); });
+        ).then(() => { expect(handlerCallCount).to.equal(2); });
       });
     });
   });

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -124,14 +124,14 @@ describe('The request handler', function() {
           return fetch(`${baseUri}/testing/123.json?colorB=123&label=foo`)
             .then(res => {
               expect(res.ok).to.equal(true);
-              expect([..._requestCache.cache.keys()]).to.have.members([expectedCacheKey]);
+              expect(_requestCache.cache).to.have.keys(expectedCacheKey);
             });
         });
         it('should match expected and use canonical order - 2', function () {
           return fetch(`${baseUri}/testing/123.json?label=foo&colorB=123`)
             .then(res => {
               expect(res.ok).to.equal(true);
-              expect([..._requestCache.cache.keys()]).to.have.members([expectedCacheKey]);
+              expect(_requestCache.cache).to.have.keys(expectedCacheKey);
             });
         });
       });

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -20,10 +20,10 @@ const baseUri = `http://127.0.0.1:${config.port}`;
 function performTwoRequests (first, second) {
   return fetch(`${baseUri}${first}`)
     .then(res => {
-      expect(res.ok).to.equal(true);
+      expect(res.ok).to.be.true;
       return fetch(`${baseUri}${second}`)
         .then(res => {
-          expect(res.ok).to.equal(true);
+          expect(res.ok).to.be.true;
         })
     });
 }
@@ -60,7 +60,7 @@ describe('The request handler', function() {
     it('should return the expected response', function () {
       return fetch(`${baseUri}/testing/123.json`)
         .then(res => {
-          expect(res.ok).to.equal(true);
+          expect(res.ok).to.be.true;
           return res.json();
         }).then(json => {
           expect(json).to.deep.equal({ name: 'testing', value: '123' });
@@ -77,7 +77,7 @@ describe('The request handler', function() {
     it('should return the expected response', function () {
       return fetch(`${baseUri}/testing/123.json`)
         .then(res => {
-          expect(res.ok).to.equal(true);
+          expect(res.ok).to.be.true;
           return res.json();
         }).then(json => {
           expect(json).to.deep.equal({ name: 'testing', value: '123' });
@@ -123,14 +123,14 @@ describe('The request handler', function() {
         it('should match expected and use canonical order - 1', function () {
           return fetch(`${baseUri}/testing/123.json?colorB=123&label=foo`)
             .then(res => {
-              expect(res.ok).to.equal(true);
+              expect(res.ok).to.be.true;
               expect(_requestCache.cache).to.have.keys(expectedCacheKey);
             });
         });
         it('should match expected and use canonical order - 2', function () {
           return fetch(`${baseUri}/testing/123.json?label=foo&colorB=123`)
             .then(res => {
-              expect(res.ok).to.equal(true);
+              expect(res.ok).to.be.true;
               expect(_requestCache.cache).to.have.keys(expectedCacheKey);
             });
         });

--- a/lib/svg-badge-parser.spec.js
+++ b/lib/svg-badge-parser.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const { makeBadgeData } = require('./badge-data');
 const { valueFromSvgBadge } = require('./svg-badge-parser');
 const testHelpers = require('./make-badge-test-helpers');
@@ -14,6 +14,6 @@ describe('The SVG badge parser', function() {
 
     const exampleSvg = makeBadge(badgeData);
 
-    assert.equal(valueFromSvgBadge(exampleSvg), 'this is the result!');
+    expect(valueFromSvgBadge(exampleSvg)).to.equal('this is the result!');
   });
 });

--- a/lib/svg-to-img.spec.js
+++ b/lib/svg-to-img.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const isPng = require('is-png');
 const sinon = require('sinon');
 const svg2img = require('./svg-to-img');
@@ -17,7 +17,7 @@ describe('The rasterizer', function () {
     const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
     return svg2img(svg, 'png')
       .then(data => {
-        assert.ok(isPng(data));
+        expect(data).to.satisfy(isPng);
       });
   });
 
@@ -25,14 +25,14 @@ describe('The rasterizer', function () {
     const svg = makeBadge({ text: ['will-this', 'be-cached?'], format: 'svg' });
     return svg2img(svg, 'png')
       .then(data => {
-        assert.ok(isPng(data));
-        assert.equal(cacheGet.called, false);
+        expect(data).to.satisfy(isPng);
+        expect(cacheGet).not.to.have.been.called;
       })
       .then(() => {
         return svg2img(svg, 'png')
           .then(data => {
-            assert.ok(isPng(data));
-            assert.ok(cacheGet.calledOnce);
+            expect(data).to.satisfy(isPng);
+            expect(cacheGet).to.have.been.calledOnce;
           });
       });
   });

--- a/lib/text-measurer.spec.js
+++ b/lib/text-measurer.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const path = require('path');
 const fs = require('fs');
 const sinon = require('sinon');
@@ -8,17 +8,16 @@ const { PDFKitTextMeasurer, QuickTextMeasurer } = require('./text-measurer');
 const { starRating } = require('./text-formatters');
 const defaults = require('./defaults');
 const testHelpers = require('./make-badge-test-helpers');
+const almostEqual = require('almost-equal');
 
-function almostEqualInPixels(first, second) {
-  return require('almost-equal')(first, second, 1e-3);
-}
+const EPSILON_PIXELS = 1e-3;
 
 describe('PDFKitTextMeasurer with DejaVu Sans', function () {
   it('should produce the same length as before', function () {
     const measurer = new PDFKitTextMeasurer(testHelpers.font.path);
     const actual = measurer.widthOf('This is the dawning of the Age of Aquariums');
     const expected = 243.546875;
-    assert.equal(actual, expected);
+    expect(actual).to.equal(expected);
   });
 });
 
@@ -65,7 +64,8 @@ function registerTests(fontPath, skip) {
       strings.forEach(function (str) {
         it(`should measure '${str}' in parity with PDFKit`, function () {
           if (skip) { this.skip(); }
-          assert.ok(almostEqualInPixels(quickMeasurer.widthOf(str), pdfKitMeasurer.widthOf(str)));
+          expect(quickMeasurer.widthOf(str))
+            .to.be.closeTo(pdfKitMeasurer.widthOf(str), EPSILON_PIXELS);
         });
       });
 
@@ -73,7 +73,7 @@ function registerTests(fontPath, skip) {
         it(`should measure '${str}' without invoking PDFKit`, function () {
           if (skip) { this.skip(); }
           quickMeasurer.widthOf(str);
-          assert.equal(pdfKitWidthOf.called, false);
+          expect(pdfKitWidthOf).not.to.have.been.called;
         });
       });
 
@@ -99,12 +99,12 @@ function registerTests(fontPath, skip) {
           stringsWithKerningPairs.forEach(str => {
             const actual = quickMeasurer.widthOf(str);
             const unadjusted = widthByMeasuringCharacters(str);
-            if (!almostEqualInPixels(actual, unadjusted)) {
+            if (!almostEqual(actual, unadjusted, EPSILON_PIXELS)) {
               adjustedStrings.push(str);
             }
           });
 
-          assert.ok(adjustedStrings.length > 0);
+          expect(adjustedStrings).to.be.an('array').that.is.not.empty;
         });
       });
     });
@@ -118,7 +118,8 @@ function registerTests(fontPath, skip) {
       strings.forEach(function (str) {
         it(`should measure '${str}' in parity with PDFKit`, function () {
           if (skip) { this.skip(); }
-          assert.ok(almostEqualInPixels(quickMeasurer.widthOf(str), pdfKitMeasurer.widthOf(str)));
+          expect(quickMeasurer.widthOf(str))
+            .to.be.closeTo(pdfKitMeasurer.widthOf(str), EPSILON_PIXELS);
         });
       });
 
@@ -126,7 +127,7 @@ function registerTests(fontPath, skip) {
         it(`should invoke the base when measuring '${str}'`, function () {
           if (skip) { this.skip(); }
           quickMeasurer.widthOf(str);
-          assert.equal(pdfKitWidthOf.called, true);
+          expect(pdfKitWidthOf).to.have.been.called;
         });
       });
     });

--- a/lib/text-measurer.spec.js
+++ b/lib/text-measurer.spec.js
@@ -15,9 +15,8 @@ const EPSILON_PIXELS = 1e-3;
 describe('PDFKitTextMeasurer with DejaVu Sans', function () {
   it('should produce the same length as before', function () {
     const measurer = new PDFKitTextMeasurer(testHelpers.font.path);
-    const actual = measurer.widthOf('This is the dawning of the Age of Aquariums');
-    const expected = 243.546875;
-    expect(actual).to.equal(expected);
+    expect(measurer.widthOf('This is the dawning of the Age of Aquariums'))
+      .to.equal(243.546875);
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1983,6 +1983,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
@@ -1995,7 +1996,8 @@
     "chai-string": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
-      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk="
+      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk=",
+      "dev": true
     },
     "chai-subset": {
       "version": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1983,7 +1983,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
-      "dev": true,
       "requires": {
         "assertion-error": "1.0.2",
         "check-error": "1.0.2",
@@ -1992,6 +1991,11 @@
         "pathval": "1.1.0",
         "type-detect": "4.0.3"
       }
+    },
+    "chai-string": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-string/-/chai-string-1.4.0.tgz",
+      "integrity": "sha1-NZFAwFHTak5LGl/GuRAVL0OKjUk="
     },
     "chai-subset": {
       "version": "1.6.0",
@@ -11753,6 +11757,12 @@
         "text-encoding": "0.6.4",
         "type-detect": "4.0.3"
       }
+    },
+    "sinon-chai": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3938,6 +3938,12 @@
         }
       }
     },
+    "eslint-plugin-chai-friendly": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.1.tgz",
+      "integrity": "sha512-hkpLN7VVoGGsofZjUhcQ+sufC3FgqMJwD0DvAcRfxY1tVRyQyVsqpaKnToPHJQOrRo0FQ0fSEDwW2gr4rsNdGA==",
+      "dev": true
+    },
     "eslint-plugin-import": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "camp": "^17.2.0",
+    "chai": "^4.1.2",
+    "chai-string": "^1.4.0",
     "chrome-web-store-item-property": "~1.1.2",
     "dot": "~1.1.2",
     "gm": "^1.23.0",
@@ -30,6 +32,7 @@
     "jsonpath": "~1.0.0",
     "lodash.countby": "^4.6.0",
     "lodash.mapkeys": "^4.6.0",
+    "lodash.uniq": "~4.5.0",
     "moment": "^2.19.3",
     "node-env-flag": "^0.1.0",
     "pdfkit": "~0.8.0",
@@ -39,8 +42,7 @@
     "request": "~2.83.0",
     "semver": "~5.4.1",
     "svgo": "~0.7.1",
-    "xml2js": "~0.4.16",
-    "lodash.uniq": "~4.5.0"
+    "xml2js": "~0.4.16"
   },
   "scripts": {
     "coverage:test:js": "nyc node_modules/mocha/bin/_mocha '*.spec.js' 'lib/**/*.spec.js' 'service-tests/**/*.spec.js'",
@@ -139,6 +141,7 @@
     "sazerac": "^0.4.2",
     "semver-regex": "^1.0.0",
     "sinon": "^4.0.1",
+    "sinon-chai": "^2.14.0",
     "url": "^0.11.0"
   },
   "greenkeeper": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   },
   "dependencies": {
     "camp": "^17.2.0",
-    "chai": "^4.1.2",
-    "chai-string": "^1.4.0",
     "chrome-web-store-item-property": "~1.1.2",
     "dot": "~1.1.2",
     "gm": "^1.23.0",
@@ -94,6 +92,8 @@
     "babel-eslint": "^8.0.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
+    "chai": "^4.1.2",
+    "chai-string": "^1.4.0",
     "chainsmoker": "^0.1.0",
     "check-node-version": "^3.1.0",
     "child-process-promise": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "eslint-config-standard": "^10.2.1",
     "eslint-config-standard-jsx": "^4.0.2",
     "eslint-config-standard-react": "^5.0.0",
+    "eslint-plugin-chai-friendly": "^0.4.1",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-prettier": "^2.3.1",

--- a/server.spec.js
+++ b/server.spec.js
@@ -31,8 +31,8 @@ describe('The server', function () {
       }).then(text => {
         expect(text)
           .to.satisfy(isSvg)
-          .and.to.contain('fruit')
-          .and.to.contain('apple');
+          .and.to.include('fruit')
+          .and.to.include('apple');
       });
   });
 
@@ -63,7 +63,7 @@ describe('The server', function () {
           expect(res.status).to.equal(200);
           return res.text();
         }).then(text => {
-          expect(text).to.contain(expectedError);
+          expect(text).to.include(expectedError);
         });
     });
   });

--- a/server.spec.js
+++ b/server.spec.js
@@ -85,8 +85,12 @@ describe('The server', function () {
           ];
           expect(json).to.have.all.keys(...expectedKeys);
 
-          Object.values(json).forEach(stats => {
-            expect(stats).to.be.an('array').with.length(36);
+          // TODO Switch this when we upgrade to Node 8.
+          // Object.values(json).forEach(stats => {
+          //   expect(stats).to.be.an('array').with.length(36);
+          // });
+          Object.keys(json).forEach(k => {
+            expect(json[k]).to.be.an('array').with.length(36);
           });
         });
     });

--- a/server.spec.js
+++ b/server.spec.js
@@ -29,9 +29,10 @@ describe('The server', function () {
         expect(res.ok).to.equal(true);
         return res.text();
       }).then(text => {
-        expect(text).to.satisfy(isSvg);
-        expect(text).to.contain('fruit');
-        expect(text).to.contain('apple');
+        expect(text)
+          .to.satisfy(isSvg)
+          .and.to.contain('fruit')
+          .and.to.contain('apple');
       });
   });
 

--- a/server.spec.js
+++ b/server.spec.js
@@ -1,4 +1,6 @@
-const assert = require('assert');
+'use strict';
+
+const { expect } = require('chai');
 const config = require('./lib/test-config');
 const fetch = require('node-fetch');
 const fs = require('fs');
@@ -24,22 +26,22 @@ describe('The server', function () {
     this.timeout(5000);
     return fetch(`${baseUri}/:fruit-apple-green.svg`)
       .then(res => {
-        assert.ok(res.ok);
+        expect(res.ok).to.equal(true);
         return res.text();
       }).then(text => {
-        assert.ok(isSvg(text));
-        assert(text.includes('fruit'), 'fruit');
-        assert(text.includes('apple'), 'apple');
+        expect(text).to.satisfy(isSvg);
+        expect(text).to.contain('fruit');
+        expect(text).to.contain('apple');
       });
   });
 
   it('should produce colorscheme PNG badges', function () {
     return fetch(`${baseUri}/:fruit-apple-green.png`)
       .then(res => {
-        assert.ok(res.ok);
+        expect(res.ok).to.equal(true);
         return res.buffer();
       }).then(data => {
-        assert.ok(isPng(data));
+        expect(data).to.satisfy(isPng);
       });
   });
 
@@ -57,10 +59,10 @@ describe('The server', function () {
       return fetch(`${baseUri}/:some_new-badge-green.png`)
         .then(res => {
           // This emits status code 200, though 500 would be preferable.
-          assert.equal(res.status, 200);
+          expect(res.status).to.equal(200);
           return res.text();
         }).then(text => {
-          assert.equal(text, expectedError);
+          expect(text).to.contain(expectedError);
         });
     });
   });
@@ -69,10 +71,9 @@ describe('The server', function () {
     it('should return analytics in the expected format', function () {
       return fetch(`${baseUri}/$analytics/v1`)
         .then(res => {
-          assert.ok(res.ok);
+          expect(res.ok).to.equal(true);
           return res.json();
         }).then(json => {
-          const keys = Object.keys(json);
           const expectedKeys = [
             'vendorMonthly',
             'rawMonthly',
@@ -81,11 +82,10 @@ describe('The server', function () {
             'vendorFlatSquareMonthly',
             'rawFlatSquareMonthly',
           ];
-          assert.deepEqual(keys.sort(), expectedKeys.sort());
+          expect(json).to.have.all.keys(...expectedKeys);
 
-          keys.forEach(k => {
-            assert.ok(Array.isArray(json[k]));
-            assert.equal(json[k].length, 36);
+          Object.values(json).forEach(stats => {
+            expect(stats).to.be.an('array').with.length(36);
           });
         });
     });

--- a/server.spec.js
+++ b/server.spec.js
@@ -26,7 +26,7 @@ describe('The server', function () {
     this.timeout(5000);
     return fetch(`${baseUri}/:fruit-apple-green.svg`)
       .then(res => {
-        expect(res.ok).to.equal(true);
+        expect(res.ok).to.be.true;
         return res.text();
       }).then(text => {
         expect(text)
@@ -39,7 +39,7 @@ describe('The server', function () {
   it('should produce colorscheme PNG badges', function () {
     return fetch(`${baseUri}/:fruit-apple-green.png`)
       .then(res => {
-        expect(res.ok).to.equal(true);
+        expect(res.ok).to.be.true;
         return res.buffer();
       }).then(data => {
         expect(data).to.satisfy(isPng);
@@ -85,7 +85,7 @@ describe('The server', function () {
     it('should return analytics in the expected format', function () {
       return fetch(`${baseUri}/$analytics/v1`)
         .then(res => {
-          expect(res.ok).to.equal(true);
+          expect(res.ok).to.be.true;
           return res.json();
         }).then(json => {
           const expectedKeys = [

--- a/server.spec.js
+++ b/server.spec.js
@@ -50,12 +50,13 @@ describe('The server', function () {
   it('should not crash with a numeric logo', function () {
     return fetch(`${baseUri}/:fruit-apple-green.svg?logo=1`)
       .then(res => {
-        assert.ok(res.ok);
-        return res.buffer();
+        expect(res.ok).to.be.true;
+        return res.text();
       }).then(text => {
-        assert.ok(isSvg(text));
-        assert(text.includes('fruit'), 'fruit');
-        assert(text.includes('apple'), 'apple');
+        expect(text)
+          .to.satisfy(isSvg)
+          .and.to.include('fruit')
+          .and.to.include('apple');
       });
   });
 

--- a/service-tests/node.js
+++ b/service-tests/node.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('assert');
+const { expect } = require('chai');
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { Range } = require('semver');
@@ -8,37 +8,37 @@ const { Range } = require('semver');
 const t = new ServiceTester({ id: 'node', title: 'Node' });
 module.exports = t;
 
-function assertIsSemverRange(value) {
-  assert.doesNotThrow(() => {
+function expectSemverRange(value) {
+  expect(() => {
     // eslint-disable-next-line no-new
     new Range(value);
-  });
+  }).not.to.throw(null, null, 'Expected value to be a semver range');
 }
 
 t.create('gets the node version of passport')
   .get('/v/passport.json')
   .expectJSONTypes(Joi.object({ name: 'node' }).unknown())
-  .afterJSON(json => { assertIsSemverRange(json.value); });
+  .afterJSON(json => { expectSemverRange(json.value); });
 
 t.create('gets the node version of @stdlib/stdlib')
   .get('/v/@stdlib/stdlib.json')
   .expectJSONTypes(Joi.object({ name: 'node' }).unknown())
-  .afterJSON(json => { assertIsSemverRange(json.value); });
+  .afterJSON(json => { expectSemverRange(json.value); });
 
 t.create("gets the tagged release's node version version of ionic")
   .get('/v/ionic/next.json')
   .expectJSONTypes(Joi.object({ name: 'node@next' }).unknown())
-  .afterJSON(json => { assertIsSemverRange(json.value); });
+  .afterJSON(json => { expectSemverRange(json.value); });
 
 t.create('gets the node version of passport from a custom registry')
   .get('/v/passport.json?registry_uri=https://registry.npmjs.com')
   .expectJSONTypes(Joi.object({ name: 'node' }).unknown())
-  .afterJSON(json => { assertIsSemverRange(json.value); });
+  .afterJSON(json => { expectSemverRange(json.value); });
 
 t.create("gets the tagged release's node version of @cycle/core")
   .get('/v/@cycle/core/canary.json')
   .expectJSONTypes(Joi.object({ name: 'node@canary' }).unknown())
-  .afterJSON(json => { assertIsSemverRange(json.value); });
+  .afterJSON(json => { expectSemverRange(json.value); });
 
 t.create('invalid package name')
   .get('/v/frodo-is-not-a-package.json')


### PR DESCRIPTION
This idea has come up a couple times before in PRs. This updates everything except the LRU cache asserts, which are in conflict with #1418.

@PyvesB was it you who'd mentioned it?