### PR TITLE
Add snapshot tests for SVG and JSON

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /build
 /coverage
+/__snapshots__

--- a/README.md
+++ b/README.md
@@ -132,7 +132,14 @@ badge preview URIs with `maxAge` &ndash; run `LONG_CACHE=true npm run build`.
 To analyze the frontend bundle, run `npm install webpack-bundle-analyzer` and
 then `ANALYZE=true npm start`.
 
+[Snapshot tests][] ensure we don't inadvertently make changes that affect the
+SVG or JSON output. When deliberately changing the output, run
+`SNAPSHOT_DRY=1 npm run test:js:server` to preview changes to the saved
+snapshots, and `SNAPSHOT_UPDATE=1 npm run test:js:server` to update them.
+
+
 [package manager]: https://nodejs.org/en/download/package-manager/
+[snapshot tests]: https://glebbahmutov.com/blog/snapshot-testing/
 
 
 Hosting your own server

--- a/__snapshots__/make-badge.spec.js
+++ b/__snapshots__/make-badge.spec.js
@@ -1,0 +1,10 @@
+exports['The badge generator SVG should always produce the same SVG (unless we have changed something!) 1'] = `
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="88" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="88" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h45v20H0z"/><path fill="#4c1" d="M45 0h43v20H45z"/><path fill="url(#b)" d="M0 0h88v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"><text x="235" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="350">cactus</text><text x="235" y="140" transform="scale(.1)" textLength="350">cactus</text><text x="655" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330">grown</text><text x="655" y="140" transform="scale(.1)" textLength="330">grown</text></g> </svg>
+`
+
+exports['The badge generator JSON should always produce the same JSON (unless we have changed something!) 1'] = `
+{
+  "name": "cactus",
+  "value": "grown"
+}
+`

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { expect } = require('chai');
+const snapshot = require('snap-shot-it');
 const { _badgeKeyWidthCache } = require('./make-badge');
 const isSvg = require('is-svg');
 const testHelpers = require('./make-badge-test-helpers');
@@ -12,43 +13,57 @@ describe('The badge generator', function () {
     _badgeKeyWidthCache.clear();
   });
 
-  it('should produce SVG', function () {
-    const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
-    expect(svg)
-      .to.satisfy(isSvg)
-      .and.to.include('cactus')
-      .and.to.include('grown');
+  describe('SVG', function () {
+    it('should produce SVG', function () {
+      const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
+      expect(svg)
+        .to.satisfy(isSvg)
+        .and.to.include('cactus')
+        .and.to.include('grown');
+    });
+
+    it('should always produce the same SVG (unless we have changed something!)', function () {
+      const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' });
+      snapshot(svg);
+    });
+
+    it('should cache width of badge key', function () {
+      makeBadge({ text: ['cached', 'not-cached'], format: 'svg' });
+      expect(_badgeKeyWidthCache.cache).to.have.keys('cached');
+    });
   });
 
-  it('should cache width of badge key', function () {
-    makeBadge({ text: ['cached', 'not-cached'], format: 'svg' });
-    expect(_badgeKeyWidthCache.cache).to.have.keys('cached');
+  describe('JSON', function () {
+    it('should always produce the same JSON (unless we have changed something!)', function () {
+      const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' });
+      snapshot(json);
+    });
+
+    it('should replace unknown json template with "default"', function () {
+      const jsonBadgeWithUnknownStyle = makeBadge({ text: ['name', 'Bob'], format: 'json', template: 'unknown_style' });
+      const jsonBadgeWithDefaultStyle = makeBadge({ text: ['name', 'Bob'], format: 'json', template: 'default' });
+      expect(jsonBadgeWithUnknownStyle).to.equal(jsonBadgeWithDefaultStyle);
+      expect(JSON.parse(jsonBadgeWithUnknownStyle)).to.deep.equal({name: "name", value: "Bob"})
+    });
+
+    it('should replace unknown svg template with "flat"', function () {
+      const jsonBadgeWithUnknownStyle = makeBadge({ text: ['name', 'Bob'], format: 'svg', template: 'unknown_style' });
+      const jsonBadgeWithDefaultStyle = makeBadge({ text: ['name', 'Bob'], format: 'svg', template: 'flat' });
+      expect(jsonBadgeWithUnknownStyle).to.equal(jsonBadgeWithDefaultStyle)
+        .and.to.satisfy(isSvg);
+    });
   });
 
-  it('should replace unknown json template with "default"', function () {
-    const jsonBadgeWithUnknownStyle = makeBadge({ text: ['name', 'Bob'], format: 'json', template: 'unknown_style' });
-    const jsonBadgeWithDefaultStyle = makeBadge({ text: ['name', 'Bob'], format: 'json', template: 'default' });
-    expect(jsonBadgeWithUnknownStyle).to.equal(jsonBadgeWithDefaultStyle);
-    expect(JSON.parse(jsonBadgeWithUnknownStyle)).to.deep.equal({name: "name", value: "Bob"})
-  });
+  describe('"for-the-badge" template badge generation', function () {
+     // https://github.com/badges/shields/issues/1280
+    it('numbers should produce a string', function () {
+      const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
+      expect(svg).to.include('1998').and.to.include('1999');
+    });
 
-  it('should replace unknown svg template with "flat"', function () {
-    const jsonBadgeWithUnknownStyle = makeBadge({ text: ['name', 'Bob'], format: 'svg', template: 'unknown_style' });
-    const jsonBadgeWithDefaultStyle = makeBadge({ text: ['name', 'Bob'], format: 'svg', template: 'flat' });
-    expect(jsonBadgeWithUnknownStyle).to.equal(jsonBadgeWithDefaultStyle)
-      .and.to.satisfy(isSvg);
-  });
-});
-
-describe('"for-the-badge" template badge generation', function () {
-   // https://github.com/badges/shields/issues/1280
-  it('numbers should produce a string', function () {
-    const svg = makeBadge({ text: [1998, 1999], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.include('1998').and.to.include('1999');
-  });
-
-  it('lowercase/mixedcase string should produce uppercase string', function () {
-    const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
-    expect(svg).to.include('LABEL').and.to.include('1 STRING');
+    it('lowercase/mixedcase string should produce uppercase string', function () {
+      const svg = makeBadge({ text: ["Label", "1 string"], format: 'svg', template: 'for-the-badge' });
+      expect(svg).to.include('LABEL').and.to.include('1 STRING');
+    });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,16 @@
         }
       }
     },
+    "@bahmutov/data-driven": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
+      "integrity": "sha512-YqW3hPS0RXriqjcCrLOTJj+LWe3c8JpwlL83k1ka1Q8U05ZjAKbGQZYeTzUd0NFEnnfPtsUiKGpFEBJG6kFuvg==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "lazy-ass": "1.6.0"
+      }
+    },
     "@mapbox/react-click-to-select": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/react-click-to-select/-/react-click-to-select-2.1.0.tgz",
@@ -2425,6 +2435,12 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
+    "check-more-types": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "dev": true
+    },
     "check-node-version": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-3.1.1.tgz",
@@ -2659,6 +2675,12 @@
         "request": "2.83.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -2887,6 +2909,15 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
       "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
+    },
+    "common-tags": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.4.0.tgz",
+      "integrity": "sha1-EYe+Tz1M8MBCfUP3Tu8fc1AWFMA=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
     },
     "commondir": {
       "version": "1.0.1",
@@ -3628,6 +3659,24 @@
         "randombytes": "2.0.6"
       }
     },
+    "disparity": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
+      "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "diff": "1.4.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+          "dev": true
+        }
+      }
+    },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
@@ -4153,6 +4202,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
+    },
+    "escape-quotes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-quotes/-/escape-quotes-1.0.2.tgz",
+      "integrity": "sha1-tIltSmz4LdWzP0m3E0CMY4D2zZc=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -4975,6 +5033,12 @@
           }
         }
       }
+    },
+    "folktale": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.0.1.tgz",
+      "integrity": "sha512-3kDSWVkSlErHIt/dC73vu+5zRqbW1mlnL46s2QfYN7Ps0JcS9MVtuLCrDQOBa7sanA+d9Fd8F+bn0VcyNe68Jw==",
+      "dev": true
     },
     "fontkit": {
       "version": "1.7.7",
@@ -6875,6 +6939,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
       "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
@@ -7763,6 +7836,12 @@
       "requires": {
         "package-json": "4.0.1"
       }
+    },
+    "lazy-ass": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -10132,6 +10211,12 @@
         }
       }
     },
+    "ramda": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.24.1.tgz",
+      "integrity": "sha1-w7d1UZfzW43DUCIoJixMkd22uFc=",
+      "dev": true
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
@@ -11044,6 +11129,91 @@
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
       "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
       "dev": true
+    },
+    "snap-shot-compare": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/snap-shot-compare/-/snap-shot-compare-2.5.1.tgz",
+      "integrity": "sha512-aWBRvEesjSxXAvyHhEuogOQYt/j/aE5q/WRUtMrzSwOwzjF61OACJRs9GRiU8n5aFwCEx3GYXXCoRE59WszDpw==",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "disparity": "2.0.0",
+        "folktale": "2.0.1",
+        "lazy-ass": "1.6.0",
+        "variable-diff": "1.1.0"
+      }
+    },
+    "snap-shot-core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/snap-shot-core/-/snap-shot-core-5.0.0.tgz",
+      "integrity": "sha1-zDppie2g68M0KdTNtga9/v0Gack=",
+      "dev": true,
+      "requires": {
+        "check-more-types": "2.24.0",
+        "common-tags": "1.4.0",
+        "debug": "3.0.1",
+        "escape-quotes": "1.0.2",
+        "folktale": "2.0.1",
+        "is-ci": "1.0.10",
+        "jsesc": "2.5.1",
+        "lazy-ass": "1.6.0",
+        "mkdirp": "0.5.1",
+        "ramda": "0.24.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.1.tgz",
+          "integrity": "sha512-6nVc6S36qbt/mutyt+UGMnawAMrPDZUPQjRZI3FS9tCtDRhvxJbK79unYBLPi+z5SLXQ3ftoVBFCblQtNSls8w==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "jsesc": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.1.tgz",
+          "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
+    },
+    "snap-shot-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/snap-shot-it/-/snap-shot-it-4.0.1.tgz",
+      "integrity": "sha512-ZWdj0VP/7KQ4RxAcXfblwFXJDyca/s36K92EzMBn350XSqeb9y/StTTHcis9wOY+OR6TrBgL4YbaraoU19tU8g==",
+      "dev": true,
+      "requires": {
+        "@bahmutov/data-driven": "1.0.0",
+        "check-more-types": "2.24.0",
+        "debug": "3.1.0",
+        "ramda": "0.24.1",
+        "snap-shot-compare": "2.5.1",
+        "snap-shot-core": "5.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "snapdragon": {
       "version": "0.8.1",
@@ -12822,6 +12992,16 @@
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
+      }
+    },
+    "variable-diff": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/variable-diff/-/variable-diff-1.1.0.tgz",
+      "integrity": "sha1-0r1cZtt2wTh52W5qMG7cmJ35eNo=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "object-assign": "4.1.1"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "semver-regex": "^1.0.0",
     "sinon": "^4.0.1",
     "sinon-chai": "^3.0.0",
+    "snap-shot-it": "^4.0.1",
     "url": "^0.11.0"
   },
   "greenkeeper": {


### PR DESCRIPTION
These tests should fail if something is accidentally changed that affects the SVG or JSON files. In the case of deliberate changes, we can update the snapshots.

This is my test nerd solution for #1473.