### PR TITLE
[badge-json] new "badge-json" service

### DIFF
--- a/frontend/components/json-badge-maker.js
+++ b/frontend/components/json-badge-maker.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { jsonBadgeUrl } from '../lib/badge-url';
+
+export default class JsonBadgeMaker extends React.Component {
+  static propTypes = {
+    baseUri: PropTypes.string,
+  };
+
+  state = {
+    url: ''
+  };
+
+  handleSubmit (e) {
+    e.preventDefault();
+
+    const { baseUri } = this.props;
+    const { url } = this.state;
+    const badgeUri = jsonBadgeUrl(baseUri || window.location.href, url);
+
+    document.location = badgeUri;
+  }
+
+  render() {
+    return (
+      <form onSubmit={e => this.handleSubmit(e)}>
+        <input
+          className="medium"
+          value={this.state.url}
+          onChange={event => this.setState({ url: event.target.value })}
+          placeholder="url" /> {}
+        <button>Make Badge</button>
+      </form>
+    );
+  }
+}

--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -2,6 +2,7 @@ import { Fragment, default as React } from 'react';
 import PropTypes from 'prop-types';
 import StaticBadgeMaker from './static-badge-maker';
 import DynamicBadgeMaker from './dynamic-badge-maker';
+import JsonBadgeMaker from './json-badge-maker';
 import { staticBadgeUrl } from '../lib/badge-url';
 import { advertisedStyles } from '../../lib/supported-features';
 
@@ -114,7 +115,73 @@ export default class Usage extends React.PureComponent {
           </tbody>
         </table>
 
+        <p>Where color is one of these named colors, or hex (xxxxxx)
+        </p>
         { this.renderColorExamples() }
+
+        <hr />
+
+        <h3 id="badge-json">Badge JSON</h3>
+        <JsonBadgeMaker baseUri={baseUri} />
+
+        <p>
+          <code>
+            {baseUri}/json/&lt;URL&gt;.svg
+          </code><br />
+          (&lt;URL&gt; must be url-encoded)
+        </p>
+
+        <p>Your service/website can speak badge by serving badge-json</p>
+
+        <p>badge-json is a simple object with the following properties/values.<br />
+          All Values are optional except for <code>label</code> and <code>value</code>
+        </p>
+
+        <table>
+          <caption>Properties specified in JSON (* = required)</caption>
+          <tbody>
+            <tr>
+              <td><code>label</code> *</td>
+              <td>left-hand-side text</td>
+            </tr>
+            <tr>
+              <td><code>value</code> *</td>
+              <td>right-hand-side text</td>
+            </tr>
+            <tr>
+              <td><code>valueClass</code></td>
+              <td>one of &quot;error&quot;, &quot;notice&quot;, &quot;success&quot;, &quot;info&quot;, or &quot;default&quot;</td>
+            </tr>
+            <tr>
+              <td><code>isSocial</code></td>
+              <td>(boolean) default = <code>false</code>.  If true, will get &quot;social&quot; style by default</td>
+            </tr>
+            <tr>
+              <td style={{verticalAlign:'top'}}><code>logo</code></td>
+              <td>
+                one of:
+                <ul>
+                  <li><a href="https://github.com/badges/shields/tree/gh-pages/logo">named logo</a></li>
+                  <li>data-uri: <code>data:image/png;base64,…</code></li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <td><code>logoWidth</code></td>
+              <td>Set the horizontal space to give to the logo</td>
+            </tr>
+            <tr>
+              <td><code>colorA</code></td>
+              <td>background color of the left part (overrides <code>valueClass</code> color scheme)</td>
+            </tr>
+            <tr>
+              <td><code>colorB</code></td>
+              <td>background color of the right part (overrides <code>valueClass</code> color scheme)</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <hr />
 
         <h3 id="dynamic-badge">Dynamic</h3>
 
@@ -124,17 +191,10 @@ export default class Usage extends React.PureComponent {
           <code>/badge/dynamic/&lt;TYPE&gt;.svg?uri=&lt;URI&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
         </p>
 
-        <hr className="spacing" />
-
-        <h2 id="styles">Styles</h2>
+        <h2 id="parameters">Parameters</h2>
 
         <p>
-          The following styles are available (flat is the default as of Feb 1st 2015):
-        </p>
-        { this.renderStyleExamples() }
-
-        <p>
-          Here are a few other parameters you can use: (connecting several with "&" is possible)
+          Optional parameters you can use: (connecting several with "&" is possible)
         </p>
         <table>
           <tbody>
@@ -198,8 +258,26 @@ export default class Usage extends React.PureComponent {
               </td>
               <td>Set the HTTP cache lifetime in secs</td>
             </tr>
+            <tr>
+              <td style={{verticalAlign:'top'}}>
+                <code>?style=flat</code>
+              </td>
+              <td>
+                Specify the badge style.<br />
+                One of : &quot;plastic&quot;, &quot;flat&quot;, &quot;flat-square&quot;, &quot;for-the-badge&quot;, or &quot;social&quot;
+              </td>
+            </tr>
           </tbody>
         </table>
+
+        <h3 id="styles">Styles</h3>
+
+        <p>
+          The following styles are available (flat is the default as of Feb 1st 2015):
+        </p>
+        { this.renderStyleExamples() }
+
+        <hr className="spacing" />
 
         <p>
           We support <code>.svg</code>, <code>.json</code>, <code>.png</code> and a

--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -122,16 +122,28 @@ export default class Usage extends React.PureComponent {
         <hr />
 
         <h3 id="badge-json">Badge JSON</h3>
+
+        <p>Your service/website can speak badge by serving badge-json</p>
+
         <JsonBadgeMaker baseUri={baseUri} />
 
         <p>
           <code>
             {baseUri}/json/&lt;URL&gt;.svg
-          </code><br />
-          (&lt;URL&gt; must be url-encoded)
+          </code>
         </p>
 
-        <p>Your service/website can speak badge by serving badge-json</p>
+        <table>
+          <tbody>
+            <tr>
+              <td style={{verticalAlign:'top'}}><code>&lt;URL&gt;</code></td>
+              <td>
+                URL that provides badge-json<br />
+                must be url-encoded (above tool will url-encode for you)
+              </td>
+            </tr>
+          </tbody>
+        </table>
 
         <p>badge-json is a simple object with the following properties/values.<br />
           All Values are optional except for <code>label</code> and <code>value</code>
@@ -191,10 +203,33 @@ export default class Usage extends React.PureComponent {
           <code>/badge/dynamic/&lt;TYPE&gt;.svg?uri=&lt;URI&gt;&amp;label=&lt;LABEL&gt;&amp;query=&lt;<a href="https://www.npmjs.com/package/jsonpath" target="_BLANK" title="JSONdata syntax">$.DATA.SUBDATA</a>&gt;&amp;colorB=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;</code>
         </p>
 
+        <table>
+          <caption>Notes</caption>
+          <tbody>
+            <tr>
+              <td style={{verticalAlign:'top'}}><code>query</code></td>
+              <td>
+                Path to value in the json.<br />
+                (see <a href="https://www.npmjs.com/package/jsonpath">https://www.npmjs.com/package/jsonpath</a>)
+              </td>
+            </tr>
+            <tr>
+              <td><code>prefix</code></td>
+              <td>prepended to value</td>
+            </tr>
+            <tr>
+              <td><code>suffix</code></td>
+              <td>appended to value</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <hr />
+
         <h2 id="parameters">Parameters</h2>
 
         <p>
-          Optional parameters you can use: (connecting several with "&" is possible)
+          All badges accept optional parameters: (connecting several with "&" is possible)
         </p>
         <table>
           <tbody>

--- a/frontend/lib/badge-url.js
+++ b/frontend/lib/badge-url.js
@@ -45,3 +45,8 @@ export function dynamicJsonBadgeUrl(baseUrl, label, jsonUrl, query, options = {}
 
   return resolveBadgeUrl('/badge/dynamic/json.svg', baseUrl, outOptions);
 }
+
+export function jsonBadgeUrl(baseUrl, url) {
+  const path = encodeURIComponent(url);
+  return resolveUrl(`/json/${path}.svg`, baseUrl, {});
+}

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -49,7 +49,7 @@ const websiteDoc = `
 </p>
 <p>
   <code>[OPTIONS]</code> can be:
-  <ul>
+  <ul class="options">
     <li>
       Nothing:&nbsp;
       <code>…/website/…</code>
@@ -2141,7 +2141,7 @@ const allBadgeExamples = [
   },
   {
     category: {
-      id: 'miscellaneous',
+      id: 'miscellaneous2',
       name: 'Longer Miscellaneous'
     },
     examples: [

--- a/service-tests/badge-json.js
+++ b/service-tests/badge-json.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+const { invalidJSON } = require('./helpers/response-fixtures');
+
+const t = new ServiceTester({ id: 'badge-json', title: 'badge json', pathPrefix: '/json' });
+
+module.exports = t;
+
+t.create('invalid urlencoding')
+  .get('/http%3A%2F%test.com%2Fbadge.json.json')
+  .expectJSON({name: 'badge json', value: 'invalid'});
+
+t.create('connection error')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
+  .networkOff()
+  .expectJSON({name: 'badge json', value: 'inaccessible'});
+
+t.create('unexpected response')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(invalidJSON)
+  )
+  .expectJSON({name: 'badge json', value: 'invalid'});
+
+t.create('invalid badge json')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(function() {
+      return [
+        200,
+        '{}',
+        { 'Content-Type': 'application/json' }
+      ];
+    })
+  )
+  .expectJSON({name: 'badge json', value: 'invalid badge-json'});
+
+t.create('label & value')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(function() {
+      return [
+        200,
+        '{"label":"test","value":"success"}',
+        { 'Content-Type': 'application/json' }
+      ];
+    })
+  )
+  .expectJSON({name: 'test', value: 'success'});

--- a/service-tests/badge-json.js
+++ b/service-tests/badge-json.js
@@ -6,6 +6,17 @@ const { invalidJSON } = require('./helpers/response-fixtures');
 
 const t = new ServiceTester({ id: 'badge-json', title: 'badge json', pathPrefix: '/json' });
 
+function genJsonResponse(obj) {
+  return function() {
+    return [
+      200,
+      JSON.stringify(obj),
+      { 'Content-Type': 'application/json' }
+    ];
+  };
+}
+
+
 module.exports = t;
 
 t.create('invalid urlencoding')
@@ -29,26 +40,54 @@ t.create('invalid badge json')
   .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
   .intercept(nock => nock('http://test.com')
     .get('/badge.json')
-    .reply(function() {
-      return [
-        200,
-        '{}',
-        { 'Content-Type': 'application/json' }
-      ];
-    })
+    .reply(genJsonResponse({}))
   )
   .expectJSON({name: 'badge json', value: 'invalid badge-json'});
 
 t.create('label & value')
-  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json?style=_shields_test')
   .intercept(nock => nock('http://test.com')
     .get('/badge.json')
-    .reply(function() {
-      return [
-        200,
-        '{"label":"test","value":"success"}',
-        { 'Content-Type': 'application/json' }
-      ];
-    })
+    .reply(genJsonResponse({label:"test", value:"success"}))
   )
-  .expectJSON({name: 'test', value: 'success'});
+  .expectJSON({
+    name: 'test',
+    value: 'success',
+    colorB: '#9f9f9f'  // default
+  });
+
+t.create('label, value, & class')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json?style=_shields_test')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(genJsonResponse({label:"test", value:"success", valueClass:"success"}))
+  )
+  .expectJSON({
+    name: 'test',
+    value: 'success',
+    colorB: '#4c1'  // success
+  });
+
+ t.create('label, value, class, & colorB')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json?style=_shields_test')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(genJsonResponse({label:"test", value:"success", valueClass:"success", colorB:"#D00D00"}))
+  )
+  .expectJSON({
+    name: 'test',
+    value: 'success',
+    colorB: '#D00D00' // colorB override
+  });
+
+ t.create('label, value, class, colorB, & colorB param')
+  .get('/http%3A%2F%2Ftest.com%2Fbadge.json.json?style=_shields_test&colorB=C001E0')
+  .intercept(nock => nock('http://test.com')
+    .get('/badge.json')
+    .reply(genJsonResponse({label:"test", value:"success", valueClass:"success", colorB:"#D00D00"}))
+  )
+  .expectJSON({
+    name: 'test',
+    value: 'success',
+    colorB: '#C001E0' // colorB param
+  });

--- a/service-tests/badge-json.js
+++ b/service-tests/badge-json.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Joi = require('joi');
+// const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
 const { invalidJSON } = require('./helpers/response-fixtures');
 

--- a/static/main.css
+++ b/static/main.css
@@ -22,6 +22,9 @@ code,
 input.short {
   width: 5em;
 }
+input.medium {
+  width: 15em;
+}
 
 input {
   text-align: center;
@@ -43,7 +46,7 @@ hr {
   border-width: 1px 0 0 0;
 }
 
-ul {
+ul.options {
   text-align: left;
   margin-left: 25%;
 }


### PR DESCRIPTION
fixes #1519 
closes #1752 

route: /^\/json\/(https?.+)\.(svg|png|gif|jpg|json)$/
added documentation to usage.js (with json-badge-maker)

a few tweaks to documentation 
* better separate "static", "dynamic", and "json"
* added "style" parameter to parameter list & moved rendered styles from above the list to below
* removed the ginormous margin-left: 25% style given to UL -> now applies to ul.options   (there was only one UL in in documentation)
* renamed duplicate "miscellaneous" id to "miscellaneous2"

Screenshot of updated docs:
![shield-doc](https://user-images.githubusercontent.com/2137404/36682445-b57f354c-1ae0-11e8-8739-ac7600ea2854.png)
