### PR TITLE
[gem cdnjs appveyor clojars] refactor clojars, establish BaseJsonService

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -886,10 +886,6 @@ const allBadgeExamples = [
         previewUri: '/maven-metadata/v/http/central.maven.org/maven2/com/google/code/gson/gson/maven-metadata.xml.svg'
       },
       {
-        title: 'Clojars',
-        previewUri: '/clojars/v/prismic.svg'
-      },
-      {
         title: 'CocoaPods',
         previewUri: '/cocoapods/v/AFNetworking.svg'
       },

--- a/server.js
+++ b/server.js
@@ -2064,38 +2064,6 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Clojars version integration
-camp.route(/^\/clojars\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  const clojar = match[1];  // eg, `prismic` or `foo/bar`.
-  const format = match[2];
-  const apiUrl = 'https://clojars.org/' + clojar + '/latest-version.json';
-  const badgeData = getBadgeData('clojars', data);
-  request(apiUrl, function(err, res, buffer) {
-    if (err !== null) {
-      badgeData.text[1] = 'inaccessible';
-      sendBadge(format, badgeData);
-      return;
-    }
-    try {
-      const json = JSON.parse(buffer);
-      if (Object.keys(json).length === 0) {
-        /* Note the 'not found' response from clojars is:
-           status code = 200, body = {} */
-        badgeData.text[1] = 'not found';
-        sendBadge(format, badgeData);
-        return;
-      }
-      badgeData.text[1] = "[" + clojar + " \"" + json.version + "\"]";
-      badgeData.colorscheme = versionColor(json.version);
-      sendBadge(format, badgeData);
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-      sendBadge(format, badgeData);
-    }
-  });
-}));
-
 // iTunes App Store version
 camp.route(/^\/itunes\/v\/(.+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/services/appveyor/appveyor.js
+++ b/services/appveyor/appveyor.js
@@ -1,21 +1,14 @@
 'use strict';
 
-const BaseService = require('../base');
-const {
-  checkErrorResponse,
-  asJson,
-} = require('../../lib/error-helper');
+const { BaseJsonService } = require('../base');
 
-module.exports = class AppVeyor extends BaseService {
+module.exports = class AppVeyor extends BaseJsonService {
   async handle({repo, branch}) {
     let apiUrl = 'https://ci.appveyor.com/api/projects/' + repo;
     if (branch != null) {
       apiUrl += '/branch/' + branch;
     }
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise({ notFoundMessage: 'project not found or access denied' }))
-      .then(asJson);
+    const json = await this._requestJson(apiUrl, {}, 'project not found or access denied');
 
     const { build: { status } } = json;
     if (status === 'success') {

--- a/services/base.js
+++ b/services/base.js
@@ -11,8 +11,13 @@ const {
   makeColor,
   setBadgeColor,
 } = require('../lib/badge-data');
+const {
+  checkErrorResponse,
+  asJson,
+} = require('../lib/error-helper');
 
-module.exports = class BaseService {
+
+class BaseService {
   constructor({ sendAndCacheRequest }, { handleInternalErrors }) {
     this._sendAndCacheRequest = sendAndCacheRequest;
     this._handleInternalErrors = handleInternalErrors;
@@ -209,4 +214,21 @@ module.exports = class BaseService {
       sendBadge(format, badgeData);
     }));
   }
+};
+
+class BaseJsonService extends BaseService {
+  async _requestJson(url, options = {}, notFoundMessage) {
+    return this._sendAndCacheRequest(url,
+      {...{ 'headers': { 'Accept': 'application/json' } }, ...options}
+    ).then(
+      checkErrorResponse.asPromise(
+        notFoundMessage ? { notFoundMessage: notFoundMessage } : undefined
+      )
+    ).then(asJson);
+  }
+};
+
+module.exports = {
+  BaseService,
+  BaseJsonService,
 };

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -4,7 +4,7 @@ const { expect } = require('chai');
 const { test, given, forCases } = require('sazerac');
 const sinon = require('sinon');
 
-const BaseService = require('./base');
+const { BaseService } = require('./base');
 
 require('../lib/register-chai-plugins.spec');
 

--- a/services/cdnjs/cdnjs.js
+++ b/services/cdnjs/cdnjs.js
@@ -35,7 +35,7 @@ module.exports = class Cdnjs extends BaseJsonService {
   static get url() {
     return {
       base: 'cdnjs/v',
-      format: '(.*)',
+      format: '(.+)',
       capture: ['library']
     };
   }

--- a/services/cdnjs/cdnjs.js
+++ b/services/cdnjs/cdnjs.js
@@ -1,21 +1,14 @@
 'use strict';
 
-const BaseService = require('../base');
-const {
-  checkErrorResponse,
-  asJson,
-} = require('../../lib/error-helper');
+const { BaseJsonService } = require('../base');
 const { NotFound } = require('../errors');
 const { addv: versionText } = require('../../lib/text-formatters');
 const { version: versionColor} = require('../../lib/color-formatters');
 
-module.exports = class Cdnjs extends BaseService {
+module.exports = class Cdnjs extends BaseJsonService {
   async handle({library}) {
     const apiUrl = 'https://api.cdnjs.com/libraries/' + library + '?fields=version';
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
 
     if (Object.keys(json).length === 0) {
       /* Note the 'not found' response from cdnjs is:

--- a/services/clojars/clojars.js
+++ b/services/clojars/clojars.js
@@ -1,20 +1,13 @@
 'use strict';
 
-const BaseService = require('../base');
-const {
-  checkErrorResponse,
-  asJson,
-} = require('../../lib/error-helper');
+const { BaseJsonService } = require('../base');
 const { NotFound } = require('../errors');
 const { version: versionColor} = require('../../lib/color-formatters');
 
-module.exports = class Clojars extends BaseService {
+module.exports = class Clojars extends BaseJsonService {
   async handle({clojar}) {
     const apiUrl = 'https://clojars.org/' + clojar + '/latest-version.json';
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
 
     if (Object.keys(json).length === 0) {
       /* Note the 'not found' response from clojars is:

--- a/services/clojars/clojars.js
+++ b/services/clojars/clojars.js
@@ -2,7 +2,7 @@
 
 const { BaseJsonService } = require('../base');
 const { NotFound } = require('../errors');
-const { version: versionColor} = require('../../lib/color-formatters');
+const { version: versionColor } = require('../../lib/color-formatters');
 
 module.exports = class Clojars extends BaseJsonService {
   async handle({clojar}) {

--- a/services/clojars/clojars.js
+++ b/services/clojars/clojars.js
@@ -33,7 +33,7 @@ module.exports = class Clojars extends BaseJsonService {
   static get url() {
     return {
       base: 'clojars/v',
-      format: '(.*)',
+      format: '(.+)',
       capture: ['clojar']
     };
   }

--- a/services/clojars/clojars.js
+++ b/services/clojars/clojars.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const BaseService = require('../base');
+const {
+  checkErrorResponse,
+  asJson,
+} = require('../../lib/error-helper');
+const { NotFound } = require('../errors');
+const { version: versionColor} = require('../../lib/color-formatters');
+
+module.exports = class Clojars extends BaseService {
+  async handle({clojar}) {
+    const apiUrl = 'https://clojars.org/' + clojar + '/latest-version.json';
+    const json = await this._sendAndCacheRequest(apiUrl, {
+      headers: { 'Accept': 'application/json' }
+    }).then(checkErrorResponse.asPromise())
+      .then(asJson);
+
+    if (Object.keys(json).length === 0) {
+      /* Note the 'not found' response from clojars is:
+          status code = 200, body = {} */
+      throw new NotFound();
+    }
+
+    return {
+      message: "[" + clojar + " \"" + json.version + "\"]",
+      color: versionColor(json.version)
+    };
+  }
+
+  // Metadata
+  static get defaultBadgeData() {
+    return { label: 'clojars' };
+  }
+
+  static get category() {
+    return 'version';
+  }
+
+  static get url() {
+    return {
+      base: 'clojars/v',
+      format: '(.*)',
+      capture: ['clojar']
+    };
+  }
+
+  static get examples() {
+    return [
+      { previewUrl: 'prismic' }
+    ];
+  }
+
+};

--- a/services/gem/gem.js
+++ b/services/gem/gem.js
@@ -2,11 +2,7 @@
 
 const semver = require('semver');
 
-const BaseService = require('../base');
-const {
-  checkErrorResponse,
-  asJson,
-} = require('../../lib/error-helper');
+const { BaseJsonService } = require('../base');
 const { InvalidResponse } = require('../errors');
 const { addv: versionText } = require('../../lib/text-formatters');
 const { version: versionColor} = require('../../lib/color-formatters');
@@ -21,13 +17,10 @@ const {
 const { latest: latestVersion } = require('../../lib/version');
 
 
-class GemVersion extends BaseService {
+class GemVersion extends BaseJsonService {
   async handle({repo}) {
     const apiUrl = 'https://rubygems.org/api/v1/gems/' + repo + '.json';
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
     const version = json.version;
 
     return {
@@ -66,7 +59,7 @@ class GemVersion extends BaseService {
   }
 };
 
-class GemDownloads extends BaseService {
+class GemDownloads extends BaseJsonService {
 
   _getApiUrl(repo, info) {
     const endpoint = info === "dv" ? 'versions/' : 'gems/';
@@ -94,10 +87,7 @@ class GemDownloads extends BaseService {
     version = (version === "stable") ? version : semver.valid(version);
     const label = this._getLabel(version, info);
     const apiUrl = this._getApiUrl(repo, info);
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/atom+json,application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
 
     let downloads;
     if (info === "dt") {
@@ -194,14 +184,11 @@ class GemDownloads extends BaseService {
   }
 };
 
-class GemOwner extends BaseService {
+class GemOwner extends BaseJsonService {
 
   async handle({user}) {
     const apiUrl = 'https://rubygems.org/api/v1/owners/' + user + '/gems.json';
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
     const count = json.length;
 
     return {
@@ -240,7 +227,7 @@ class GemOwner extends BaseService {
   }
 };
 
-class GemRank extends BaseService {
+class GemRank extends BaseJsonService {
 
   _getApiUrl(repo, totalRank, dailyRank) {
     let endpoint;
@@ -256,10 +243,7 @@ class GemRank extends BaseService {
     const totalRank = (info === 'rt');
     const dailyRank = (info === 'rd');
     const apiUrl = this._getApiUrl(repo, totalRank, dailyRank);
-    const json = await this._sendAndCacheRequest(apiUrl, {
-      headers: { 'Accept': 'application/json' }
-    }).then(checkErrorResponse.asPromise())
-      .then(asJson);
+    const json = await this._requestJson(apiUrl);
 
     let rank;
     if (totalRank) {

--- a/services/gem/gem.js
+++ b/services/gem/gem.js
@@ -41,7 +41,7 @@ class GemVersion extends BaseJsonService {
   static get url() {
     return {
       base: 'gem/v',
-      format: '(.*)',
+      format: '(.+)',
       capture: ['repo']
     };
   }
@@ -145,7 +145,7 @@ class GemDownloads extends BaseJsonService {
   static get url() {
     return {
       base: 'gem',
-      format: '(dt|dtv|dv)/(.*)',
+      format: '(dt|dtv|dv)/(.+)',
       capture: ['info', 'rubygem']
     };
   }
@@ -209,7 +209,7 @@ class GemOwner extends BaseJsonService {
   static get url() {
     return {
       base: 'gem/u',
-      format: '(.*)',
+      format: '(.+)',
       capture: ['user']
     };
   }
@@ -273,7 +273,7 @@ class GemRank extends BaseJsonService {
   static get url() {
     return {
       base: 'gem',
-      format: '(rt|rd)/(.*)',
+      format: '(rt|rd)/(.+)',
       capture: ['info', 'repo']
     };
   }


### PR DESCRIPTION
Refactored the clojars version badge. While I was doing it, I decided we really need to get the abstraction discussed [here](https://github.com/badges/shields/pull/1590#discussion_r176240097) in place sooner rather than later.

Doing this makes the code for simple badges really terse. For example this reduces the gem version badge implementation down to:

```js
  async handle({repo}) {
    const apiUrl = 'https://rubygems.org/api/v1/gems/' + repo + '.json';
    const json = await this._requestJson(apiUrl);
    const version = json.version;

    return {
      message: versionText(version),
      color: versionColor(version)
    };
  }
```