### PR TITLE
[DotnetStatus] Service deprecation

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -2172,10 +2172,6 @@ const allBadgeExamples = [
         previewUri: '/david/peer/webcomponents/generator-element.svg'
       },
       {
-        title: '.Net Status (GitHub)',
-        previewUri: '/dotnetstatus/gh/jaredcnance/dotnet-status/API.svg'
-      },
-      {
         title: 'bitHound',
         previewUri: '/bithound/dependencies/github/rexxars/sse-channel.svg'
       },

--- a/lib/deprecated-services.js
+++ b/lib/deprecated-services.js
@@ -7,6 +7,7 @@ const deprecatedServices = {
   'snap': new Date('2018-01-23'),
   'snap-ci': new Date('2018-01-23'),
   'cauditor': new Date('2018-02-15'),
+  'dotnetstatus': new Date('2018-04-01'),
 };
 
 module.exports = {

--- a/server.js
+++ b/server.js
@@ -2940,50 +2940,12 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// dotnet-status integration.
+// dotnet-status integration - deprecated as of April 2018.
 camp.route(/^\/dotnetstatus\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var projectUri = match[1]; // gh/{USER}/{REPO}/{PROJECT}
-  var format = match[2];
-  var url = 'http://dotnet-status.com/api/status/' + projectUri + '/';
-  var badgeData = getBadgeData('dependencies', data);
-  var sendErrorBadge = function() {
-    badgeData.text[1] = 'inconclusive';
-    sendBadge(format, badgeData);
-  };
-
-  request(url, function (err, res, buffer) {
-    if (err != null || res.statusCode === 404) {
-      sendErrorBadge();
-      return;
-    }
-
-    if (res.statusCode === 202) {
-      badgeData.text[1] = 'processing';
-      sendBadge(format, badgeData);
-      return;
-    }
-
-    try {
-      var data = JSON.parse(buffer);
-      if(data.projectResults.length === 1 && data.projectResults[0] !== null) {
-        if (data.projectResults[0].outOfDate) {
-          badgeData.text[1] = 'out of date';
-          badgeData.colorscheme = 'red';
-        } else {
-          badgeData.text[1] = 'up to date';
-          badgeData.colorscheme = 'blue';
-        }
-      }
-      else {
-        badgeData.text[1] = 'project not found';
-      }
-      sendBadge(format, badgeData);
-    }
-    catch (e) {
-      sendErrorBadge();
-    }
-  });
+  const format = match[2];
+  const badgeData = getDeprecatedBadge('dotnet status', data);
+  sendBadge(format, badgeData);
 }));
 
 // Gemnasium integration

--- a/services/dotnetstatus/dotnetstatus.tester.js
+++ b/services/dotnetstatus/dotnetstatus.tester.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 
 const t = new ServiceTester({ id: 'dotnetstatus', title: 'dotnet-status' });

--- a/services/dotnetstatus/dotnetstatus.tester.js
+++ b/services/dotnetstatus/dotnetstatus.tester.js
@@ -1,30 +1,14 @@
-"use strict";
+'use strict';
 
-const Joi = require("joi");
+const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 
-const t = new ServiceTester({
-  id: "dotnetstatus",
-  title: "dotnet-status"
-});
+const t = new ServiceTester({ id: 'dotnetstatus', title: 'dotnet-status' });
 module.exports = t;
 
-t
-  .create("get nuget package status")
-  .get("/gh/jaredcnance/dotnet-status/API.json")
-  .expectJSONTypes(
-    Joi.object().keys({
-      name: "dependencies",
-      value: Joi.equal("up to date", "out of date", "processing")
-    })
-  );
-
-t
-  .create("get nuget package status")
-  .get("/gh/jaredcnance/dotnet-status/invalid-project.json")
-  .expectJSON({ name: "dependencies", value: "project not found" });
-
-t
-  .create("get nuget package status error")
-  .get("/not-a-valid-uri.json")
-  .expectJSON({ name: "dependencies", value: "inconclusive" });
+t.create('no longer available (previously get package status)')
+  .get('/gh/jaredcnance/dotnet-status/API.json')
+  .expectJSON({
+    name: 'dotnet status',
+    value: 'no longer available'
+  });


### PR DESCRIPTION
This pull request is related to discussions in #1591. It's now been over a month that the tests are failing due to the service being down (see [this issue](https://github.com/jaredcnance/dotnet-status/issues/18)). There is no news from the author, I suggest we deprecate the service.