### PR TITLE
[github] Commit merge status badge

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1624,6 +1624,17 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
+        title: 'Github commit merge status',
+        previewUri: '/github/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.svg',
+        keywords: [
+          'GitHub',
+          'commit',
+          'branch',
+          'merge'
+        ],
+        documentation: githubDoc,
+      },
+      {
         title: 'GitHub contributors',
         previewUri: '/github/contributors/cdnjs/cdnjs.svg',
         keywords: [

--- a/server.js
+++ b/server.js
@@ -4287,12 +4287,13 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       const parsedData = JSON.parse(buffer);
-      const isIn = parsedData.status === 'identical' || parsedData.status === 'behind';
-      if (isIn) {
-        badgeData.text[1] = 'in ' + branch;
+      const isInBranch = parsedData.status === 'identical' || parsedData.status === 'behind';
+      if (isInBranch) {
+        badgeData.text[1] = `in ${branch}`;
         badgeData.colorscheme = 'brightgreen';
       } else {
-        badgeData.text[1] = 'not in ' + branch;
+        // status: ahead or diverged
+        badgeData.text[1] = `not in ${branch}`;
         badgeData.colorscheme = 'yellow';
       }
       sendBadge(format, badgeData);

--- a/server.js
+++ b/server.js
@@ -4267,7 +4267,7 @@ cache(function(data, match, sendBadge, request) {
 camp.route(/^\/github\/commit-status\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   const [, user, repo, branch, commit, format] = match;
-  const apiUrl = `${githubApiUrl}/repos/${user}/${repo}/compare/${commit}...${branch}`;
+  const apiUrl = `${githubApiUrl}/repos/${user}/${repo}/compare/${branch}...${commit}`;
   const badgeData = getBadgeData('commit status', data);
   githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'commit or branch not found')) {
@@ -4287,7 +4287,7 @@ cache(function(data, match, sendBadge, request) {
     }
     try {
       const parsedData = JSON.parse(buffer);
-      const isIn = parsedData.status === 'identical' || parsedData.status === 'ahead';
+      const isIn = parsedData.status === 'identical' || parsedData.status === 'behind';
       if (isIn) {
         badgeData.text[1] = 'in ' + branch;
         badgeData.colorscheme = 'brightgreen';

--- a/server.js
+++ b/server.js
@@ -4272,8 +4272,13 @@ cache(function(data, match, sendBadge, request) {
   githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'commit or branch not found')) {
       if (res && res.statusCode === 404) {
-        if (JSON.parse(buffer).message.startsWith('No common ancestor between')) {
-          badgeData.text[1] = 'no common ancestor';
+        try {
+          if (JSON.parse(buffer).message.startsWith('No common ancestor between')) {
+            badgeData.text[1] = 'no common ancestor';
+            badgeData.colorscheme = 'lightgrey';
+          }
+        } catch(e) {
+          badgeData.text[1] = 'invalid';
           badgeData.colorscheme = 'lightgrey';
         }
       }

--- a/server.js
+++ b/server.js
@@ -4263,6 +4263,35 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
+// GitHub commit status integration.
+camp.route(/^\/github\/commit-status\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
+cache(function(data, match, sendBadge, request) {
+  const [, user, repo, branch, commit, format] = match;
+  const apiUrl = `${githubApiUrl}/repos/${user}/${repo}/compare/${commit}...${branch}`;
+  const badgeData = getBadgeData('commit status', data);
+  githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
+    if (checkErrorResponse(badgeData, err, res, 'commit not found')) {
+      sendBadge(format, badgeData);
+      return;
+    }
+    try {
+      const parsedData = JSON.parse(buffer);
+      const isIn = parsedData.status === 'identical' || parsedData.status === 'ahead';
+      if (isIn) {
+        badgeData.text[1] = 'in ' + branch;
+        badgeData.colorscheme = 'brightgreen';
+      } else {
+        badgeData.text[1] = 'not in ' + branch;
+        badgeData.colorscheme = 'yellow';
+      }
+      sendBadge(format, badgeData);
+    } catch(e) {
+      badgeData.text[1] = 'invalid';
+      sendBadge(format, badgeData);
+    }
+  });
+}));
+
 // Bitbucket issues integration.
 camp.route(/^\/bitbucket\/issues(-raw)?\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {

--- a/server.js
+++ b/server.js
@@ -4270,7 +4270,7 @@ cache(function(data, match, sendBadge, request) {
   const apiUrl = `${githubApiUrl}/repos/${user}/${repo}/compare/${commit}...${branch}`;
   const badgeData = getBadgeData('commit status', data);
   githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
-    if (checkErrorResponse(badgeData, err, res, 'commit not found')) {
+    if (checkErrorResponse(badgeData, err, res, 'commit or branch not found')) {
       if (res.statusCode === 404) {
         if (JSON.parse(buffer).message.startsWith('No common ancestor between')) {
           badgeData.text[1] = 'no common ancestor';

--- a/server.js
+++ b/server.js
@@ -4271,7 +4271,7 @@ cache(function(data, match, sendBadge, request) {
   const badgeData = getBadgeData('commit status', data);
   githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'commit or branch not found')) {
-      if (res.statusCode === 404) {
+      if (res && res.statusCode === 404) {
         if (JSON.parse(buffer).message.startsWith('No common ancestor between')) {
           badgeData.text[1] = 'no common ancestor';
           badgeData.colorscheme = 'lightgrey';

--- a/server.js
+++ b/server.js
@@ -4271,6 +4271,12 @@ cache(function(data, match, sendBadge, request) {
   const badgeData = getBadgeData('commit status', data);
   githubAuth.request(request, apiUrl, {}, function(err, res, buffer) {
     if (checkErrorResponse(badgeData, err, res, 'commit not found')) {
+      if (res.statusCode === 404) {
+        if (JSON.parse(buffer).message.startsWith('No common ancestor between')) {
+          badgeData.text[1] = 'no common ancestor';
+          badgeData.colorscheme = 'lightgrey';
+        }
+      }
       sendBadge(format, badgeData);
       return;
     }

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -536,3 +536,12 @@ t.create('commit status - commit not in branch (tag)')
   value: 'commit not found',
   colorB: colorsB.lightgrey
 });
+
+
+t.create('commit status - no common ancestor')
+.get('/commit-status/badges/shields/master/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'no common ancestor',
+  colorB: colorsB.lightgrey
+});

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -538,7 +538,7 @@ t.create('commit status - commit not in branch (tag)')
   colorB: colorsB.lightgrey
 });
 
-t.create('commit status - no common ancestor')
+t.create('commit status - no common ancestor between commit and branch')
 .get('/commit-status/badges/shields/master/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
 .expectJSON({
   name: 'commit status',
@@ -579,6 +579,28 @@ t.create('commit status - github server error')
   .intercept(nock => nock('https://api.github.com')
     .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
     .reply(500))
+  .expectJSON({
+    name: 'commit status',
+    value: 'invalid',
+    colorB: colorsB.lightgrey
+});
+
+t.create('commit status - 404 with empty JSON form github')
+  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .intercept(nock => nock('https://api.github.com')
+    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .reply(404, {}))
+  .expectJSON({
+    name: 'commit status',
+    value: 'invalid',
+    colorB: colorsB.lightgrey
+});
+
+t.create('commit status - 404 with invalid JSON form github')
+  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .intercept(nock => nock('https://api.github.com')
+    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .reply(404, invalidJSON))
   .expectJSON({
     name: 'commit status',
     value: 'invalid',

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -557,7 +557,7 @@ t.create('commit status - unknown branch')
 t.create('commit status - invalid JSON')
   .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
     .reply(invalidJSON))
   .expectJSON({
     name: 'commit status',
@@ -577,7 +577,7 @@ t.create('commit status - network error')
 t.create('commit status - github server error')
   .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
     .reply(500))
   .expectJSON({
     name: 'commit status',
@@ -588,7 +588,7 @@ t.create('commit status - github server error')
 t.create('commit status - 404 with empty JSON form github')
   .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
     .reply(404, {}))
   .expectJSON({
     name: 'commit status',
@@ -599,7 +599,7 @@ t.create('commit status - 404 with empty JSON form github')
 t.create('commit status - 404 with invalid JSON form github')
   .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/960c5bf72d7d1539fcd453343eed3f8617427a40...master')
+    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
     .reply(404, invalidJSON))
   .expectJSON({
     name: 'commit status',

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -522,6 +522,17 @@ t.create('commit status - commit in branch')
   colorB: colorsB.brightgreen
 });
 
+t.create('commit status - checked commit is identical with the newest commit in branch')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
+  .intercept(nock => nock('https://api.github.com')
+    .get('/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c')
+    .reply(200, { status: 'identical' }))
+  .expectJSON({
+    name: 'commit status',
+    value: 'in master',
+    colorB: colorsB.brightgreen
+});
+
 t.create('commit status - commit not in branch')
 .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a41.json?style=_shields_test')
 .expectJSON({

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -522,6 +522,14 @@ t.create('commit status - commit in branch')
   colorB: colorsB.brightgreen
 });
 
+t.create('commit status - commit not in branch')
+.get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a41.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'commit or branch not found',
+  colorB: colorsB.lightgrey
+});
+
 t.create('commit status - unknown commit id')
 .get('/commit-status/atom/atom/v1.27.1/7dfb45eb61a48a4ce18a0dd2e31f944ed4467ae3.json?style=_shields_test')
 .expectJSON({
@@ -530,8 +538,8 @@ t.create('commit status - unknown commit id')
   colorB: colorsB.yellow
 });
 
-t.create('commit status - commit not in branch (tag)')
-.get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a41.json?style=_shields_test')
+t.create('commit status - unknown branch')
+.get('/commit-status/badges/shields/this-branch-does-not-exist/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
 .expectJSON({
   name: 'commit status',
   value: 'commit or branch not found',
@@ -543,14 +551,6 @@ t.create('commit status - no common ancestor between commit and branch')
 .expectJSON({
   name: 'commit status',
   value: 'no common ancestor',
-  colorB: colorsB.lightgrey
-});
-
-t.create('commit status - unknown branch')
-.get('/commit-status/badges/shields/this-branch-does-not-exist/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
-.expectJSON({
-  name: 'commit status',
-  value: 'commit or branch not found',
   colorB: colorsB.lightgrey
 });
 

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -511,3 +511,28 @@ t.create('repository size')
   name: 'repo size',
   value: isFileSize,
 }));
+
+// Commit status
+t.create('commit status - commit in branch')
+.get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'in master',
+  colorB: colorsB.brightgreen
+});
+
+t.create('commit status - unknown commit id')
+.get('/commit-status/atom/atom/v1.27.1/7dfb45eb61a48a4ce18a0dd2e31f944ed4467ae3.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'not in v1.27.1',
+  colorB: colorsB.yellow
+});
+
+t.create('commit status - commit not in branch (tag)')
+.get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a41.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'commit not found',
+  colorB: colorsB.lightgrey
+});

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -533,15 +533,22 @@ t.create('commit status - commit not in branch (tag)')
 .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a41.json?style=_shields_test')
 .expectJSON({
   name: 'commit status',
-  value: 'commit not found',
+  value: 'commit or branch not found',
   colorB: colorsB.lightgrey
 });
-
 
 t.create('commit status - no common ancestor')
 .get('/commit-status/badges/shields/master/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
 .expectJSON({
   name: 'commit status',
   value: 'no common ancestor',
+  colorB: colorsB.lightgrey
+});
+
+t.create('commit status - unknown branch')
+.get('/commit-status/badges/shields/this-branch-does-not-exist/b551a3a8daf1c48dba32a3eab1edf99b10c28863.json?style=_shields_test')
+.expectJSON({
+  name: 'commit status',
+  value: 'commit or branch not found',
   colorB: colorsB.lightgrey
 });

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -515,7 +515,7 @@ t.create('repository size')
 
 // Commit status
 t.create('commit status - commit in branch')
-.get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+.get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
 .expectJSON({
   name: 'commit status',
   value: 'in master',
@@ -555,9 +555,9 @@ t.create('commit status - no common ancestor between commit and branch')
 });
 
 t.create('commit status - invalid JSON')
-  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
+    .get('/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c')
     .reply(invalidJSON))
   .expectJSON({
     name: 'commit status',
@@ -566,7 +566,7 @@ t.create('commit status - invalid JSON')
 });
 
 t.create('commit status - network error')
-  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
   .networkOff()
   .expectJSON({
     name: 'commit status',
@@ -575,9 +575,9 @@ t.create('commit status - network error')
 });
 
 t.create('commit status - github server error')
-  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
+    .get('/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c')
     .reply(500))
   .expectJSON({
     name: 'commit status',
@@ -586,9 +586,9 @@ t.create('commit status - github server error')
 });
 
 t.create('commit status - 404 with empty JSON form github')
-  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
+    .get('/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c')
     .reply(404, {}))
   .expectJSON({
     name: 'commit status',
@@ -597,9 +597,9 @@ t.create('commit status - 404 with empty JSON form github')
 });
 
 t.create('commit status - 404 with invalid JSON form github')
-  .get('/commit-status/badges/shields/master/960c5bf72d7d1539fcd453343eed3f8617427a40.json?style=_shields_test')
+  .get('/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test')
   .intercept(nock => nock('https://api.github.com')
-    .get('/repos/badges/shields/compare/master...960c5bf72d7d1539fcd453343eed3f8617427a40')
+    .get('/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c')
     .reply(404, invalidJSON))
   .expectJSON({
     name: 'commit status',


### PR DESCRIPTION
Implements https://github.com/badges/shields/issues/1616#issue-309141574. Probot app has access to merge commit sha, so we don't need more useful API (described here https://github.com/badges/shields/issues/1616#issuecomment-377700209).
Service tests describes all cases I was able to come up with. Feel free to suggest other cases. 