### PR TITLE
service tests for [dub]

### DIFF
--- a/server.js
+++ b/server.js
@@ -6074,15 +6074,14 @@ cache(function (data, match, sendBadge, request) {
   var pkg = match[2]; // package name, e.g. vibe-d
   var version = match[3]; // version (1.2.3 or latest)
   var format = match[4];
-  var apiUrl = 'http://code.dlang.org/api/packages/'+pkg;
+  var apiUrl = 'https://code.dlang.org/api/packages/'+pkg;
   if (version) {
     apiUrl += '/' + version;
   }
   apiUrl += '/stats';
   var badgeData = getBadgeData('dub', data);
   request(apiUrl, function(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }
@@ -6128,7 +6127,7 @@ cache(function (data, match, sendBadge, request) {
   var info = match[1];  // (v - version, l - license)
   var pkg = match[2];  // package name, e.g. vibe-d
   var format = match[3];
-  var apiUrl = 'http://code.dlang.org/api/packages/' + pkg;
+  var apiUrl = 'https://code.dlang.org/api/packages/' + pkg;
   if (info === 'v') {
     apiUrl += '/latest';
   } else if (info === 'l') {
@@ -6136,8 +6135,7 @@ cache(function (data, match, sendBadge, request) {
   }
   var badgeData = getBadgeData('dub', data);
   request(apiUrl, function(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }

--- a/service-tests/dub.js
+++ b/service-tests/dub.js
@@ -33,13 +33,14 @@ t.create('total downloads (valid)')
     colorB: isVersionColor
   }));
 
-/*t.create('total downloads, specific version (valid)')
+t.create('total downloads, specific version (valid)')
   .get('/dt/vibe-d/0.7.23.json?style=_shields_test')
   .expectJSONTypes(Joi.object().keys({
     name: 'downloads',
     value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.7.23$/),
     colorB: isVersionColor
-  }));*/
+  }))
+  .timeout(15000);
 
 t.create('total downloads, latest version (valid)')
   .get('/dt/vibe-d/latest.json?style=_shields_test')

--- a/service-tests/dub.js
+++ b/service-tests/dub.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('./runner/service-tester');
+
+const { invalidJSON } = require('./helpers/response-fixtures');
+const colorscheme = require('../lib/colorscheme.json');
+
+const {
+  isVPlusDottedVersionNClausesWithOptionalSuffix,
+  isMetric,
+  isMetricOverTimePeriod
+} = require('./helpers/validators');
+const isVersionColor = Joi.equal(
+  colorscheme.red.colorB,
+  colorscheme.yellow.colorB,
+  colorscheme.yellowgreen.colorB,
+  colorscheme.green.colorB,
+  colorscheme.brightgreen.colorB,
+)
+
+const t = new ServiceTester({ id: 'dub', title: 'Dub' });
+module.exports = t;
+
+
+// downloads
+
+t.create('total downloads (valid)')
+  .get('/dt/vibe-d.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: isMetric,
+    colorB: isVersionColor
+  }));
+
+/*t.create('total downloads, specific version (valid)')
+  .get('/dt/vibe-d/0.7.23.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.7.23$/),
+    colorB: isVersionColor
+  }));*/
+
+t.create('total downloads, latest version (valid)')
+  .get('/dt/vibe-d/latest.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? latest$/),
+    colorB: isVersionColor
+  }));
+
+t.create('daily downloads (valid)')
+  .get('/dd/vibe-d.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: isMetricOverTimePeriod,
+    colorB: isVersionColor
+  }));
+
+t.create('weekly downloads (valid)')
+  .get('/dw/vibe-d.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: isMetricOverTimePeriod,
+    colorB: isVersionColor
+  }));
+
+t.create('monthly downloads (valid)')
+  .get('/dm/vibe-d.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads',
+    value: isMetricOverTimePeriod,
+    colorB: isVersionColor
+  }));
+
+t.create('total downloads (not found)')
+  .get('/dt/not-a-package.json')
+  .expectJSON({name: 'dub', value: 'not found'});
+
+t.create('total downloads (connection error)')
+  .get('/dt/vibe-d.json')
+  .networkOff()
+  .expectJSON({name: 'dub', value: 'inaccessible'});
+
+t.create('total downloads (unexpected response)')
+  .get('/dt/vibe-d.json')
+  .intercept(nock => nock('https://code.dlang.org')
+    .get('/api/packages/vibe-d/stats')
+    .reply(invalidJSON)
+  )
+  .expectJSON({name: 'dub', value: 'invalid'});
+
+
+// version
+
+t.create('version (valid)')
+  .get('/v/vibe-d.json?style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'dub',
+    value: isVPlusDottedVersionNClausesWithOptionalSuffix,
+    colorB: Joi.equal(colorscheme.blue.colorB, colorscheme.orange.colorB)
+  }));
+
+t.create('version (not found)')
+  .get('/v/not-a-package.json')
+  .expectJSON({name: 'dub', value: 'not found'});
+
+t.create('version (connection error)')
+  .get('/v/vibe-d.json')
+  .networkOff()
+  .expectJSON({name: 'dub', value: 'inaccessible'});
+
+t.create('version (unexpected response)')
+  .get('/v/vibe-d.json')
+  .intercept(nock => nock('https://code.dlang.org')
+    .get('/api/packages/vibe-d/latest')
+    .reply(invalidJSON)
+  )
+  .expectJSON({name: 'dub', value: 'invalid'});
+
+
+// license
+
+t.create('license (valid)')
+  .get('/l/vibe-d.json?style=_shields_test')
+  .expectJSON({
+    name: 'license',
+    value: 'MIT',
+    colorB: colorscheme.blue.colorB
+  });
+
+t.create('license (not found)')
+  .get('/l/not-a-package.json')
+  .expectJSON({name: 'dub', value: 'not found'});
+
+t.create('license (connection error)')
+  .get('/l/vibe-d.json')
+  .networkOff()
+  .expectJSON({name: 'dub', value: 'inaccessible'});
+
+t.create('license (unexpected response)')
+  .get('/l/vibe-d.json')
+  .intercept(nock => nock('https://code.dlang.org')
+    .get('/api/packages/vibe-d/latest/info')
+    .reply(invalidJSON)
+  )
+  .expectJSON({name: 'dub', value: 'invalid'});

--- a/service-tests/dub.js
+++ b/service-tests/dub.js
@@ -16,8 +16,8 @@ const isVersionColor = Joi.equal(
   colorscheme.yellow.colorB,
   colorscheme.yellowgreen.colorB,
   colorscheme.green.colorB,
-  colorscheme.brightgreen.colorB,
-)
+  colorscheme.brightgreen.colorB
+);
 
 const t = new ServiceTester({ id: 'dub', title: 'Dub' });
 module.exports = t;


### PR DESCRIPTION
- add tests
- improve error handling
- switch to https

For the moment I have commented out the test for "total downloads, specific version (valid)" because the endpoint used in this call seems to frequently take more than the 5 second timeout to respond so that test often fails. Is there a way to increase the timeout for one specific test? All the others seem to consistently complete inside the expected time.

Simultaneously, another question that arises here is: does it provide good user experience to have a badge which often takes >5 seconds to render?