### PR TITLE
Add Joi to greenkeeper ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
   },
   "greenkeeper": {
     "ignore": [
+      "joi",
       "redis"
     ]
   },


### PR DESCRIPTION
We can't upgrade Joi until we upgrade to Node 8.  