### PR TITLE
[CodeClimate] Added missing try-catch block

### DIFF
--- a/server.js
+++ b/server.js
@@ -2716,34 +2716,39 @@ cache(function(data, match, sendBadge, request) {
           return;
         }
 
-        const parsedData = JSON.parse(buffer);
-        if (type === 'coverage' && isAlternativeFormat) {
-          const score = parsedData.data.attributes.rating.letter;
-          badgeData.text[1] = score;
-          badgeData.colorscheme = letterScoreColor(score);
-        } else if (type === 'coverage') {
-          const percentage = parseFloat(parsedData.data.attributes.covered_percent);
-          badgeData.text[1] = percentage.toFixed(0) + '%';
-          badgeData.colorscheme = coveragePercentageColor(percentage);
-        } else if (type === 'issues') {
-          const count = parsedData.data.meta.issues_count;
-          badgeData.text[1] = count;
-          badgeData.colorscheme = colorScale([1, 5, 10, 20], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(count);
-        } else if (type === 'technical debt') {
-          const percentage = parseFloat(parsedData.data.attributes.ratings[0].measure.value);
-          badgeData.text[1] = percentage.toFixed(0) + '%';
-          badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
-        } else if (type === 'maintainability' && isAlternativeFormat) {
-          // maintainability = 100 - technical debt
-          const percentage = 100 - parseFloat(parsedData.data.attributes.ratings[0].measure.value);
-          badgeData.text[1] = percentage.toFixed(0) + '%';
-          badgeData.colorscheme = colorScale([50, 80, 90, 95], ['red', 'yellow', 'yellowgreen', 'green', 'brightgreen'])(percentage);
-        } else if (type === 'maintainability') {
-          const score = parsedData.data.attributes.ratings[0].letter;
-          badgeData.text[1] = score;
-          badgeData.colorscheme = letterScoreColor(score);
+        try {
+          const parsedData = JSON.parse(buffer);
+          if (type === 'coverage' && isAlternativeFormat) {
+            const score = parsedData.data.attributes.rating.letter;
+            badgeData.text[1] = score;
+            badgeData.colorscheme = letterScoreColor(score);
+          } else if (type === 'coverage') {
+            const percentage = parseFloat(parsedData.data.attributes.covered_percent);
+            badgeData.text[1] = percentage.toFixed(0) + '%';
+            badgeData.colorscheme = coveragePercentageColor(percentage);
+          } else if (type === 'issues') {
+            const count = parsedData.data.meta.issues_count;
+            badgeData.text[1] = count;
+            badgeData.colorscheme = colorScale([1, 5, 10, 20], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(count);
+          } else if (type === 'technical debt') {
+            const percentage = parseFloat(parsedData.data.attributes.ratings[0].measure.value);
+            badgeData.text[1] = percentage.toFixed(0) + '%';
+            badgeData.colorscheme = colorScale([5, 10, 20, 50], ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red'])(percentage);
+          } else if (type === 'maintainability' && isAlternativeFormat) {
+            // maintainability = 100 - technical debt
+            const percentage = 100 - parseFloat(parsedData.data.attributes.ratings[0].measure.value);
+            badgeData.text[1] = percentage.toFixed(0) + '%';
+            badgeData.colorscheme = colorScale([50, 80, 90, 95], ['red', 'yellow', 'yellowgreen', 'green', 'brightgreen'])(percentage);
+          } else if (type === 'maintainability') {
+            const score = parsedData.data.attributes.ratings[0].letter;
+            badgeData.text[1] = score;
+            badgeData.colorscheme = letterScoreColor(score);
+          }
+          sendBadge(format, badgeData);
+        } catch(e) {
+            badgeData.text[1] = 'invalid';
+            sendBadge(format, badgeData);
         }
-        sendBadge(format, badgeData);
       });
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/services/codeclimate/codeclimate.tester.js
+++ b/services/codeclimate/codeclimate.tester.js
@@ -95,4 +95,27 @@ t.create('maintainability letter for repo without snapshots')
     value: 'unknown'
   });
 
+t.create('malformed response for outer user repos query')
+  .get('/maintainability/angular/angular.js.json')
+  .intercept(nock => nock('https://api.codeclimate.com')
+    .get('/v1/repos?github_slug=angular/angular.js')
+    .reply(200, {
+      data: [{}] // No relationships in the list of data elements.
+    }))
+  .expectJSON({
+    name: 'maintainability',
+    value: 'invalid'
+  });
+
+t.create('malformed response for inner specific repo query')
+  .get('/maintainability/angular/angular.js.json')
+  .intercept(nock => nock('https://api.codeclimate.com', {allowUnmocked: true})
+    .get('/v1/repos/526933117e00a40567008444/snapshots/5ab4427859c16c0001003cad')
+    .reply(200, {})) // No data.
+  .networkOn() // Combined with allowUnmocked: true, this allows the outer user repos query to go through.
+  .expectJSON({
+    name: 'maintainability',
+    value: 'invalid'
+  });
+
 module.exports = t;


### PR DESCRIPTION
This pull request should resolve #1607. I believe we were missing a try/catch block for the inner API request. It seems that were are kind of duplicating the same try/catch block twice for this service, but I'm unsure how to handle that in a better way. 😉 