### PR TITLE
Log + fail tests on unhandled promise rejections

### DIFF
--- a/lib/unhandled-rejection.spec.js
+++ b/lib/unhandled-rejection.spec.js
@@ -1,0 +1,5 @@
+'use strict';
+
+// Cause unhandled promise rejections to fail unit tests, and print with stack
+// traces.
+process.on('unhandledRejection', error => { throw error; });

--- a/service-tests/runner/cli.js
+++ b/service-tests/runner/cli.js
@@ -50,6 +50,8 @@ const readAllStdinSync = require('read-all-stdin-sync');
 const Runner = require('./runner');
 const serverHelpers = require('../../lib/in-process-server-test-helpers');
 
+require('../../lib/unhandled-rejection.spec');
+
 let server;
 before('Start running the server', function () {
   this.timeout(5000);


### PR DESCRIPTION
I added this while doing some error-handling work on the `node-8` branch, and it seems like it will not hurt anything to add it to master as well.