### PR TITLE
handle malformed url [dynamic-json]

### DIFF
--- a/server.js
+++ b/server.js
@@ -7247,7 +7247,15 @@ cache({
       sendBadge(format, badgeData);
       return;
     }
-    var url = encodeURI(decodeURIComponent(query.url || query.uri));
+
+    try {
+      var url = encodeURI(decodeURIComponent(query.url || query.uri));
+    } catch(e){
+      setBadgeColor(badgeData, 'red');
+      badgeData.text[1] = 'malformed url';
+      sendBadge(format, badgeData);
+      return;
+    }
 
     switch (type) {
       case 'json':

--- a/services/json/json.tester.js
+++ b/services/json/json.tester.js
@@ -24,6 +24,10 @@ t.create('No query specified')
   .get('.json?url=https://github.com/badges/shields/raw/master/package.json&label=Package Name&style=_shields_test')
   .expectJSON({ name: 'Package Name', value: 'no query specified', colorB: colorsB.red });
 
+t.create('Malformed url')
+  .get('.json?url=https://github.com/badges/shields/raw/master/%0package.json&query=$.name&label=Package Name&style=_shields_test')
+  .expectJSON({ name: 'Package Name', value: 'malformed url', colorB: colorsB.red });
+
 t.create('JSON from url')
   .get('.json?url=https://github.com/badges/shields/raw/master/package.json&query=$.name&style=_shields_test')
   .expectJSON({ name: 'custom badge', value: 'gh-badges', colorB: colorsB.brightgreen });


### PR DESCRIPTION
Closes #1779
returns ![](https://img.shields.io/:badge-malformed%20url-red.svg) on error

```javascript
decodeURIComponent('%1') // URI Malformed
decodeURIComponent('%01') // ''
```