### PR TITLE
[gratipay gemnasium snap-ci cauditor] add deprecation helpers, deprecate gemnasium

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1264,10 +1264,6 @@ const allBadgeExamples = [
         previewUri: '/bithound/code/github/rexxars/sse-channel.svg'
       },
       {
-        title: 'Gemnasium',
-        previewUri: '/gemnasium/mathiasbynens/he.svg'
-      },
-      {
         title: 'Hackage-Deps',
         previewUri: '/hackage-deps/v/lens.svg'
       },

--- a/lib/deprecated-services.js
+++ b/lib/deprecated-services.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const deprecatedServices = {
+  'gittip': new Date('2017-12-29'),
+  'gratipay': new Date('2017-12-29'),
+  'gemnasium': new Date('2018-05-15'),
+  'snap': new Date('2018-01-23'),
+  'snap-ci': new Date('2018-01-23'),
+  'cauditor': new Date('2018-02-15'),
+};
+
+module.exports = {
+  deprecatedServices
+}

--- a/lib/deprecation-helpers.js
+++ b/lib/deprecation-helpers.js
@@ -15,10 +15,7 @@ const isDeprecated = function (service, now=new Date(), depServices=deprecatedSe
   if (!(service in depServices)) {
     return false;
   }
-  if (now.getTime() >= depServices[service].getTime()) {
-    return true;
-  }
-  return false;
+  return now.getTime() >= depServices[service].getTime();
 };
 
 const getDeprecatedBadge = function (label, data) {

--- a/lib/deprecation-helpers.js
+++ b/lib/deprecation-helpers.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { makeBadgeData } = require('./badge-data');
+
+const deprecatedServices = {
+  'gittip': new Date('2017-12-29'),
+  'gratipay': new Date('2017-12-29'),
+  'gemnasium': new Date('2018-05-15'),
+  'snap': new Date('2018-01-23'),
+  'snap-ci': new Date('2018-01-23'),
+  'cauditor': new Date('2018-02-15'),
+};
+
+const isDeprecated = function (service, now=new Date(), depServices=deprecatedServices) {
+  if (!(service in depServices)) {
+    return false;
+  }
+  if (now.getTime() >= depServices[service].getTime()) {
+    return true;
+  }
+  return false;
+};
+
+const getDeprecatedBadge = function (label, data) {
+  const badgeData = makeBadgeData(label, data);
+  badgeData.colorscheme = 'lightgray';
+  badgeData.text[1] = 'no longer available';
+  return badgeData;
+};
+
+module.exports = {
+  isDeprecated,
+  getDeprecatedBadge,
+};

--- a/lib/deprecation-helpers.js
+++ b/lib/deprecation-helpers.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { makeBadgeData } = require('./badge-data');
+const { makeBadgeData, setBadgeColor } = require('./badge-data');
 
 const deprecatedServices = {
   'gittip': new Date('2017-12-29'),
@@ -20,7 +20,7 @@ const isDeprecated = function (service, now=new Date(), depServices=deprecatedSe
 
 const getDeprecatedBadge = function (label, data) {
   const badgeData = makeBadgeData(label, data);
-  badgeData.colorscheme = 'lightgray';
+  setBadgeColor(badgeData, 'lightgray');
   badgeData.text[1] = 'no longer available';
   return badgeData;
 };

--- a/lib/deprecation-helpers.js
+++ b/lib/deprecation-helpers.js
@@ -1,15 +1,7 @@
 'use strict';
 
 const { makeBadgeData, setBadgeColor } = require('./badge-data');
-
-const deprecatedServices = {
-  'gittip': new Date('2017-12-29'),
-  'gratipay': new Date('2017-12-29'),
-  'gemnasium': new Date('2018-05-15'),
-  'snap': new Date('2018-01-23'),
-  'snap-ci': new Date('2018-01-23'),
-  'cauditor': new Date('2018-02-15'),
-};
+const { deprecatedServices } = require('./deprecated-services');
 
 const isDeprecated = function (service, now=new Date(), depServices=deprecatedServices) {
   if (!(service in depServices)) {

--- a/lib/deprecation-helpers.spec.js
+++ b/lib/deprecation-helpers.spec.js
@@ -11,6 +11,11 @@ describe('Deprecated Badge Helper', function() {
     expect(badge.text[1]).to.equal('no longer available');
     expect(badge.colorscheme).to.equal('lightgray');
   });
+
+  it('ignores colorB param', function() {
+    const badge = getDeprecatedBadge('foo', {colorB: 'fedcba'});
+    expect(badge.colorscheme).to.equal('lightgray');
+  });
 });
 
 describe('isDeprecated function', function () {

--- a/lib/deprecation-helpers.spec.js
+++ b/lib/deprecation-helpers.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { assert } = require('chai');
+const { test, given } = require('sazerac');
+const { isDeprecated, getDeprecatedBadge } = require('./deprecation-helpers');
+
+describe('Deprecated Badge Helper', function() {
+  it('makes "no longer available" badge', function() {
+    const badge = getDeprecatedBadge('foo', {});
+    assert.equal('foo', badge.text[0]);
+    assert.equal('no longer available', badge.text[1]);
+    assert.equal('lightgray', badge.colorscheme);
+  });
+});
+
+describe('isDeprecated function', function () {
+  test(isDeprecated, function () {
+
+    given('fooservice', new Date(), {}).expect(false);
+
+    given(
+      'fooservice',
+      new Date('2001-01-11 23:59:00'),
+      {'fooservice': new Date('2001-01-12')}
+    ).expect(false);
+
+    given(
+      'fooservice',
+      new Date('2001-01-12 00:00:01'),
+      {'fooservice': new Date('2001-01-12')}
+    ).expect(true);
+
+  });
+});

--- a/lib/deprecation-helpers.spec.js
+++ b/lib/deprecation-helpers.spec.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const { assert } = require('chai');
+const { expect } = require('chai');
 const { test, given } = require('sazerac');
 const { isDeprecated, getDeprecatedBadge } = require('./deprecation-helpers');
 
 describe('Deprecated Badge Helper', function() {
   it('makes "no longer available" badge', function() {
     const badge = getDeprecatedBadge('foo', {});
-    assert.equal('foo', badge.text[0]);
-    assert.equal('no longer available', badge.text[1]);
-    assert.equal('lightgray', badge.colorscheme);
+    expect(badge.text[0]).to.equal('foo');
+    expect(badge.text[1]).to.equal('no longer available');
+    expect(badge.colorscheme).to.equal('lightgray');
   });
 });
 

--- a/server.js
+++ b/server.js
@@ -8,6 +8,7 @@ const queryString = require('query-string');
 const semver = require('semver');
 const xml2js = require('xml2js');
 
+const { isDeprecated, getDeprecatedBadge } = require('./lib/deprecation-helpers');
 const { checkErrorResponse } = require('./lib/error-helper');
 const analytics = require('./lib/analytics');
 const config = require('./lib/server-config');
@@ -1094,12 +1095,10 @@ cache(function(data, match, sendBadge, request) {
 camp.route(/^\/(?:gittip|gratipay(\/user|\/team|\/project)?)\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(queryParams, match, sendBadge, request) {
   const format = match[3];
-  const badgeData = getBadgeData('gratipay', queryParams);
+  const badgeData = getDeprecatedBadge('gratipay', queryParams);
   if (badgeData.template === 'social') {
     badgeData.logo = getLogo('gratipay', queryParams);
   }
-  badgeData.colorscheme = 'lightgray';
-  badgeData.text[1] = 'no longer available';
   sendBadge(format, badgeData);
 }));
 
@@ -2995,6 +2994,13 @@ camp.route(/^\/gemnasium\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var userRepo = match[1];  // eg, `jekyll/jekyll`.
   var format = match[2];
+
+  if (isDeprecated('gemnasium', serverStartTime)) {
+    const badgeData = getDeprecatedBadge('gemnasium', data);
+    sendBadge(format, badgeData);
+    return;
+  }
+
   var options = 'https://gemnasium.com/' + userRepo + '.svg';
   var badgeData = getBadgeData('dependencies', data);
   request(options, function(err, res, buffer) {
@@ -6364,9 +6370,7 @@ cache(function(data, match, sendBadge, request) {
 camp.route(/^\/snap(-ci?)\/([^/]+\/[^/]+)(?:\/(.+))\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   const format = match[4];
-  const badgeData = getBadgeData('snap CI', data);
-  badgeData.colorscheme = 'lightgray';
-  badgeData.text[1] = 'no longer available';
+  const badgeData = getDeprecatedBadge('snap CI', data);
   sendBadge(format, badgeData);
 }));
 
@@ -6855,9 +6859,7 @@ cache(function(data, match, sendBadge, request) {
 camp.route(/^\/cauditor\/(mi|ccn|npath|hi|i|ca|ce|dit)\/([^/]+)\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   const format = match[5];
-  const badgeData = getBadgeData('cauditor', data);
-  setBadgeColor(badgeData, 'lightgray');
-  badgeData.text[1] = 'no longer available';
+  const badgeData = getDeprecatedBadge('cauditor', data);
   sendBadge(format, badgeData);
 }));
 

--- a/service-tests/gemnasium.js
+++ b/service-tests/gemnasium.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const ServiceTester = require('./runner/service-tester');
+const { expect } = require('chai')
+
+const { isDeprecated } = require('../lib/deprecation-helpers');
+
+const t = new ServiceTester({ id: 'gemnasium', title: 'gemnasium' });
+module.exports = t;
+
+
+t.create('no longer available (previously dependencies)')
+  .get('/mathiasbynens/he.json')
+  .afterJSON(function(badge) {
+    if (isDeprecated('gemnasium')) {
+      expect(badge.name).to.equal('gemnasium');
+      expect(badge.value).to.equal('no longer available');
+    } else {
+      expect(badge.name).to.equal('dependencies');
+    }
+  });


### PR DESCRIPTION
As noted in #1523 gemnasium will shut down their service on May 15th.

I'm not suggesting merging this now, but once that happens, this can be merged to replace the badge with an error.

Also refs #1449 - if I need to update based on that I will do :)