### PR TITLE
Add SF UI Display as default font on Apple devices

### DIFF
--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -3,7 +3,7 @@
     <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
     <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
   </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+  <g fill="#fff" text-anchor="middle" font-family="SF UI Display,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -14,7 +14,7 @@
     <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
   </g>
 
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+  <g fill="#fff" text-anchor="middle" font-family="SF UI Display,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}

--- a/templates/for-the-badge-template.svg
+++ b/templates/for-the-badge-template.svg
@@ -3,7 +3,7 @@
     <rect width="{{=it.widths[0]}}" height="28" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>
     <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="28" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
   </g>
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
+  <g fill="#fff" text-anchor="middle" font-family="SF UI Display,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="100">
     {{?it.logo}}
       <image x="9" y="7" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -16,7 +16,7 @@
     <rect width="{{=it.widths[0]+it.widths[1]}}" height="18" fill="url(#smooth)"/>
   </g>
 
-  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+  <g fill="#fff" text-anchor="middle" font-family="SF UI Display,DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
       <image x="5" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}


### PR DESCRIPTION
macOS and iOS devices have the new San Francisco fonts as a default. This PR adds it before DejaVu Sans on all SVG templates, so the badges render with the default system fonts on all Apple devices.