### PR TITLE
Add [launchpad].net support

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -726,15 +726,7 @@ const allBadgeExamples = [
       {
         title: 'Ansible Role',
         previewUri: '/ansible/role/d/3078.svg'
-      },
-      {
-        title: 'Launchpad.net PPA downloads',
-        previewUri: '/launchpad/ppa/downloads/otto-kesselgulasch/gimp/gimp.svg',
-        keywords: [
-            'launchpad',
-            'ppa'
-        ]
-      },
+      }
     ]
   },
   {

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -726,7 +726,15 @@ const allBadgeExamples = [
       {
         title: 'Ansible Role',
         previewUri: '/ansible/role/d/3078.svg'
-      }
+      },
+      {
+        title: 'Launchpad.net PPA downloads',
+        previewUri: '/launchpad/ppa/downloads/otto-kesselgulasch/gimp/gimp.svg',
+        keywords: [
+            'launchpad',
+            'ppa'
+        ]
+      },
     ]
   },
   {
@@ -1159,6 +1167,14 @@ const allBadgeExamples = [
       {
         title: 'PHP version from PHP-Eye',
         previewUri: '/php-eye/symfony/symfony.svg',
+      },
+      {
+        title: 'Launchpad.net PPA',
+        previewUri: '/launchpad/ppa/version/boltgolt/howdy/howdy.svg',
+        keywords: [
+            'launchpad',
+            'ppa'
+        ]
       },
     ]
   },

--- a/server.js
+++ b/server.js
@@ -7968,7 +7968,7 @@ cache(function (data, match, sendBadge, request) {
 }));
 
 // Launchpad integration
-camp.route(/^\/launchpad\/ppa\/([^\/]+)\/([^\/]+)\/([^\/]+)\/([^\/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/launchpad\/ppa\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   // The type of badge, either version or downloads
   var type = match[1];
@@ -8013,7 +8013,7 @@ cache(function(data, match, sendBadge, request) {
 
     // If the type requested was version we can return that
     if (type == 'version') {
-      badgeData.text[1] = foundEntry.binary_package_version
+      badgeData.text[1] = foundEntry.binary_package_version;
       badgeData.colorscheme = 'blue';
       sendBadge(format, badgeData);
     }
@@ -8028,24 +8028,24 @@ cache(function(data, match, sendBadge, request) {
 
           // Sum the total of al binaries
           for (let entry of data.entries) {
-            totalCount += entry.count
+            totalCount += entry.count;
           }
 
           // Put the total on the badge
-          badgeData.text[1] = totalCount
+          badgeData.text[1] = totalCount;
           badgeData.colorscheme = 'blue';
           sendBadge(format, badgeData);
         } catch (e) {
           badgeData.text[1] = 'invalid';
           sendBadge(format, badgeData);
         }
-      })
+    });
     }
   } catch (e) {
     badgeData.text[1] = 'invalid';
     sendBadge(format, badgeData);
   }
-})}));
+});}));
 
 // Any badge.
 camp.route(/^\/(:|badge\/)(([^-]|--)*?)-(([^-]|--)*)-(([^-]|--)+)\.(svg|png|gif|jpg)$/,

--- a/server.js
+++ b/server.js
@@ -7997,8 +7997,12 @@ cache(function(data, match, sendBadge, request) {
       for (let entry of data.entries) {
           // Don't run if the package name doesn't match
           if (entry.source_package_name != name) continue;
+          
           // If this is the first entry, set it as most recent
-          if (recentEntry == false) recentEntry = entry; continue;
+          if (recentEntry == false) {
+              recentEntry = entry;
+              continue;
+          }
 
           // Check if the entry date is later than the current max date and replace it if it is
           if (Date.parse(entry.date_published) > Date.parse(recentEntry.date_published)) {

--- a/server.js
+++ b/server.js
@@ -7997,7 +7997,7 @@ cache(function(data, match, sendBadge, request) {
       for (let entry of data.entries) {
           // Don't run if the package name doesn't match
           if (entry.source_package_name != name) continue;
-          
+
           // If this is the first entry, set it as most recent
           if (recentEntry == false) {
               recentEntry = entry;

--- a/server.js
+++ b/server.js
@@ -7984,7 +7984,7 @@ cache(function(data, match, sendBadge, request) {
   // Keep in mind that this will also return packages _starting_ with the package name
   var apiUrl = 'https://api.launchpad.net/1.0/~' + user + '/+archive/' + ppa + '?ws.op=getPublishedSources&status=Published&source_name=' + name;
   request(apiUrl, function(err, res, buffer) {
-    checkErrorResponse(badgeData, err, res, "not found")
+    checkErrorResponse(badgeData, err, res, "not found");
 
     try {
       var data = JSON.parse(buffer);

--- a/services/launchpad/launchpad.tester.js
+++ b/services/launchpad/launchpad.tester.js
@@ -9,27 +9,13 @@ module.exports = t;
 t.create('gimp ppa version')
   .get('/ppa/version/otto-kesselgulasch/gimp/gimp.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'version',
-    value: Joi.string()
-  }));
-
-t.create('gimp ppa downloads')
-  .get('/ppa/downloads/otto-kesselgulasch/gimp/gimp.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads 24h',
-    value: Joi.number()
+    name: 'launchpad',
+    value: Joi.string().regex(/^\d\.\d/)
   }));
 
 t.create('invalid version')
   .get('/ppa/version/invalid/invalid/invalid.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'version',
-    value: 'invalid'
-  }));
-
-t.create('invalid downloads')
-  .get('/ppa/downloads/invalid/invalid/invalid.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'downloads 24h',
-    value: 'invalid'
+    name: 'launchpad',
+    value: 'not found'
   }));

--- a/services/launchpad/launchpad.tester.js
+++ b/services/launchpad/launchpad.tester.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('../service-tester');
+
+const t = new ServiceTester({ id: 'launchpad', title: 'Launchpad.net' })
+module.exports = t;
+
+t.create('gimp ppa version')
+  .get('/ppa/version/otto-kesselgulasch/gimp/gimp.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'version',
+    value: Joi.string()
+  }));
+
+t.create('gimp ppa downloads')
+  .get('/ppa/downloads/otto-kesselgulasch/gimp/gimp.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads 24h',
+    value: Joi.number()
+  }));
+
+t.create('invalid version')
+  .get('/ppa/version/invalid/invalid/invalid.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'version',
+    value: 'invalid'
+  }));
+
+t.create('invalid downloads')
+  .get('/ppa/downloads/invalid/invalid/invalid.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'downloads 24h',
+    value: 'invalid'
+  }));

--- a/services/launchpad/launchpad.tester.js
+++ b/services/launchpad/launchpad.tester.js
@@ -6,16 +6,31 @@ const ServiceTester = require('../service-tester');
 const t = new ServiceTester({ id: 'launchpad', title: 'Launchpad.net' })
 module.exports = t;
 
+t.create('connection error')
+  .get('/ppa/version/otto-kesselgulasch/gimp/gimp.json')
+  .networkOff()
+  .expectJSON({
+    name: 'launchpad',
+    value: 'inaccessible'
+  });
+
 t.create('gimp ppa version')
   .get('/ppa/version/otto-kesselgulasch/gimp/gimp.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'launchpad',
-    value: Joi.string().regex(/^\d\.\d/)
+    value: Joi.string().regex(/^v\d+\.\d/)
+  }));
+
+t.create('invalid name')
+  .get('/ppa/version/otto-kesselgulasch/gimp/invalid.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'launchpad',
+    value: 'no package'
   }));
 
 t.create('invalid version')
   .get('/ppa/version/invalid/invalid/invalid.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'launchpad',
-    value: 'not found'
+    value: 'invalid'
   }));


### PR DESCRIPTION
This adds both a "version" and a "downloads" badge for packages on a launchpad.net PPA using their API. Inspired by #560.