### PR TITLE
loosely detect semver versions

### DIFF
--- a/lib/version.js
+++ b/lib/version.js
@@ -83,14 +83,14 @@ function compareDottedVersion(v1, v2) {
 // Slice the specified number of dotted parts from the given semver version.
 // e.g. slice('2.4.7', 'minor') -> '2.4'
 function slice(v, releaseType) {
-  if (! semver.valid(v)) {
+  if (! semver.valid(v, true)) {
     return null;
   }
 
-  const major = semver.major(v);
-  const minor = semver.minor(v);
-  const patch = semver.patch(v);
-  const prerelease = semver.prerelease(v);
+  const major = semver.major(v, true);
+  const minor = semver.minor(v, true);
+  const patch = semver.patch(v, true);
+  const prerelease = semver.prerelease(v, true);
 
   const dottedParts = {
     major: [major],
@@ -115,7 +115,7 @@ function minor(v) {
 }
 
 function rangeStart(v) {
-  const range = new semver.Range(v);
+  const range = new semver.Range(v, true);
   return range.set[0][0].semver.version;
 }
 

--- a/lib/version.js
+++ b/lib/version.js
@@ -18,7 +18,7 @@ function latest(versions) {
     return (/[0-9]/).test(version);
   });
   try {
-    version = semver.maxSatisfying(versions, '');
+    version = semver.maxSatisfying(versions, '', true);
   } catch(e) {
     version = latestDottedVersion(versions);
   }


### PR DESCRIPTION
Closes #1622 
refer: https://www.npmjs.com/package/semver#functions
>All methods and classes take a final loose boolean argument that, if true, will be more forgiving about not-quite-valid semver strings. The resulting output will always be 100% strict, of course.

This PR will allow "not-quite-valid semver strings" example: `1.023.4`
```javascript
semver.valid('1.023.4') // null
semver.valid('1.023.4', true) // '1.23.4'
```

#### Note:
Only the change on line 21 is needed to close #1622, but figured we should add support for the other places these functions are used also.