### PR TITLE
fix [dub] service test

### DIFF
--- a/services/dub/dub.tester.js
+++ b/services/dub/dub.tester.js
@@ -34,10 +34,10 @@ t.create('total downloads (valid)')
   }));
 
 t.create('total downloads, specific version (valid)')
-  .get('/dt/vibe-d/0.7.23.json?style=_shields_test')
+  .get('/dt/vibe-d/0.7.27.json?style=_shields_test')
   .expectJSONTypes(Joi.object().keys({
     name: 'downloads',
-    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.7.23$/),
+    value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.7.27$/),
     colorB: isVersionColor
   }))
   .timeout(15000);


### PR DESCRIPTION
The version we were testing against seems to have gone away - spooky :ghost:
https://code.dlang.org/api/packages/vibe-d/0.7.23/stats

Switch to a version that exists:
https://code.dlang.org/api/packages/vibe-d/0.7.27/stats