### PR TITLE
Required files added to now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,8 +1,9 @@
 {
   "name": "shields",
   "files": [
-    "*.js",
-    "*.png",
+    "server.js",
+    "favicon.png",
+    "next.config.js",
     "build/",
     "frontend/",
     "lib/",
@@ -11,8 +12,7 @@
     "public/",
     "static/",
     "templates/",
-    "!**/*.spec.js",
-    "!**/*.integration.js"
+    "services/"
   ],
   "env": {
     "PERSISTENCE_DIR": "/tmp/persistence",


### PR DESCRIPTION
I tried to [deploy Shields to Now](https://github.com/badges/shields/blob/master/doc/self-hosting.md#zeit-now) but it didn't work for me. I think that [files](https://zeit.co/docs/features/configuration#files-(array)) in `now.json` in does not support file patterns (there wasn't `server.js` after deployment and there were `*.spec.js` files). This PR add required files and directories. Working instance https://shields-pr-1718.now.sh/ (will be running as long as this PR is open). 
List of files before this change:
![screenshot-2018-6-3 zeit deployment](https://user-images.githubusercontent.com/1526000/40884538-9f6b8c3e-6715-11e8-8cde-380d7cbb0268.png)
After:
![screenshot-2018-6-3 zeit deployment 1](https://user-images.githubusercontent.com/1526000/40884541-a3945b24-6715-11e8-8165-8dfabf1b09f3.png)
