### PR TITLE
Number support for version color formatter

### DIFF
--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -7,11 +7,13 @@
 const moment = require('moment');
 
 function version(version) {
-  let first = version[0];
+  // The passed in version may or may not already be a string. See #1599.
+  const stringifiedVersion = '' + version;
+  let first = stringifiedVersion[0];
   if (first === 'v') {
-    first = version[1];
+    first = stringifiedVersion[1];
   }
-  if (first === '0' || /alpha|beta|snapshot|dev|pre/.test(version.toLowerCase())) {
+  if (first === '0' || /alpha|beta|snapshot|dev|pre/i.test(stringifiedVersion)) {
     return 'orange';
   } else {
     return 'blue';

--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -7,13 +7,12 @@
 const moment = require('moment');
 
 function version(version) {
-  // The passed in version may or may not already be a string. See #1599.
-  const stringifiedVersion = '' + version;
-  let first = stringifiedVersion[0];
+  version = '' + version;
+  let first = version[0];
   if (first === 'v') {
-    first = stringifiedVersion[1];
+    first = version[1];
   }
-  if (first === '0' || /alpha|beta|snapshot|dev|pre/i.test(stringifiedVersion)) {
+  if (first === '0' || /alpha|beta|snapshot|dev|pre/i.test(version)) {
     return 'orange';
   } else {
     return 'blue';

--- a/lib/color-formatters.spec.js
+++ b/lib/color-formatters.spec.js
@@ -66,9 +66,14 @@ describe('Color formatters', function() {
   });
 
   test(version, () => {
-    given('1.0').expect('blue');
+    forCases([
+      given('1.0'),
+      given(9),
+      given(1.0),
+    ]).expect('blue');
 
     forCases([
+      given(0.1),
       given('0.9'),
       given('1.0-Beta'),
       given('1.1-alpha'),


### PR DESCRIPTION
This pull request is related to discussions in #1599.

Tests to cover cases where the version is provided as a numerical value were added. I thought of several different ways of tackling the implementation and went with one, but a more experienced Javascript reviewer may have some better ideas. 👍 