### PR TITLE
Add grade badge for [lgtm]

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -302,6 +302,10 @@ const allBadgeExamples = [
         previewUri: '/lgtm/alerts/g/apache/cloudstack.svg'
       },
       {
+        title: 'LGTM Grade',
+        previewUri: '/lgtm/grade/java/g/apache/cloudstack.svg'
+      },
+      {
         title: 'HHVM',
         previewUri: '/hhvm/symfony/symfony.svg'
       },

--- a/server.js
+++ b/server.js
@@ -1123,6 +1123,8 @@ cache(function(data, match, sendBadge, request) {
             switch(language) {
               case 'cpp':
                 return 'C/C++';
+              case 'csharp':
+                return 'C#';
               // Javascript analysis on LGTM also includes TypeScript
               case 'javascript':
                 return 'JS/TS';

--- a/server.js
+++ b/server.js
@@ -1119,7 +1119,7 @@ cache(function(data, match, sendBadge, request) {
         return language;
     }
   })();
-  const badgeData = getBadgeData('lgtm: ' + languageLabel, data);
+  const badgeData = getBadgeData('code quality: ' + languageLabel, data);
   request(url, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'project not found')) {
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -1106,7 +1106,20 @@ cache(function(data, match, sendBadge, request) {
   const projectId = match[2]; // eg, `g/apache/cloudstack`
   const format = match[3];
   const url = 'https://lgtm.com/api/v0.1/project/' + projectId + '/details';
-  const badgeData = getBadgeData('lgtm', data);
+  const languageLabel = (() => {
+    switch(language) {
+      case 'cpp':
+        return 'c/c++';
+      case 'csharp':
+        return 'c#';
+      // Javascript analysis on LGTM also includes TypeScript
+      case 'javascript':
+        return 'js/ts';
+      default:
+        return language;
+    }
+  })();
+  const badgeData = getBadgeData('lgtm: ' + languageLabel, data);
   request(url, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'project not found')) {
       sendBadge(format, badgeData);
@@ -1119,20 +1132,7 @@ cache(function(data, match, sendBadge, request) {
       for (const languageData of data.languages) {
         if (languageData.lang === language && 'grade' in languageData) {
           // Pretty label for the language
-          const languageLabel = (() => {
-            switch(language) {
-              case 'cpp':
-                return 'C/C++';
-              case 'csharp':
-                return 'C#';
-              // Javascript analysis on LGTM also includes TypeScript
-              case 'javascript':
-                return 'JS/TS';
-              default:
-                return language.charAt(0).toUpperCase() + language.slice(1);
-            }
-          })();
-          badgeData.text[1] = `${languageLabel}: ${languageData.grade}`;
+          badgeData.text[1] = languageData.grade;
           // Pick colour based on grade
           if (languageData.grade === 'A+') {
             badgeData.colorscheme = 'brightgreen';

--- a/services/lgtm/lgtm.tester.js
+++ b/services/lgtm/lgtm.tester.js
@@ -6,56 +6,161 @@ const ServiceTester = require('../service-tester');
 const t = new ServiceTester({ id: 'lgtm', title: 'LGTM' })
 module.exports = t;
 
-t.create('total alerts for a project')
+// Alerts Badge
+
+t.create('alerts: total alerts for a project')
   .get('/alerts/g/apache/cloudstack.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'lgtm',
     value: Joi.string().regex(/^[0-9kM.]+ alerts?$/)
   }));
 
-t.create('missing project')
+t.create('alerts: missing project')
   .get('/alerts/g/some-org/this-project-doesnt-exist.json')
   .expectJSON({
     name: 'lgtm',
     value: 'project not found'
   });
 
-t.create('no alerts')
+t.create('alerts: no alerts')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {alerts: 0}))
   .expectJSON({ name: 'lgtm', value: '0 alerts' });
 
-t.create('single alert')
+t.create('alerts: single alert')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {alerts: 1}))
   .expectJSON({ name: 'lgtm', value: '1 alert' });
 
-t.create('multiple alerts')
+t.create('alerts: multiple alerts')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {alerts: 123}))
   .expectJSON({ name: 'lgtm', value: '123 alerts' });
 
-t.create('json missing alerts')
+t.create('alerts: json missing alerts')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {}))
   .expectJSON({ name: 'lgtm', value: 'invalid' });
 
-t.create('invalid json')
+t.create('alerts: invalid json')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, 'not a json string'))
   .expectJSON({ name: 'lgtm', value: 'invalid' });
 
-t.create('lgtm inaccessible')
+t.create('alerts: lgtm inaccessible')
   .get('/alerts/g/apache/cloudstack.json')
   .networkOff()
   .expectJSON({ name: 'lgtm', value: 'inaccessible' });
+
+// Grade Badge
+
+t.create('grade: missing project')
+  .get('/grade/java/g/some-org/this-project-doesnt-exist.json')
+  .expectJSON({
+    name: 'lgtm',
+    value: 'project not found'
+  });
+
+t.create('grade: lgtm inaccessible')
+  .get('/grade/java/g/apache/cloudstack.json')
+  .networkOff()
+  .expectJSON({ name: 'lgtm', value: 'inaccessible' });
+
+t.create('grade: invalid json')
+  .get('/grade/java/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, 'not a json string'))
+  .expectJSON({ name: 'lgtm', value: 'invalid' });
+
+t.create('grade: json missing languages')
+  .get('/grade/java/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, {}))
+  .expectJSON({ name: 'lgtm', value: 'invalid' });
+
+t.create('grade: grade for a project (java)')
+  .get('/grade/java/g/apache/cloudstack.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'lgtm',
+    value: Joi.string().regex(/^Java: (?:A\+)|A|B|C|D|E$/)
+  }));
+
+t.create('grade: grade for missing language')
+  .get('/grade/foo/g/apache/cloudstack.json')
+  .expectJSON({
+    name: 'lgtm',
+    value: 'no data for language'
+  });
+
+// Test display of languages
+
+const data = {languages: [
+  {lang: 'cpp', grade: 'A+'},
+  {lang: 'javascript', grade: 'A'},
+  {lang: 'java', grade: 'B'},
+  {lang: 'python', grade: 'C'},
+  {lang: 'csharp', grade: 'D'},
+  {lang: 'other', grade: 'E'},
+  {lang: 'foo'}
+]}
+
+t.create('grade: cpp')
+  .get('/grade/cpp/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'C/C++: A+' });
+
+t.create('grade: javascript')
+  .get('/grade/javascript/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'JS/TS: A' });
+
+t.create('grade: java')
+  .get('/grade/java/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'Java: B' });
+
+t.create('grade: python')
+  .get('/grade/python/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'Python: C' });
+
+t.create('grade: csharp')
+  .get('/grade/csharp/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'C#: D' });
+
+t.create('grade: other')
+  .get('/grade/other/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'Other: E' });
+
+t.create('grade: foo (no grade for valid language)')
+  .get('/grade/foo/g/apache/cloudstack.json')
+  .intercept(nock => nock('https://lgtm.com')
+    .get('/api/v0.1/project/g/apache/cloudstack/details')
+    .reply(200, data))
+  .expectJSON({ name: 'lgtm', value: 'no data for language' });

--- a/services/lgtm/lgtm.tester.js
+++ b/services/lgtm/lgtm.tester.js
@@ -67,40 +67,40 @@ t.create('alerts: lgtm inaccessible')
 t.create('grade: missing project')
   .get('/grade/java/g/some-org/this-project-doesnt-exist.json')
   .expectJSON({
-    name: 'lgtm: java',
+    name: 'code quality: java',
     value: 'project not found'
   });
 
 t.create('grade: lgtm inaccessible')
   .get('/grade/java/g/apache/cloudstack.json')
   .networkOff()
-  .expectJSON({ name: 'lgtm: java', value: 'inaccessible' });
+  .expectJSON({ name: 'code quality: java', value: 'inaccessible' });
 
 t.create('grade: invalid json')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, 'not a json string'))
-  .expectJSON({ name: 'lgtm: java', value: 'invalid' });
+  .expectJSON({ name: 'code quality: java', value: 'invalid' });
 
 t.create('grade: json missing languages')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {}))
-  .expectJSON({ name: 'lgtm: java', value: 'invalid' });
+  .expectJSON({ name: 'code quality: java', value: 'invalid' });
 
 t.create('grade: grade for a project (java)')
   .get('/grade/java/g/apache/cloudstack.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'lgtm: java',
+    name: 'code quality: java',
     value: Joi.string().regex(/^(?:A\+)|A|B|C|D|E$/)
   }));
 
 t.create('grade: grade for missing language')
   .get('/grade/foo/g/apache/cloudstack.json')
   .expectJSON({
-    name: 'lgtm: foo',
+    name: 'code quality: foo',
     value: 'no data for language'
   });
 
@@ -121,46 +121,46 @@ t.create('grade: cpp')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: c/c++', value: 'A+' });
+  .expectJSON({ name: 'code quality: c/c++', value: 'A+' });
 
 t.create('grade: javascript')
   .get('/grade/javascript/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: js/ts', value: 'A' });
+  .expectJSON({ name: 'code quality: js/ts', value: 'A' });
 
 t.create('grade: java')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: java', value: 'B' });
+  .expectJSON({ name: 'code quality: java', value: 'B' });
 
 t.create('grade: python')
   .get('/grade/python/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: python', value: 'C' });
+  .expectJSON({ name: 'code quality: python', value: 'C' });
 
 t.create('grade: csharp')
   .get('/grade/csharp/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: c#', value: 'D' });
+  .expectJSON({ name: 'code quality: c#', value: 'D' });
 
 t.create('grade: other')
   .get('/grade/other/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: other', value: 'E' });
+  .expectJSON({ name: 'code quality: other', value: 'E' });
 
 t.create('grade: foo (no grade for valid language)')
   .get('/grade/foo/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm: foo', value: 'no data for language' });
+  .expectJSON({ name: 'code quality: foo', value: 'no data for language' });

--- a/services/lgtm/lgtm.tester.js
+++ b/services/lgtm/lgtm.tester.js
@@ -67,40 +67,40 @@ t.create('alerts: lgtm inaccessible')
 t.create('grade: missing project')
   .get('/grade/java/g/some-org/this-project-doesnt-exist.json')
   .expectJSON({
-    name: 'lgtm',
+    name: 'lgtm: java',
     value: 'project not found'
   });
 
 t.create('grade: lgtm inaccessible')
   .get('/grade/java/g/apache/cloudstack.json')
   .networkOff()
-  .expectJSON({ name: 'lgtm', value: 'inaccessible' });
+  .expectJSON({ name: 'lgtm: java', value: 'inaccessible' });
 
 t.create('grade: invalid json')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, 'not a json string'))
-  .expectJSON({ name: 'lgtm', value: 'invalid' });
+  .expectJSON({ name: 'lgtm: java', value: 'invalid' });
 
 t.create('grade: json missing languages')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, {}))
-  .expectJSON({ name: 'lgtm', value: 'invalid' });
+  .expectJSON({ name: 'lgtm: java', value: 'invalid' });
 
 t.create('grade: grade for a project (java)')
   .get('/grade/java/g/apache/cloudstack.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'lgtm',
-    value: Joi.string().regex(/^Java: (?:A\+)|A|B|C|D|E$/)
+    name: 'lgtm: java',
+    value: Joi.string().regex(/^(?:A\+)|A|B|C|D|E$/)
   }));
 
 t.create('grade: grade for missing language')
   .get('/grade/foo/g/apache/cloudstack.json')
   .expectJSON({
-    name: 'lgtm',
+    name: 'lgtm: foo',
     value: 'no data for language'
   });
 
@@ -121,46 +121,46 @@ t.create('grade: cpp')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'C/C++: A+' });
+  .expectJSON({ name: 'lgtm: c/c++', value: 'A+' });
 
 t.create('grade: javascript')
   .get('/grade/javascript/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'JS/TS: A' });
+  .expectJSON({ name: 'lgtm: js/ts', value: 'A' });
 
 t.create('grade: java')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'Java: B' });
+  .expectJSON({ name: 'lgtm: java', value: 'B' });
 
 t.create('grade: python')
   .get('/grade/python/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'Python: C' });
+  .expectJSON({ name: 'lgtm: python', value: 'C' });
 
 t.create('grade: csharp')
   .get('/grade/csharp/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'C#: D' });
+  .expectJSON({ name: 'lgtm: c#', value: 'D' });
 
 t.create('grade: other')
   .get('/grade/other/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'Other: E' });
+  .expectJSON({ name: 'lgtm: other', value: 'E' });
 
 t.create('grade: foo (no grade for valid language)')
   .get('/grade/foo/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
     .reply(200, data))
-  .expectJSON({ name: 'lgtm', value: 'no data for language' });
+  .expectJSON({ name: 'lgtm: foo', value: 'no data for language' });


### PR DESCRIPTION
We've just launched project grades on lgtm: https://discuss.lgtm.com/t/announcing-project-grades-on-lgtm-com/1003

And this PR uses this data (that's exposed over the API) to add a new lgtm badge that displays the grade for a particular language.

EG:

![rsyslog](https://user-images.githubusercontent.com/3319932/39847899-df36da32-53b8-11e8-9c9e-c9950a7bffbe.png)
![rsyslog 1](https://user-images.githubusercontent.com/3319932/39847904-e6f81998-53b8-11e8-98f5-748d3ea75950.png)
![cloudstack 2](https://user-images.githubusercontent.com/3319932/39847921-f4b707f6-53b8-11e8-9173-5151e6236479.png)

Added new tests as appropriate.