### PR TITLE
[packagist] use semver latestVersion

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,6 @@ const {licenseToColor} = require('./lib/licenses');
 const { latest: latestVersion } = require('./lib/version');
 const {
   compare: phpVersionCompare,
-  latest: phpLatestVersion,
   isStable: phpStableVersion,
   minorVersion: phpMinorVersion,
   versionReduction: phpVersionReduction,

--- a/server.js
+++ b/server.js
@@ -1564,9 +1564,9 @@ cache(function(data, match, sendBadge, request) {
       switch (info) {
       case 'v':
         var stableVersions = versions.filter(phpStableVersion);
-        var stableVersion = phpLatestVersion(stableVersions);
+        var stableVersion = latestVersion(stableVersions);
         if (!stableVersion) {
-          stableVersion = phpLatestVersion(versions);
+          stableVersion = latestVersion(versions);
         }
         //if (!!aliasesMap[stableVersion]) {
         //  stableVersion = aliasesMap[stableVersion];
@@ -1575,7 +1575,7 @@ cache(function(data, match, sendBadge, request) {
         badgeColor = versionColor(stableVersion);
         break;
       case 'vpre':
-        var unstableVersion = phpLatestVersion(versions);
+        var unstableVersion = latestVersion(versions);
         //if (!!aliasesMap[unstableVersion]) {
         //  unstableVersion = aliasesMap[unstableVersion];
         //}

--- a/services/packagist/packagist.tester.js
+++ b/services/packagist/packagist.tester.js
@@ -4,18 +4,10 @@ const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 const {
   isComposerVersion,
+  isVPlusDottedVersionNClausesWithOptionalSuffix,
   isMetric,
   isMetricOverTimePeriod
 } = require('../test-validators');
-
-/*
-  validator for a packagist version number
-
-  From https://packagist.org/about :
-  "version names should match 'X.Y.Z', or 'vX.Y.Z',
-  with an optional suffix for RC, beta, alpha or patch versions"
-*/
-const isPackagistVersion = Joi.string().regex(/^v?[0-9]+.[0-9]+.[0-9]+[\S]*$/);
 
 const t = new ServiceTester({ id: 'packagist', title: 'PHP version from Packagist' });
 module.exports = t;
@@ -93,7 +85,7 @@ t.create('version (valid)')
   .get('/v/symfony/symfony.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'packagist',
-    value: isPackagistVersion
+    value: isVPlusDottedVersionNClausesWithOptionalSuffix
   }));
 
 t.create('version (invalid package name)')


### PR DESCRIPTION
closes #1586 

Use `latestVersion()` instead of `phpLatestVersion()` for packagist `/v` & `/vpre` endpoint

**Note:** there is still a couple of issues with `latestVersion()` - should be fixed in #1628 
