### PR TITLE
User defined XML source badge [dynamic-xml dynamic-json]

### DIFF
--- a/frontend/components/dynamic-badge-maker.js
+++ b/frontend/components/dynamic-badge-maker.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { dynamicJsonBadgeUrl } from '../lib/badge-url';
+import { dynamicBadgeUrl } from '../lib/badge-url';
 
 export default class DynamicBadgeMaker extends React.Component {
   static propTypes = {
@@ -20,7 +20,7 @@ export default class DynamicBadgeMaker extends React.Component {
   makeBadgeUri () {
     const { datatype, label, url, query, color, prefix, suffix } = this.state;
     const { baseUri: baseUrl = document.location.href } = this.props;
-    return dynamicJsonBadgeUrl(baseUrl, datatype, label, url, query, { color, prefix, suffix });
+    return dynamicBadgeUrl(baseUrl, datatype, label, url, query, { color, prefix, suffix });
   }
 
   handleSubmit(e) {

--- a/frontend/components/dynamic-badge-maker.js
+++ b/frontend/components/dynamic-badge-maker.js
@@ -36,16 +36,14 @@ export default class DynamicBadgeMaker extends React.Component {
   render() {
     return (
       <form onSubmit={e => this.handleSubmit(e)}>
-        <input
+        <select
           className="short"
           value={this.state.datatype}
-          onChange={event => this.setState({ datatype: event.target.value })}
-          list="datatypes"
-          placeholder="data type" /> {}
-        <datalist id="datatypes">
-          <option value="json" />
-          <option value="xml" />
-        </datalist> {}
+          onChange={event => this.setState({ datatype: event.target.value })}>
+          <option value="" disabled>data type</option>
+          <option value="json">json</option>
+          <option value="xml">xml</option>
+        </select> {}
         <input
           className="short"
           value={this.state.label}

--- a/frontend/components/dynamic-badge-maker.js
+++ b/frontend/components/dynamic-badge-maker.js
@@ -8,6 +8,7 @@ export default class DynamicBadgeMaker extends React.Component {
   };
 
   state = {
+    datatype: '',
     label: '',
     url: '',
     query: '',
@@ -17,9 +18,9 @@ export default class DynamicBadgeMaker extends React.Component {
   };
 
   makeBadgeUri () {
-    const { label, url, query, color, prefix, suffix } = this.state;
+    const { datatype, label, url, query, color, prefix, suffix } = this.state;
     const { baseUri: baseUrl = document.location.href } = this.props;
-    return dynamicJsonBadgeUrl(baseUrl, label, url, query, { color, prefix, suffix });
+    return dynamicJsonBadgeUrl(baseUrl, datatype, label, url, query, { color, prefix, suffix });
   }
 
   handleSubmit(e) {
@@ -28,13 +29,23 @@ export default class DynamicBadgeMaker extends React.Component {
   }
 
   get isValid() {
-    const { label, url, query } = this.state;
-    return label && url && query;
+    const { datatype, label, url, query } = this.state;
+    return datatype && label && url && query;
   }
 
   render() {
     return (
       <form onSubmit={e => this.handleSubmit(e)}>
+        <input
+          className="short"
+          value={this.state.datatype}
+          onChange={event => this.setState({ datatype: event.target.value })}
+          list="datatypes"
+          placeholder="data type" /> {}
+        <datalist id="datatypes">
+          <option value="json" />
+          <option value="xml" />
+        </datalist> {}
         <input
           className="short"
           value={this.state.label}

--- a/frontend/components/dynamic-badge-maker.js
+++ b/frontend/components/dynamic-badge-maker.js
@@ -53,7 +53,7 @@ export default class DynamicBadgeMaker extends React.Component {
           className="short"
           value={this.state.url}
           onChange={event => this.setState({ url: event.target.value })}
-          placeholder="json url" /> {}
+          placeholder="url" /> {}
         <input
           className="short"
           value={this.state.query}

--- a/frontend/components/dynamic-badge-maker.js
+++ b/frontend/components/dynamic-badge-maker.js
@@ -58,7 +58,7 @@ export default class DynamicBadgeMaker extends React.Component {
           className="short"
           value={this.state.query}
           onChange={event => this.setState({ query: event.target.value })}
-          placeholder="$.data.subdata" /> {}
+          placeholder="query" /> {}
         <input
           className="short"
           value={this.state.color}

--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -121,7 +121,7 @@ export default class Usage extends React.PureComponent {
         <DynamicBadgeMaker baseUri={baseUri} />
 
         <p>
-          <code>/badge/dynamic/&lt;DATATYPE&gt;.svg?uri=&lt;URI&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>|<a href="https://www.npmjs.com/package/xpath" target="_BLANK" title="XPath syntax">//data/subdata</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
+          <code>/badge/dynamic/&lt;DATATYPE&gt;.svg?url=&lt;URL&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>|<a href="https://www.npmjs.com/package/xpath" target="_BLANK" title="XPath syntax">//data/subdata</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
         </p>
 
         <hr className="spacing" />

--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -121,7 +121,7 @@ export default class Usage extends React.PureComponent {
         <DynamicBadgeMaker baseUri={baseUri} />
 
         <p>
-          <code>/badge/dynamic/&lt;TYPE&gt;.svg?uri=&lt;URI&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
+          <code>/badge/dynamic/&lt;DATATYPE&gt;.svg?uri=&lt;URI&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>|<a href="https://www.npmjs.com/package/xpath" target="_BLANK" title="XPath syntax">//data/subdata</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
         </p>
 
         <hr className="spacing" />

--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -121,7 +121,10 @@ export default class Usage extends React.PureComponent {
         <DynamicBadgeMaker baseUri={baseUri} />
 
         <p>
-          <code>/badge/dynamic/&lt;DATATYPE&gt;.svg?url=&lt;URL&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>|<a href="https://www.npmjs.com/package/xpath" target="_BLANK" title="XPath syntax">//data/subdata</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
+          <code>/badge/dynamic/json.svg?url=&lt;URL&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
+        </p>
+        <p>
+          <code>/badge/dynamic/xml.svg?url=&lt;URL&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/xpath" target="_BLANK" title="XPath syntax">//data/subdata</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
         </p>
 
         <hr className="spacing" />

--- a/frontend/lib/badge-url.js
+++ b/frontend/lib/badge-url.js
@@ -22,7 +22,7 @@ export function staticBadgeUrl(baseUrl, subject, status, color, options) {
 }
 
 // Options can include: { prefix, suffix, color, longCache, style, queryParams }
-export function dynamicJsonBadgeUrl(baseUrl, datatype, label, jsonUrl, query, options = {}) {
+export function dynamicBadgeUrl(baseUrl, datatype, label, jsonUrl, query, options = {}) {
   const { prefix, suffix, color, queryParams = {}, ...rest } = options;
 
   Object.assign(queryParams, {

--- a/frontend/lib/badge-url.js
+++ b/frontend/lib/badge-url.js
@@ -22,12 +22,12 @@ export function staticBadgeUrl(baseUrl, subject, status, color, options) {
 }
 
 // Options can include: { prefix, suffix, color, longCache, style, queryParams }
-export function dynamicBadgeUrl(baseUrl, datatype, label, jsonUrl, query, options = {}) {
+export function dynamicBadgeUrl(baseUrl, datatype, label, dataUrl, query, options = {}) {
   const { prefix, suffix, color, queryParams = {}, ...rest } = options;
 
   Object.assign(queryParams, {
     label,
-    uri: jsonUrl,
+    url: dataUrl,
     query,
   });
 

--- a/frontend/lib/badge-url.js
+++ b/frontend/lib/badge-url.js
@@ -22,7 +22,7 @@ export function staticBadgeUrl(baseUrl, subject, status, color, options) {
 }
 
 // Options can include: { prefix, suffix, color, longCache, style, queryParams }
-export function dynamicJsonBadgeUrl(baseUrl, label, jsonUrl, query, options = {}) {
+export function dynamicJsonBadgeUrl(baseUrl, datatype, label, jsonUrl, query, options = {}) {
   const { prefix, suffix, color, queryParams = {}, ...rest } = options;
 
   Object.assign(queryParams, {
@@ -43,5 +43,5 @@ export function dynamicJsonBadgeUrl(baseUrl, label, jsonUrl, query, options = {}
 
   const outOptions = Object.assign({ queryParams }, rest);
 
-  return resolveBadgeUrl('/badge/dynamic/json.svg', baseUrl, outOptions);
+  return resolveBadgeUrl(`/badge/dynamic/${datatype}.svg`, baseUrl, outOptions);
 }

--- a/frontend/lib/badge-url.spec.js
+++ b/frontend/lib/badge-url.spec.js
@@ -3,7 +3,7 @@ import {
   default as resolveBadgeUrl,
   encodeField,
   staticBadgeUrl,
-  dynamicJsonBadgeUrl,
+  dynamicBadgeUrl,
 } from './badge-url';
 
 const resolveBadgeUrlWithLongCache = (url, baseUrl) =>
@@ -37,13 +37,14 @@ describe('Badge URL functions', function() {
       .expect('http://img.example.com/badge/foo-bar-blue.svg?style=plastic');
   });
 
-  test(dynamicJsonBadgeUrl, () => {
+  test(dynamicBadgeUrl, () => {
     const jsonUrl = 'http://example.com/foo.json';
     const query = '$.bar';
     const prefix = 'value: ';
 
     given(
       'http://img.example.com',
+      'json',
       'foo',
       jsonUrl,
       query,
@@ -52,6 +53,28 @@ describe('Badge URL functions', function() {
       'http://img.example.com/badge/dynamic/json.svg',
       '?label=foo',
       `&uri=${encodeURIComponent(jsonUrl)}`,
+      `&query=${encodeURIComponent(query)}`,
+      `&prefix=${encodeURIComponent(prefix)}`,
+      '&style=plastic',
+    ].join(''))
+  });
+
+  test(dynamicBadgeUrl, () => {
+    const xmlUrl = 'http://example.com/foo.xml';
+    const query = '//bar';
+    const prefix = 'value: ';
+
+    given(
+      'http://img.example.com',
+      'xml',
+      'foo',
+      xmlUrl,
+      query,
+      { prefix, style: 'plastic' }
+    ).expect([
+      'http://img.example.com/badge/dynamic/xml.svg',
+      '?label=foo',
+      `&uri=${encodeURIComponent(xmlUrl)}`,
       `&query=${encodeURIComponent(query)}`,
       `&prefix=${encodeURIComponent(prefix)}`,
       '&style=plastic',

--- a/frontend/lib/badge-url.spec.js
+++ b/frontend/lib/badge-url.spec.js
@@ -52,7 +52,7 @@ describe('Badge URL functions', function() {
     ).expect([
       'http://img.example.com/badge/dynamic/json.svg',
       '?label=foo',
-      `&uri=${encodeURIComponent(jsonUrl)}`,
+      `&url=${encodeURIComponent(jsonUrl)}`,
       `&query=${encodeURIComponent(query)}`,
       `&prefix=${encodeURIComponent(prefix)}`,
       '&style=plastic',
@@ -74,7 +74,7 @@ describe('Badge URL functions', function() {
     ).expect([
       'http://img.example.com/badge/dynamic/xml.svg',
       '?label=foo',
-      `&uri=${encodeURIComponent(xmlUrl)}`,
+      `&url=${encodeURIComponent(xmlUrl)}`,
       `&query=${encodeURIComponent(query)}`,
       `&prefix=${encodeURIComponent(prefix)}`,
       '&style=plastic',

--- a/package-lock.json
+++ b/package-lock.json
@@ -12317,10 +12317,20 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
     },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+    },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
       "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
+    },
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
     },
     "xss-filters": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "request": "~2.83.0",
     "semver": "~5.5.0",
     "svgo": "~0.7.1",
-    "xml2js": "~0.4.16"
+    "xml2js": "~0.4.16",
+    "xmldom": "~0.1.27",
+    "xpath": "~0.0.27"
   },
   "scripts": {
     "coverage:test:js": "nyc node_modules/mocha/bin/_mocha '*.spec.js' 'lib/**/*.spec.js' 'service-tests/**/*.spec.js'",

--- a/server.js
+++ b/server.js
@@ -7468,7 +7468,7 @@ camp.route(/^\/maven-metadata\/v\/(https?)\/(.+\.xml)\.(svg|png|gif|jpg|json)$/,
 // User defined sources - JSON response
 camp.route(/^\/badge\/dynamic\/(json|xml)\.(svg|png|gif|jpg|json)$/,
 cache({
-  queryParams: ['uri', 'query', 'prefix', 'suffix'],
+  queryParams: ['uri', 'url', 'query', 'prefix', 'suffix'],
   handler: function(query, match, sendBadge, request) {
     var type = match[1];
     var format = match[2];
@@ -7478,15 +7478,15 @@ cache({
 
     var badgeData = getBadgeData('custom badge', query);
 
-    if (!query.uri || !query.query){
+    if (!query.uri && !query.url || !query.query){
       setBadgeColor(badgeData, 'red');
-      badgeData.text[1] = !query.uri ? 'no uri specified' : 'no query specified';
+      badgeData.text[1] = !query.query ? 'no query specified' : 'no url specified';
       sendBadge(format, badgeData);
       return;
     }
-    var uri = encodeURI(decodeURIComponent(query.uri));
+    var url = encodeURI(decodeURIComponent(query.url || query.uri));
 
-    request(uri, (err, res, data) => {
+    request(url, (err, res, data) => {
       try {
         if (checkErrorResponse(badgeData, err, res, 'resource not found')) {
           return;

--- a/server.js
+++ b/server.js
@@ -7478,9 +7478,9 @@ cache({
 
     var badgeData = getBadgeData('custom badge', query);
 
-    if (!query.uri){
+    if (!query.uri || !query.query){
       setBadgeColor(badgeData, 'red');
-      badgeData.text[1] = 'no uri specified';
+      badgeData.text[1] = !query.uri ? 'no uri specified' : 'no query specified';
       sendBadge(format, badgeData);
       return;
     }

--- a/server.js
+++ b/server.js
@@ -7494,24 +7494,28 @@ cache({
 
         badgeData.colorscheme = 'brightgreen';
 
+        let innerText = [];
         switch (type){
           case 'json':
             data = (typeof data == 'object' ? data : JSON.parse(data));
-            var jsonpath = jp.query(data, pathExpression);
-            if (!jsonpath.length)
+            data = jp.query(data, pathExpression);
+            if (!data.length) {
               throw 'no result';
-            var innerText = jsonpath.join(', ');
-            badgeData.text[1] = (prefix || '') + innerText + (suffix || '');
+            }
+            innerText = data;
             break;
           case 'xml':
             data = new dom().parseFromString(data);
-            var xpathdata = xpath.select(pathExpression, data, true);
-            if (xpathdata) {
-              badgeData.text[1] = (prefix || '') + (pathExpression.indexOf('@') + 1 ? xpathdata.value : xpathdata.firstChild.data) + (suffix || '');
-            } else {
+            data = xpath.select(pathExpression, data);
+            if (!data.length) {
               throw 'no result';
             }
+            data.forEach((i,v)=>{
+              innerText.push(pathExpression.indexOf('@') + 1 ? i.value : i.firstChild.data);
+            });
+            break;
         }
+        badgeData.text[1] = (prefix || '') + innerText.join(', ') + (suffix || '');
       } catch (e) {
         setBadgeColor(badgeData, 'lightgrey');
         badgeData.text[1] = e;

--- a/server.js
+++ b/server.js
@@ -7488,7 +7488,7 @@ cache({
 
     request(uri, (err, res, data) => {
       try {
-        if (checkErrorResponse(badgeData, err, res, 'uri not found')) {
+        if (checkErrorResponse(badgeData, err, res, 'resource not found')) {
           return;
         }
 

--- a/server.js
+++ b/server.js
@@ -7508,16 +7508,10 @@ cache({
           case 'xml':
             data = new dom().parseFromString(data);
             var xpathdata = xpath.select(pathExpression, data, true);
-            try {
+            if (xpathdata) {
               badgeData.text[1] = (prefix || '') + (pathExpression.indexOf('@') + 1 ? xpathdata.value : xpathdata.firstChild.data) + (suffix || '');
-            } catch (e) {
-              switch (e.toString()){
-                case "TypeError: Cannot read property 'value' of undefined":
-                case "TypeError: Cannot read property 'firstChild' of undefined":
-                  throw 'no result';
-                default:
-                  throw e;
-              }
+            } else {
+              throw 'no result';
             }
         }
       } catch (e) {

--- a/server.js
+++ b/server.js
@@ -7488,11 +7488,9 @@ cache({
 
     request(uri, (err, res, data) => {
       try {
-        if (res && res.statusCode === 404)
-          throw 'invalid resource';
-
-        if (err != null || !res || res.statusCode !== 200)
-          throw 'inaccessible';
+        if (checkErrorResponse(badgeData, err, res, 'uri not found')) {
+          return;
+        }
 
         badgeData.colorscheme = 'brightgreen';
 

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -11,56 +11,60 @@ const t = new ServiceTester({ id: 'dynamic-json', title: 'User Defined JSON Sour
 module.exports = t;
 
 t.create('Connection error')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&label=Package Name&style=_shields_test')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.name&label=Package Name&style=_shields_test')
   .networkOff()
   .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.red });
 
-t.create('No URI specified')
+t.create('No URL specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')
-  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
+  .expectJSON({ name: 'Package Name', value: 'no url specified', colorB: colorsB.red });
 
 t.create('No query specified')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&label=Package Name&style=_shields_test')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&label=Package Name&style=_shields_test')
   .expectJSON({ name: 'Package Name', value: 'no query specified', colorB: colorsB.red });
 
-t.create('JSON from uri')
+t.create('JSON from url')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });
+
+t.create('JSON from uri (support uri query paramater)')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });
 
-t.create('JSON from uri | multiple results')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$..keywords[0:2:1]')
+t.create('JSON from url | multiple results')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$..keywords[0:2:1]')
   .expectJSON({ name: 'custom badge', value: 'GitHub, badge' });
 
-t.create('JSON from uri | caching with new query params')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version')
+t.create('JSON from url | caching with new query params')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.version')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom badge',
     value: Joi.string().regex(/^\d+(\.\d+)?(\.\d+)?$/)
   }));
 
-t.create('JSON from uri | with prefix & suffix & label')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version&prefix=v&suffix= dev&label=Shields')
+t.create('JSON from url | with prefix & suffix & label')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.version&prefix=v&suffix= dev&label=Shields')
   .expectJSONTypes(Joi.object().keys({
     name: 'Shields',
     value: Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?\sdev$/)
   }));
 
-t.create('JSON from uri | object doesnt exist')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.does_not_exist&style=_shields_test')
+t.create('JSON from url | object doesnt exist')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.does_not_exist&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'no result', colorB: colorsB.lightgrey });
 
-t.create('JSON from uri | invalid uri')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
+t.create('JSON from url | invalid url')
+  .get('.json?url=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
-t.create('JSON from uri | user color overrides default')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&colorB=10ADED&style=_shields_test')
+t.create('JSON from url | user color overrides default')
+  .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.name&colorB=10ADED&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: '#10ADED' });
 
-t.create('JSON from uri | error color overrides default')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
+t.create('JSON from url | error color overrides default')
+  .get('.json?url=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
-t.create('JSON from uri | error color overrides user specified')
+t.create('JSON from url | error color overrides user specified')
   .get('.json?query=$.version&colorB=10ADED&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.red });
+  .expectJSON({ name: 'custom badge', value: 'no url specified', colorB: colorsB.red });

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -27,6 +27,13 @@ t.create('JSON from uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });
 
+t.create('JSON from uri | multiple results')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$..keywords[0:10:1]')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'custom badge',
+    value: Joi.string().regex(/^.+,\s.+$/)
+  }));
+
 t.create('JSON from uri | caching with new query params')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version')
   .expectJSONTypes(Joi.object().keys({

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -19,6 +19,10 @@ t.create('No URI specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')
   .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
 
+t.create('No query specified')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&label=Package Name&style=_shields_test')
+  .expectJSON({ name: 'Package Name', value: 'no query specified', colorB: colorsB.red });
+
 t.create('JSON from uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -7,7 +7,7 @@ const mapValues = require('lodash.mapvalues');
 
 const colorsB = mapValues(colorscheme, 'colorB');
 
-const t = new ServiceTester({ id: 'badge/dynamic/json', title: 'User Defined JSON Source Data' });
+const t = new ServiceTester({ id: 'dynamic-json', title: 'User Defined JSON Source Data', pathPrefix: '/badge/dynamic/json' });
 module.exports = t;
 
 t.create('Connection error')

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -28,11 +28,8 @@ t.create('JSON from uri')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });
 
 t.create('JSON from uri | multiple results')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$..keywords[0:10:1]')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'custom badge',
-    value: Joi.string().regex(/^.+,\s.+$/)
-  }));
+  .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$..keywords[0:2:1]')
+  .expectJSON({ name: 'custom badge', value: 'GitHub, badge' });
 
 t.create('JSON from uri | caching with new query params')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version')

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -13,7 +13,7 @@ module.exports = t;
 t.create('Connection error')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&label=Package Name&style=_shields_test')
   .networkOff()
-  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.red });
 
 t.create('No URI specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')
@@ -47,7 +47,7 @@ t.create('JSON from uri | object doesnt exist')
 
 t.create('JSON from uri | invalid uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | user color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&colorB=10ADED&style=_shields_test')
@@ -55,7 +55,7 @@ t.create('JSON from uri | user color overrides default')
 
 t.create('JSON from uri | error color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | error color overrides user specified')
   .get('.json?query=$.version&colorB=10ADED&style=_shields_test')

--- a/service-tests/json.js
+++ b/service-tests/json.js
@@ -54,7 +54,7 @@ t.create('JSON from uri | object doesnt exist')
 
 t.create('JSON from uri | invalid uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | user color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.name&colorB=10ADED&style=_shields_test')
@@ -62,7 +62,7 @@ t.create('JSON from uri | user color overrides default')
 
 t.create('JSON from uri | error color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.json&query=$.version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
 t.create('JSON from uri | error color overrides user specified')
   .get('.json?query=$.version&colorB=10ADED&style=_shields_test')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -13,7 +13,7 @@ module.exports = t;
 t.create('Connection error')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&label=Package Name&style=_shields_test')
   .networkOff()
-  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.red });
 
 t.create('No URI specified')
   .get('.json?query=//name&label=Package Name&style=_shields_test')
@@ -47,7 +47,7 @@ t.create('XML from uri | object doesnt exist')
 
 t.create('XML from uri | invalid uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
 
 t.create('XML from uri | user color overrides default')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//name&colorB=10ADED&style=_shields_test')
@@ -55,7 +55,7 @@ t.create('XML from uri | user color overrides default')
 
 t.create('XML from uri | error color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
 
 t.create('XML from uri | error color overrides user specified')
   .get('.json?query=//version&colorB=10ADED&style=_shields_test')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -38,6 +38,13 @@ t.create('XML from uri (attribute)')
     value: Joi.string().regex(/^\d+$/)
   }));
 
+t.create('XML from uri | multiple results')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//name')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'custom badge',
+    value: Joi.string().regex(/^.+,\s.+$/)
+  }));
+
 t.create('XML from uri | caching with new query params')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/version')
   .expectJSONTypes(Joi.object().keys({
@@ -65,7 +72,7 @@ t.create('XML from uri | invalid uri')
   .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
 
 t.create('XML from uri | user color overrides default')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//name&colorB=10ADED&style=_shields_test')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&colorB=10ADED&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: '#10ADED' });
 
 t.create('XML from uri | error color overrides default')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -15,70 +15,74 @@ const t = new ServiceTester({ id: 'dynamic-xml', title: 'User Defined XML Source
 module.exports = t;
 
 t.create('Connection error')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&label=Package Name&style=_shields_test')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&label=Package Name&style=_shields_test')
   .networkOff()
   .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.red });
 
-t.create('No URI specified')
+t.create('No URL specified')
   .get('.json?query=//name&label=Package Name&style=_shields_test')
-  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
+  .expectJSON({ name: 'Package Name', value: 'no url specified', colorB: colorsB.red });
 
 t.create('No query specified')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&label=Package Name&style=_shields_test')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&label=Package Name&style=_shields_test')
   .expectJSON({ name: 'Package Name', value: 'no query specified', colorB: colorsB.red });
 
-t.create('XML from uri')
+t.create('XML from url')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: colorsB.brightgreen });
+
+t.create('XML from uri (support uri query paramater)')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: colorsB.brightgreen });
 
-t.create('XML from uri (attribute)')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/reviews/@num')
+t.create('XML from url (attribute)')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/reviews/@num')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom badge',
     value: Joi.string().regex(/^\d+$/)
   }));
 
-t.create('XML from uri | multiple results')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/compatible_applications/application/name')
+t.create('XML from url | multiple results')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/compatible_applications/application/name')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom badge',
     value: Joi.string().regex(/^Firefox( for Android)?,\sFirefox( for Android)?$/)
   }));
 
-t.create('XML from uri | caching with new query params')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/version')
+t.create('XML from url | caching with new query params')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/version')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom badge',
     value: isSemver
   }));
 
-t.create('XML from uri | with prefix & suffix & label')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//version&prefix=v&suffix= dev&label=IndieGala Helper')
+t.create('XML from url | with prefix & suffix & label')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//version&prefix=v&suffix= dev&label=IndieGala Helper')
   .expectJSONTypes(Joi.object().keys({
     name: 'IndieGala Helper',
     value: Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?\sdev$/)
   }));
 
-t.create('XML from uri | query doesnt exist')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/does/not/exist&style=_shields_test')
+t.create('XML from url | query doesnt exist')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/does/not/exist&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'no result', colorB: colorsB.lightgrey });
 
-t.create('XML from uri | query doesnt exist (attribute)')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/does/not/@exist&style=_shields_test')
+t.create('XML from url | query doesnt exist (attribute)')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/does/not/@exist&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'no result', colorB: colorsB.lightgrey });
 
-t.create('XML from uri | invalid uri')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
+t.create('XML from url | invalid url')
+  .get('.json?url=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
-t.create('XML from uri | user color overrides default')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&colorB=10ADED&style=_shields_test')
+t.create('XML from url | user color overrides default')
+  .get('.json?url=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&colorB=10ADED&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: '#10ADED' });
 
-t.create('XML from uri | error color overrides default')
-  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
+t.create('XML from url | error color overrides default')
+  .get('.json?url=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
-t.create('XML from uri | error color overrides user specified')
+t.create('XML from url | error color overrides user specified')
   .get('.json?query=//version&colorB=10ADED&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.red });
+  .expectJSON({ name: 'custom badge', value: 'no url specified', colorB: colorsB.red });

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -69,7 +69,7 @@ t.create('XML from uri | query doesnt exist (attribute)')
 
 t.create('XML from uri | invalid uri')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
 t.create('XML from uri | user color overrides default')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&colorB=10ADED&style=_shields_test')
@@ -77,7 +77,7 @@ t.create('XML from uri | user color overrides default')
 
 t.create('XML from uri | error color overrides default')
   .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
-  .expectJSON({ name: 'custom badge', value: 'uri not found', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'custom badge', value: 'resource not found', colorB: colorsB.lightgrey });
 
 t.create('XML from uri | error color overrides user specified')
   .get('.json?query=//version&colorB=10ADED&style=_shields_test')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -19,6 +19,10 @@ t.create('No URI specified')
   .get('.json?query=//name&label=Package Name&style=_shields_test')
   .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
 
+t.create('No query specified')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&label=Package Name&style=_shields_test')
+  .expectJSON({ name: 'Package Name', value: 'no query specified', colorB: colorsB.red });
+
 t.create('XML from uri')
   .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: colorsB.brightgreen });

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -11,7 +11,7 @@ const mapValues = require('lodash.mapvalues');
 
 const colorsB = mapValues(colorscheme, 'colorB');
 
-const t = new ServiceTester({ id: 'badge/dynamic/xml', title: 'User Defined XML Source Data' });
+const t = new ServiceTester({ id: 'dynamic-xml', title: 'User Defined XML Source Data', pathPrefix: '/badge/dynamic/xml' });
 module.exports = t;
 
 t.create('Connection error')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -39,10 +39,10 @@ t.create('XML from uri (attribute)')
   }));
 
 t.create('XML from uri | multiple results')
-  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//name')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/compatible_applications/application/name')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom badge',
-    value: Joi.string().regex(/^.+,\s.+$/)
+    value: Joi.string().regex(/^Firefox( for Android)?,\sFirefox( for Android)?$/)
   }));
 
 t.create('XML from uri | caching with new query params')

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+const colorscheme = require('../lib/colorscheme.json');
+const mapValues = require('lodash.mapvalues');
+
+const colorsB = mapValues(colorscheme, 'colorB');
+
+const t = new ServiceTester({ id: 'badge/dynamic/xml', title: 'User Defined XML Source Data' });
+module.exports = t;
+
+t.create('Connection error')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&label=Package Name&style=_shields_test')
+  .networkOff()
+  .expectJSON({ name: 'Package Name', value: 'inaccessible', colorB: colorsB.lightgrey });
+
+t.create('No URI specified')
+  .get('.json?query=//name&label=Package Name&style=_shields_test')
+  .expectJSON({ name: 'Package Name', value: 'no uri specified', colorB: colorsB.red });
+
+t.create('XML from uri')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/name&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: colorsB.brightgreen });
+
+t.create('XML from uri | caching with new query params')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/addon/version')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'custom badge',
+    value: Joi.string().regex(/^\d+(\.\d+)?(\.\d+)?$/)
+  }));
+
+t.create('XML from uri | with prefix & suffix & label')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//version&prefix=v&suffix= dev&label=Shields')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'Shields',
+    value: Joi.string().regex(/^v\d+(\.\d+)?(\.\d+)?\sdev$/)
+  }));
+
+t.create('XML from uri | object doesnt exist')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=/does/not/exist&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'no result', colorB: colorsB.lightgrey });
+
+t.create('XML from uri | invalid uri')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+
+t.create('XML from uri | user color overrides default')
+  .get('.json?uri=https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078&query=//name&colorB=10ADED&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'IndieGala Helper', colorB: '#10ADED' });
+
+t.create('XML from uri | error color overrides default')
+  .get('.json?uri=https://github.com/badges/shields/raw/master/notafile.xml&query=//version&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'invalid resource', colorB: colorsB.lightgrey });
+
+t.create('XML from uri | error color overrides user specified')
+  .get('.json?query=//version&colorB=10ADED&style=_shields_test')
+  .expectJSON({ name: 'custom badge', value: 'no uri specified', colorB: colorsB.red });


### PR DESCRIPTION
Continuation of #820
## Description:
This PR Adds XML support to the dynamic badges.
**Other:**
_added a test for query param specified_
_changed `uri` param to `url` (`uri` still supported)_

## To do:
- [x] Add tests
- [x] Add support for multiple results
- [x] Update front end dynamic badge generator

## Examples:
_[All examples based on this XML](https://services.addons.mozilla.org/en-US/firefox/api/1.5/addon/707078)_

`?query=` param | badge
:-- | :--
`/addon/name` | ![](https://img.shields.io/:name-IndieGala%20Helper-brightgreen.svg)
`/addon/@id` | ![](https://img.shields.io/:ID-707078-brightgreen.svg)
`//version` | ![](https://img.shields.io/:version-4.5.1-brightgreen.svg)
`/addon/reviews/@num` | ![](https://img.shields.io/:total%20reviews-7-brightgreen.svg)
`//daily_users` | ![](https://img.shields.io/:daily%20users-160-brightgreen.svg)


## Usage:
`?a=b` params | Usage | Example | Example Badge
:--: | :-- | :-- | :--:
`uri` (required) | Address where json is located | `uri=http://path.to.json` | ![](https://img.shields.io/:Custom%20Badge-1.2.3-brightgreen.svg)
`query` (required) | [JSONpath expression](https://www.npmjs.com/package/jsonpath#jsonpath-syntax) | `query=$.version` | ![](https://img.shields.io/:Custom%20Badge-1.2.3-brightgreen.svg)
`label` |  Left hand side text | `label=ProjectX` | ![](https://img.shields.io/:ProjectX-1.2.3-brightgreen.svg)
`colorB` | Hex color of background for right hand side | `colorB=10ADED` | ![](https://img.shields.io/:Custom%20Badge-1.2.3-10ADED.svg)
`prefix` | Prefix for right hand text | `prefix=v` | ![](https://img.shields.io/:Custom%20Badge-v1.2.3-brightgreen.svg)
`suffix` | Suffix for right hand text | `suffix=%20dev` | ![](https://img.shields.io/:Custom%20Badge-1.2.3%20dev-brightgreen.svg)
`logo` | Logo for badge | `logo=twitter` | ![](https://img.shields.io/:Custom%20Badge-1.2.3-brightgreen.svg?logo=twitter)
`style` | Badge style | `style=for-the-badge` | ![](https://img.shields.io/:Custom%20Badge-1.2.3-brightgreen.svg?style=for-the-badge)