### PR TITLE
remove whitespace from data URIs

### DIFF
--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -16,11 +16,7 @@ function isDataUri(s) {
   return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
 }
 
-function prependPrefix(s, prefix) {
-  if (s === undefined) {
-    return undefined;
-  }
-
+function prependPrefix(s = '', prefix) {
   s = '' + s;
 
   if (s.startsWith(prefix)) {

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -70,7 +70,7 @@ function makeLogo(defaultNamedLogo, overrides) {
   if (isDataUri(maybeDataUri)) {
     // +'s are replaced with spaces when used in query params, this returns them to +'s - #1527
     // remove all whitespace characters (newlines tabs etc) - #1540
-    return decodeURI(maybeDataUri).replace(/ /g, '+').replace(/\s/g, '');
+    return maybeDataUri.replace(/ /g, '+').replace(/\s/g, '');
   } else {
     return logos[maybeNamedLogo];
   }

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -13,7 +13,7 @@ function toArray(val) {
 }
 
 function isDataUri(s) {
-  return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
+  return s !== undefined && /^(data:)([^;]+);([^,]+),(\s|.)+$/.test(s);
 }
 
 function prependPrefix(s, prefix) {

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -16,7 +16,11 @@ function isDataUri(s) {
   return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
 }
 
-function prependPrefix(s = '', prefix) {
+function prependPrefix(s, prefix) {
+  if (s === undefined) {
+    return undefined;
+  }
+
   s = '' + s;
 
   if (s.startsWith(prefix)) {
@@ -58,16 +62,17 @@ function makeLabel(defaultLabel, overrides) {
 }
 
 function makeLogo(defaultNamedLogo, overrides) {
-  const logo = overrides.logo === undefined ? undefined : '' + overrides.logo ;
+  if (overrides.logo === undefined){
+    return logos[defaultNamedLogo];
+  }
 
   // +'s are replaced with spaces when used in query params, this returns them to +'s, then removes remaining whitespace - #1546
-  const maybeDataUri = prependPrefix(logo, 'data:').replace(/ /g, '+').replace(/\s/g, '');
-  const maybeNamedLogo = logo === undefined ? defaultNamedLogo : logo;
+  const maybeDataUri = prependPrefix(overrides.logo, 'data:').replace(/ /g, '+').replace(/\s/g, '');
 
   if (isDataUri(maybeDataUri)) {
     return maybeDataUri;
   } else {
-    return logos[maybeNamedLogo];
+    return logos[overrides.logo];
   }
 }
 

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -69,7 +69,8 @@ function makeLogo(defaultNamedLogo, overrides) {
 
   if (isDataUri(maybeDataUri)) {
     // +'s are replaced with spaces when used in query params, this returns them to +'s - #1527
-    return maybeDataUri.replace(/\s/g, '+');
+    // remove all whitespace characters (newlines tabs etc) - #1540
+    return decodeURI(maybeDataUri).replace(/ /g, '+').replace(/\s/g, '');
   } else {
     return logos[maybeNamedLogo];
   }

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -13,7 +13,7 @@ function toArray(val) {
 }
 
 function isDataUri(s) {
-  return s !== undefined && /^(data:)([^;]+);([^,]+),(\s|.)+$/.test(s);
+  return s !== undefined && /^(data:)([^;]+);([^,]+),(.+)$/.test(s);
 }
 
 function prependPrefix(s, prefix) {
@@ -64,13 +64,12 @@ function makeLabel(defaultLabel, overrides) {
 function makeLogo(defaultNamedLogo, overrides) {
   const logo = overrides.logo === undefined ? undefined : '' + overrides.logo ;
 
-  const maybeDataUri = prependPrefix(logo, 'data:');
+  // +'s are replaced with spaces when used in query params, this returns them to +'s, then removes remaining whitespace - #1546
+  const maybeDataUri = prependPrefix(logo, 'data:').replace(/ /g, '+').replace(/\s/g, '');
   const maybeNamedLogo = logo === undefined ? defaultNamedLogo : logo;
 
   if (isDataUri(maybeDataUri)) {
-    // +'s are replaced with spaces when used in query params, this returns them to +'s - #1527
-    // remove all whitespace characters (newlines tabs etc) - #1540
-    return maybeDataUri.replace(/ /g, '+').replace(/\s/g, '');
+    return maybeDataUri;
   } else {
     return logos[maybeNamedLogo];
   }

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -16,7 +16,7 @@ describe('Badge data helpers', function() {
   test(prependPrefix, () => {
     given('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:').expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
     given('foobar', 'data:').expect('data:foobar');
-    given(undefined, 'data:').expect('data:');
+    given(undefined, 'data:').expect(undefined);
   });
 
   test(isDataUri, () => {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -16,7 +16,7 @@ describe('Badge data helpers', function() {
   test(prependPrefix, () => {
     given('data:image/svg+xml;base64,PHN2ZyB4bWxu', 'data:').expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
     given('foobar', 'data:').expect('data:foobar');
-    given(undefined, 'data:').expect(undefined);
+    given(undefined, 'data:').expect('data:');
   });
 
   test(isDataUri, () => {

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -45,8 +45,8 @@ describe('Badge data helpers', function() {
     forCases([
       given('gratipay', { logo: 'image/svg+xml;base64,PHN2ZyB4bWxu' }),
       given('gratipay', { logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu' }),
-      given('gratipay', { logo: 'data:image/svg%20xml;base64,PHN2ZyB4bWxu' }),
-      given('gratipay', { logo: 'data:image/svg+xml;%0abase64,PHN2ZyB4bWxu' }),
+      given('gratipay', { logo: 'data:image/svg xml;base64,PHN2ZyB4bWxu' }),
+      given('gratipay', { logo: 'data:image/svg+xml;base64,PHN2ZyB\n4bWxu' }),
     ]).expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
     forCases([
       given('gratipay', { logo: '' }),

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -45,7 +45,8 @@ describe('Badge data helpers', function() {
     forCases([
       given('gratipay', { logo: 'image/svg+xml;base64,PHN2ZyB4bWxu' }),
       given('gratipay', { logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu' }),
-      given('gratipay', { logo: 'data:image/svg xml;base64,PHN2ZyB4bWxu' }),
+      given('gratipay', { logo: 'data:image/svg%20xml;base64,PHN2ZyB4bWxu' }),
+      given('gratipay', { logo: 'data:image/svg+xml;%0abase64,PHN2ZyB4bWxu' }),
     ]).expect('data:image/svg+xml;base64,PHN2ZyB4bWxu');
     forCases([
       given('gratipay', { logo: '' }),


### PR DESCRIPTION
closes #1540 

Replaces all spaces with `+` symbol's (#1527), then removes all remaining whitespace (newlines, tabs etc)