### PR TITLE
Add immutable rule to cache-control header

### DIFF
--- a/server.js
+++ b/server.js
@@ -7915,7 +7915,7 @@ function(data, match, end, ask) {
 
   // Cache management - the badge is constant.
   var cacheDuration = (3600*24*1)|0;    // 1 day.
-  ask.res.setHeader('Cache-Control', 'max-age=' + cacheDuration);
+  ask.res.setHeader('Cache-Control', 'max-age=' + cacheDuration + ', immutable');
   if (+(new Date(ask.req.headers['if-modified-since'])) >= +serverStartTime) {
     ask.res.statusCode = 304;
     ask.res.end();  // not modified.
@@ -7956,7 +7956,7 @@ function(data, match, end, ask) {
 let bitFlip = false;
 camp.route(/^\/flip\.svg$/, function(data, match, end, ask) {
   var cacheSecs = 60;
-  ask.res.setHeader('Cache-Control', 'max-age=' + cacheSecs);
+  ask.res.setHeader('Cache-Control', 'max-age=' + cacheSecs + ', immutable');
   var reqTime = new Date();
   var date = (new Date(+reqTime + cacheSecs * 1000)).toGMTString();
   ask.res.setHeader('Expires', date);
@@ -7977,7 +7977,7 @@ function(data, match, end, ask) {
 
   // Cache management - the badge is constant.
   var cacheDuration = (3600*24*1)|0;    // 1 day.
-  ask.res.setHeader('Cache-Control', 'max-age=' + cacheDuration);
+  ask.res.setHeader('Cache-Control', 'max-age=' + cacheDuration + ', immutable');
   if (+(new Date(ask.req.headers['if-modified-since'])) >= +serverStartTime) {
     ask.res.statusCode = 304;
     ask.res.end();  // not modified.


### PR DESCRIPTION
Adds the `Cache-Control` `immutable` to the response headers, [supported browsers ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#Browser_compatibility)benefit greatly, and unsupported browsers will (should) ignore it safely.