### PR TITLE
[MicroBadger] Fix tests - new attempt

### DIFF
--- a/services/microbadger/microbadger.tester.js
+++ b/services/microbadger/microbadger.tester.js
@@ -9,18 +9,14 @@ const t = new ServiceTester({ id: 'microbadger', title: 'MicroBadger' });
 module.exports = t;
 
 t.create('image size without a specified tag')
-  .get('/image-size/fedora/apache.json')
+  .get('/image-size/wikiwi/docker-build.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'image size',
     value: isFileSize
   }));
 
-t.create('image size without a specified tag and no download size data returned')
-  .get('/image-size/puppet/puppetserver.json')
-  .expectJSON({ name: 'image size', value: 'unknown' });
-
 t.create('image size with a specified tag')
-  .get('/image-size/_/httpd/alpine.json')
+  .get('/image-size/kelseyhightower/helloworld/appengine.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'image size',
     value: isFileSize
@@ -80,3 +76,11 @@ t.create('unexpected response')
     .reply(invalidJSON)
   )
   .expectJSON({ name: 'image size', value: 'error' });
+
+t.create('missing download size')
+  .get('/image-size/puppet/puppetserver.json')
+  .intercept(nock => nock('https://api.microbadger.com')
+    .get('/v1/images/puppet/puppetserver')
+    .reply(200, {})
+  )
+  .expectJSON({ name: 'image size', value: 'unknown' });


### PR DESCRIPTION
The stability of our MicroBadger service tests has been quite variable lately, due to temporary losses of metadata (in particular the download size) in some of the images we were using.

I opened [an issue](https://github.com/microscaling/microbadger/issues/38) on their service repository, which they promptly resolved by doing a full refresh of their data. I haven't noticed anything unexpected since then.

Consequently, I've rearranged the tests once again, with the hope that we won't have to revisit this again in a few weeks.
* our two"happy"  image size tests use images that haven't changed in a few years, in order to minimise the risk of the data from being lost/taking too long to be refreshed when updated.
* the "unhappy" test where no `DownloadSize` is present in the response is now mocked.

Note that I haven't changed the examples on the homepage, as they seem to be working fine at this point.