### PR TITLE
fix typescript regex in [npm] tests

### DIFF
--- a/services/npm/npm.tester.js
+++ b/services/npm/npm.tester.js
@@ -11,7 +11,7 @@ const t = new ServiceTester({ id: 'npm', title: 'NPM' });
 module.exports = t;
 const colorsB = mapValues(colorscheme, 'colorB');
 
-const isTypeDefinition = Joi.string().regex(/^(Flow|TypeScript) v?[0-9]+.[0-9]( (Flow|TypeScript) v?[0-9]+.[0-9])?$/);
+const isTypeDefinition = Joi.string().regex(/^(Flow|TypeScript) v?[0-9]+.[0-9]+( \| (Flow|TypeScript) v?[0-9]+.[0-9]+)?$/);
 
 t.create('total downloads of left-pad')
   .get('/dt/left-pad.json?style=_shields_test')


### PR DESCRIPTION
* Expect `TypeScript vX.Y | Flow vX.Y` instead of `TypeScript vX.Y Flow vX.Y`
* Allow version numbers to have more than >1 digit after the point