### PR TITLE
fix [sonar] legacy/unsupported service tests

### DIFF
--- a/services/sonarqube/sonarqube.tester.js
+++ b/services/sonarqube/sonarqube.tester.js
@@ -38,9 +38,9 @@ t.create('Coverage (legacy API supported)')
   }));
 
 t.create('Tech Debt (legacy API unsupported)')
-  .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.json')
+  .get('/4.2/https/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.json')
   .expectJSON({ name: 'tech debt', value: 'invalid' });
 
 t.create('Coverage (legacy API unsupported)')
-  .get('/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/coverage.json')
+  .get('/4.2/https/sonarqube.com/com.github.dannil:scb-java-client/coverage.json')
   .expectJSON({ name: 'coverage', value: 'invalid' });


### PR DESCRIPTION
The service tests for

* Tech Debt (legacy API unsupported)
* Coverage (legacy API unsupported)

have been failing consistently on the daily build for some time. It looks like their API now only returns the error response over HTTPS and times out over HTTP:

```
$ curl "https://sonarqube.com/api/resources?resource=com.github.dannil:scb-java-client&depth=0&metrics=sqale_debt_ratio&includetrends=true"
{"errors":[{"msg":"Unknown url : /api/resources"}]}

$ curl "http://sonarqube.com/api/resources?resource=com.github.dannil:scb-java-client&depth=0&metrics=sqale_debt_ratio&includetrends=true"
curl: (7) Failed to connect to sonarqube.com port 80: Connection timed out
```

Hence

https://img.shields.io/sonar/4.2/https/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.svg does render a badge: ![](https://img.shields.io/sonar/4.2/https/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.svg)

but https://img.shields.io/sonar/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.svg will time out: ![](https://img.shields.io/sonar/4.2/http/sonarqube.com/com.github.dannil:scb-java-client/tech_debt.svg)

Not sure why this is. I think the outputs we produce here are correct given the API behaviour so I propose just updating the 2 tests.