### PR TITLE
Uncaught TypeError crashes server on numeric or boolean 'link' parameter

### DIFF
--- a/lib/make-badge.js
+++ b/lib/make-badge.js
@@ -67,12 +67,17 @@ templateFiles.forEach(function(filename) {
 });
 
 function escapeXml(s) {
-  return s.replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/"/g, '&quot;')
-          .replace(/'/g, '&apos;');
+  if (s === undefined || typeof s !== 'string') {
+    return undefined;
+  } else {
+    return s.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&apos;');
+  }
 }
+
 function capitalize(s) {
   return s[0].toUpperCase() + s.slice(1);
 }

--- a/server.spec.js
+++ b/server.spec.js
@@ -60,6 +60,32 @@ describe('The server', function () {
       });
   });
 
+  it('should not crash with a numeric link', function () {
+    return fetch(`${baseUri}/:fruit-apple-green.svg?link=1`)
+      .then(res => {
+        expect(res.ok).to.be.true;
+        return res.text();
+      }).then(text => {
+        expect(text)
+          .to.satisfy(isSvg)
+          .and.to.include('fruit')
+          .and.to.include('apple');
+      });
+  });
+
+  it('should not crash with a boolean link', function () {
+    return fetch(`${baseUri}/:fruit-apple-green.svg?link=true`)
+      .then(res => {
+        expect(res.ok).to.be.true;
+        return res.text();
+      }).then(text => {
+        expect(text)
+          .to.satisfy(isSvg)
+          .and.to.include('fruit')
+          .and.to.include('apple');
+      });
+  });
+
   context('with svg2img error', function () {
     const expectedError = fs.readFileSync(path.resolve(__dirname, 'public', '500.html'));
 


### PR DESCRIPTION
Our fuzzer found a TypeError triggered by:

`http://localhost:8080/circleci/project/github/RedSparr0w/node-csgo-parser.svg?link=1`
`http://localhost:8080/circleci/project/github/RedSparr0w/node-csgo-parser.svg?link=true`

```
0222045033 Vendor hook error: TypeError: s.replace is not a function
    at escapeXml (/home/fuzzstati0n/shields/lib/make-badge.js:71:12)
    at Array.map (<anonymous>)
    at makeBadge (/home/fuzzstati0n/shields/lib/make-badge.js:157:18)
    at data (/home/fuzzstati0n/shields/lib/make-badge.js:174:40)
    at sendBadge (/home/fuzzstati0n/shields/lib/request-handler.js:193:23)
    at /home/fuzzstati0n/shields/server.js:5961:7
    at Request.request [as _callback] (/home/fuzzstati0n/shields/lib/request-handler.js:166:9)
    at Request.self.callback (/home/fuzzstati0n/shields/node_modules/request/request.js:186:22)
    at emitTwo (events.js:126:13)
    at Request.emit (events.js:214:7)
```
