### PR TITLE
homebrew: ⬆️ formula API

### DIFF
--- a/server.js
+++ b/server.js
@@ -6459,7 +6459,7 @@ camp.route(/^\/homebrew\/v\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var pkg = match[1];  // eg. cake
   var format = match[2];
-  var apiUrl = 'http://formulae.brew.sh/formula/' + pkg + '/version';
+  var apiUrl = 'http://formulae.brew.sh/api/formula/' + pkg + '.json';
 
   var badgeData = getBadgeData('homebrew', data);
   request(apiUrl, { headers: { 'Accept': 'application/json' } }, function(err, res, buffer) {
@@ -6469,7 +6469,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       var data = JSON.parse(buffer);
-      var version = data.stable;
+      var version = data.versions.stable;
 
       badgeData.text[1] = versionText(version);
       badgeData.colorscheme = versionColor(version);

--- a/services/homebrew/homebrew.tester.js
+++ b/services/homebrew/homebrew.tester.js
@@ -19,8 +19,8 @@ t.create('homebrew (valid)')
 t.create('homebrew (valid, mocked response)')
   .get('/v/cake.json')
   .intercept(nock => nock('http://formulae.brew.sh')
-    .get('/formula/cake/version')
-    .reply(200, {stable: '0.23.0', devel: null, head: null})
+    .get('/api/formula/cake.json')
+    .reply(200, {versions: {stable: '0.23.0', devel: null, head: null}})
   )
   .expectJSON({name: 'homebrew', value: 'v0.23.0'});
 


### PR DESCRIPTION
fix #1688 

new API of brew formula: https://formulae.brew.sh/api/formula/annie.json

```json
{
  "name": "annie",
  "full_name": "annie",
  "oldname": null,
  "aliases": [],
  "versioned_formulae": [],
  "desc": "Fast, simple and clean video downloader",
  "homepage": "https://github.com/iawia002/annie",
  "versions": {
    "stable": "0.6.11",
    "devel": null,
    "head": null,
    "bottle": true
  },
  ...
}
```