### PR TITLE
Do not prettify package.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 server.js
 server.spec.js
+package.json


### PR DESCRIPTION
This causes extremely strange failures in CircleCI. `npm install`, oddly, rewrites and reformats package.json. We hash package.json to determine the cache keys, and oddly enough Circle computes a new hash when we write the cache. `npm-install` writes to one cache key. The tasks that follow read from another. Nothing runs.

I'm running into this because I'm using prettier auto-format on another project, and the presence of a `.prettierrc` means it's started trying to format Shields code.

In separate news, I'm loving auto-formatting!