### PR TITLE
[travis] Updated an expected value in a service test of Travis PHP version badge

### DIFF
--- a/service-tests/travis.js
+++ b/service-tests/travis.js
@@ -15,7 +15,7 @@ t.create('gets the package version of symfony 2.8')
 
 t.create('gets the package version of yii')
     .get('/php-v/yiisoft/yii.json')
-    .expectJSON({ name: 'PHP', value: '5.3 - 7.1, HHVM' });
+    .expectJSON({ name: 'PHP', value: '>= 5.3, HHVM' });
 
 t.create('invalid package name')
     .get('/php-v/frodo/is-not-a-package.json')

--- a/service-tests/travis.js
+++ b/service-tests/travis.js
@@ -1,21 +1,23 @@
 'use strict';
 
+const Joi = require('joi');
 const ServiceTester = require('./runner/service-tester');
+const {isPhpVersionReduction} = require('./helpers/validators');
 
 const t = new ServiceTester({ id: 'travis', title: 'PHP version from .travis.yml' });
 module.exports = t;
 
 t.create('gets the package version of symfony')
     .get('/php-v/symfony/symfony.json')
-    .expectJSON({ name: 'PHP', value: '>= 7.1' });
+    .expectJSONTypes(Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction }));
 
 t.create('gets the package version of symfony 2.8')
     .get('/php-v/symfony/symfony/2.8.json')
-    .expectJSON({ name: 'PHP', value: '>= 5.4, HHVM' });
+    .expectJSONTypes(Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction }));
 
 t.create('gets the package version of yii')
     .get('/php-v/yiisoft/yii.json')
-    .expectJSON({ name: 'PHP', value: '>= 5.3, HHVM' });
+    .expectJSONTypes(Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction }));
 
 t.create('invalid package name')
     .get('/php-v/frodo/is-not-a-package.json')


### PR DESCRIPTION
Currently one service test of travis fails:
```
1) PHP version from .travis.yml
       gets the package version of yii
         
	[ GET http://localhost:1111/travis/php-v/yiisoft/yii.json ]:

      AssertionError: expected { name: 'PHP', value: '>= 5.3, HHVM' } to deeply equal { Object (name, value) }
      + expected - actual

       {
         "name": "PHP"
      -  "value": ">= 5.3, HHVM"
      +  "value": "5.3 - 7.1, HHVM"
       }

```
Version 7.2 was added to https://github.com/yiisoft/yii/blob/master/.travis.yml on Jan 25, 2018. This version is currently the newest version of PHP https://github.com/php/php-src/releases. 