### PR TITLE
fix for invalid [jenkins] tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -4536,11 +4536,11 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job
-      + '/lastBuild/api/json?tree=actions%5BfailCount,skipCount,totalCount%5D'
+      + '/lastBuild/api/json?tree=' + encodeURIComponent('actions[failCount,skipCount,totalCount]')
   };
   if (job.indexOf('/') > -1 ) {
     options.uri = scheme + '://' + host + '/' + job
-      + '/lastBuild/api/json?tree=actions%5BfailCount,skipCount,totalCount%5D';
+      + '/lastBuild/api/json?tree=' + encodeURIComponent('actions[failCount,skipCount,totalCount]');
   }
 
   if (serverSecrets && serverSecrets.jenkins_user) {

--- a/server.js
+++ b/server.js
@@ -4536,11 +4536,11 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job
-      + '/lastBuild/api/json?tree=actions[failCount,skipCount,totalCount]'
+      + '/lastBuild/api/json?tree=actions%5BfailCount,skipCount,totalCount%5D'
   };
   if (job.indexOf('/') > -1 ) {
     options.uri = scheme + '://' + host + '/' + job
-      + '/lastBuild/api/json?tree=actions[failCount,skipCount,totalCount]';
+      + '/lastBuild/api/json?tree=actions%5BfailCount,skipCount,totalCount%5D';
   }
 
   if (serverSecrets && serverSecrets.jenkins_user) {


### PR DESCRIPTION
This fixes issue #1776. The issue was caused because the following api call: 

https://builds.apache.org/job/Any23-trunk/lastBuild/api/json?tree=actions[failCount,skipCount,totalCount]

returns a 400 BAD REQUEST due to the "invalid characters" `[` and `]`.  

I simply URL-encoded these characters.