### PR TITLE
Make isDeprecated tests more resilient to time zone

### DIFF
--- a/lib/deprecation-helpers.spec.js
+++ b/lib/deprecation-helpers.spec.js
@@ -25,13 +25,13 @@ describe('isDeprecated function', function () {
 
     given(
       'fooservice',
-      new Date('2001-01-11 23:59:00'),
+      new Date('2001-01-11 23:59:00Z'),
       {'fooservice': new Date('2001-01-12')}
     ).expect(false);
 
     given(
       'fooservice',
-      new Date('2001-01-12 00:00:01'),
+      new Date('2001-01-12 00:00:01Z'),
       {'fooservice': new Date('2001-01-12')}
     ).expect(true);
 


### PR DESCRIPTION
These tests were failing locally and I suspect it’s because I’m in a different time zone.

@chris48s would you mind giving this a once-over?