### PR TITLE
Skip Twitter suggestion if URL does not have protocol

### DIFF
--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -60,6 +60,7 @@ function findSuggestions (url, cb) {
 }
 
 function twitterPage (url) {
+  if (url.protocol === null) { return Promise.resolve(null); }
   const schema = url.protocol.slice(0, -1);
   const host = url.host;
   const path = url.path;


### PR DESCRIPTION
This resolves the following error occurring in production:

```
TypeError: Cannot read property 'slice' of null
/home/m/shields/lib/suggest.js in twitterPage at line 63:31
  const schema = url.protocol.slice(0, -1);
```