### PR TITLE
Add [Jenkins] Jacoco coverage badge ☘

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -207,12 +207,16 @@ const allBadgeExamples = [
         previewUri: '/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg'
       },
       {
-        title: 'Jenkins tests',
+        title: 'Jenkins Tests',
         previewUri: '/jenkins/t/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg'
       },
       {
-        title: 'Jenkins coverage',
+        title: 'Jenkins Coverage (Cobertura)',
         previewUri: '/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
+      },
+      {
+        title: 'Jenkins Coverage (Jacoco)',
+        previewUri: '/jenkins/j/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
       },
       {
         title: 'Bitbucket Pipelines',

--- a/server.js
+++ b/server.js
@@ -4820,7 +4820,7 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Jenkins coverage integration
+// Jenkins coverage integration (cobertura)
 camp.route(/^\/jenkins(?:-ci)?\/c\/(http(?:s)?)\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var scheme = match[1];  // http(s)
@@ -4862,6 +4862,61 @@ cache(function(data, match, sendBadge, request) {
         return;
       }
       var coverage = coverageObject.ratio;
+      if (+coverage !== +coverage) {
+        badgeData.text[1] = 'unknown';
+        sendBadge(format, badgeData);
+        return;
+      }
+      badgeData.text[1] = coverage.toFixed(0) + '%';
+      badgeData.colorscheme = coveragePercentageColor(coverage);
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
+// Jenkins coverage integration (jacoco)
+camp.route(/^\/jenkins(?:-ci)?\/j\/(http(?:s)?)\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  var scheme = match[1];  // http(s)
+  var host = match[2];  // example.org:8080
+  var job = match[3];  // folder/job
+  var format = match[4];
+  var options = {
+    json: true,
+    uri: scheme + '://' + host + '/job/' + job
+      + '/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]'
+  };
+  if (job.indexOf('/') > -1 ) {
+    options.uri = scheme + '://' + host + '/' + job
+      + '/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]';
+  }
+
+  if (serverSecrets && serverSecrets.jenkins_user) {
+    options.auth = {
+      user: serverSecrets.jenkins_user,
+      pass: serverSecrets.jenkins_pass
+    };
+  }
+
+  var badgeData = getBadgeData('coverage', data);
+  request(options, function(err, res, json) {
+    if (err !== null) {
+      badgeData.text[1] = 'inaccessible';
+      sendBadge(format, badgeData);
+      return;
+    }
+
+    try {
+      var coverageObject = json.instructionCoverage;
+      if (coverageObject === undefined) {
+        badgeData.text[1] = 'inaccessible';
+        sendBadge(format, badgeData);
+        return;
+      }
+      var coverage = coverageObject.percentage;
       if (+coverage !== +coverage) {
         badgeData.text[1] = 'unknown';
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -4914,7 +4914,7 @@ cache(function(data, match, sendBadge, request) {
         return;
       }
       const coverage = coverageObject.percentage;
-      if (+coverage !== +coverage) {
+      if (isNaN(coverage)) {
         badgeData.text[1] = 'unknown';
         sendBadge(format, badgeData);
         return;

--- a/server.js
+++ b/server.js
@@ -4901,8 +4901,7 @@ cache(function(data, match, sendBadge, request) {
 
   const badgeData = getBadgeData('coverage', data);
   request(options, function(err, res, json) {
-    if (err !== null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }

--- a/server.js
+++ b/server.js
@@ -4880,11 +4880,11 @@ cache(function(data, match, sendBadge, request) {
 // Jenkins coverage integration (jacoco)
 camp.route(/^\/jenkins(?:-ci)?\/j\/(http(?:s)?)\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var scheme = match[1];  // http(s)
-  var host = match[2];  // example.org:8080
-  var job = match[3];  // folder/job
-  var format = match[4];
-  var options = {
+  const scheme = match[1];  // http(s)
+  const host = match[2];  // example.org:8080
+  const job = match[3];  // folder/job
+  const format = match[4];
+  const options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job
       + '/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]'
@@ -4901,7 +4901,7 @@ cache(function(data, match, sendBadge, request) {
     };
   }
 
-  var badgeData = getBadgeData('coverage', data);
+  const badgeData = getBadgeData('coverage', data);
   request(options, function(err, res, json) {
     if (err !== null) {
       badgeData.text[1] = 'inaccessible';
@@ -4910,13 +4910,13 @@ cache(function(data, match, sendBadge, request) {
     }
 
     try {
-      var coverageObject = json.instructionCoverage;
+      const coverageObject = json.instructionCoverage;
       if (coverageObject === undefined) {
         badgeData.text[1] = 'inaccessible';
         sendBadge(format, badgeData);
         return;
       }
-      var coverage = coverageObject.percentage;
+      const coverage = coverageObject.percentage;
       if (+coverage !== +coverage) {
         badgeData.text[1] = 'unknown';
         sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -4845,7 +4845,7 @@ cache(function(data, match, sendBadge, request) {
       options.uri += 'lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]';
       break;
   }
-  
+
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
       user: serverSecrets.jenkins_user,

--- a/server.js
+++ b/server.js
@@ -4886,12 +4886,10 @@ cache(function(data, match, sendBadge, request) {
   const format = match[4];
   const options = {
     json: true,
-    uri: scheme + '://' + host + '/job/' + job
-      + '/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]'
+    uri: `${scheme}://${host}/job/${job}/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]`
   };
   if (job.indexOf('/') > -1 ) {
-    options.uri = scheme + '://' + host + '/' + job
-      + '/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]';
+    options.uri = `${scheme}://${host}/${job}/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]`;
   }
 
   if (serverSecrets && serverSecrets.jenkins_user) {

--- a/services/jenkins/jenkins.tester.js
+++ b/services/jenkins/jenkins.tester.js
@@ -41,6 +41,14 @@ t.create('cobertura: connection error')
   .networkOff()
   .expectJSON({ name: 'plugin', value: 'inaccessible' });
 
+t.create('jacoco: 81% | valid coverage')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
+    .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: 81, percentageFloat: 80.5983, total: 49006 } })
+  )
+  .expectJSONTypes({ name: 'coverage', value: '81%' });
+
 t.create('jacoco: inaccessible | request error')
   .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
   .networkOff()
@@ -61,14 +69,6 @@ t.create('jacoco: unknown | invalid coverage (non-numeric)')
     .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: 'non-numeric', percentageFloat: 80.5983, total: 49006 } })
   )
   .expectJSONTypes({ name: 'coverage', value: 'unknown' });
-
-t.create('jacoco: 81% | valid coverage')
-  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
-  .intercept(nock => nock('https://updates.jenkins-ci.org')
-    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
-    .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: 81, percentageFloat: 80.5983, total: 49006 } })
-  )
-  .expectJSONTypes({ name: 'coverage', value: '81%' });
 
 t.create('jacoco: unknown | exception handling')
   .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')

--- a/services/jenkins/jenkins.tester.js
+++ b/services/jenkins/jenkins.tester.js
@@ -6,7 +6,7 @@ const ServiceTester = require('../service-tester');
 const t = new ServiceTester({ id: 'jenkins', title: 'Jenkins' });
 module.exports = t;
 
-t.create('latest version')
+t.create('cobertura: latest version')
   .get('/plugin/v/blueocean.json')
   .intercept(nock => nock('https://updates.jenkins-ci.org')
     .get('/current/update-center.actual.json')
@@ -17,7 +17,7 @@ t.create('latest version')
     value: Joi.string().regex(/^v(.*)$/)
   }));
 
-t.create('version 0')
+t.create('cobertura: version 0')
   .get('/plugin/v/blueocean.json')
   .intercept(nock => nock('https://updates.jenkins-ci.org')
     .get('/current/update-center.actual.json')
@@ -28,7 +28,7 @@ t.create('version 0')
     value: Joi.string().regex(/^v0$/)
   }));
 
-t.create('inexistent artifact')
+t.create('cobertura: inexistent artifact')
   .get('/plugin/v/inexistent-artifact-id.json')
   .intercept(nock => nock('https://updates.jenkins-ci.org')
     .get('/current/update-center.actual.json')
@@ -36,7 +36,7 @@ t.create('inexistent artifact')
   )
   .expectJSON({ name: 'plugin', value: 'not found' });
 
-t.create('connection error')
+t.create('cobertura: connection error')
   .get('/plugin/v/blueocean.json')
   .networkOff()
   .expectJSON({ name: 'plugin', value: 'inaccessible' });

--- a/services/jenkins/jenkins.tester.js
+++ b/services/jenkins/jenkins.tester.js
@@ -40,3 +40,40 @@ t.create('connection error')
   .get('/plugin/v/blueocean.json')
   .networkOff()
   .expectJSON({ name: 'plugin', value: 'inaccessible' });
+
+t.create('jacoco: inaccessible | request error')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .networkOff()
+  .expectJSONTypes({ name: 'coverage', value: 'inaccessible' });
+
+t.create('jacoco: inaccessible | invalid coverage object')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
+    .reply(200, { invalidCoverageObject: { covered: 39498, missed: 9508, percentage: 81, percentageFloat: 80.5983, total: 49006 } })
+  )
+  .expectJSONTypes({ name: 'coverage', value: 'inaccessible' });
+
+t.create('jacoco: unknown | invalid coverage (non-numeric)')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
+    .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: 'non-numeric', percentageFloat: 80.5983, total: 49006 } })
+  )
+  .expectJSONTypes({ name: 'coverage', value: 'unknown' });
+
+t.create('jacoco: 81% | valid coverage')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
+    .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: 81, percentageFloat: 80.5983, total: 49006 } })
+  )
+  .expectJSONTypes({ name: 'coverage', value: '81%' });
+
+t.create('jacoco: unknown | exception handling')
+  .get('/j/https/updates.jenkins-ci.org/job/hello-project/job/master.json')
+  .intercept(nock => nock('https://updates.jenkins-ci.org')
+    .get('/job/hello-project/job/master/lastBuild/jacoco/api/json?tree=instructionCoverage[covered,missed,percentage,total]')
+    .reply(200, { instructionCoverage: { covered: 39498, missed: 9508, percentage: '81.x', percentageFloat: 80.5983, total: 49006 } })
+  )
+  .expectJSONTypes({ name: 'coverage', value: 'unknown' });


### PR DESCRIPTION
This PR added a new badge support for Jenkins Jacoco Code Coverage using `/jenkins/j` in the route.

> https://img.shields.io/jenkins/j/https/[jenkins-project-url].svg

Url Pattern for Jenkins Jacoco coverage report in json format.
> https://[jenkins-host]/job/[project]/job/[branch]/lastBuild/jacoco/api/json

Sample Jenkins Jacoco coverage report in json format.
```
{
   "_class":"hudson.plugins.jacoco.report.CoverageReport",
   "branchCoverage":{
      "covered":1796,
      "missed":819,
      "percentage":69,
      "percentageFloat":68.68069,
      "total":2615
   },
   "classCoverage":{
      "covered":235,
      "missed":48,
      "percentage":83,
      "percentageFloat":83.038864,
      "total":283
   },
   "complexityScore":{
      "covered":2398,
      "missed":1205,
      "percentage":67,
      "percentageFloat":66.55565,
      "total":3603
   },
   "instructionCoverage":{
      "covered":39498,
      "missed":9508,
      "percentage":81,
      "percentageFloat":80.5983,
      "total":49006
   },
   "lineCoverage":{
      "covered":7724,
      "missed":1723,
      "percentage":82,
      "percentageFloat":81.761406,
      "total":9447
   },
   "methodCoverage":{
      "covered":1627,
      "missed":597,
      "percentage":73,
      "percentageFloat":73.15648,
      "total":2224
   },
   "previousResult":{
      "_class":"hudson.plugins.jacoco.report.CoverageReport"
   }
}
```