### PR TITLE
Add [buildkite] service

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -155,8 +155,12 @@ const allBadgeExamples = [
         previewUri: '/appveyor/tests/NZSmartie/coap-net-iu0to/master.svg'
       },
       {
-        title: 'Codeship',
-        previewUri: '/codeship/d6c1ddd0-16a3-0132-5f85-2e35c05e22b1.svg'
+        title: 'Buildkite',
+        previewUri: '/buildkite/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/branch/master.svg'
+      },
+      {
+        title: 'Buildkite',
+        previewUri: '/buildkite/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/branch/master/label/Pipeline%20name.svg'
       },
       {
         title: 'Codeship',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -156,11 +156,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Buildkite',
-        previewUri: '/buildkite/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/branch/master.svg'
-      },
-      {
-        title: 'Buildkite',
-        previewUri: '/buildkite/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/branch/master/label/Pipeline%20name.svg'
+        previewUri: '/buildkite/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/master.svg'
       },
       {
         title: 'Codeship',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -160,6 +160,10 @@ const allBadgeExamples = [
       },
       {
         title: 'Codeship',
+        previewUri: '/codeship/d6c1ddd0-16a3-0132-5f85-2e35c05e22b1.svg'
+      },
+      {
+        title: 'Codeship',
         previewUri: '/codeship/d6c1ddd0-16a3-0132-5f85-2e35c05e22b1/master.svg'
       },
       {

--- a/server.js
+++ b/server.js
@@ -6218,18 +6218,17 @@ cache(function(data, match, sendBadge, request) {
 
 
 // Buildkite integration.
-camp.route(/^\/buildkite\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/buildkite\/([^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var identifier = match[1];  // eg, 3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489
-  var branch = match[2];  // eg, master
+  var branch = match[2] || 'master';  // Defaults to master if not specified
   var format = match[3];
 
   var url = 'https://badge.buildkite.com/' + identifier + '.json?branch=' + branch;
-  var badgeData = getBadgeData('buildkite', data);
+  var badgeData = getBadgeData('build', data);
 
   request(url, function(err, res, buffer) {
-    if (err != null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res)) {
       sendBadge(format, badgeData);
       return;
     }
@@ -6238,13 +6237,13 @@ cache(function(data, match, sendBadge, request) {
       var data = JSON.parse(buffer);
       var status = data.status;
       if (status === 'passing') {
-        badgeData.text[1] = 'Passing';
+        badgeData.text[1] = 'passing';
         badgeData.colorscheme = 'green';
       } else if (status === 'failing') {
-        badgeData.text[1] = 'Failing';
+        badgeData.text[1] = 'failing';
         badgeData.colorscheme = 'red';
       } else {
-        badgeData.text[1] = 'Unknown';
+        badgeData.text[1] = 'unknown';
         badgeData.colorscheme = 'gray';
       }
 

--- a/server.js
+++ b/server.js
@@ -6218,15 +6218,14 @@ cache(function(data, match, sendBadge, request) {
 
 
 // Buildkite integration.
-camp.route(/^\/buildkite\/([^/]+)\/branch\/([^/]+)(?:\/label\/)?([^/]+)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/buildkite\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var identifier = match[1];  // eg, 3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489
   var branch = match[2];  // eg, master
-  var label = match[3];  // eg, iOS (optional)
-  var format = match[4];
+  var format = match[3];
 
   var url = 'https://badge.buildkite.com/' + identifier + '.json?branch=' + branch;
-  var badgeData = getBadgeData('Buildlkite', data);
+  var badgeData = getBadgeData('buildkite', data);
 
   request(url, function(err, res, buffer) {
     if (err != null) {
@@ -6247,10 +6246,6 @@ cache(function(data, match, sendBadge, request) {
       } else {
         badgeData.text[1] = 'Unknown';
         badgeData.colorscheme = 'gray';
-      }
-
-      if (label !== undefined) {
-        badgeData.text[0] = label;
       }
 
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -6244,7 +6244,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'red';
       } else {
         badgeData.text[1] = 'unknown';
-        badgeData.colorscheme = 'gray';
+        badgeData.colorscheme = 'lightgray';
       }
 
       sendBadge(format, badgeData);

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -27,7 +27,7 @@ t.create('buildkite connection error')
   .expectJSON({ name: 'build', value: 'inaccessible' });
 
 t.create('buildkite unexpected response')
-  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json?branch=master')
+  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json')
   .intercept(nock => nock('https://badge.buildkite.com')
     .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json?branch=master')
     .reply(invalidJSON)

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -6,8 +6,16 @@ module.exports = t;
 
 t.create('buildkite invalid pipeline')
   .get('/unknown-identifier/unknown-branch.json')
-  .expectJSON({ name: 'buildkite', value: 'invalid' });
+  .expectJSON({ name: 'build', value: 'not found' });
 
 t.create('buildkite valid pipeline')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/master.json')
-  .expectJSON({ name: 'buildkite', value: 'Passing' });
+  .expectJSON({ name: 'build', value: 'passing' });
+
+t.create('buildkite valid pipeline skipping branch')
+  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json')
+  .expectJSON({ name: 'build', value: 'passing' });
+
+t.create('buildkite unknown branch')
+  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/unknown-branch.json')
+  .expectJSON({ name: 'build', value: 'unknown' });

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('../service-tester');
+const isBuildStatus = Joi.string().regex(/^(passing|failing|unknown)$/);
+
+const t = new ServiceTester({ id: 'buildkite', title: 'Buildite Builds' });
+module.exports = t;
+
+// automated build endpoint
+
+t.create('buildkite branch build (valid, branch)')
+  .get('/_/branch/_.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'Buildkite',
+    value: isBuildStatus
+  }));
+
+t.create('buildkite branch build with label (valid, branch, label)')
+  .get('/_/branch/_/label/custom%20label.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'custom label',
+    value: isBuildStatus
+  }));

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 const t = new ServiceTester({ id: 'buildkite', title: 'Buildkite Builds' });
 const { invalidJSON } = require('../response-fixtures');
@@ -11,7 +12,10 @@ t.create('buildkite invalid pipeline')
 
 t.create('buildkite valid pipeline')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/master.json')
-  .expectJSON({ name: 'build', value: 'passing' });
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: Joi.equal('failing', 'passing', 'unknown')
+  }));
 
 t.create('buildkite valid pipeline skipping branch')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json')

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -19,3 +19,8 @@ t.create('buildkite valid pipeline skipping branch')
 t.create('buildkite unknown branch')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/unknown-branch.json')
   .expectJSON({ name: 'build', value: 'unknown' });
+
+t.create('buildkite connection error')
+  .get('/_.json')
+  .networkOff()
+  .expectJSON({ name: 'build', value: 'inaccessible' });

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -2,6 +2,7 @@
 
 const ServiceTester = require('../service-tester');
 const t = new ServiceTester({ id: 'buildkite', title: 'Buildkite Builds' });
+const { invalidJSON } = require('../response-fixtures');
 module.exports = t;
 
 t.create('buildkite invalid pipeline')
@@ -24,3 +25,11 @@ t.create('buildkite connection error')
   .get('/_.json')
   .networkOff()
   .expectJSON({ name: 'build', value: 'inaccessible' });
+
+t.create('buildkite unexpected response')
+  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json?branch=master')
+  .intercept(nock => nock('https://badge.buildkite.com')
+    .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json?branch=master')
+    .reply(invalidJSON)
+  )
+  .expectJSON({name: 'build', value: 'invalid'});

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -4,20 +4,20 @@ const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 const isBuildStatus = Joi.string().regex(/^(passing|failing|unknown)$/);
 
-const t = new ServiceTester({ id: 'buildkite', title: 'Buildite Builds' });
+const t = new ServiceTester({ id: 'buildkite', title: 'Buildkite Builds' });
 module.exports = t;
 
 // automated build endpoint
 
 t.create('buildkite branch build (valid, branch)')
-  .get('/_/branch/_.json')
+  .get('/_/_.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'Buildkite',
     value: isBuildStatus
   }));
 
 t.create('buildkite branch build with label (valid, branch, label)')
-  .get('/_/branch/_/label/custom%20label.json')
+  .get('/_/_/.json?label=custom%20label')
   .expectJSONTypes(Joi.object().keys({
     name: 'custom label',
     value: isBuildStatus

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -1,24 +1,13 @@
 'use strict';
 
-const Joi = require('joi');
 const ServiceTester = require('../service-tester');
-const isBuildStatus = Joi.string().regex(/^(passing|failing|unknown)$/);
-
 const t = new ServiceTester({ id: 'buildkite', title: 'Buildkite Builds' });
 module.exports = t;
 
-// automated build endpoint
+t.create('buildkite invalid pipeline')
+  .get('/unknown-identifier/unknown-branch.json')
+  .expectJSON({ name: 'buildkite', value: 'invalid' });
 
-t.create('buildkite branch build (valid, branch)')
-  .get('/_/_.json')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'Buildkite',
-    value: isBuildStatus
-  }));
-
-t.create('buildkite branch build with label (valid, branch, label)')
-  .get('/_/_/.json?label=custom%20label')
-  .expectJSONTypes(Joi.object().keys({
-    name: 'custom label',
-    value: isBuildStatus
-  }));
+t.create('buildkite valid pipeline')
+  .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/master.json')
+  .expectJSON({ name: 'buildkite', value: 'Passing' });

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -19,7 +19,10 @@ t.create('buildkite valid pipeline')
 
 t.create('buildkite valid pipeline skipping branch')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489.json')
-  .expectJSON({ name: 'build', value: 'passing' });
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: Joi.equal('failing', 'passing', 'unknown')
+  }));
 
 t.create('buildkite unknown branch')
   .get('/3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489/unknown-branch.json')


### PR DESCRIPTION
Fixes https://github.com/badges/shields/issues/1261 by providing Buildkite support for Shield.

Usage is:

- `/buildkite/{id}/{name}` for the default Buildkite shield `eg Buildkite | passing`