### PR TITLE
[badge/dynamic/json] fix colorscheme on error

### DIFF
--- a/server.js
+++ b/server.js
@@ -7625,10 +7625,10 @@ cache({
         switch (type){
           case 'json':
             data = (typeof data == 'object' ? data : JSON.parse(data));
-            let jsonpath = jp.query(data, pathExpression);
+            var jsonpath = jp.query(data, pathExpression);
             if (!jsonpath.length)
               throw 'no result';
-            let innerText = jsonpath.join(', ');
+            var innerText = jsonpath.join(', ');
             badgeData.text[1] = (prefix || '') + innerText + (suffix || '');
             break;
         }

--- a/server.js
+++ b/server.js
@@ -7623,7 +7623,11 @@ cache({
         switch (type){
           case 'json':
             data = (typeof data == 'object' ? data : JSON.parse(data));
-            badgeData.text[1] = (prefix || '') + jp.query(data, pathExpression).join(', ') + (suffix || '');
+            let jsonpath = jp.query(data, pathExpression);
+            if (!jsonpath.length)
+              throw 'no result';
+            let innerText = jsonpath.join(', ');
+            badgeData.text[1] = (prefix || '') + innerText + (suffix || '');
             break;
         }
       } catch(e) {

--- a/server.js
+++ b/server.js
@@ -7606,7 +7606,7 @@ cache({
     var badgeData = getBadgeData('custom badge', query);
 
     if (!query.uri){
-      badgeData.colorB = '#e05d44'; // red
+      setBadgeColor(badgeData, 'red');
       badgeData.text[1] = 'no uri specified';
       sendBadge(format, badgeData);
       return;
@@ -7634,7 +7634,7 @@ cache({
             break;
         }
       } catch(e) {
-        badgeData.colorB = '#9f9f9f'; // lightgrey
+        setBadgeColor(badgeData, 'lightgrey');
         badgeData.text[1] = e;
       } finally {
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -7620,6 +7620,8 @@ cache({
         if (err != null || !res || res.statusCode !== 200)
           throw 'inaccessible';
 
+        badgeData.colorscheme = 'brightgreen';
+
         switch (type){
           case 'json':
             data = (typeof data == 'object' ? data : JSON.parse(data));

--- a/server.js
+++ b/server.js
@@ -7606,6 +7606,7 @@ cache({
     var badgeData = getBadgeData('custom badge', query);
 
     if (!query.uri){
+      badgeData.colorB = '#9f9f9f'; // lightgrey
       badgeData.text[1] = 'no uri specified';
       sendBadge(format, badgeData);
       return;

--- a/server.js
+++ b/server.js
@@ -7631,7 +7631,7 @@ cache({
             break;
         }
       } catch(e) {
-        badgeData.colorscheme = 'lightgrey';
+        badgeData.colorB = '#9f9f9f'; // lightgrey
         badgeData.text[1] = e;
       } finally {
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -7627,7 +7627,7 @@ cache({
             break;
         }
       } catch(e) {
-        badgeData.colorB = 'lightgrey';
+        badgeData.colorscheme = 'lightgrey';
         badgeData.text[1] = e;
       } finally {
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -7606,7 +7606,7 @@ cache({
     var badgeData = getBadgeData('custom badge', query);
 
     if (!query.uri){
-      badgeData.colorB = '#9f9f9f'; // lightgrey
+      badgeData.colorB = '#e05d44'; // red
       badgeData.text[1] = 'no uri specified';
       sendBadge(format, badgeData);
       return;

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -2,22 +2,26 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
+const colorscheme = require('../lib/colorscheme.json');
+const mapValues = require('lodash.mapvalues');
+
+const colorsB = mapValues(colorscheme, 'colorB');
 
 const t = new ServiceTester({ id: 'badge/dynamic/json', title: 'User Defined JSON Source Data' });
 module.exports = t;
 
 t.create('Connection error')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&label=Package Name')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&label=Package Name&style=_shields_test')
   .networkOff()
-  .expectJSON({ name: 'Package Name', value: 'inaccessible' });
+  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.lightgrey });
 
 t.create('No URI specified')
-  .get('.json?query=$.name&label=Package Name')
-  .expectJSON({ name: 'Package Name', value: 'no uri specified' });
+  .get('.json?query=$.name&label=Package Name&style=_shields_test')
+  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name')
-  .expectJSON({ name: 'custom badge', value: 'gh-badges'});
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });
 
 t.create('JSON from uri | caching with new query params')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version')
@@ -34,9 +38,21 @@ t.create('JSON from uri | with prefix & suffix & label')
   }));
 
 t.create('JSON from uri | object doesnt exist')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.does_not_exist')
-  .expectJSON({ name: 'custom badge', value: 'no result' });
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.does_not_exist&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'no result', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | invalid uri')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version')
-  .expectJSON({ name: 'custom badge', value: 'invalid resource' });
+  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+
+t.create('JSON from uri | user color overrides default')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&colorB=10ADED&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: '#10ADED' });
+
+t.create('JSON from uri | error color overrides default')
+  .get('.json?query=$.version&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.lightgrey });
+
+t.create('JSON from uri | error color overrides user specified')
+  .get('.json?query=$.version&colorB=10ADED&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.lightgrey });

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -35,7 +35,7 @@ t.create('JSON from uri | with prefix & suffix & label')
 
 t.create('JSON from uri | object doesnt exist')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.does_not_exist')
-  .expectJSON({ name: 'custom badge', value: '' });
+  .expectJSON({ name: 'custom badge', value: 'no result' });
 
 t.create('JSON from uri | invalid uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version')

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -17,7 +17,7 @@ t.create('Connection error')
 
 t.create('No URI specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')
-  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
 
 t.create('JSON from uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
@@ -50,9 +50,9 @@ t.create('JSON from uri | user color overrides default')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: '#10ADED' });
 
 t.create('JSON from uri | error color overrides default')
-  .get('.json?query=$.version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.lightgrey });
+  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | error color overrides user specified')
   .get('.json?query=$.version&colorB=10ADED&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.red });


### PR DESCRIPTION
Closes #1442 

All dynamic badges are currently showing `brightgreen` on right hand side even on error.

This PR causes the right hand side to be `red` if no uri specified or `lightgrey` on other errors.
This also adds an error if the jsonpath/`?query` returns an empty array `no result`

**Notes:**
Was failing due to trying to set `colorB = 'lightgrey'` instead of `colorB = '#9f9f9f'`
Also tried using `colorscheme = 'lightgrey'` but that didn't work due to the users color choice always taking priority and the user needing to specify `?colorB=10ADED` for any color other than brightgreen