### PR TITLE
change CC0 example in [github] service tests

### DIFF
--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -24,7 +24,7 @@ const copyleftLicenseColor = colorsB[licenseToColor('GPL-3.0')];
 const unknownLicenseColor = colorsB[licenseToColor()];
 
 t.create('Public domain license')
-  .get('/license/badges/shields.json?style=_shields_test')
+  .get('/license/github/gitignore.json?style=_shields_test')
   .expectJSON({ name: 'license', value: 'CC0-1.0', colorB: publicDomainLicenseColor });
 
 t.create('Copyleft license')


### PR DESCRIPTION
This is a suggested quick fix for the last failure identified in issue #1591

This test is failing because the license on our repo is not recognised as being CC0. If we hit https://api.github.com/repos/badges/shields GH describes our license as:

```
...
  "license": {
    "key": "other",
    "name": "Other",
    "spdx_id": null,
    "url": null
  },
...
```

This PR just switches the test to use an example which GH does identify as CC0 licensed to get the tests passing agiain.

There is a second issue though which is that GH no longer recognises our repo as being CC0 licensed. If we look at https://github.com/badges/shields/blob/master/LICENSE.md there is no banner but if we look at https://github.com/github/gitignore/blob/master/LICENSE there is. This is obviously something in the way GH identifies licenses that has changed fairly recently because that test passed at some point and `LICENSE.md` hasn't changed in 4 years. However, the path of least resistance may be to bring the wording/layout in our LICENSE file into line with the standard GH version so it will be correctly identified. Happy to submit a PR to do that, but I'm not familiar with the history around license choice for this project so might benefit from some input?