### PR TITLE
[UptimeRobot] Test with regex that accepts decimals

### DIFF
--- a/service-tests/codecov.js
+++ b/service-tests/codecov.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const { isPercentage } = require('./helpers/validators');
+const { isIntegerPercentage } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'codecov', title: 'Codecov.io' });
 module.exports = t;
@@ -11,12 +11,12 @@ t.create('gets coverage status')
   .get('/c/github/codecov/example-python.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: isPercentage
+    value: isIntegerPercentage,
   }));
 
 t.create('gets coverate status for branch')
   .get('/c/github/codecov/example-python/master.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: isPercentage
+    value: isIntegerPercentage,
   }));

--- a/service-tests/coveralls.js
+++ b/service-tests/coveralls.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
-const { isPercentage } = require('./helpers/validators');
+const { isIntegerPercentage } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'coveralls', title: 'Coveralls.io' });
 module.exports = t;
@@ -92,12 +92,12 @@ t.create('show coverage for bitbucket with branch')
 
 t.create('github coverage')
   .get('/github/jekyll/jekyll.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isPercentage }));
+  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isIntegerPercentage }));
 
 t.create('github coverage for legacy link')
   .get('/jekyll/jekyll.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isPercentage }));
+  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isIntegerPercentage }));
 
 t.create('bitbucket coverage')
   .get('/bitbucket/pyKLIP/pyklip.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isPercentage }));
+  .expectJSONTypes(Joi.object().keys({ name: 'coverage', value: isIntegerPercentage }));

--- a/service-tests/helpers/validators.js
+++ b/service-tests/helpers/validators.js
@@ -48,7 +48,8 @@ const isMetricOpenIssues = withRegex(/^[1-9][0-9]*[kMGTPEZY]? open$/);
 
 const isMetricOverTimePeriod = withRegex(/^[1-9][0-9]*[kMGTPEZY]?\/(year|month|4 weeks|week|day)$/);
 
-const isPercentage = withRegex(/^[0-9]+%$/);
+const isIntegerPercentage = withRegex(/^[0-9]+%$/);
+const isDecimalPercentage = withRegex(/^[0-9]+\.[0-9]*%$/);
 
 const isFileSize = withRegex(/^[0-9]*[.]?[0-9]+\s(B|kB|MB|GB|TB|PB|EB|ZB|YB)$/);
 
@@ -67,7 +68,8 @@ module.exports = {
   isMetric,
   isMetricOpenIssues,
   isMetricOverTimePeriod,
-  isPercentage,
+  isIntegerPercentage,
+  isDecimalPercentage,
   isFileSize,
   isFormattedDate
 };

--- a/service-tests/sonarqube.js
+++ b/service-tests/sonarqube.js
@@ -3,7 +3,7 @@
 const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const {
-  isPercentage,
+  isIntegerPercentage,
 } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'sonar', title: 'SonarQube' });
@@ -13,28 +13,28 @@ t.create('Tech Debt')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: isPercentage
+    value: isIntegerPercentage
   }));
 
 t.create('Coverage')
   .get('/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: isPercentage
+    value: isIntegerPercentage
   }));
 
 t.create('Tech Debt (legacy API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/tech_debt.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'tech debt',
-    value: isPercentage
+    value: isIntegerPercentage
   }));
 
 t.create('Coverage (legacy API supported)')
   .get('/4.2/http/sonar.petalslink.com/org.ow2.petals%3Apetals-se-ase/coverage.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
-    value: isPercentage
+    value: isIntegerPercentage
   }));
 
 t.create('Tech Debt (legacy API unsupported)')

--- a/service-tests/uptimerobot.js
+++ b/service-tests/uptimerobot.js
@@ -4,7 +4,7 @@ const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
 const isUptimeStatus = Joi.string().regex(/^(paused|not checked yet|up|seems down|down)$/);
-const { isPercentage } = require('./helpers/validators');
+const { isDecimalPercentage } = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'uptimerobot', title: 'Uptime Robot' });
 module.exports = t;
@@ -66,14 +66,14 @@ t.create('Uptime Robot: Percentage (valid)')
   .get('/ratio/m778918918-3e92c097147760ee39d02d36.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'uptime',
-    value: isPercentage,
+    value: isDecimalPercentage,
   }));
 
 t.create('Uptime Robot: Percentage (valid, with numberOfDays param)')
   .get('/ratio/7/m778918918-3e92c097147760ee39d02d36.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'uptime',
-    value: isPercentage,
+    value: isDecimalPercentage,
   }));
 
 t.create('Uptime Robot: Percentage (invalid, correct format)')


### PR DESCRIPTION
For #1359

This failure from https://circleci.com/gh/badges/shields/1411?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
  26) Uptime Robot
       Uptime Robot: Percentage (valid)
         
  [ GET http://localhost:1111/uptimerobot/ratio/m778918918-3e92c097147760ee39d02d36.json ]:
     ValidationError: child "value" fails because ["value" with value "99.992%" fails to match the required pattern: /^[0-9]+%$/]
      at Object.exports.process (node_modules/joi/lib/errors.js:190:19)
      at internals.Object._validateWithOptions (node_modules/joi/lib/types/any/index.js:669:31)
      at module.exports.internals.Any.root.validate (node_modules/joi/lib/index.js:139:23)
      at Object.pathMatch.matchJSONTypes (node_modules/icedfrisby/lib/pathMatch.js:303:9)
      at node_modules/icedfrisby/lib/icedfrisby.js:703:10
      at IcedFrisbyNock._invokeExpects (node_modules/icedfrisby/lib/icedfrisby.js:1294:33)
      at start (node_modules/icedfrisby/lib/icedfrisby.js:1274:12)
      at Request.runCallback [as _callback] (node_modules/icedfrisby/lib/icedfrisby.js:1232:16)
      at Request.self.callback (node_modules/request/request.js:186:22)
      at Request.<anonymous> (node_modules/request/request.js:1163:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1085:12)
      at endReadableNT (_stream_readable.js:1056:12)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickDomainCallback (internal/process/next_tick.js:218:9)

  27) Uptime Robot
       Uptime Robot: Percentage (valid, with numberOfDays param)
         
  [ GET http://localhost:1111/uptimerobot/ratio/7/m778918918-3e92c097147760ee39d02d36.json ]:
     ValidationError: child "value" fails because ["value" with value "99.967%" fails to match the required pattern: /^[0-9]+%$/]
      at Object.exports.process (node_modules/joi/lib/errors.js:190:19)
      at internals.Object._validateWithOptions (node_modules/joi/lib/types/any/index.js:669:31)
      at module.exports.internals.Any.root.validate (node_modules/joi/lib/index.js:139:23)
      at Object.pathMatch.matchJSONTypes (node_modules/icedfrisby/lib/pathMatch.js:303:9)
      at node_modules/icedfrisby/lib/icedfrisby.js:703:10
      at IcedFrisbyNock._invokeExpects (node_modules/icedfrisby/lib/icedfrisby.js:1294:33)
      at start (node_modules/icedfrisby/lib/icedfrisby.js:1274:12)
      at Request.runCallback [as _callback] (node_modules/icedfrisby/lib/icedfrisby.js:1232:16)
      at Request.self.callback (node_modules/request/request.js:186:22)
      at Request.<anonymous> (node_modules/request/request.js:1163:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1085:12)
      at endReadableNT (_stream_readable.js:1056:12)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickDomainCallback (internal/process/next_tick.js:218:9)
```