### PR TITLE
add tests for composer version compare function

### DIFF
--- a/lib/php-version.spec.js
+++ b/lib/php-version.spec.js
@@ -2,6 +2,7 @@
 
 const { test, given } = require('sazerac');
 const {
+  compare,
   minorVersion,
   versionReduction
 } = require('./php-version');
@@ -27,5 +28,37 @@ describe('Text PHP version', function() {
     given(['7.1'], phpReleases).expect('7.1');
     given(['8.1'], phpReleases).expect('');
     given([]).expect('');
+  });
+});
+
+describe('Composer version comparison', function() {
+  test(compare, () => {
+    // composer version scheme ordering
+    given('0.9.0', '1.0.0-alpha').expect(-1);
+    given('1.0.0-alpha', '1.0.0-alpha2').expect(-1);
+    given('1.0.0-alpha2', '1.0.0-beta').expect(-1);
+    given('1.0.0-beta', '1.0.0-beta2').expect(-1);
+    given('1.0.0-beta2', '1.0.0-RC').expect(-1);
+    given('1.0.0-RC', '1.0.0-RC2').expect(-1);
+    given('1.0.0-RC2', '1.0.0').expect(-1);
+    given('1.0.0', '1.0.0-patch').expect(-1);
+    given('1.0.0-patch', '1.0.0-dev').expect(-1);
+    given('1.0.0-dev', '1.0.1').expect(-1);
+    given('1.0.1', '1.0.x-dev').expect(-1);
+
+    // short versions should compare equal to long versions
+    given('1.0.0-p', '1.0.0-patch').expect(0);
+    given('1.0.0-a', '1.0.0-alpha').expect(0);
+    given('1.0.0-a2', '1.0.0-alpha2').expect(0);
+    given('1.0.0-b', '1.0.0-beta').expect(0);
+    given('1.0.0-b2', '1.0.0-beta2').expect(0);
+
+    // numeric suffixes
+    given('1.0.0-b1', '1.0.0-b2').expect(-1);
+    given('1.0.0-b10', '1.0.0-b11').expect(-1);
+    given('1.0.0-a1', '1.0.0-a2').expect(-1);
+    given('1.0.0-a10', '1.0.0-a11').expect(-1);
+    given('1.0.0-RC1', '1.0.0-RC2').expect(-1);
+    given('1.0.0-RC10', '1.0.0-RC11').expect(-1);
   });
 });


### PR DESCRIPTION
There have been various discussions about whether we should change the behaviour of our code for comparing versions from composer. For the moment I'm not going to propose any functional changes to this, but one of the problems we have here is that that our code for comparing and ordering composer versions is non-trivial and has no tests. This makes it difficult to change.

This PR helps this by adding tests to formalise the 'happy path' behaviour of the `compare()` function (i.e: when processing valid version strings). Note that `compare()` exhibits some spurious behaviour when processing invalid versions. For example:

```js
> const { compare } = require("./lib/php-version");

> compare('1.0.0-aardvarks', '1.0.0-alpha');  // 1.0.0-aardvarks is not a valid version
0                                             // ..but we say it is equal to 1.0.0-alpha
```

.. but I'm going to abstract that issue for now. For the moment I just want to get this code under test so we can validate that proposed changes are not breaking correct behaviour.