### PR TITLE
[librariesio] Missing try/catch block and tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -7084,9 +7084,9 @@ cache(function(data, match, sendBadge, request) {
   const badgeData = getBadgeData('dependencies', data);
 
   request(options, function(err, res, json) {
-    if (err || res.statusCode !== 200) {
-      badgeData.text[1] = 'not available';
-      return sendBadge(format, badgeData);
+    if (checkErrorResponse(badgeData, err, res, 'not available')) {
+      sendBadge(format, badgeData);
+      return;
     }
 
     try {

--- a/server.js
+++ b/server.js
@@ -7069,13 +7069,15 @@ cache(function(data, match, sendBadge, request) {
 
   let uri;
   switch (resource) {
-    case 'github':
+    case 'github': {
       uri = 'https://libraries.io/api/github/' + project + '/dependencies';
       break;
-    case 'release':
+    }
+    case 'release': {
       const v = version || 'latest';
       uri = 'https://libraries.io/api/' + project + '/' + v + '/dependencies';
       break;
+    }
   }
 
   const options = {method: 'GET', json: true, uri: uri};

--- a/services/librariesio/librariesio.tester.js
+++ b/services/librariesio/librariesio.tester.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('../service-tester');
+const {
+  isDependencyState
+} = require('../test-validators');
+
+const t = new ServiceTester({ id: 'librariesio', title: 'Libraries.io' });
+module.exports = t;
+
+t.create('dependencies for releases')
+  .get('/release/hex/phoenix/1.0.3.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'dependencies',
+    value: isDependencyState,
+  }));
+
+t.create('dependencies for github')
+  .get('/github/pyvesb/notepad4e.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'dependencies',
+    value: isDependencyState,
+  }));
+
+t.create('release not found')
+  .get('/release/hex/invalid/4.0.4.json')
+  .expectJSON({
+    name: 'dependencies',
+    value: 'not available',
+  });
+
+t.create('no response data')
+  .get('/github/phoenixframework/phoenix.json')
+  .intercept(nock => nock('https://libraries.io')
+    .get('/api/github/phoenixframework/phoenix/dependencies')
+    .reply(200))
+  .expectJSON({
+     name: 'dependencies',
+     value: 'invalid',
+  });

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -67,6 +67,8 @@ const isFormattedDate = Joi.alternatives().try(
   Joi.string().regex(/^last (sun|mon|tues|wednes|thurs|fri|satur)day$/),
   Joi.string().regex(/^(january|february|march|april|may|june|july|august|september|october|november|december)( \d{4})?$/));
 
+const isDependencyState = withRegex(/^(\d+ out of date|\d+ deprecated|up to date)$/);
+
 module.exports = {
   isSemver,
   isVPlusTripleDottedVersion,
@@ -83,5 +85,6 @@ module.exports = {
   isIntegerPercentage,
   isDecimalPercentage,
   isFileSize,
-  isFormattedDate
+  isFormattedDate,
+  isDependencyState
 };


### PR DESCRIPTION
This pull request should close #1621 by adding our usual try/catch block. There weren't any tests for this service, so I implemented a simple test suite (one extra box ticked in #1358! 👍 ) and also got rid of the `var` keyword in favour of more appropriate identifiers.