### PR TITLE
[hackage] switch to the `/licenses` endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -3308,7 +3308,7 @@ camp.route(/^\/hackage-deps\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   const repo = match[1];  // eg, `lens`.
   const format = match[2];
-  const reverseUrl = 'http://packdeps.haskellers.com/reverse/' + repo;
+  const reverseUrl = 'http://packdeps.haskellers.com/licenses/' + repo;
   const feedUrl = 'http://packdeps.haskellers.com/feed/' + repo;
   const badgeData = getBadgeData('dependencies', data);
 

--- a/server.js
+++ b/server.js
@@ -3292,7 +3292,7 @@ cache(function(data, match, sendBadge, request) {
       // We don't have to check length of versionLines, because if we throw,
       // we'll render the 'invalid' badge below, which is the correct thing
       // to do.
-      var version = versionLines[0].replace(/\s+/, '').split(/:/)[1];
+      var version = versionLines[0].split(/:/)[1].trim();
       badgeData.text[1] = versionText(version);
       badgeData.colorscheme = versionColor(version);
       sendBadge(format, badgeData);


### PR DESCRIPTION
Closes #1498

Switch to the `/licenses` endpoint to see if the package exists on the `hackage-deps` badge.

Unrelated: one of the other hackage tests failed due to some trailing whitespace on a version number, so I've also added a fix for that.