### PR TITLE
WIP: cache headers

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -79,14 +79,12 @@ function handleRequest (makeBadge, handlerOptions) {
   return (queryParams, match, end, ask) => {
     const reqTime = new Date();
 
+    let maxAge = 600;
     if (queryParams.maxAge !== undefined && /^[0-9]+$/.test(queryParams.maxAge)) {
-      ask.res.setHeader('Cache-Control', 'max-age=' + queryParams.maxAge);
-      ask.res.setHeader('Expires', new Date(+reqTime + queryParams.maxAge * 1000).toGMTString());
-    } else {
-      // Cache management - no cache, so it won't be cached by GitHub's CDN.
-      ask.res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-      ask.res.setHeader('Expires', reqTime.toGMTString());  // Proxies, GitHub, see #221.
+      maxAge = queryParams.maxAge;
     }
+    ask.res.setHeader('Cache-Control', 'max-age=' + maxAge);
+    ask.res.setHeader('Expires', new Date(+reqTime + maxAge * 1000).toGMTString());
 
     ask.res.setHeader('Date', reqTime.toGMTString());
 

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -105,9 +105,10 @@ describe('The request handler', function() {
         expect(handlerCallCount).to.equal(1);
       });
 
-      it('should set the expires header to current time', async function () {
+      it('should set the expires header to current time + 10 mins', async function () {
         const res = await fetch(`${baseUri}/testing/123.json`);
-        expect(res.headers.get('expires')).to.equal(res.headers.get('date'));
+        const expectedExpiry = new Date(+(new Date(res.headers.get('date'))) + 600000).toGMTString();
+        expect(res.headers.get('expires')).to.equal(expectedExpiry);
       });
 
       it('should set the expires header to current time + max-age', async function () {


### PR DESCRIPTION
Following on from conversation in https://github.com/badges/shields/issues/1723#issuecomment-395564990 ...

Having thought about this a bit, I think a default cache time of 1 hour is a bit long. For a badge like licence that we don't expect to change much, it is probably too short, but for something like a CI build status or coverage amount, I think an hour would be annoying as a default behaviour. In some cases, users switch to this service due to this behaviour (e.g: https://github.com/lemurheavy/coveralls-public/issues/971#issuecomment-384330647 ). Maybe a good future improvement would be to define a default cache length for different types of badges?

My hypothesis is that even quite a short cache will help. Also, due to the infrequent nature of deploys, I think it would be better to start small and crank it up gradually if needed. If we introduce a long cache, annoy all our users and can't get a fix deployed for ~3 months, I think that is worse than if we introduce a short cache and it only improves performance very slightly and we have to wait ~3 months to bump it up a bit. What do you think @RedSparr0w ?

Having done some reading on this (e.g: https://github.com/github/markup/issues/224#issuecomment-48532178 ) I was slightly nervous about camo respecting the headers, but I set up ngrok on my dev copy and tested this configuration with various URLs (http, https, with and without GET params etc) via GitHub's camo proxy using markdown files in gist. Camo respects the headers as expected in all cases so I think we can safely introduce this.

So far so good, but in its current state this will make development really annoying. What we want to do is use these headers in production and use `'no-cache, no-store, must-revalidate'` in dev, but I'm not sure about how the prod environment is configured. What's the best way to set set `NODE_ENV` default safely on this project? Can anyone advise?