### PR TITLE
Bugfix: override colorB in [docker] badges

### DIFF
--- a/server.js
+++ b/server.js
@@ -6209,8 +6209,7 @@ cache(function(data, match, sendBadge, request) {
       var parseData = JSON.parse(buffer);
       var pulls = parseData.pull_count;
       badgeData.text[1] = metric(pulls);
-      badgeData.colorscheme = null;
-      badgeData.colorB = data.colorB || '#008bb8';
+      setBadgeColor(badgeData, data.colorB || '008bb8');
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/server.js
+++ b/server.js
@@ -6179,8 +6179,7 @@ cache(function(data, match, sendBadge, request) {
         throw Error('Unexpected response.');
       }
       badgeData.text[1] = metric(stars);
-      badgeData.colorscheme = null;
-      badgeData.colorB = data.colorB || '#008bb8';
+      setBadgeColor(badgeData, data.colorB || '008bb8');
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/server.js
+++ b/server.js
@@ -6179,7 +6179,7 @@ cache(function(data, match, sendBadge, request) {
         throw Error('Unexpected response.');
       }
       badgeData.text[1] = metric(stars);
-      setBadgeColor(badgeData, data.colorB || '008bb8');
+      setBadgeColor(badgeData, data.colorB || '066da5');
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';
@@ -6209,7 +6209,7 @@ cache(function(data, match, sendBadge, request) {
       var parseData = JSON.parse(buffer);
       var pulls = parseData.pull_count;
       badgeData.text[1] = metric(pulls);
-      setBadgeColor(badgeData, data.colorB || '008bb8');
+      setBadgeColor(badgeData, data.colorB || '066da5');
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';
@@ -6279,7 +6279,7 @@ cache(function(data, match, sendBadge, request) {
       var is_automated = parsedData.is_automated;
       if (is_automated) {
         badgeData.text[1] = 'automated';
-        setBadgeColor(badgeData, data.colorB || '008bb8');
+        setBadgeColor(badgeData, data.colorB || '066da5');
       } else {
         badgeData.text[1] = 'manual';
         badgeData.colorscheme = 'yellow';
@@ -6320,7 +6320,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'red';
       } else {
         badgeData.text[1] = 'building';
-        setBadgeColor(badgeData, data.colorB || '008bb8');
+        setBadgeColor(badgeData, data.colorB || '066da5');
       }
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -6312,8 +6312,8 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var data = JSON.parse(buffer);
-      var most_recent_status = data.results[0].status;
+      var parsedData = JSON.parse(buffer);
+      var most_recent_status = parsedData.results[0].status;
       if (most_recent_status == 10) {
         badgeData.text[1] = 'passing';
         badgeData.colorscheme = 'brightgreen';
@@ -6322,7 +6322,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.colorscheme = 'red';
       } else {
         badgeData.text[1] = 'building';
-        badgeData.colorB = data.colorB || '#008bb8';
+        setBadgeColor(badgeData, data.colorB || '008bb8');
       }
       sendBadge(format, badgeData);
     } catch(e) {

--- a/server.js
+++ b/server.js
@@ -6279,7 +6279,7 @@ cache(function(data, match, sendBadge, request) {
       var is_automated = parsedData.is_automated;
       if (is_automated) {
         badgeData.text[1] = 'automated';
-        badgeData.colorB = data.colorB || '#008bb8';
+        setBadgeColor(badgeData, data.colorB || '008bb8');
       } else {
         badgeData.text[1] = 'manual';
         badgeData.colorscheme = 'yellow';

--- a/server.js
+++ b/server.js
@@ -6281,7 +6281,7 @@ cache(function(data, match, sendBadge, request) {
       var is_automated = parsedData.is_automated;
       if (is_automated) {
         badgeData.text[1] = 'automated';
-        badgeData.colorscheme = 'blue';
+        badgeData.colorB = data.colorB || '#008bb8';
       } else {
         badgeData.text[1] = 'manual';
         badgeData.colorscheme = 'yellow';

--- a/server.js
+++ b/server.js
@@ -6286,7 +6286,6 @@ cache(function(data, match, sendBadge, request) {
         badgeData.text[1] = 'manual';
         badgeData.colorscheme = 'yellow';
       }
-      badgeData.colorB = data.colorB || '#008bb8';
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -22,7 +22,7 @@ t.create('docker stars (valid, library)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker stars',
     value: isMetric,
-    colorB: '#008bb8'
+    colorB: Joi.any().equal('#008bb8').required()
   }));
 
 t.create('docker stars (override colorB)')
@@ -65,7 +65,7 @@ t.create('docker pulls (valid, library)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker pulls',
     value: isMetric,
-    colorB: '#008bb8'
+    colorB: Joi.any().equal('#008bb8').required()
   }));
 
 t.create('docker pulls (override colorB)')
@@ -159,7 +159,7 @@ t.create('docker automated build - colorB override in manual')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker build',
     value: isAutomatedBuildStatus,
-    colorB: '#fedcba'
+    colorB: Joi.any().equal('#fedcba').required()
   }));
 
 t.create('docker automated build - colorB override in automated')

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -30,7 +30,7 @@ t.create('docker stars (override colorB)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker stars',
     value: isMetric,
-    colorB: '#fedcba'
+    colorB: Joi.any().equal('#fedcba').required()
   }));
 
 t.create('docker stars (valid, user)')

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -61,10 +61,19 @@ t.create('docker stars (unexpected response)')
 // pulls endpoint
 
 t.create('docker pulls (valid, library)')
-  .get('/pulls/_/ubuntu.json')
+  .get('/pulls/_/ubuntu.json?style=_shields_test')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker pulls',
-    value: isMetric
+    value: isMetric,
+    colorB: '#008bb8'
+  }));
+
+t.create('docker pulls (override colorB)')
+  .get('/pulls/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'docker pulls',
+    value: isMetric,
+    colorB: '#fedcba'
   }));
 
 t.create('docker pulls (valid, user)')

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -18,10 +18,19 @@ module.exports = t;
 // stars endpoint
 
 t.create('docker stars (valid, library)')
-  .get('/stars/_/ubuntu.json')
+  .get('/stars/_/ubuntu.json?style=_shields_test')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker stars',
-    value: isMetric
+    value: isMetric,
+    colorB: '#008bb8'
+  }));
+
+t.create('docker stars (override colorB)')
+  .get('/stars/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'docker stars',
+    value: isMetric,
+    colorB: '#fedcba'
   }));
 
 t.create('docker stars (valid, user)')

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -140,7 +140,7 @@ t.create('docker automated build - automated')
     .get('/v2/repositories/library/ubuntu')
     .reply(200, {is_automated: true})
   )
-  .expectJSON({name: 'docker build', value: 'automated', colorB: colorsB.blue});
+  .expectJSON({name: 'docker build', value: 'automated', colorB: '#008bb8'});
 
 t.create('docker automated build - manual')
   .get('/automated/_/ubuntu.json?style=_shields_test')
@@ -150,8 +150,24 @@ t.create('docker automated build - manual')
   )
   .expectJSON({name: 'docker build', value: 'manual', colorB: colorsB.yellow});
 
-t.create('docker automated build - colorB override')
+t.create('docker automated build - colorB override in manual')
   .get('/automated/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu')
+    .reply(200, {is_automated: false})
+  )
+  .expectJSONTypes(Joi.object().keys({
+    name: 'docker build',
+    value: isAutomatedBuildStatus,
+    colorB: '#fedcba'
+  }));
+
+t.create('docker automated build - colorB override in automated')
+  .get('/automated/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu')
+    .reply(200, {is_automated: true})
+  )
   .expectJSONTypes(Joi.object().keys({
     name: 'docker build',
     value: isAutomatedBuildStatus,

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -171,7 +171,7 @@ t.create('docker automated build - colorB override in automated')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker build',
     value: isAutomatedBuildStatus,
-    colorB: '#fedcba'
+    colorB: Joi.any().equal('#fedcba').required()
   }));
 
 // build status endpoint

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -22,7 +22,7 @@ t.create('docker stars (valid, library)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker stars',
     value: isMetric,
-    colorB: Joi.any().equal('#008bb8').required()
+    colorB: Joi.any().equal('#066da5').required()
   }));
 
 t.create('docker stars (override colorB)')
@@ -65,7 +65,7 @@ t.create('docker pulls (valid, library)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker pulls',
     value: isMetric,
-    colorB: Joi.any().equal('#008bb8').required()
+    colorB: Joi.any().equal('#066da5').required()
   }));
 
 t.create('docker pulls (override colorB)')
@@ -140,7 +140,7 @@ t.create('docker automated build - automated')
     .get('/v2/repositories/library/ubuntu')
     .reply(200, {is_automated: true})
   )
-  .expectJSON({name: 'docker build', value: 'automated', colorB: '#008bb8'});
+  .expectJSON({name: 'docker build', value: 'automated', colorB: '#066da5'});
 
 t.create('docker automated build - manual')
   .get('/automated/_/ubuntu.json?style=_shields_test')
@@ -222,7 +222,7 @@ t.create('docker build status (building)')
     .get('/v2/repositories/library/ubuntu/buildhistory')
     .reply(200, {results: [{status: 1}]})
   )
-  .expectJSON({name: 'docker build', value: 'building', colorB: '#008bb8'});
+  .expectJSON({name: 'docker build', value: 'building', colorB: '#066da5'});
 
 t.create('docker build status (override colorB for passing)')
   .get('/build/_/ubuntu.json?colorB=fedcba&style=_shields_test')

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -199,3 +199,51 @@ t.create('docker build status (unexpected response)')
     .reply(invalidJSON)
   )
   .expectJSON({name: 'docker build', value: 'invalid'});
+
+t.create('docker build status (passing)')
+  .get('/build/_/ubuntu.json?style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: 10}]})
+  )
+  .expectJSON({name: 'docker build', value: 'passing', colorB: colorsB.brightgreen});
+
+t.create('docker build status (failing)')
+  .get('/build/_/ubuntu.json?style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: -1}]})
+  )
+  .expectJSON({name: 'docker build', value: 'failing', colorB: colorsB.red});
+
+t.create('docker build status (building)')
+  .get('/build/_/ubuntu.json?style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: 1}]})
+  )
+  .expectJSON({name: 'docker build', value: 'building', colorB: '#008bb8'});
+
+t.create('docker build status (override colorB for passing)')
+  .get('/build/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: 10}]})
+  )
+  .expectJSON({name: 'docker build', value: 'passing', colorB: '#fedcba'});
+
+t.create('docker build status (override colorB for failing)')
+  .get('/build/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: -1}]})
+  )
+  .expectJSON({name: 'docker build', value: 'failing', colorB: '#fedcba'});
+
+t.create('docker build status (override colorB for building)')
+  .get('/build/_/ubuntu.json?colorB=fedcba&style=_shields_test')
+  .intercept(nock => nock('https://registry.hub.docker.com/')
+    .get('/v2/repositories/library/ubuntu/buildhistory')
+    .reply(200, {results: [{status: 1}]})
+  )
+  .expectJSON({name: 'docker build', value: 'building', colorB: '#fedcba'});

--- a/services/docker/docker.tester.js
+++ b/services/docker/docker.tester.js
@@ -73,7 +73,7 @@ t.create('docker pulls (override colorB)')
   .expectJSONTypes(Joi.object().keys({
     name: 'docker pulls',
     value: isMetric,
-    colorB: '#fedcba'
+    colorB: Joi.any().equal('#fedcba').required()
   }));
 
 t.create('docker pulls (valid, user)')


### PR DESCRIPTION
Problem described here: https://github.com/badges/shields/pull/1675#discussion_r186843360
Before:
![before](https://user-images.githubusercontent.com/1526000/40015681-6b58c79c-57b4-11e8-8243-e5761059b89e.png)
After:
![after](https://user-images.githubusercontent.com/1526000/40015687-6f86535c-57b4-11e8-89b3-9e63a8f2a6d5.png)
