### PR TITLE
Fix [bundlephobia] tests and rm errant inspectJSON

### DIFF
--- a/services/bugzilla/bugzilla.tester.js
+++ b/services/bugzilla/bugzilla.tester.js
@@ -20,7 +20,6 @@ module.exports = t;
 
 t.create('Bugzilla valid bug status')
   .get('/996038.json')
-  .inspectJSON()
   .expectJSONTypes(Joi.object().keys({
     name: 'bug 996038',
     value: bzBugStatus

--- a/services/bundlephobia/bundlephobia.tester.js
+++ b/services/bundlephobia/bundlephobia.tester.js
@@ -56,7 +56,7 @@ const data = [
   {
     format: formats.D,
     get: '/minzip/@cycle/core/7.0.0.json',
-    expect: { name: 'minzipped size', value: '1.23 kB' },
+    expect: { name: 'minzipped size', value: '1.22 kB' },
   },
   {
     format: formats.A,

--- a/services/bundlephobia/bundlephobia.tester.js
+++ b/services/bundlephobia/bundlephobia.tester.js
@@ -26,7 +26,7 @@ const data = [
   {
     format: formats.B,
     get: '/min/preact/8.0.0.json',
-    expect: { name: 'minified size', value: '7.94 kB' },
+    expect: { name: 'minified size', value: '7.93 kB' },
   },
   {
     format: formats.C,
@@ -36,7 +36,7 @@ const data = [
   {
     format: formats.D,
     get: '/min/@cycle/core/7.0.0.json',
-    expect: { name: 'minified size', value: '3.51 kB' },
+    expect: { name: 'minified size', value: '3.5 kB' },
   },
   {
     format: formats.A,
@@ -46,7 +46,7 @@ const data = [
   {
     format: formats.B,
     get: '/minzip/preact/8.0.0.json',
-    expect: { name: 'minzipped size', value: '3.35 kB' },
+    expect: { name: 'minzipped size', value: '3.33 kB' },
   },
   {
     format: formats.C,


### PR DESCRIPTION
I’m guessing something has changed with the way rounding happens in bundlephobia. I don’t expect this to happen again, but if it does we can change this to a regex.

For #1359