### PR TITLE
[cdnjs gem] make exception classes more consistent

### DIFF
--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -26,10 +26,10 @@ const checkErrorResponse = function(badgeData, err, res, notFoundMessage = 'not 
 checkErrorResponse.asPromise = function ({ notFoundMessage } = {}) {
   return async function ({ buffer, res }) {
     if (res.statusCode === 404) {
-      throw new NotFound(notFoundMessage);
+      throw new NotFound({ prettyMessage: notFoundMessage });
     } else if (res.statusCode !== 200) {
       const underlying = Error(`Got status code ${res.statusCode} (expected 200)`);
-      throw new InvalidResponse(undefined, underlying);
+      throw new InvalidResponse({ underlyingError: underlying});
     }
     return { buffer, res };
   };
@@ -39,7 +39,7 @@ async function asJson({ buffer, res }) {
   try {
     return JSON.parse(buffer);
   } catch (err) {
-    throw new InvalidResponse(undefined, err);
+    throw new InvalidResponse({ underlyingError: err });
   }
 };
 

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -176,7 +176,7 @@ function handleRequest (makeBadge, handlerOptions) {
         if (err) {
           // Wrap the error in an Inaccessible so it can be identified
           // by the BaseService handler.
-          reject(new Inaccessible(err));
+          reject(new Inaccessible({ underlyingError: err }));
         } else {
           resolve({ res, buffer });
         }

--- a/services/errors.js
+++ b/services/errors.js
@@ -9,7 +9,9 @@ class ShieldsRuntimeError extends Error {
     props = props || {};
     super(message);
     this.prettyMessage = props.prettyMessage || this.defaultPrettyMessage;
-    this.stack = props.underlyingError ? props.underlyingError.stack : '';
+    if (props.underlyingError) {
+      this.stack = props.underlyingError.stack;
+    }
   }
 }
 

--- a/services/errors.js
+++ b/services/errors.js
@@ -14,14 +14,17 @@ class ShieldsRuntimeError extends Error {
   }
 }
 
+
+const defaultNotFoundError = 'not found';
+
 class NotFound extends ShieldsRuntimeError {
 
   get name() { return 'NotFound'; }
-  get defaultPrettyMessage() { return 'not found'; }
+  get defaultPrettyMessage() { return defaultNotFoundError; }
 
   constructor(props = {}) {
-    const prettyMessage = props.prettyMessage || 'not found';
-    const message = prettyMessage === 'not found'
+    const prettyMessage = props.prettyMessage || defaultNotFoundError;
+    const message = prettyMessage === defaultNotFoundError
       ? 'Not Found'
       : `Not Found: ${prettyMessage}`;
     super(props, message);

--- a/services/errors.js
+++ b/services/errors.js
@@ -5,8 +5,7 @@ class ShieldsRuntimeError extends Error {
   get name() { return 'ShieldsRuntimeError'; }
   get defaultPrettyMessage() { throw new Error('Must implement abstract method'); }
 
-  constructor(props, message) {
-    props = props || {};
+  constructor(props = {}, message) {
     super(message);
     this.prettyMessage = props.prettyMessage || this.defaultPrettyMessage;
     if (props.underlyingError) {
@@ -20,8 +19,7 @@ class NotFound extends ShieldsRuntimeError {
   get name() { return 'NotFound'; }
   get defaultPrettyMessage() { return 'not found'; }
 
-  constructor(props) {
-    props = props || {};
+  constructor(props = {}) {
     const prettyMessage = props.prettyMessage || 'not found';
     const message = prettyMessage === 'not found'
       ? 'Not Found'
@@ -35,8 +33,7 @@ class InvalidResponse extends ShieldsRuntimeError {
   get name() { return 'InvalidResponse'; }
   get defaultPrettyMessage() { return 'invalid'; }
 
-  constructor(props) {
-    props = props || {};
+  constructor(props = {}) {
     const message = props.underlyingError
       ? `Invalid Response: ${props.underlyingError.message}`
       : 'Invalid Response';
@@ -49,8 +46,7 @@ class Inaccessible extends ShieldsRuntimeError {
   get name() { return 'Inaccessible'; }
   get defaultPrettyMessage() { return 'inaccessible'; }
 
-  constructor(props) {
-    props = props || {};
+  constructor(props = {}) {
     const message = props.underlyingError
       ? `Inaccessible: ${props.underlyingError.message}`
       : 'Inaccessible';

--- a/services/errors.js
+++ b/services/errors.js
@@ -1,34 +1,58 @@
 'use strict';
 
-class NotFound extends Error {
-  constructor(prettyMessage = 'not found') {
+class ShieldsRuntimeError extends Error {
+
+  get name() { return 'ShieldsRuntimeError'; }
+  get defaultPrettyMessage() { throw new Error('Must implement abstract method'); }
+
+  constructor(props, message) {
+    props = props || {};
+    super(message);
+    this.prettyMessage = props.prettyMessage || this.defaultPrettyMessage;
+    this.stack = props.underlyingError ? props.underlyingError.stack : '';
+  }
+}
+
+class NotFound extends ShieldsRuntimeError {
+
+  get name() { return 'NotFound'; }
+  get defaultPrettyMessage() { return 'not found'; }
+
+  constructor(props) {
+    props = props || {};
+    const prettyMessage = props.prettyMessage || 'not found';
     const message = prettyMessage === 'not found'
       ? 'Not Found'
       : `Not Found: ${prettyMessage}`;
-    super(message);
-    this.prettyMessage = prettyMessage;
-    this.name = 'NotFound';
+    super(props, message);
   }
 }
 
-class InvalidResponse extends Error {
-  constructor(prettyMessage = 'invalid', underlyingError) {
-    const message = underlyingError
-      ? `Invalid Response: ${underlyingError.message}`
+class InvalidResponse extends ShieldsRuntimeError {
+
+  get name() { return 'InvalidResponse'; }
+  get defaultPrettyMessage() { return 'invalid'; }
+
+  constructor(props) {
+    props = props || {};
+    const message = props.underlyingError
+      ? `Invalid Response: ${props.underlyingError.message}`
       : 'Invalid Response';
-    super(message);
-    this.stack = underlyingError.stack;
-    this.prettyMessage = prettyMessage;
-    this.name = 'InvalidResponse';
+    super(props, message);
   }
 }
 
-class Inaccessible extends Error {
-  constructor(underlyingError, prettyMessage = 'inaccessible') {
-    super(`Inaccessible: ${underlyingError.message}`);
-    this.stack = underlyingError.stack;
-    this.prettyMessage = prettyMessage;
-    this.name = 'Inaccessible';
+class Inaccessible extends ShieldsRuntimeError {
+
+  get name() { return 'Inaccessible'; }
+  get defaultPrettyMessage() { return 'inaccessible'; }
+
+  constructor(props) {
+    props = props || {};
+    const message = props.underlyingError
+      ? `Inaccessible: ${props.underlyingError.message}`
+      : 'Inaccessible';
+    super(props, message);
   }
 }
 

--- a/services/gem/gem.js
+++ b/services/gem/gem.js
@@ -129,11 +129,11 @@ class GemDownloads extends BaseService {
 
         downloads = metric(versionData.downloads_count);
       } else {
-        throw new InvalidResponse('invalid', new Error('version is null'));
+        throw new InvalidResponse();
       }
 
     } else {
-      throw new InvalidResponse('invalid', new Error('info is invalid'));
+      throw new InvalidResponse();
     }
 
     return {

--- a/services/gem/gem.js
+++ b/services/gem/gem.js
@@ -129,11 +129,11 @@ class GemDownloads extends BaseService {
 
         downloads = metric(versionData.downloads_count);
       } else {
-        throw new InvalidResponse();
+        throw new InvalidResponse({ underlyingError: new Error('version is null') });
       }
 
     } else {
-      throw new InvalidResponse();
+      throw new InvalidResponse({ underlyingError: new Error('info is invalid') });
     }
 
     return {


### PR DESCRIPTION
As I've been working on the new service code, I've had a couple of thoughts on the exception classes:

https://github.com/badges/shields/pull/1590#issuecomment-377359085
https://github.com/badges/shields/pull/1680#discussion_r187159093

I think its worth looking at this before we are using this code in too many places and it becomes difficult to change the constructor signatures. This PR proposes the following changes:

* All exception classes now have the same signature. I find this confusing:

```js
class InvalidResponse extends Error {
  constructor(prettyMessage = 'invalid', underlyingError) {
    // ...
  }
}

class Inaccessible extends Error {
  constructor(underlyingError, prettyMessage = 'inaccessible') {
    // ...
  }
}
```

* Passing a `props` object means `underlyingError` and `prettyMessage` are always optional. This means we don't need to use workarounds like `throw new InvalidResponse(undefined, err);` or `throw new InvalidResponse('invalid', new Error());` if we don't want to customise the error or don't have an exception to wrap.

* Declare a base class which our runtime exceptions inherit from

does this seem like a reasonable approach?