### PR TITLE
Disable Node 6 tests on node-8 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,18 +195,18 @@ workflows:
       - main:
           requires:
             - npm-install
-      - main@node-6:
-          requires:
-            - npm-install
+      # - main@node-6:
+      #     requires:
+      #       - npm-install
       - frontend:
           requires:
             - npm-install
       - services-pr:
           requires:
             - npm-install
-      - services-pr@node-6:
-          requires:
-            - npm-install
+      # - services-pr@node-6:
+      #     requires:
+      #       - npm-install
 
   daily:
     triggers:


### PR DESCRIPTION
These should be switched over to Node 9, but disabling them in Node 6 should get the build back to green.