### PR TITLE
[microbadger] Handle no DownloadSize being returned

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1901,7 +1901,7 @@ const allBadgeExamples = [
       },
       {
         title: 'MicroBadger Size',
-        previewUri: '/microbadger/image-size/_/httpd.svg',
+        previewUri: '/microbadger/image-size/jumanjiman/puppet.svg',
         keywords: [
           'docker'
         ]

--- a/server.js
+++ b/server.js
@@ -6557,8 +6557,13 @@ cache(function(data, match, sendBadge, request) {
       }
 
       if (type === 'image-size') {
-        const size = prettyBytes(parseInt(image.DownloadSize));
-        badgeData.text[1] = size;
+        const downloadSize = image.DownloadSize;
+        if (downloadSize === undefined) {
+          badgeData.text[1] = 'unknown';
+          sendBadge(format, badgeData);
+          return;
+        }
+        badgeData.text[1] = prettyBytes(parseInt(downloadSize));
       } else if (type === 'layers') {
         badgeData.text[1] = image.LayerCount;
       }

--- a/service-tests/microbadger.js
+++ b/service-tests/microbadger.js
@@ -9,11 +9,15 @@ const t = new ServiceTester({ id: 'microbadger', title: 'MicroBadger' });
 module.exports = t;
 
 t.create('image size without a specified tag')
-  .get('/image-size/_/centos.json')
+  .get('/image-size/jumanjiman/puppet.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'image size',
     value: isFileSize
   }));
+
+t.create('image size without a specified tag and no download size data returned')
+  .get('/image-size/_/centos.json')
+  .expectJSON({ name: 'image size', value: 'unknown' });
 
 t.create('image size with a specified tag')
   .get('/image-size/_/httpd/alpine.json')


### PR DESCRIPTION
I noticed that we had one failing MicroBadger test as well as an error badge on our homepage.

Turns out that some API responses now come back with no top-level `DownloadSize` field (for instance [this query](https://api.microbadger.com/v1/images/library/centos)). Our parsing currently throws an exception resulting in the error MicroBadger badge.

This pull request handles things more cleanly with a new "unknown" badge, and fixes the test and homepage example.

@goozler as you submitted the MicroBadger implementation a few months ago, could you please give this a look and see whether we're on the right track here? 😉 