### PR TITLE
README.md add logos to badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
         <img src="https://img.shields.io/github/last-commit/badges/shields/gh-pages.svg?label=last%20deployed"
             alt="last deployed"></a>
     <a href="https://discord.gg/HjJCwm5">
-        <img src="https://img.shields.io/discord/308323056592486420.svg"
+        <img src="https://img.shields.io/discord/308323056592486420.svg?logo=discord"
             alt="chat on Discord"></a>
     <a href="https://twitter.com/intent/follow?screen_name=shields_io">
-        <img src="https://img.shields.io/twitter/follow/shields_io.svg?style=social"
+        <img src="https://img.shields.io/twitter/follow/shields_io.svg?style=social&logo=twitter"
             alt="follow on Twitter"></a>
 </p>
 


### PR DESCRIPTION
Adds logos to the discord & twitter badges in README.md
![image](https://user-images.githubusercontent.com/7288322/36284789-f0fa7012-130d-11e8-9af1-f8c85891a2bb.png)
![image](https://user-images.githubusercontent.com/7288322/36284858-3b058c0a-130e-11e8-8630-d00cf03640ce.png)



The social badge by default does have a logo, but the current live badges exclude the logo on social badges (fixed in #1456)