### PR TITLE
[github] update package/manifest for private repos

### DIFF
--- a/server.js
+++ b/server.js
@@ -3476,8 +3476,10 @@ cache(function(query_data, match, sendBadge, request) {
   var repo = match[4];
   var branch = match[5] || 'master';
   var format = match[6];
-  var hasTokens = !!githubAuth.getTokenDebugInfo({ sanitize: false }).tokens.length
-  var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/contents/' + type + '.json?ref=' + branch;
+  var hasTokens = !!githubAuth.getTokenDebugInfo({ sanitize: false }).tokens.length;
+  var apiUrl = hasToken
+    ? githubApiUrl + '/repos/' + user + '/' + repo + '/contents/' + type + '.json?ref=' + branch
+    : 'https://raw.githubusercontent.com/' + user + '/' + repo + '/' + branch + '/' + type + '.json';
   var badgeData = getBadgeData(type, query_data);
   var requestCallback = function(err, res, buffer) {
     if (err != null) {
@@ -3510,7 +3512,7 @@ cache(function(query_data, match, sendBadge, request) {
       badgeData.text[1] = 'invalid data';
       sendBadge(format, badgeData);
     }
-  }
+  };
   if (hasTokens) githubAuth.request(request, apiUrl, { }, requestCallback);
   else request(apiUrl, requestCallback);
 }));

--- a/server.js
+++ b/server.js
@@ -3477,7 +3477,7 @@ cache(function(query_data, match, sendBadge, request) {
   var branch = match[5] || 'master';
   var format = match[6];
   var hasTokens = !!githubAuth.getTokenDebugInfo({ sanitize: false }).tokens.length;
-  var apiUrl = hasToken
+  var apiUrl = hasTokens
     ? githubApiUrl + '/repos/' + user + '/' + repo + '/contents/' + type + '.json?ref=' + branch
     : 'https://raw.githubusercontent.com/' + user + '/' + repo + '/' + branch + '/' + type + '.json';
   var badgeData = getBadgeData(type, query_data);

--- a/server.js
+++ b/server.js
@@ -3476,16 +3476,17 @@ cache(function(query_data, match, sendBadge, request) {
   var repo = match[4];
   var branch = match[5] || 'master';
   var format = match[6];
-  var apiUrl = 'https://raw.githubusercontent.com/' + user + '/' + repo + '/' + branch + '/' + type + '.json';
+  var apiUrl = githubApiUrl + '/repos/' + user + '/' + repo + '/contents/' + type + '.json?ref=' + branch;
   var badgeData = getBadgeData(type, query_data);
-  request(apiUrl, function(err, res, buffer) {
+  githubAuth.request(request, apiUrl, { }, function(err, res, buffer) {
     if (err != null) {
       badgeData.text[1] = 'inaccessible';
       sendBadge(format, badgeData);
       return;
     }
     try {
-      var json_data = JSON.parse(buffer);
+      var response_data = JSON.parse(buffer);
+      var json_data = JSON.parse(Buffer.from(response_data.content, 'base64').toString('utf-8'));
       switch(info) {
         case 'v':
         case 'version':


### PR DESCRIPTION
This edit allows for the `/github/(package|manifest)-json/` badges to work with private repositories.

I've updated the `raw.githubusercontent.com` URL to use GitHub's own API instead, and this allows it to work for private repositories. The old tests for this badge are still passing.

EDIT: The checks are failing on an unrelated badge, I think? I only ran tests for this one badge and everything looked good there. The failure seems to be for `hit-counter`.