### PR TITLE
[Travis] Add travis-ci.com support

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -118,12 +118,12 @@ const allBadgeExamples = [
     },
     examples: [
       {
-        title: 'Travis',
+        title: 'Travis (.org)',
         previewUri: '/travis/rust-lang/rust.svg',
         exampleUri: '/travis/USER/REPO.svg'
       },
       {
-        title: 'Travis branch',
+        title: 'Travis (.org) branch',
         previewUri: '/travis/rust-lang/rust/master.svg',
         exampleUri: '/travis/USER/REPO/BRANCH.svg'
       },

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -128,6 +128,16 @@ const allBadgeExamples = [
         exampleUri: '/travis/USER/REPO/BRANCH.svg'
       },
       {
+        title: 'Travis (.com)',
+        previewUri: '/travis/com/ivandelabeldad/rackian-gateway.svg',
+        exampleUri: '/travis/com/USER/REPO.svg'
+      },
+      {
+        title: 'Travis (.com) branch',
+        previewUri: '/travis/com/ivandelabeldad/rackian-gateway/master.svg',
+        exampleUri: '/travis/com/USER/REPO/BRANCH.svg'
+      },
+      {
         title: 'Wercker',
         previewUri: '/wercker/ci/wercker/docs.svg'
       },

--- a/server.js
+++ b/server.js
@@ -340,7 +340,7 @@ cache(function(data, match, sendBadge, request) {
     }
     request(options, (err, res, buffer) => {
       if (err !== null) {
-        log.error('Travis CI error: ' + err.stack);
+        log.error(`Travis CI error: ${err.stack}`);
         if (res) {
           log.error('' + res);
         }
@@ -402,7 +402,7 @@ cache(function(data, match, sendBadge, request) {
   const badgeData = getBadgeData('build', data);
   request(options, function(err, res) {
     if (err != null) {
-      log.error('Travis error: ' + err.stack);
+      log.error(`Travis error: ${err.stack}`);
       if (res) { log.error(''+res); }
     }
     if (checkErrorResponse(badgeData, err, res)) {

--- a/server.js
+++ b/server.js
@@ -385,58 +385,16 @@ cache(function(data, match, sendBadge, request) {
   });
 }));
 
-// Travis (.com) integration
-camp.route(/^\/travis(-ci)?\/com\/([^/]+\/[^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
+// Travis integration (.org and .com)
+camp.route(/^\/travis(-ci)?\/(?:(com)\/)?([^/]+\/[^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var userRepo = match[2];  // eg, espadrine/sc
-  var branch = match[3];
-  var format = match[4];
+  var travisDomain = match[2] || 'org';  // (com | org) org by default
+  var userRepo = match[3];  // eg, espadrine/sc
+  var branch = match[4];
+  var format = match[5];
   var options = {
     method: 'HEAD',
-    uri: 'https://api.travis-ci.com/' + userRepo + '.svg',
-  };
-  if (branch != null) {
-    options.uri += '?branch=' + branch;
-  }
-  var badgeData = getBadgeData('build', data);
-  request(options, function(err, res) {
-    if (err != null) {
-      log.error('Travis error: ' + err.stack);
-      if (res) { log.error(''+res); }
-    }
-    if (checkErrorResponse(badgeData, err, res)) {
-      sendBadge(format, badgeData);
-      return;
-    }
-    try {
-      var state = res.headers['content-disposition']
-                     .match(/filename="(.+)\.svg"/)[1];
-      badgeData.text[1] = state;
-      if (state === 'passing') {
-        badgeData.colorscheme = 'brightgreen';
-      } else if (state === 'failing') {
-        badgeData.colorscheme = 'red';
-      } else {
-        badgeData.text[1] = state;
-      }
-      sendBadge(format, badgeData);
-
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-      sendBadge(format, badgeData);
-    }
-  });
-}));
-
-// Travis integration
-camp.route(/^\/travis(-ci)?\/([^/]+\/[^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var userRepo = match[2];  // eg, espadrine/sc
-  var branch = match[3];
-  var format = match[4];
-  var options = {
-    method: 'HEAD',
-    uri: 'https://api.travis-ci.org/' + userRepo + '.svg',
+    uri: `https://api.travis-ci.${travisDomain}/${userRepo}.svg`
   };
   if (branch != null) {
     options.uri += '?branch=' + branch;

--- a/server.js
+++ b/server.js
@@ -329,7 +329,7 @@ cache(function(data, match, sendBadge, request) {
   const format = match[3];
   const options = {
     method: 'GET',
-    uri: 'https://api.travis-ci.org/repos/' + userRepo + '/branches/' + version,
+    uri: `https://api.travis-ci.org/repos/${userRepo}/branches/${version}`,
   };
   const badgeData = getBadgeData('PHP', data);
   getPhpReleases(githubAuth.request, (err, phpReleases) => {
@@ -388,18 +388,18 @@ cache(function(data, match, sendBadge, request) {
 // Travis integration (.org and .com)
 camp.route(/^\/travis(-ci)?\/(?:(com)\/)?([^/]+\/[^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var travisDomain = match[2] || 'org';  // (com | org) org by default
-  var userRepo = match[3];  // eg, espadrine/sc
-  var branch = match[4];
-  var format = match[5];
-  var options = {
+  const travisDomain = match[2] || 'org';  // (com | org) org by default
+  const userRepo = match[3];  // eg, espadrine/sc
+  const branch = match[4];
+  const format = match[5];
+  const options = {
     method: 'HEAD',
-    uri: `https://api.travis-ci.${travisDomain}/${userRepo}.svg`
+    uri: `https://api.travis-ci.${travisDomain}/${userRepo}.svg`,
   };
   if (branch != null) {
-    options.uri += '?branch=' + branch;
+    options.uri += `?branch=${branch}`;
   }
-  var badgeData = getBadgeData('build', data);
+  const badgeData = getBadgeData('build', data);
   request(options, function(err, res) {
     if (err != null) {
       log.error('Travis error: ' + err.stack);
@@ -410,7 +410,7 @@ cache(function(data, match, sendBadge, request) {
       return;
     }
     try {
-      var state = res.headers['content-disposition']
+      const state = res.headers['content-disposition']
                      .match(/filename="(.+)\.svg"/)[1];
       badgeData.text[1] = state;
       if (state === 'passing') {
@@ -421,7 +421,6 @@ cache(function(data, match, sendBadge, request) {
         badgeData.text[1] = state;
       }
       sendBadge(format, badgeData);
-
     } catch(e) {
       badgeData.text[1] = 'invalid';
       sendBadge(format, badgeData);

--- a/services/travis/travis.tester.js
+++ b/services/travis/travis.tester.js
@@ -39,6 +39,38 @@ t.create('connection error')
   .networkOff()
   .expectJSON({ name: 'build', value: 'inaccessible' });
 
+// Travis (.com) CI
+
+t.create('build status on default branch')
+  .get('/com/ivandelabeldad/rackian-gateway.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: Joi.equal('failing', 'passing', 'unknown')
+  }));
+
+t.create('build status on named branch')
+  .get('/com/ivandelabeldad/rackian-gateway.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: Joi.equal('failing', 'passing', 'unknown')
+  }));
+
+t.create('unknown repo')
+  .get('/com/this-repo/does-not-exist.json')
+  .expectJSON({ name: 'build', value: 'unknown' });
+
+t.create('missing content-disposition header')
+  .get('/com/foo/bar.json')
+  .intercept(nock => nock('https://api.travis-ci.com')
+    .head('/foo/bar.svg')
+    .reply(200))
+  .expectJSON({ name: 'build', value: 'invalid' });
+
+t.create('connection error')
+  .get('/com/foo/bar.json')
+  .networkOff()
+  .expectJSON({ name: 'build', value: 'inaccessible' });
+
 // PHP version from .travis.yml
 
 t.create('gets the package version of symfony')


### PR DESCRIPTION
Add new badges for `travis-ci.com` using two new possible paths (maintaining consistency with travis-ci.org badges): 

`/travis/com/USER/REPO.(svg|png|gif|jpg|json)`
`/travis-ci/com/USER/REPO.(svg|png|gif|jpg|json)`

close #1674  #1710 