### PR TITLE
Fix sinon deprecation warning

### DIFF
--- a/lib/text-measurer.spec.js
+++ b/lib/text-measurer.spec.js
@@ -41,7 +41,7 @@ function registerTests(fontPath, skip) {
       beforeEach(function () {
         // This often times out: https://circleci.com/gh/badges/shields/2786
         this.timeout(5000);
-        sandbox = sinon.sandbox.create();
+        sandbox = sinon.createSandbox();
         pdfKitWidthOf = sandbox.spy(PDFKitTextMeasurer.prototype, 'widthOf');
         pdfKitMeasurer = new PDFKitTextMeasurer(fontPath);
       });


### PR DESCRIPTION
This message gets spit out a lot by the tests:

```
`sandbox.create()` is deprecated. Use default sandbox at `sinon.sandbox` or create new sandboxes with `sinon.createSandbox()`
```