### PR TITLE
[dynamic-xml dynamic-json] Set request options for dynamic json badges.

### DIFF
--- a/server.js
+++ b/server.js
@@ -7480,13 +7480,22 @@ cache({
     }
     var url = encodeURI(decodeURIComponent(query.url || query.uri));
 
-    if (type === 'json') {
-      requestOptions = {
-        headers: {
-          Accept: 'application/json'
-        },
-        json: true
-      };
+    switch (type) {
+      case 'json':
+        requestOptions = {
+          headers: {
+            Accept: 'application/json'
+          },
+          json: true
+        };
+        break;
+      case 'xml':
+        requestOptions = {
+          headers: {
+            Accept: 'application/xml, text/xml'
+          }
+        };
+        break;
     }
 
     request(url, requestOptions, (err, res, data) => {

--- a/server.js
+++ b/server.js
@@ -7468,6 +7468,7 @@ cache({
     var prefix = query.prefix || '';
     var suffix = query.suffix || '';
     var pathExpression = query.query;
+    var requestOptions = {};
 
     var badgeData = getBadgeData('custom badge', query);
 
@@ -7479,7 +7480,16 @@ cache({
     }
     var url = encodeURI(decodeURIComponent(query.url || query.uri));
 
-    request(url, (err, res, data) => {
+    if (type === 'json') {
+      requestOptions = {
+        headers: {
+          Accept: 'application/json'
+        },
+        json: true
+      };
+    }
+
+    request(url, requestOptions, (err, res, data) => {
       try {
         if (checkErrorResponse(badgeData, err, res, 'resource not found')) {
           return;

--- a/service-tests/xml.js
+++ b/service-tests/xml.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Joi = require('joi');
+const { expect } = require('chai');
 const ServiceTester = require('./runner/service-tester');
 const {
   isSemver,
@@ -86,3 +87,18 @@ t.create('XML from url | error color overrides default')
 t.create('XML from url | error color overrides user specified')
   .get('.json?query=//version&colorB=10ADED&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'no url specified', colorB: colorsB.red });
+
+let headers;
+t.create('XML from url | request should set Accept header')
+  .get('.json?url=https://xml-test/api.xml&query=/name')
+  .intercept(nock => nock('https://xml-test')
+    .get('/api.xml')
+    .reply(200, function (uri, requestBody) {
+      headers = this.req.headers;
+      return '<?xml version="1.0" encoding="utf-8" ?><name>dynamic xml</name>';
+    })
+  )
+  .expectJSON({ name: 'custom badge', value: 'dynamic xml' })
+  .after(function () {
+    expect(headers).to.have.property('accept', 'application/xml, text/xml');
+  });


### PR DESCRIPTION
This change is specifically for CircleCI API but it could occur for others. The problem is CircleCI's API requires the requester to set `Accept: application/json` else it returns plain text and pretty printed json which fails JSON.parse. Adding the header makes CircleCI return expected JSON payload.
CircleCIs API Doc: https://circleci.com/docs/api/v1-reference/#accept-header

This shouldn't affect any existing request it's just including an extra header now.

