### PR TITLE
[Bitbucket] #1509 - Add Bitbucket Pipelines service

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -213,6 +213,14 @@ const allBadgeExamples = [
         previewUri: '/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
       },
       {
+        title: 'Bitbucket Pipelines',
+        previewUri: '/bitbucket/pipelines/atlassian/adf-builder-javascript.svg'
+      },
+      {
+        title: 'Bitbucket Pipelines branch',
+        previewUri: '/bitbucket/pipelines/atlassian/adf-builder-javascript/task/SECO-2168.svg'
+      },
+      {
         title: 'Coveralls github',
         previewUri: '/coveralls/github/jekyll/jekyll.svg'
       },

--- a/server.js
+++ b/server.js
@@ -4458,6 +4458,75 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// Bitbucket Pipelines integration.
+camp.route(/^\/bitbucket\/pipelines\/([^/]+)\/([^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var user = match[1];  // eg, atlassian
+  var repo = match[2];  // eg, adf-builder-javascript
+  var branch = match[3] || 'master';  // eg, development
+  var format = match[4];
+  var apiUrl = 'https://api.bitbucket.org/2.0/repositories/'
+    + encodeURIComponent(user) + '/' + encodeURIComponent(repo)
+    + '/pipelines/?fields=values.state&page=1&pagelen=2&sort=-created_on'
+    + '&target.ref_type=BRANCH&target.ref_name=' + encodeURIComponent(branch);
+
+  var badgeData = getBadgeData('build', data);
+
+  request(apiUrl, function(err, res, buffer) {
+    if (err != null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      if (res.statusCode !== 200) {
+        throw Error('Failed to get build results');
+      }
+      var data = JSON.parse(buffer);
+      if (!data.values) {
+        throw Error('Unexpected response');
+      }
+      var values = data.values.filter(value => value.state && value.state.name === 'COMPLETED');
+      if (values.length > 0) {
+        switch (values[0].state.result.name) {
+          case 'SUCCESSFUL':
+            badgeData.text[1] = 'passing';
+            badgeData.colorscheme = 'brightgreen';
+            break;
+          case 'FAILED':
+            badgeData.text[1] = 'failing';
+            badgeData.colorscheme = 'red';
+            break;
+          case 'ERROR':
+            badgeData.text[1] = 'error';
+            badgeData.colorscheme = 'red';
+            break;
+          case 'STOPPED':
+            badgeData.text[1] = 'stopped';
+            badgeData.colorscheme = 'yellow';
+            break;
+          case 'EXPIRED':
+            badgeData.text[1] = 'expired';
+            badgeData.colorscheme = 'yellow';
+            break;
+          default:
+            badgeData.text[1] = 'unknown';
+        }
+      } else {
+        badgeData.text[1] = 'never built';
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      if (res.statusCode === 404) {
+        badgeData.text[1] = 'not found';
+      } else {
+        badgeData.text[1] = 'invalid';
+      }
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Chef cookbook integration.
 camp.route(/^\/cookbook\/v\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {


### PR DESCRIPTION
Adding support for Bitbucket Pipelines builds: #1509 . 

The format is the same as for the other Bitbucket badges:
`/bitbucket/pipelines/<user>/<repo>.svg`
and
`/bitbucket/pipelines/<user>/<repo>/<branch>.svg`

The implementation is looking at the last completed build result (ignoring builds that are about to start or in progress). It supports all current Pipelines result states:

- passing
- failing
- error
- stopped
- expired

The tests cover 100% of the added lines.

Let me know what you think, thanks a lot!