### PR TITLE
[cocoapods] fix Metric regexes

### DIFF
--- a/services/cocoapods/cocoapods.tester.js
+++ b/services/cocoapods/cocoapods.tester.js
@@ -142,7 +142,9 @@ t.create('downloads (valid, weekly)')
   .get('/dw/AFNetworking.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'downloads',
-    value: isMetricOverTimePeriod
+    // this is deliberately not isMetricOverTimePeriod due to
+    // https://github.com/CocoaPods/cocoapods.org/issues/348
+    value: Joi.string().regex(/^(0|[1-9][0-9]*)[kMGTPEZY]?\/week$/)
   }));
 
 t.create('downloads (valid, total)')
@@ -176,7 +178,9 @@ t.create('apps (valid, weekly)')
   .get('/aw/AFNetworking.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'apps',
-    value: isMetricOverTimePeriod
+    // this is deliberately not isMetricOverTimePeriod due to
+    // https://github.com/CocoaPods/cocoapods.org/issues/348
+    value: Joi.string().regex(/^(0|[1-9][0-9]*)[kMGTPEZY]?\/week$/)
   }));
 
 t.create('apps (valid, total)')


### PR DESCRIPTION
There are a couple of `cocoapods` tests failing because the package we are testing against has been getting 0 downloads/week (how sad :disappointed: ) and the `isMetricOverTimePeriod` regex didn't allow `0/week`. In principle though, it should also be valid to have 0 open issues + so on, so I've changed the others