### PR TITLE
set expires header corresponding to maxAge

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -77,17 +77,18 @@ function handleRequest (makeBadge, handlerOptions) {
   const allowedKeys = flattenQueryParams(handlerOptions.queryParams);
 
   return (queryParams, match, end, ask) => {
+    const reqTime = new Date();
+
     if (queryParams.maxAge !== undefined && /^[0-9]+$/.test(queryParams.maxAge)) {
       ask.res.setHeader('Cache-Control', 'max-age=' + queryParams.maxAge);
+      ask.res.setHeader('Expires', new Date(+reqTime + queryParams.maxAge * 1000).toGMTString());
     } else {
       // Cache management - no cache, so it won't be cached by GitHub's CDN.
       ask.res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+      ask.res.setHeader('Expires', reqTime.toGMTString());  // Proxies, GitHub, see #221.
     }
 
-    const reqTime = new Date();
-    const date = reqTime.toGMTString();
-    ask.res.setHeader('Expires', date);  // Proxies, GitHub, see #221.
-    ask.res.setHeader('Date', date);
+    ask.res.setHeader('Date', reqTime.toGMTString());
 
     analytics.noteRequest(queryParams, match);
 

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -105,6 +105,17 @@ describe('The request handler', function() {
         expect(handlerCallCount).to.equal(1);
       });
 
+      it('should set the expires header to current time', async function () {
+        const res = await fetch(`${baseUri}/testing/123.json`);
+        expect(res.headers.get('expires')).to.equal(res.headers.get('date'));
+      });
+
+      it('should set the expires header to current time + max-age', async function () {
+        const res = await fetch(`${baseUri}/testing/123.json?maxAge=3600`);
+        const expectedExpiry = new Date(+(new Date(res.headers.get('date'))) + 3600000).toGMTString();
+        expect(res.headers.get('expires')).to.equal(expectedExpiry);
+      });
+
       describe('the cache key', function () {
         const expectedCacheKey = '/testing/123.json?colorB=123&label=foo';
         it('should match expected and use canonical order - 1', async function () {


### PR DESCRIPTION
closes #1650
currently when using `?maxAge=` the `cache-control` header is set correctly but the `expires` header is always set to the current time.

### This PR:
```text
Cache-Control: max-age=3600
Date: Mon, 16 Apr 2018 21:57:47 GMT
Expires: Mon, 16 Apr 2018 22:57:47 GMT
```
### Current:
```text
cache-control: max-age=3600
date: Mon, 16 Apr 2018 21:55:33 GMT
expires: Mon, 16 Apr 2018 21:55:33 GMT
```