### PR TITLE
upgrade to Joi 13.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6812,7 +6812,7 @@
         "chai-things": "0.2.0",
         "chalk": "2.3.0",
         "check-types": "7.3.0",
-        "joi": "12.0.0",
+        "joi": "13.3.0",
         "lodash": "4.17.4",
         "qs": "6.4.0",
         "request": "2.85.0",
@@ -7366,9 +7366,9 @@
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isemail": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.0.0.tgz",
-      "integrity": "sha512-rz0ng/c+fX+zACpLgDB8fnUQ845WSU06f4hlhk4K8TJxmR6f5hyvitu9a9JdMD7aq/P4E0XdG1uaab2OiXgHlA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.2.tgz",
+      "integrity": "sha512-zfRhJn9rFSGhzU5tGZqepRSAj3+g6oTOHxMGGriWNJZzyLPUK8H7VHpqKntegnW8KLyGA9zwuNaCoopl40LTpg==",
       "dev": true,
       "requires": {
         "punycode": "2.1.0"
@@ -7582,14 +7582,22 @@
       }
     },
     "joi": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-12.0.0.tgz",
-      "integrity": "sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-13.3.0.tgz",
+      "integrity": "sha512-iF6jEYVfBIoYXztYymia1JfuoVbxBNuOcwdbsdoGin9/jjhBLhonKmfTQOvePss8r8v4tU4JOcNmYPHZzKEFag==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0",
-        "isemail": "3.0.0",
-        "topo": "2.0.2"
+        "hoek": "5.0.3",
+        "isemail": "3.1.2",
+        "topo": "3.0.0"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        }
       }
     },
     "js-beautify": {
@@ -12693,12 +12701,20 @@
       }
     },
     "topo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
-      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+      "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "5.0.3"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+          "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw==",
+          "dev": true
+        }
       }
     },
     "touch": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "icedfrisby-nock": "^1.0.0",
     "is-png": "^1.1.0",
     "is-svg": "^3.0.0",
-    "joi": "^12.0.0",
+    "joi": "^13.3.0",
     "lodash.debounce": "^4.0.8",
     "lodash.difference": "^4.5.0",
     "lodash.mapvalues": "^4.6.0",


### PR DESCRIPTION
Now that we are running node 8 we can safely upgrade to Joi 13.

V12 -> V13 is a major version change because it drops support for older versions of node, but [does not change the public API surface](https://github.com/hapijs/joi/compare/v12.0.0...v13.0.0#diff-88333ba11114e014e87198d04680144d) so no code changes are required to support the upgrade.

Includes update to transitive dependency on `hoek`