### PR TITLE
[scrutinizer] Fix #1739, add tests and refactor

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -276,7 +276,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Scrutinizer branch',
-        previewUri: '/scrutinizer/coverage/g/phpmyadmin/phpmyadmin/master.svg'
+        previewUri: '/scrutinizer/coverage/g/doctrine/doctrine2/master.svg'
       },
       {
         title: 'Scrutinizer Build',

--- a/server.js
+++ b/server.js
@@ -2616,7 +2616,7 @@ cache(function(data, match, sendBadge, request) {
           badgeData.colorscheme = 'orange';
         } else if (status === 'unknown') {
           badgeData.colorscheme = 'gray';
-        } 
+        }
       } else {
         let score = parsedData.applications[branch].index._embedded
           .project.metric_values['scrutinizer.quality'];

--- a/server.js
+++ b/server.js
@@ -2598,7 +2598,7 @@ cache(function(data, match, sendBadge, request) {
         const percentage = parsedData.applications[branch].index._embedded
           .project.metric_values['scrutinizer.test_coverage'] * 100;
         if (isNaN(percentage)) {
-          badgeData.text[1] = 'inaccessible';
+          badgeData.text[1] = 'unknown';
           badgeData.colorscheme = 'gray';
         } else {
           badgeData.text[1] = percentage.toFixed(0) + '%';

--- a/server.js
+++ b/server.js
@@ -2569,136 +2569,71 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // Scrutinizer coverage integration.
-camp.route(/^\/scrutinizer\/coverage\/(.*)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/scrutinizer(\/(build|coverage))?\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, g/phpmyadmin/phpmyadmin
-  var format = match[2];
+  const type = match[2] ? match[2] : 'code quality';
+  let repo = match[3];  // eg, g/phpmyadmin/phpmyadmin
+  const format = match[4];
   // The repo may contain a branch, which would be unsuitable.
-  var repoParts = repo.split('/');
-  var branch = null;
-  // Normally, there are 2 slashes in `repo` when the branch isn't specified.
-  var slashesInRepo = 2;
-  if (repoParts[0] === 'gp') { slashesInRepo = 1; }
+  const repoParts = repo.split('/');
+  let branch = null;
+  // Normally, there are 2 slashes in `repo` when the branch is specified.
+  const slashesInRepo = repoParts[0] === 'gp' ? 1 : 2;
   if ((repoParts.length - 1) > slashesInRepo) {
     branch = repoParts.slice(slashesInRepo + 1).join('/');
     repo = repoParts.slice(0, slashesInRepo + 1).join('/');
   }
-  var apiUrl = 'https://scrutinizer-ci.com/api/repositories/' + repo;
-  var badgeData = getBadgeData('coverage', data);
+  const apiUrl = `https://scrutinizer-ci.com/api/repositories/${repo}`;
+  const badgeData = getBadgeData(type, data);
   request(apiUrl, {}, function(err, res, buffer) {
-    if (err !== null) {
-      badgeData.text[1] = 'inaccessible';
+    if (checkErrorResponse(badgeData, err, res, 'project or branch not found')) {
       sendBadge(format, badgeData);
       return;
     }
     try {
-      var data = JSON.parse(buffer);
+      const parsedData = JSON.parse(buffer);
       // Which branch are we dealing with?
-      if (branch === null) { branch = data.default_branch; }
-      var percentage = data.applications[branch].index._embedded
-        .project.metric_values['scrutinizer.test_coverage'] * 100;
-      badgeData.text[1] = percentage.toFixed(0) + '%';
-      badgeData.colorscheme = coveragePercentageColor(percentage);
-      sendBadge(format, badgeData);
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-      sendBadge(format, badgeData);
-    }
-  });
-}));
-
-// Scrutinizer build integration.
-camp.route(/^\/scrutinizer\/build\/(.*)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, g/phpmyadmin/phpmyadmin
-  var format = match[2];
-  // The repo may contain a branch, which would be unsuitable.
-  var repoParts = repo.split('/');
-  var branch = null;
-  // Normally, there are 2 slashes in `repo` when the branch isn't specified.
-  var slashesInRepo = 2;
-  if (repoParts[0] === 'gp') { slashesInRepo = 1; }
-  if ((repoParts.length - 1) > slashesInRepo) {
-    branch = repoParts.slice(slashesInRepo + 1).join('/');
-    repo = repoParts.slice(0, slashesInRepo + 1).join('/');
-  }
-  var apiUrl = 'https://scrutinizer-ci.com/api/repositories/' + repo;
-  var badgeData = getBadgeData('build', data);
-  request(apiUrl, {}, function(err, res, buffer) {
-    if (err !== null) {
-      badgeData.text[1] = 'inaccessible';
-      sendBadge(format, badgeData);
-      return;
-    }
-    try {
-      var data = JSON.parse(buffer);
-      // Which branch are we dealing with?
-      if (branch === null) { branch = data.default_branch; }
-      var status = data.applications[branch].build_status.status;
-      badgeData.text[1] = status;
-      if (status === 'passed') {
-        badgeData.colorscheme = 'brightgreen';
-        badgeData.text[1] = 'passing';
-      } else if (status === 'failed' || status === 'error') {
-        badgeData.colorscheme = 'red';
-      } else if (status === 'pending') {
-        badgeData.colorscheme = 'orange';
-      } else if (status === 'unknown') {
-        badgeData.colorscheme = 'gray';
-      }
-      sendBadge(format, badgeData);
-
-    } catch(e) {
-      badgeData.text[1] = 'invalid';
-      sendBadge(format, badgeData);
-    }
-  });
-}));
-
-// Scrutinizer integration.
-camp.route(/^\/scrutinizer\/(.*)\.(svg|png|gif|jpg|json)$/,
-cache(function(data, match, sendBadge, request) {
-  var repo = match[1];  // eg, g/phpmyadmin/phpmyadmin
-  var format = match[2];
-  // The repo may contain a branch, which would be unsuitable.
-  var repoParts = repo.split('/');
-  var branch = null;
-  // Normally, there are 2 slashes in `repo` when the branch isn't specified.
-  var slashesInRepo = 2;
-  if (repoParts[0] === 'gp') { slashesInRepo = 1; }
-  if ((repoParts.length - 1) > slashesInRepo) {
-    branch = repoParts.slice(slashesInRepo + 1).join('/');
-    repo = repoParts.slice(0, slashesInRepo + 1).join('/');
-  }
-  var apiUrl = 'https://scrutinizer-ci.com/api/repositories/' + repo;
-  var badgeData = getBadgeData('code quality', data);
-  request(apiUrl, {}, function(err, res, buffer) {
-    if (err !== null) {
-      badgeData.text[1] = 'inaccessible';
-      sendBadge(format, badgeData);
-      return;
-    }
-    try {
-      var data = JSON.parse(buffer);
-      // Which branch are we dealing with?
-      if (branch === null) { branch = data.default_branch; }
-      var score = data.applications[branch].index._embedded
-        .project.metric_values['scrutinizer.quality'];
-      score = Math.round(score * 100) / 100;
-      badgeData.text[1] = score;
-      badgeData.colorscheme = 'blue';
-      if (score > 9) {
-        badgeData.colorscheme = 'brightgreen';
-      } else if (score > 7) {
-        badgeData.colorscheme = 'green';
-      } else if (score > 5) {
-        badgeData.colorscheme = 'yellow';
-      } else if (score > 4) {
-        badgeData.colorscheme = 'orange';
+      if (branch === null) { branch = parsedData.default_branch; }
+      if (type === 'coverage') {
+        const percentage = parsedData.applications[branch].index._embedded
+          .project.metric_values['scrutinizer.test_coverage'] * 100;
+        if (isNaN(percentage)) {
+          badgeData.text[1] = 'inaccessible';
+          badgeData.colorscheme = 'gray';
+        } else {
+          badgeData.text[1] = percentage.toFixed(0) + '%';
+          badgeData.colorscheme = coveragePercentageColor(percentage);
+        }
+      } else if (type === 'build') {
+        const status = parsedData.applications[branch].build_status.status;
+        badgeData.text[1] = status;
+        if (status === 'passed') {
+          badgeData.colorscheme = 'brightgreen';
+          badgeData.text[1] = 'passing';
+        } else if (status === 'failed' || status === 'error') {
+          badgeData.colorscheme = 'red';
+        } else if (status === 'pending') {
+          badgeData.colorscheme = 'orange';
+        } else if (status === 'unknown') {
+          badgeData.colorscheme = 'gray';
+        } 
       } else {
-        badgeData.colorscheme = 'red';
+        let score = parsedData.applications[branch].index._embedded
+          .project.metric_values['scrutinizer.quality'];
+        score = Math.round(score * 100) / 100;
+        badgeData.text[1] = score;
+        if (score > 9) {
+          badgeData.colorscheme = 'brightgreen';
+        } else if (score > 7) {
+          badgeData.colorscheme = 'green';
+        } else if (score > 5) {
+          badgeData.colorscheme = 'yellow';
+        } else if (score > 4) {
+          badgeData.colorscheme = 'orange';
+        } else {
+          badgeData.colorscheme = 'red';
+        }
       }
-
       sendBadge(format, badgeData);
     } catch(e) {
       badgeData.text[1] = 'invalid';

--- a/services/scrutinizer/scrutinizer.tester.js
+++ b/services/scrutinizer/scrutinizer.tester.js
@@ -59,11 +59,11 @@ t.create('project not found')
      value: 'project or branch not found',
   });
 
-t.create('code coverage inaccessible')
+t.create('code coverage unknown')
   .get('/coverage/g/phpmyadmin/phpmyadmin/master.json')
   .expectJSON({
      name: 'coverage',
-     value: 'inaccessible',
+     value: 'unknown',
   });
 
 t.create('unexpected response data')

--- a/services/scrutinizer/scrutinizer.tester.js
+++ b/services/scrutinizer/scrutinizer.tester.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('../service-tester');
+const {
+  isIntegerPercentage
+} = require('../test-validators');
+const isBuildStatus = Joi.string().regex(/^(passing|failed|error|pending|unknown)$/);
+
+const t = new ServiceTester({ id: 'scrutinizer', title: 'Scrutinizer' });
+module.exports = t;
+
+t.create('code quality')
+  .get('/g/filp/whoops.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'code quality',
+    value: Joi.number().positive(),
+  }));
+
+t.create('code quality (branch)')
+  .get('/g/phpmyadmin/phpmyadmin/master.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'code quality',
+    value: Joi.number().positive(),
+  }));
+
+t.create('code coverage')
+  .get('/coverage/g/filp/whoops.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: isIntegerPercentage,
+  }));
+
+t.create('code coverage (branch)')
+  .get('/coverage/g/phpmyadmin/phpmyadmin/master.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'coverage',
+    value: isIntegerPercentage,
+  }));
+
+t.create('build')
+  .get('/build/g/filp/whoops.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: isBuildStatus,
+  }));
+
+t.create('build (branch)')
+  .get('/build/g/phpmyadmin/phpmyadmin/master.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'build',
+    value: isBuildStatus,
+  }));
+
+t.create('no response data')
+  .get('/g/filp/whoops.json')
+  .intercept(nock => nock('https://scrutinizer-ci.com')
+    .get('/api/repositories/g/filp/whoops')
+    .reply(200))
+  .expectJSON({
+     name: 'code quality',
+     value: 'inaccessible',
+  });
+
+t.create('unexpected response data')
+  .get('/coverage/g/filp/whoops.json')
+  .intercept(nock => nock('https://scrutinizer-ci.com')
+    .get('/api/repositories/g/filp/whoops')
+    .reply(200, '{"unexpected":"data"}'))
+  .expectJSON({
+     name: 'coverage',
+     value: 'invalid',
+  });

--- a/services/scrutinizer/scrutinizer.tester.js
+++ b/services/scrutinizer/scrutinizer.tester.js
@@ -32,7 +32,7 @@ t.create('code coverage')
   }));
 
 t.create('code coverage (branch)')
-  .get('/coverage/g/phpmyadmin/phpmyadmin/master.json')
+  .get('/coverage/g/doctrine/doctrine2/master.json')
   .expectJSONTypes(Joi.object().keys({
     name: 'coverage',
     value: isIntegerPercentage,
@@ -52,13 +52,17 @@ t.create('build (branch)')
     value: isBuildStatus,
   }));
 
-t.create('no response data')
-  .get('/g/filp/whoops.json')
-  .intercept(nock => nock('https://scrutinizer-ci.com')
-    .get('/api/repositories/g/filp/whoops')
-    .reply(200))
+t.create('project not found')
+  .get('/build/g/does-not-exist/does-not-exist.json')
   .expectJSON({
-     name: 'code quality',
+     name: 'build',
+     value: 'project or branch not found',
+  });
+
+t.create('code coverage inaccessible')
+  .get('/coverage/g/phpmyadmin/phpmyadmin/master.json')
+  .expectJSON({
+     name: 'coverage',
      value: 'inaccessible',
   });
 


### PR DESCRIPTION
This pull request covers the following:
* the NaN error reported in #1739 was fixed, as well as the example updated on the homepage.
* a proper test suite was added.
* the service code was refactored. We had three handler functions which were mostly copy-pasted code, which were merged into one. When we get round to modularising this service, we'll be able to break down the bulky _if_ statements into nice separate functions. I also modernised and rearranged the existing code.

I noticed that we had very similar `isBuildStatus` validators in several service tests, I'm planning on extracting them to _test-validators.js_ once this is merged. 😉 

As usual, looking forward to feedback! 👍