### PR TITLE
GitHub badges: extend for pr in title

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1505,7 +1505,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue state',
+        title: 'GitHub issue/pull request state',
         previewUri: '/github/issues/detail/s/badges/shields/979.svg',
         keywords: [
           'GitHub',
@@ -1516,7 +1516,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue title',
+        title: 'GitHub issue/pull request title',
         previewUri: '/github/issues/detail/title/badges/shields/1290.svg',
         keywords: [
           'GitHub',
@@ -1527,7 +1527,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue author',
+        title: 'GitHub issue/pull request author',
         previewUri: '/github/issues/detail/u/badges/shields/979.svg',
         keywords: [
           'GitHub',
@@ -1538,7 +1538,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue label',
+        title: 'GitHub issue/pull request label',
         previewUri: '/github/issues/detail/label/badges/shields/979.svg',
         keywords: [
           'GitHub',
@@ -1549,7 +1549,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue comments',
+        title: 'GitHub issue/pull request comments',
         previewUri: '/github/issues/detail/comments/badges/shields/979.svg',
         keywords: [
           'GitHub',
@@ -1560,7 +1560,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue age',
+        title: 'GitHub issue/pull request age',
         previewUri: '/github/issues/detail/age/badges/shields/979.svg',
         keywords: [
           'GitHub',
@@ -1571,7 +1571,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'GitHub issue last update',
+        title: 'GitHub issue/pull request last update',
         previewUri: '/github/issues/detail/last-update/badges/shields/979.svg',
         keywords: [
           'GitHub',


### PR DESCRIPTION
The issue badges deliver the same information for pr's, too!

Alternative, shorter wording, would be `pr`.
Any preferences here?