### PR TITLE
fix [ansible] galaxy role name badge

### DIFF
--- a/server.js
+++ b/server.js
@@ -4772,7 +4772,7 @@ cache(function(data, match, sendBadge, request) {
         badgeData.text[1] = metric(json.download_count);
         badgeData.colorscheme = 'blue';
       } else {
-        badgeData.text[1] = json.namespace + '.' + json.name;
+        badgeData.text[1] = json.summary_fields.namespace.name + '.' + json.name;
         badgeData.colorscheme = 'blue';
       }
       sendBadge(format, badgeData);


### PR DESCRIPTION
Daily tests have been failing for the last few days.

Looks like the API has changed slightly so the `namespace` property is the namespace id, not the namespace name.