### PR TITLE
invalidJSON fixture documented

### DIFF
--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -357,7 +357,7 @@ t.create('bounties (unexpected response)')
     .get('/teams/mozilla-core')
     .reply(invalidJSON)
   )
-.expectJSON({name: 'bounties', value: 'invalid'});
+  .expectJSON({ name: 'bounties', value: 'invalid' });
 ```
 
 Further reading

--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -346,7 +346,7 @@ Helpers
 -------
 
 ### Invalid JSON
-[`invalidJSON`](https://github.com/badges/shields/blob/master/services/response-fixtures.js), is a response fixture of an invalid JSON for Nock.
+[`invalidJSON`](https://github.com/badges/shields/blob/master/services/response-fixtures.js) is a response fixture of an invalid JSON for Nock.
 Example usage from [bountysource.tester.js](https://github.com/badges/shields/blob/master/services/bountysource/bountysource.tester.js):
 ```js
 const { invalidJSON } = require('../response-fixtures');

--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -347,7 +347,7 @@ Helpers
 
 ### Invalid JSON
 [`invalidJSON`](https://github.com/badges/shields/blob/master/services/response-fixtures.js) is a response fixture of an invalid JSON for Nock.
-Example usage from [bountysource.tester.js](https://github.com/badges/shields/blob/master/services/bountysource/bountysource.tester.js):
+Example usage from [services/bountysource/bountysource.tester.js](https://github.com/badges/shields/blob/master/services/bountysource/bountysource.tester.js):
 ```js
 const { invalidJSON } = require('../response-fixtures');
 // ...

--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -26,7 +26,7 @@ and ideally, all code branches:
   - Non-default parameters like tags and branches
 4. Server errors and other malformed responses
   - Service may return status code 500 and higher
-  - Invalid JSON
+  - [Invalid JSON](#invalid-json)
   - Attributes missing or have incorrect types
   - Headers missing
 5. Connection errors
@@ -342,6 +342,23 @@ t.create('connection error')
   .expectJSON({ name: 'build', value: 'inaccessible' });
 ```
 
+Helpers
+-------
+
+### Invalid JSON
+[`invalidJSON`](https://github.com/badges/shields/blob/master/services/response-fixtures.js), is a response fixture of an invalid JSON for Nock.
+Example usage from [bountysource.tester.js](https://github.com/badges/shields/blob/master/services/bountysource/bountysource.tester.js):
+```js
+const { invalidJSON } = require('../response-fixtures');
+// ...
+t.create('bounties (unexpected response)')
+  .get('/team/mozilla-core/activity.json')
+  .intercept(nock => nock('https://api.bountysource.com')
+    .get('/teams/mozilla-core')
+    .reply(invalidJSON)
+  )
+.expectJSON({name: 'bounties', value: 'invalid'});
+```
 
 Further reading
 ---------------


### PR DESCRIPTION
This pull request adds info about `invalidJSON` fixture to the service tests documentation. This should increase awareness about existence of this fixture. 

Not all tests which mocks an invalid JSON use this fixture. We can improve it in a separate PR :-)