### PR TITLE
Provide a descriptive message when json can’t be parsed [cdnjs clojars gem]

### DIFF
--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -39,9 +39,12 @@ async function asJson({ buffer, res }) {
   try {
     return JSON.parse(buffer);
   } catch (err) {
-    throw new InvalidResponse({ underlyingError: err });
+    throw new InvalidResponse({
+      prettyMessage: 'unparseable json response',
+      underlyingError: err,
+    });
   }
-};
+}
 
 module.exports = {
   checkErrorResponse,

--- a/services/base-json.spec.js
+++ b/services/base-json.spec.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { expect } = require('chai');
+
+const { BaseJsonService } = require('./base');
+const { invalidJSON } = require('./response-fixtures');
+
+class DummyJsonService extends BaseJsonService {
+  static get category() {
+    return 'cat';
+  }
+
+  static get url() {
+    return {
+      base: 'foo',
+    };
+  }
+
+  async handle() {
+    const { value } = await this._requestJson();
+    return { message: value };
+  }
+}
+
+describe('BaseJsonService', () => {
+  it('handles unparseable json responses', async function() {
+    const sendAndCacheRequest = async () => ({
+      buffer: invalidJSON,
+      res: { statusCode: 200 },
+    });
+    const serviceInstance = new DummyJsonService(
+      { sendAndCacheRequest },
+      { handleInternalErrors: false }
+    );
+    const serviceData = await serviceInstance.invokeHandler({}, {});
+    expect(serviceData).to.deep.equal({
+      color: 'lightgray',
+      message: 'unparseable json response',
+    });
+  });
+});

--- a/services/cdnjs/cdnjs.tester.js
+++ b/services/cdnjs/cdnjs.tester.js
@@ -3,7 +3,6 @@
 const Joi = require('joi');
 const ServiceTester = require('../service-tester');
 const { isVPlusTripleDottedVersion } = require('../test-validators');
-const { invalidJSON } = require('../response-fixtures');
 
 const t = new ServiceTester({ id: 'cdnjs', title: 'CDNJs' });
 module.exports = t;
@@ -24,14 +23,6 @@ t.create('cdnjs (connection error)')
   .get('/v/jquery.json')
   .networkOff()
   .expectJSON({name: 'cdnjs', value: 'inaccessible'});
-
-t.create('cdnjs (unexpected response)')
-  .get('/v/jquery.json')
-  .intercept(nock => nock('https://api.cdnjs.com')
-    .get('/libraries/jquery?fields=version')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'cdnjs', value: 'unparseable json response' });
 
 t.create('cdnjs (error response)')
   .get('/v/jquery.json')

--- a/services/cdnjs/cdnjs.tester.js
+++ b/services/cdnjs/cdnjs.tester.js
@@ -31,7 +31,7 @@ t.create('cdnjs (unexpected response)')
     .get('/libraries/jquery?fields=version')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'cdnjs', value: 'invalid'});
+  .expectJSON({ name: 'cdnjs', value: 'unparseable json response' });
 
 t.create('cdnjs (error response)')
   .get('/v/jquery.json')

--- a/services/clojars/clojars.tester.js
+++ b/services/clojars/clojars.tester.js
@@ -2,7 +2,6 @@
 
 const Joi = require('joi');
 const ServiceTester = require('../service-tester');
-const { invalidJSON } = require('../response-fixtures');
 
 const t = new ServiceTester({ id: 'clojars', title: 'clojars' });
 module.exports = t;
@@ -23,14 +22,6 @@ t.create('clojars (connection error)')
   .get('/v/jquery.json')
   .networkOff()
   .expectJSON({name: 'clojars', value: 'inaccessible'});
-
-t.create('clojars (unexpected response)')
-  .get('/v/prismic.json')
-  .intercept(nock => nock('https://clojars.org')
-    .get('/prismic/latest-version.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'clojars', value: 'unparseable json response' });
 
 t.create('clojars (error response)')
   .get('/v/prismic.json')

--- a/services/clojars/clojars.tester.js
+++ b/services/clojars/clojars.tester.js
@@ -30,7 +30,7 @@ t.create('clojars (unexpected response)')
     .get('/prismic/latest-version.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'clojars', value: 'invalid'});
+  .expectJSON({ name: 'clojars', value: 'unparseable json response' });
 
 t.create('clojars (error response)')
   .get('/v/prismic.json')

--- a/services/gem/gem.tester.js
+++ b/services/gem/gem.tester.js
@@ -7,7 +7,6 @@ const {
   isVPlusDottedVersionAtLeastOne,
   isMetric
 } = require('../test-validators');
-const { invalidJSON } = require('../response-fixtures');
 const isOrdinalNumber = Joi.string().regex(/^[1-9][0-9]+(ᵗʰ|ˢᵗ|ⁿᵈ|ʳᵈ)$/);
 const isOrdinalNumberDaily = Joi.string().regex(/^[1-9][0-9]+(ᵗʰ|ˢᵗ|ⁿᵈ|ʳᵈ) daily$/);
 
@@ -33,14 +32,6 @@ t.create('version (connection error)')
   .networkOff()
   .expectJSON({name: 'gem', value: 'inaccessible'});
 
-t.create('version (unexpected response)')
-  .get('/v/formatador.json')
-  .intercept(nock => nock('https://rubygems.org')
-    .get('/api/v1/gems/formatador.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'gem', value: 'unparseable json response' });
-
 
 // downloads endpoints
 
@@ -60,14 +51,6 @@ t.create('total downloads (connection error)')
   .get('/dt/rails.json')
   .networkOff()
   .expectJSON({name: 'downloads', value: 'inaccessible'});
-
-t.create('total downloads (unexpected response)')
-  .get('/dt/rails.json')
-  .intercept(nock => nock('https://rubygems.org')
-    .get('/api/v1/gems/rails.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
 
 
 // version downloads
@@ -102,14 +85,6 @@ t.create('version downloads (connection error)')
   .networkOff()
   .expectJSON({name: 'downloads', value: 'inaccessible'});
 
-t.create('version downloads (unexpected response)')
-  .get('/dv/rails/4.1.0.json')
-  .intercept(nock => nock('https://rubygems.org')
-    .get('/api/v1/versions/rails.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
-
 
 // latest version downloads
 t.create('latest version downloads (valid)')
@@ -127,14 +102,6 @@ t.create('latest version downloads (connection error)')
   .get('/dtv/rails.json')
   .networkOff()
   .expectJSON({name: 'downloads', value: 'inaccessible'});
-
-t.create('latest version downloads (unexpected response)')
-  .get('/dtv/rails.json')
-  .intercept(nock => nock('https://rubygems.org')
-    .get('/api/v1/gems/rails.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
 
 
 // users endpoint
@@ -154,14 +121,6 @@ t.create('users (connection error)')
   .get('/u/raphink.json')
   .networkOff()
   .expectJSON({name: 'gems', value: 'inaccessible'});
-
-t.create('users (unexpected response)')
-.get('/u/raphink.json')
-  .intercept(nock => nock('https://rubygems.org')
-    .get('/api/v1/owners/raphink/gems.json')
-    .reply(invalidJSON)
-  )
-  .expectJSON({ name: 'gems', value: 'unparseable json response' });
 
 
 // rank endpoint
@@ -188,11 +147,3 @@ t.create('rank (connection error)')
   .get('/rt/rspec-puppet-facts.json')
   .networkOff()
   .expectJSON({name: 'rank', value: 'inaccessible'});
-
-t.create('rank (unexpected response)')
-  .get('/rt/rspec-puppet-facts.json')
-    .intercept(nock => nock('http://bestgems.org')
-      .get('/api/v1/gems/rspec-puppet-facts/total_ranking.json')
-      .reply(invalidJSON)
-    )
-    .expectJSON({ name: 'rank', value: 'unparseable json response' });

--- a/services/gem/gem.tester.js
+++ b/services/gem/gem.tester.js
@@ -39,7 +39,7 @@ t.create('version (unexpected response)')
     .get('/api/v1/gems/formatador.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'gem', value: 'invalid'});
+  .expectJSON({ name: 'gem', value: 'unparseable json response' });
 
 
 // downloads endpoints
@@ -67,7 +67,7 @@ t.create('total downloads (unexpected response)')
     .get('/api/v1/gems/rails.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'downloads', value: 'invalid'});
+  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
 
 
 // version downloads
@@ -108,7 +108,7 @@ t.create('version downloads (unexpected response)')
     .get('/api/v1/versions/rails.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'downloads', value: 'invalid'});
+  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
 
 
 // latest version downloads
@@ -134,7 +134,7 @@ t.create('latest version downloads (unexpected response)')
     .get('/api/v1/gems/rails.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'downloads', value: 'invalid'});
+  .expectJSON({ name: 'downloads', value: 'unparseable json response' });
 
 
 // users endpoint
@@ -161,7 +161,7 @@ t.create('users (unexpected response)')
     .get('/api/v1/owners/raphink/gems.json')
     .reply(invalidJSON)
   )
-  .expectJSON({name: 'gems', value: 'invalid'});
+  .expectJSON({ name: 'gems', value: 'unparseable json response' });
 
 
 // rank endpoint
@@ -195,4 +195,4 @@ t.create('rank (unexpected response)')
       .get('/api/v1/gems/rspec-puppet-facts/total_ranking.json')
       .reply(invalidJSON)
     )
-    .expectJSON({name: 'rank', value: 'invalid'});
+    .expectJSON({ name: 'rank', value: 'unparseable json response' });

--- a/services/npm/npm.tester.js
+++ b/services/npm/npm.tester.js
@@ -58,7 +58,7 @@ t.create('total downloads when API returns an invalid JSON')
   .intercept(nock => nock('https://api.npmjs.org')
     .get('/downloads/range/1000-01-01:3000-01-01/invalid-json')
     .reply(invalidJSON))
-  .expectJSON({ name: 'downloads', value: 'unparseable json response', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'downloads', value: 'invalid', colorB: colorsB.lightgrey });
 
 t.create('total downloads of unknown package')
   .get('/dt/npm-api-does-not-have-this-package.json?style=_shields_test')
@@ -161,7 +161,7 @@ t.create('license when registry returns an invalid JSON')
   .intercept(nock => nock('https://registry.npmjs.org')
     .get('/invalid-json/latest')
     .reply(invalidJSON))
-  .expectJSON({ name: 'license', value: 'unparseable json response', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'license', value: 'invalid', colorB: colorsB.lightgrey });
 
 t.create('license when network is off')
   .get('/l/pakage-network-off.json?style=_shields_test')

--- a/services/npm/npm.tester.js
+++ b/services/npm/npm.tester.js
@@ -58,7 +58,7 @@ t.create('total downloads when API returns an invalid JSON')
   .intercept(nock => nock('https://api.npmjs.org')
     .get('/downloads/range/1000-01-01:3000-01-01/invalid-json')
     .reply(invalidJSON))
-  .expectJSON({ name: 'downloads', value: 'invalid', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'downloads', value: 'unparseable json response', colorB: colorsB.lightgrey });
 
 t.create('total downloads of unknown package')
   .get('/dt/npm-api-does-not-have-this-package.json?style=_shields_test')
@@ -161,7 +161,7 @@ t.create('license when registry returns an invalid JSON')
   .intercept(nock => nock('https://registry.npmjs.org')
     .get('/invalid-json/latest')
     .reply(invalidJSON))
-  .expectJSON({ name: 'license', value: 'invalid', colorB: colorsB.lightgrey });
+  .expectJSON({ name: 'license', value: 'unparseable json response', colorB: colorsB.lightgrey });
 
 t.create('license when network is off')
   .get('/l/pakage-network-off.json?style=_shields_test')


### PR DESCRIPTION
This message **unparseable json response** is consistent with the error messaging in #1743. That's a fair amount of test, though that doesn't seem like a big problem since it's not something we expect users to see terribly often.