### PR TITLE
[Gratipay] Replace with error message

### DIFF
--- a/server.js
+++ b/server.js
@@ -1131,48 +1131,15 @@ cache(function(data, match, sendBadge, request) {
 
 // Gratipay integration.
 camp.route(/^\/(?:gittip|gratipay(\/user|\/team|\/project)?)\/(.*)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var type = match[1];  // eg, `user`.
-  var user = match[2];  // eg, `dougwilson`.
-  var format = match[3];
-  if (type === '') { type = '/user'; }
-  if (type === '/user') { user = '~' + user; }
-  var apiUrl = 'https://gratipay.com/' + user + '/public.json';
-  var badgeData = getBadgeData('receives', data);
+cache(function(queryParams, match, sendBadge, request) {
+  const format = match[3];
+  const badgeData = getBadgeData('gratipay', queryParams);
   if (badgeData.template === 'social') {
-    badgeData.logo = getLogo('gratipay', data);
+    badgeData.logo = getLogo('gratipay', queryParams);
   }
-  request(apiUrl, function dealWithData(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
-      sendBadge(format, badgeData);
-      return;
-    }
-    try {
-      var data = JSON.parse(buffer);
-      // Avoid falsey checks because amounts may be 0
-      var receiving = isNaN(data.receiving) ? data.taking : data.receiving;
-      if (!isNaN(receiving)) {
-        badgeData.text[1] = '$' + metric(receiving) + '/week';
-        if (receiving === 0) {
-          badgeData.colorscheme = 'red';
-        } else if (receiving < 10) {
-          badgeData.colorscheme = 'yellow';
-        } else if (receiving < 100) {
-          badgeData.colorscheme = 'green';
-        } else {
-          badgeData.colorscheme = 'brightgreen';
-        }
-        sendBadge(format, badgeData);
-      } else {
-        badgeData.text[1] = 'anonymous';
-        sendBadge(format, badgeData);
-      }
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-      sendBadge(format, badgeData);
-    }
-  });
+  badgeData.colorscheme = 'red';
+  badgeData.text[1] = 'no longer available';
+  sendBadge(format, badgeData);
 }));
 
 // Liberapay integration.

--- a/server.js
+++ b/server.js
@@ -1137,7 +1137,7 @@ cache(function(queryParams, match, sendBadge, request) {
   if (badgeData.template === 'social') {
     badgeData.logo = getLogo('gratipay', queryParams);
   }
-  badgeData.colorscheme = 'red';
+  badgeData.colorscheme = 'lightgray';
   badgeData.text[1] = 'no longer available';
   sendBadge(format, badgeData);
 }));

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -9,15 +9,6 @@ module.exports = t;
 t.create('Receiving')
   .get('/Gratipay.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'receives',
-    value: Joi.string().regex(/^\$[0-9]+(\.[0-9]{2})?\/week/)
+    name: 'gratipay',
+    value: 'no longer available',
   }));
-
-
-t.create('Empty')
-  .get('/Gratipay.json')
-  .intercept(nock => nock('https://gratipay.com')
-    .get('/Gratipay/public.json')
-    .reply(200, { receiving: 0.00 })
-  )
-  .expectJSON({ name: 'receives', value: '$0/week'});

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -8,7 +8,7 @@ module.exports = t;
 
 t.create('Receiving')
   .get('/Gratipay.json')
-  .expectJSONTypes(Joi.object().keys({
+  .expectJSON({
     name: 'gratipay',
     value: 'no longer available',
-  }));
+  });

--- a/service-tests/gratipay.js
+++ b/service-tests/gratipay.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 
 const t = new ServiceTester({ id: 'gratipay', title: 'Gratipay' });


### PR DESCRIPTION
Gratipay is gone :(

For #1359

This failure from https://circleci.com/gh/badges/shields/1411?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

```
  7) Gratipay
       Receiving

	[ GET http://localhost:1111/gratipay/Gratipay.json ]:
     ValidationError: child "value" fails because ["value" with value "invalid" fails to match the required pattern: /^\$[0-9]+(\.[0-9]{2})?\/week/]
      at Object.exports.process (node_modules/joi/lib/errors.js:190:19)
      at internals.Object._validateWithOptions (node_modules/joi/lib/types/any/index.js:669:31)
      at module.exports.internals.Any.root.validate (node_modules/joi/lib/index.js:139:23)
      at Object.pathMatch.matchJSONTypes (node_modules/icedfrisby/lib/pathMatch.js:303:9)
      at node_modules/icedfrisby/lib/icedfrisby.js:703:10
      at IcedFrisbyNock._invokeExpects (node_modules/icedfrisby/lib/icedfrisby.js:1294:33)
      at start (node_modules/icedfrisby/lib/icedfrisby.js:1274:12)
      at Request.runCallback [as _callback] (node_modules/icedfrisby/lib/icedfrisby.js:1232:16)
      at Request.self.callback (node_modules/request/request.js:186:22)
      at Request.<anonymous> (node_modules/request/request.js:1163:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1085:12)
      at endReadableNT (_stream_readable.js:1056:12)
      at _combinedTickCallback (internal/process/next_tick.js:138:11)
      at process._tickDomainCallback (internal/process/next_tick.js:218:9)
```