### PR TITLE
[resharper chocolatey powershellgallery nuget myget] Standard name in nuget v2 downloads badge

### DIFF
--- a/lib/nuget-provider.js
+++ b/lib/nuget-provider.js
@@ -98,11 +98,10 @@ function mapNugetFeedv2({ camp, cache }, pattern, offset, getInfo) {
   camp.route(dtRegex,
   cache(function(data, match, sendBadge, request) {
     const info = getInfo(match);
-    const site = info.site;  // eg, `Chocolatey`, or `YoloDev`
     const repo = match[offset+ 1];  // eg, `Nuget.Core`.
     const format = match[offset + 2];
     const apiUrl = info.feed;
-    const badgeData = getBadgeData(site, data);
+    const badgeData = getBadgeData('downloads', data);
     getNugetPackage(apiUrl, repo, null, request, function(err, data) {
       if (err != null) {
         badgeData.text[1] = err.message;

--- a/services/chocolatey/chocolatey.tester.js
+++ b/services/chocolatey/chocolatey.tester.js
@@ -24,18 +24,18 @@ module.exports = t;
 t.create('total downloads (valid)')
   .get('/dt/scriptcs.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'chocolatey',
+    name: 'downloads',
     value: isMetric,
   }));
 
 t.create('total downloads (not found)')
   .get('/dt/not-a-real-package.json')
-  .expectJSON({name: 'chocolatey', value: 'not found'});
+  .expectJSON({name: 'downloads', value: 'not found'});
 
 t.create('total downloads (connection error)')
   .get('/dt/scriptcs.json')
   .networkOff()
-  .expectJSON({name: 'chocolatey', value: 'inaccessible'});
+  .expectJSON({name: 'downloads', value: 'inaccessible'});
 
 t.create('total downloads (unexpected response)')
   .get('/dt/scriptcs.json')
@@ -43,7 +43,7 @@ t.create('total downloads (unexpected response)')
     .get("/api/v2/Packages()?$filter=Id%20eq%20%27scriptcs%27%20and%20IsLatestVersion%20eq%20true")
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'chocolatey', value: 'invalid'});
+  .expectJSON({name: 'downloads', value: 'invalid'});
 
 
 // version

--- a/services/powershellgallery/powershellgallery.tester.js
+++ b/services/powershellgallery/powershellgallery.tester.js
@@ -24,18 +24,18 @@ module.exports = t;
 t.create('total downloads (valid)')
   .get('/dt/ACMESharp.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'powershellgallery',
+    name: 'downloads',
     value: isMetric,
   }));
 
 t.create('total downloads (not found)')
   .get('/dt/not-a-real-package.json')
-  .expectJSON({name: 'powershellgallery', value: 'not found'});
+  .expectJSON({name: 'downloads', value: 'not found'});
 
 t.create('total downloads (connection error)')
   .get('/dt/ACMESharp.json')
   .networkOff()
-  .expectJSON({name: 'powershellgallery', value: 'inaccessible'});
+  .expectJSON({name: 'downloads', value: 'inaccessible'});
 
 t.create('total downloads (unexpected response)')
   .get('/dt/ACMESharp.json')
@@ -43,7 +43,7 @@ t.create('total downloads (unexpected response)')
     .get("/api/v2/Packages()?$filter=Id%20eq%20%27ACMESharp%27%20and%20IsLatestVersion%20eq%20true")
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'powershellgallery', value: 'invalid'});
+  .expectJSON({name: 'downloads', value: 'invalid'});
 
 
 // version

--- a/services/resharper/resharper.tester.js
+++ b/services/resharper/resharper.tester.js
@@ -24,18 +24,18 @@ module.exports = t;
 t.create('total downloads (valid)')
   .get('/dt/ReSharper.Nuke.json')
   .expectJSONTypes(Joi.object().keys({
-    name: 'resharper',
+    name: 'downloads',
     value: isMetric,
   }));
 
 t.create('total downloads (not found)')
   .get('/dt/not-a-real-package.json')
-  .expectJSON({name: 'resharper', value: 'not found'});
+  .expectJSON({name: 'downloads', value: 'not found'});
 
 t.create('total downloads (connection error)')
   .get('/dt/ReSharper.Nuke.json')
   .networkOff()
-  .expectJSON({name: 'resharper', value: 'inaccessible'});
+  .expectJSON({name: 'downloads', value: 'inaccessible'});
 
 t.create('total downloads (unexpected response)')
   .get('/dt/ReSharper.Nuke.json')
@@ -43,7 +43,7 @@ t.create('total downloads (unexpected response)')
     .get("/api/v2/Packages()?$filter=Id%20eq%20%27ReSharper.Nuke%27%20and%20IsLatestVersion%20eq%20true")
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'resharper', value: 'invalid'});
+  .expectJSON({name: 'downloads', value: 'invalid'});
 
 
 // version


### PR DESCRIPTION
Downloads badges based on NuGet v2 have its service name as a badge name. 
![shields io quality metadata badges for open source projects](https://user-images.githubusercontent.com/1526000/41200306-862bc62a-6ca2-11e8-984a-002161ae685c.png)
Other downloads badges (like Nuget, MyGet) uses "downloads" as a badge name. This PR changes name of NuGet v2 based downloads badge to "downloads". 