### PR TITLE
Fixes for github deploy

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-shields.io

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEPLOY_TEMP=${TMPDIR}shields-deploy
 all: website favicon test
 
 favicon:
+	# This isn't working right now. See https://github.com/badges/shields/issues/1788
 	node lib/badge-cli.js '' '' '#bada55' .png > favicon.png
 
 website:

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ favicon:
 website: favicon
 	LONG_CACHE=false npm run build
 
-deploy: website deploy-s0 deploy-s1 deploy-s2 deploy-gh-pages deploy-gh-pages-clean
+deploy: deploy-s0 deploy-s1 deploy-s2 favicon deploy-gh-pages deploy-gh-pages-clean
 
 deploy-s0:
 	# Ship a copy of the front end to each server for debugging.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ deploy-gh-pages:
 	git worktree prune
 	LONG_CACHE=true \
 		BASE_URL=https://img.shields.io \
-		NEXT_ASSET_PREFIX=https://badges.github.io/shields \
+		NEXT_ASSET_PREFIX=https://shields.io \
 		npm run build
 	git worktree add -B gh-pages ${DEPLOY_TEMP}
 	git -C ${DEPLOY_TEMP} ls-files | xargs git -C ${DEPLOY_TEMP} rm

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ favicon:
 website: favicon
 	LONG_CACHE=false npm run build
 
-deploy: deploy-s0 deploy-s1 deploy-s2 deploy-gh-pages deploy-gh-pages-clean
+# `website` is needed for the server deploys.
+deploy: website deploy-s0 deploy-s1 deploy-s2 deploy-gh-pages deploy-gh-pages-clean
 
 deploy-s0:
 	# Ship a copy of the front end to each server for debugging.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ favicon:
 website: favicon
 	LONG_CACHE=false npm run build
 
-deploy: deploy-s0 deploy-s1 deploy-s2 favicon deploy-gh-pages deploy-gh-pages-clean
+deploy: deploy-s0 deploy-s1 deploy-s2 deploy-gh-pages deploy-gh-pages-clean
 
 deploy-s0:
 	# Ship a copy of the front end to each server for debugging.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: website favicon test
 favicon:
 	node lib/badge-cli.js '' '' '#bada55' .png > favicon.png
 
-website:
+website: favicon
 	LONG_CACHE=false npm run build
 
 deploy: website deploy-s0 deploy-s1 deploy-s2 deploy-gh-pages deploy-gh-pages-clean
@@ -46,6 +46,7 @@ deploy-gh-pages:
 	git -C ${DEPLOY_TEMP} ls-files | xargs git -C ${DEPLOY_TEMP} rm
 	git -C ${DEPLOY_TEMP} commit -m '[DEPLOY] Completely clean the index'
 	cp -r build/* ${DEPLOY_TEMP}
+	cp favicon.png ${DEPLOY_TEMP}
 	echo shields.io > ${DEPLOY_TEMP}/CNAME
 	touch ${DEPLOY_TEMP}/.nojekyll
 	git -C ${DEPLOY_TEMP} add .

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: website favicon test
 favicon:
 	node lib/badge-cli.js '' '' '#bada55' .png > favicon.png
 
-website: favicon
+website:
 	LONG_CACHE=false npm run build
 
 # `website` is needed for the server deploys.

--- a/next.config.js
+++ b/next.config.js
@@ -32,5 +32,10 @@ module.exports = {
   exportPathMap: () => ({
     '/': { page: '/' },
   }),
-  assetPrefix: assetPrefix,
 };
+
+// Avoid setting an `undefined` value. This causes
+// `TypeError: Cannot read property 'replace' of undefined` at build time.
+if (assetPrefix) {
+  module.exports.assetPrefix = assetPrefix;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 const envFlag = require('node-env-flag');
 const webpack = require('webpack');
 const shouldAnalyze = envFlag(process.env.ANALYZE);
+const assetPrefix = process.env.NEXT_ASSET_PREFIX;
 
 module.exports = {
   webpack: config => {
@@ -22,9 +23,14 @@ module.exports = {
       loader: 'json-loader',
     });
 
+    if (assetPrefix) {
+      config.output.publicPath = `${assetPrefix}/${config.output.publicPath}`;
+    }
+
     return config;
   },
   exportPathMap: () => ({
     '/': { page: '/' },
   }),
+  assetPrefix,
 };

--- a/next.config.js
+++ b/next.config.js
@@ -32,5 +32,5 @@ module.exports = {
   exportPathMap: () => ({
     '/': { page: '/' },
   }),
-  assetPrefix,
+  assetPrefix: assetPrefix,
 };


### PR DESCRIPTION
This addresses some long-standing comments in https://github.com/badges/shields/issues/1458#issuecomment-368270996

We should also adopt Gatsby, create-react-app, or something similar designed for static sites, to eliminate the unnecessary runtime dependency on Next.js while also letting someone else maintain our front-end tooling. :-D These alternative tools might work just fine in subdirectories without config, and we might be able to leave Jekyll turned on (though we don’t need it). However these git-related changes are orthogonal.

- Don’t check out master, making it possible to deploy the currently checked-out commit
- Disable Jekyll which we don’t need. This allows _next folders to be deployed, and the related URL rewriting to be removed.
- ~~Set NEXT_ASSET_PREFIX so the site works at both shields.io and badges.github.io/shields~~
    - This was possible in my github account, but doesn't seem to be possible in the badges account.
- Completely empty the deploy branch’s index before deployment. This prevents errors from broken symlinks, while preserving the commit history in the deploy branch.
- Do the deployment work in a git working tree. This requires Git 2.18 but makes it possible to do the above very safely.

Closes #1784 