### PR TITLE
Hide left hand of badge if no label

### DIFF
--- a/templates/flat-square-template.svg
+++ b/templates/flat-square-template.svg
@@ -1,3 +1,4 @@
+{{it.widths[0] = it.text[0] && it.text[0].length ? it.widths[0] : 0;}}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+it.widths[1]}}" height="20">
   <g shape-rendering="crispEdges">
     <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>

--- a/templates/flat-template.svg
+++ b/templates/flat-template.svg
@@ -1,3 +1,4 @@
+{{it.widths[0] = it.text[0] && it.text[0].length ? it.widths[0] : 0;}}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+it.widths[1]}}" height="20">
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>

--- a/templates/for-the-badge-template.svg
+++ b/templates/for-the-badge-template.svg
@@ -1,3 +1,4 @@
+{{it.widths[0] = it.text[0] && it.text[0].length ? it.widths[0] : 0;}}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=(it.widths[0]+=(10+(it.text[0].length*1.5)))+(it.widths[1]+=(10+(it.text[1].length*2)))}}" height="28">
   <g shape-rendering="crispEdges">
     <rect width="{{=it.widths[0]}}" height="28" fill="{{=it.escapeXml(it.colorA||"#555")}}"/>

--- a/templates/plastic-template.svg
+++ b/templates/plastic-template.svg
@@ -1,3 +1,4 @@
+{{it.widths[0] = it.text[0] && it.text[0].length ? it.widths[0] : 0;}}
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=it.widths[0]+it.widths[1]}}" height="18">
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0"  stop-color="#fff" stop-opacity=".7"/>


### PR DESCRIPTION
Closes #343 

Allows badges to only show the message part without the label.


### Examples:
example uri:
`/badge/-message%20only-blue.svg`

- [x] `flat`:
![image](https://user-images.githubusercontent.com/7288322/37620723-efb510ea-2c21-11e8-8436-48b67f1c69a5.png)
- [x] `flat-square`:
![image](https://user-images.githubusercontent.com/7288322/37620758-02488368-2c22-11e8-9c92-e788ba50f6f0.png)
- [x] `plastic`:
![image](https://user-images.githubusercontent.com/7288322/37620771-0df7bdd2-2c22-11e8-8e68-0eff0ecf7836.png)
- [ ] `for-the-badge`:
![image](https://user-images.githubusercontent.com/7288322/37620794-1eeed346-2c22-11e8-9c07-3a715929dc4d.png)

### Todo:
- [ ] Fix logos:
![image](https://user-images.githubusercontent.com/7288322/37621150-fe1440ba-2c22-11e8-9795-2905e4b975a2.png)
- [ ] Make the first `-` optional:
`/badge/message%20only-blue.svg`
- [ ] Add test:
_unsure how to add tests for these, any suggestions welcomed :smile:_