### PR TITLE
[microbadger] Fix tests

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1917,7 +1917,7 @@ const allBadgeExamples = [
       },
       {
         title: 'MicroBadger Size',
-        previewUri: '/microbadger/image-size/jumanjiman/puppet.svg',
+        previewUri: '/microbadger/image-size/fedora/apache.svg',
         keywords: [
           'docker'
         ]

--- a/services/microbadger/microbadger.tester.js
+++ b/services/microbadger/microbadger.tester.js
@@ -9,14 +9,14 @@ const t = new ServiceTester({ id: 'microbadger', title: 'MicroBadger' });
 module.exports = t;
 
 t.create('image size without a specified tag')
-  .get('/image-size/jumanjiman/puppet.json')
+  .get('/image-size/fedora/apache.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'image size',
     value: isFileSize
   }));
 
 t.create('image size without a specified tag and no download size data returned')
-  .get('/image-size/_/centos.json')
+  .get('/image-size/puppet/puppetserver.json')
   .expectJSON({ name: 'image size', value: 'unknown' });
 
 t.create('image size with a specified tag')


### PR DESCRIPTION
This pull request should fix the failing MicroBadger tests reported in #1591 (`image size without a specified tag` and `image size without a specified tag and no download size data returned`). If they start failing again in the near future, I suggest we rethink our testing strategy for this service (perhaps looser validation?), but for now, let's give it another try!