### PR TITLE
[david] add support for path

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -2120,6 +2120,10 @@ const allBadgeExamples = [
         previewUri: '/david/peer/webcomponents/generator-element.svg'
       },
       {
+        title: 'David (path)',
+        previewUri: '/david/babel/babel.svg?path=packages/babel-core'
+      },
+      {
         title: 'bitHound',
         previewUri: '/bithound/dependencies/github/rexxars/sse-channel.svg'
       },

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -53,7 +53,7 @@ t.create('david dependencies (repo not found)')
   .expectJSON({name: 'dependencies', value: 'invalid'});
 
 t.create('david dependencies (path not found')
-  .get('/babel/babel.json?path=does/not/exist')
+  .get('/babel/babel.json?path=invalid/path')
   .expectJSON({name: 'dependencies', value: 'invalid'});
 
 t.create('david dependencies (connection error)')

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -37,7 +37,7 @@ t.create('david peer dependencies (valid)')
     value: isDependencyStatus
   }));
 
-t.create('david dependencies (path)')
+t.create('david dependencies with path (valid)')
   .get('/babel/babel.json?path=packages/babel-core')
   .expectJSONTypes(Joi.object().keys({
     name: 'dependencies',
@@ -50,6 +50,10 @@ t.create('david dependencies (none)')
 
 t.create('david dependencies (repo not found)')
   .get('/pyvesb/emptyrepo.json')
+  .expectJSON({name: 'dependencies', value: 'invalid'});
+
+t.create('david dependencies (path not found')
+  .get('/babel/babel.json?path=does/not/exist')
   .expectJSON({name: 'dependencies', value: 'invalid'});
 
 t.create('david dependencies (connection error)')

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -37,6 +37,13 @@ t.create('david peer dependencies (valid)')
     value: isDependencyStatus
   }));
 
+t.create('david dependencies (path)')
+  .get('/babel/babel.json?path=packages/babel-core')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'dependencies',
+    value: isDependencyStatus
+  }));
+
 t.create('david dependencies (none)')
   .get('/peer/expressjs/express.json') // express does not specify peer dependencies
   .expectJSON({name: 'peerDependencies', value: 'none'});


### PR DESCRIPTION
This PR adds support for David's `path` query parameter (used to specify in which folder the package.json file is located).

The diff is a bit messy because the indentation had to be changed, but all it really does is adding the path query param declaration and an if block to append `?path=x` when sending the HTTP request.

Note: this closes #637 