### PR TITLE
Add [npm] type definitions badge

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -835,6 +835,15 @@ const allBadgeExamples = [
         ]
       },
       {
+        title: 'npm type definitions',
+        previewUri: '/npm/types/chalk.svg',
+        keywords: [
+          'node',
+          'typescript',
+          'flow'
+        ]
+      },
+      {
         title: 'PyPI',
         previewUri: '/pypi/v/nine.svg',
         keywords: [

--- a/lib/npm-badge-helpers.js
+++ b/lib/npm-badge-helpers.js
@@ -1,7 +1,46 @@
 'use strict';
 
+const { rangeStart, minor } = require('./version');
+
 const defaultNpmRegistryUri = 'https://registry.npmjs.org';
+
+function makePackageDataUrl({ registryUrl, scope, packageName }) {
+  registryUrl = registryUrl || defaultNpmRegistryUri;
+  if (scope === undefined) {
+    // e.g. https://registry.npmjs.org/express/latest
+    // Use this endpoint as an optimization. It covers the vast majority of
+    // these badges, and the response is smaller.
+    return `${registryUrl}/${packageName}/latest`;
+  } else {
+    // e.g. https://registry.npmjs.org/@cedx%2Fgulp-david
+    // because https://registry.npmjs.org/@cedx%2Fgulp-david/latest does not work
+    const path = encodeURIComponent(`${scope}/${packageName}`);
+    return `${registryUrl}/@${path}`;
+  }
+}
+
+function typeDefinitions(packageData) {
+  const { devDependencies } = packageData;
+
+  const supportedLanguages = [
+    { name: 'TypeScript', range: devDependencies.typescript },
+    { name: 'Flow', range: devDependencies['flow-bin'] },
+  ]
+    .filter(lang => lang.range !== undefined)
+    .map(({ name, range }) => {
+      const version = minor(rangeStart(range));
+      return `${name} v${version}`;
+    });
+
+  if (supportedLanguages.length > 0) {
+    return supportedLanguages.join(' | ');
+  } else {
+    return 'none';
+  }
+}
 
 module.exports = {
   defaultNpmRegistryUri,
+  makePackageDataUrl,
+  typeDefinitions,
 };

--- a/lib/npm-badge-helpers.spec.js
+++ b/lib/npm-badge-helpers.spec.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { test, given } = require('sazerac');
+const { typeDefinitions } = require('./npm-badge-helpers');
+
+describe('NPM badge helpers', function () {
+  test(typeDefinitions, () => {
+    given({ devDependencies: { typescript: '^2.4.7' } }).expect('TypeScript v2.4');
+  });
+});

--- a/lib/version.js
+++ b/lib/version.js
@@ -28,7 +28,6 @@ function latest(versions) {
   }
   return version;
 }
-exports.latest = latest;
 
 function listCompare(a, b) {
   const alen = a.length, blen = b.length;
@@ -41,7 +40,6 @@ function listCompare(a, b) {
   }
   return alen - blen;
 }
-exports.listCompare = listCompare;
 
 // === Private helper functions ===
 
@@ -81,3 +79,50 @@ function compareDottedVersion(v1, v2) {
   }
   return v1 < v2? -1: v1 > v2? 1: 0;
 }
+
+// Slice the specified number of dotted parts from the given semver version.
+// e.g. slice('2.4.7', 'minor') -> '2.4'
+function slice(v, releaseType) {
+  if (! semver.valid(v)) {
+    return null;
+  }
+
+  const major = semver.major(v);
+  const minor = semver.minor(v);
+  const patch = semver.patch(v);
+  const prerelease = semver.prerelease(v);
+
+  const dottedParts = {
+    major: [major],
+    minor: [major, minor],
+    patch: [major, minor, patch],
+  }[releaseType];
+
+  if (dottedParts === undefined) {
+    throw Error(`Unknown releaseType: ${releaseType}`);
+  }
+
+  const dotted = dottedParts.join('.');
+  if (prerelease) {
+    return `${dotted}-${prerelease.join('.')}`;
+  } else {
+    return dotted;
+  }
+}
+
+function minor(v) {
+  return slice(v, 'minor');
+}
+
+function rangeStart(v) {
+  const range = new semver.Range(v);
+  return range.set[0][0].semver.version;
+}
+
+module.exports = {
+  latest,
+  listCompare,
+  slice,
+  minor,
+  rangeStart,
+};

--- a/lib/version.spec.js
+++ b/lib/version.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { test, given } = require('sazerac');
-const {latest} = require('./version');
+const { latest, slice, rangeStart } = require('./version');
 
 describe('Version helpers', function () {
   test(latest, () => {
@@ -30,5 +30,18 @@ describe('Version helpers', function () {
 
     // Simple (one-number) versions
     given(['2', '10', '1']).expect('10');
+  });
+
+  test(slice, () => {
+    given('2.4.7', 'major').expect('2');
+    given('2.4.7', 'minor').expect('2.4');
+    given('2.4.7', 'patch').expect('2.4.7');
+    given('2.4.7-alpha.1', 'major').expect('2-alpha.1');
+    given('2.4.7-alpha.1', 'minor').expect('2.4-alpha.1');
+    given('2.4.7-alpha.1', 'patch').expect('2.4.7-alpha.1');
+  });
+
+  test(rangeStart, () => {
+    given('^2.4.7').expect('2.4.7');
   });
 });

--- a/server.js
+++ b/server.js
@@ -1897,13 +1897,7 @@ cache({
     });
     const badgeData = getBadgeData('type definitions', queryParams);
     request(apiUrl, { headers: { 'Accept': '*/*' } }, function(err, res, buffer) {
-      if (err != null) {
-        badgeData.text[1] = 'inaccessible';
-        sendBadge(format, badgeData);
-        return;
-      }
-      if (res.statusCode === 404) {
-        badgeData.text[1] = 'package not found';
+      if (checkErrorResponse(badgeData, err, res, 'package not found')) {
         sendBadge(format, badgeData);
         return;
       }

--- a/service-tests/npm.js
+++ b/service-tests/npm.js
@@ -11,6 +11,8 @@ const t = new ServiceTester({ id: 'npm', title: 'NPM' });
 module.exports = t;
 const colorsB = mapValues(colorscheme, 'colorB');
 
+const isTypeDefinition = Joi.string().regex(/^(Flow|TypeScript) v?[0-9]+.[0-9]( (Flow|TypeScript) v?[0-9]+.[0-9])?$/);
+
 t.create('total downloads of left-pad')
   .get('/dt/left-pad.json?style=_shields_test')
   .expectJSONTypes(Joi.object().keys({ name: 'downloads', value: isMetric, colorB: colorsB.brightgreen }));
@@ -165,3 +167,11 @@ t.create('license when network is off')
   .get('/l/pakage-network-off.json?style=_shields_test')
   .networkOff()
   .expectJSON({ name: 'license', value: 'inaccessible', colorB: colorsB.lightgrey });
+
+t.create('types')
+  .get('/types/chalk.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'type definitions', value: isTypeDefinition }));
+
+t.create('no types')
+  .get('/types/left-pad.json')
+  .expectJSON({ name: 'type definitions', value: 'none' });


### PR DESCRIPTION
Let a package show off its type definitions based on devDependency data in the published npm package.

Close #1252