### PR TITLE
[bower clojars] version() should throw on invalid inputs

### DIFF
--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -7,7 +7,7 @@
 const moment = require('moment');
 
 function version(version) {
-  if ((version === undefined) || (version === null)) {
+  if (typeof(version) !== 'string' && typeof(version) !== 'number') {
     throw new Error(`Can't generate a version color for ${version}`);
   }
   version = '' + version;

--- a/lib/color-formatters.js
+++ b/lib/color-formatters.js
@@ -7,6 +7,9 @@
 const moment = require('moment');
 
 function version(version) {
+  if ((version === undefined) || (version === null)) {
+    throw new Error(`Can't generate a version color for ${version}`);
+  }
   version = '' + version;
   let first = version[0];
   if (first === 'v') {

--- a/lib/color-formatters.spec.js
+++ b/lib/color-formatters.spec.js
@@ -85,5 +85,7 @@ describe('Color formatters', function() {
 
     expect(() => version(null)).to.throw(Error, "Can't generate a version color for null");
     expect(() => version(undefined)).to.throw(Error, "Can't generate a version color for undefined");
+    expect(() => version(true)).to.throw(Error, "Can't generate a version color for true");
+    expect(() => version({})).to.throw(Error, "Can't generate a version color for [object Object]");
   });
 });

--- a/lib/color-formatters.spec.js
+++ b/lib/color-formatters.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { test, given, forCases } = require('sazerac');
+const { expect } = require('chai');
 const {
   coveragePercentage,
   colorScale,
@@ -80,6 +81,9 @@ describe('Color formatters', function() {
       given('6.0-SNAPSHOT'),
       given('1.0.1-dev'),
       given('2.1.6-prerelease'),
-      ]).expect('orange');
+    ]).expect('orange');
+
+    expect(() => version(null)).to.throw(Error, "Can't generate a version color for null");
+    expect(() => version(undefined)).to.throw(Error, "Can't generate a version color for undefined");
   });
 });


### PR DESCRIPTION
I'm having a look through the failing service tests on the daily build.

It looks like several of the test failures are due to the behaviour change to `version()` introduced in #1615. Examples: https://circleci.com/gh/badges/shields/5328 I've picked bower and clojars to run in this PR just to demonstrate but I think there are others.

There are some badges which were relying on `version.toLowerCase()` throwing an error when passed an input like `null` or `undefined`. Now that we're turning everything into a string at the start of the function this no longer happens.

My proposed solution is we should explicitly throw an `Error` on invalid inputs to this function.