### PR TITLE
[cocoapods david lgtm] An invalid JSON is mocked using invalidJSON in all service tests

### DIFF
--- a/services/cocoapods/cocoapods.tester.js
+++ b/services/cocoapods/cocoapods.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('../service-tester');
-
+const { invalidJSON } = require('../response-fixtures');
 const {
     isIntegerPercentage,
     isVPlusDottedVersionAtLeastOne,
@@ -45,7 +45,7 @@ t.create('version (unexpected response)')
   .get('/v/AFNetworking.json')
   .intercept(nock => nock('https://trunk.cocoapods.org')
     .get('/api/v1/pods/AFNetworking/specs/latest')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'pod', value: 'invalid'});
 
@@ -72,7 +72,7 @@ t.create('platform (unexpected response)')
   .get('/p/AFNetworking.json')
   .intercept(nock => nock('https://trunk.cocoapods.org')
     .get('/api/v1/pods/AFNetworking/specs/latest')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'platform', value: 'invalid'});
 
@@ -96,7 +96,7 @@ t.create('license (unexpected response)')
   .get('/l/AFNetworking.json')
   .intercept(nock => nock('https://trunk.cocoapods.org')
     .get('/api/v1/pods/AFNetworking/specs/latest')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'license', value: 'invalid'});
 
@@ -131,7 +131,7 @@ t.create('doc percent (unexpected response)')
   .get('/metrics/doc-percent/AFNetworking.json')
   .intercept(nock => nock('https://metrics.cocoapods.org')
     .get('/api/v1/pods/AFNetworking')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'docs', value: 'invalid'});
 
@@ -172,7 +172,7 @@ t.create('downloads (unexpected response)')
   .get('/dt/AFNetworking.json')
   .intercept(nock => nock('https://metrics.cocoapods.org')
     .get('/api/v1/pods/AFNetworking')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'downloads', value: 'invalid'});
 
@@ -206,6 +206,6 @@ t.create('apps (unexpected response)')
   .get('/at/AFNetworking.json')
   .intercept(nock => nock('https://metrics.cocoapods.org')
     .get('/api/v1/pods/AFNetworking')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'apps', value: 'invalid'});

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('../service-tester');
-
+const { invalidJSON } = require('../response-fixtures');
 const isDependencyStatus = Joi.string().valid('insecure', 'up to date', 'out of date');
 
 const t = new ServiceTester({ id: 'david', title: 'David' });
@@ -65,6 +65,6 @@ t.create('david dependencies (unexpected response)')
   .get('/expressjs/express.json')
   .intercept(nock => nock('https://david-dm.org')
     .get('/expressjs/express/info.json')
-    .reply(200, "{{{{{invalid json}}")
+    .reply(invalidJSON)
   )
   .expectJSON({name: 'dependencies', value: 'invalid'});

--- a/services/lgtm/lgtm.tester.js
+++ b/services/lgtm/lgtm.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi');
 const ServiceTester = require('../service-tester');
-
+const { invalidJSON } = require('../response-fixtures');
 const t = new ServiceTester({ id: 'lgtm', title: 'LGTM' })
 module.exports = t;
 
@@ -54,7 +54,7 @@ t.create('alerts: invalid json')
   .get('/alerts/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
-    .reply(200, 'not a json string'))
+    .reply(invalidJSON))
   .expectJSON({ name: 'lgtm', value: 'invalid' });
 
 t.create('alerts: lgtm inaccessible')
@@ -80,7 +80,7 @@ t.create('grade: invalid json')
   .get('/grade/java/g/apache/cloudstack.json')
   .intercept(nock => nock('https://lgtm.com')
     .get('/api/v0.1/project/g/apache/cloudstack/details')
-    .reply(200, 'not a json string'))
+    .reply(invalidJSON))
   .expectJSON({ name: 'code quality: java', value: 'invalid' });
 
 t.create('grade: json missing languages')


### PR DESCRIPTION
This PR standardize mocking a invalid JSON in service tests. This is a follow-up to https://github.com/badges/shields/pull/1755. I tried to find all custom mocks of the invalid JSON using grep, but I could miss something. 