### PR TITLE
Only compute user/repo if suggesting badges for GitHub

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -37,11 +37,11 @@ function suggest (allowedOrigin, data, end, ask) {
 // url: string
 // cb: function({badges})
 function findSuggestions (url, cb) {
-  const userRepo = url.pathname.slice(1).split('/');
-  const user = userRepo[0];
-  const repo = userRepo[1];
   let promises = [];
   if (url.hostname === 'github.com') {
+    const userRepo = url.pathname.slice(1).split('/');
+    const user = userRepo[0];
+    const repo = userRepo[1];
     promises = promises.concat([
       githubIssues(user, repo),
       githubForks(user, repo),


### PR DESCRIPTION
This resolves the following error occurring in production:

```
TypeError: Cannot read property 'slice' of null
/home/m/shields/lib/suggest.js in findSuggestions at line 40:33
  const userRepo = url.pathname.slice(1).split('/');
```