### PR TITLE
Add tests for BaseService + fix hex colors

### DIFF
--- a/services/base.js
+++ b/services/base.js
@@ -131,7 +131,7 @@ module.exports = class BaseService {
       links: toArray(overrideLink || serviceLink),
       colorA: makeColor(overrideColorA),
     };
-    const color = makeColor(overrideColorB || serviceColor || defaultColor || 'lightgrey');
+    const color = overrideColorB || serviceColor || defaultColor || 'lightgrey';
     setBadgeColor(badgeData, color);
 
     return badgeData;

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -85,6 +85,11 @@ describe('BaseService', () => {
         const badgeData = DummyService._makeBadgeData({ label: 'purr count' }, { label: 'purrs' });
         expect(badgeData.text).to.deep.equal(['purr count', 'n/a']);
       });
+
+      it('overrides the color', function () {
+        const badgeData = DummyService._makeBadgeData({ colorB: '10ADED' }, { color: 'red' });
+        expect(badgeData.colorB).to.equal('#10ADED');
+      });
     });
 
     describe('Service data', function () {
@@ -92,12 +97,22 @@ describe('BaseService', () => {
         const badgeData = DummyService._makeBadgeData({}, { message: '10k' });
         expect(badgeData.text).to.deep.equal(['cat', '10k']);
       });
+
+      it('applies the service color', function () {
+        const badgeData = DummyService._makeBadgeData({}, { color: 'red' });
+        expect(badgeData.colorscheme).to.equal('red');
+      });
     });
 
     describe('Defaults', function () {
       it('uses the default label', function () {
         const badgeData = DummyService._makeBadgeData({}, {});
         expect(badgeData.text).to.deep.equal(['cat', 'n/a']);
+      });
+
+      it('uses the default color', function () {
+        const badgeData = DummyService._makeBadgeData({}, {});
+        expect(badgeData.colorscheme).to.equal('lightgrey');
       });
     });
   });


### PR DESCRIPTION
Breaking `invokeHandler` into its own function makes it easy to test the error handling, and also to expand the error handling as I've done in this WIP branch: https://github.com/badges/shields/compare/master...paulmelnikow:rewrite-npm-typedefs