### PR TITLE
re-organise badge examples

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -207,16 +207,12 @@ const allBadgeExamples = [
         previewUri: '/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg'
       },
       {
-        title: 'Jenkins Tests',
+        title: 'Jenkins tests',
         previewUri: '/jenkins/t/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg'
       },
       {
-        title: 'Jenkins Coverage (Cobertura)',
+        title: 'Jenkins coverage',
         previewUri: '/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
-      },
-      {
-        title: 'Jenkins Coverage (Jacoco)',
-        previewUri: '/jenkins/j/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
       },
       {
         title: 'Bitbucket Pipelines',
@@ -272,7 +268,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Scrutinizer branch',
-        previewUri: '/scrutinizer/coverage/g/doctrine/doctrine2/master.svg'
+        previewUri: '/scrutinizer/coverage/g/phpmyadmin/phpmyadmin/master.svg'
       },
       {
         title: 'Scrutinizer Build',
@@ -333,6 +329,73 @@ const allBadgeExamples = [
         previewUri: '/continuousphp/git-hub/doctrine/dbal/master.svg'
       },
       {
+        title: 'Read the Docs',
+        previewUri: '/readthedocs/pip.svg',
+        keywords: [
+          'documentation'
+        ]
+      },
+      {
+        title: 'Read the Docs (version)',
+        previewUri: '/readthedocs/pip/stable.svg',
+        keywords: [
+          'documentation'
+        ]
+      },
+      {
+        title: 'Bitrise',
+        previewUri: '/bitrise/cde737473028420d/master.svg?token=GCIdEzacE4GW32jLVrZb7A',
+        exampleUri: '/bitrise/APP-ID/BRANCH.svg?token=APP-STATUS-BADGE-TOKEN'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/issues/twbs/bootstrap.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/maintainability/angular/angular.js.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/maintainability-percentage/angular/angular.js.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/coverage/jekyll/jekyll.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/coverage-letter/jekyll/jekyll.svg'
+      },
+      {
+        title: 'Code Climate',
+        previewUri: '/codeclimate/tech-debt/jekyll/jekyll.svg'
+      },
+      {
+        title: 'Codacy grade',
+        previewUri: '/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg'
+      },
+      {
+        title: 'Codacy branch grade',
+        previewUri: '/codacy/grade/e27821fb6289410b8f58338c7e0bc686/master.svg'
+      },
+      {
+        title: 'Codacy coverage',
+        previewUri: '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd.svg'
+      },
+      {
+        title: 'Codacy branch coverage',
+        previewUri: '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg'
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'chat',
+      name: 'Chat'
+    },
+    examples: [
+      {
         title: 'Discourse topics',
         previewUri: '/discourse/https/meta.discourse.org/topics.svg'
       },
@@ -353,24 +416,61 @@ const allBadgeExamples = [
         previewUri: '/discourse/https/meta.discourse.org/status.svg'
       },
       {
-        title: 'Read the Docs',
-        previewUri: '/readthedocs/pip.svg',
-        keywords: [
-          'documentation'
-        ]
+        title: 'Gitter',
+        previewUri: '/gitter/room/nwjs/nw.js.svg'
       },
       {
-        title: 'Read the Docs (version)',
-        previewUri: '/readthedocs/pip/stable.svg',
-        keywords: [
-          'documentation'
-        ]
+        title: 'Discord',
+        previewUri: '/discord/102860784329052160.svg'
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'dependencies',
+      name: 'Dependencies'
+    },
+    examples: [
+      {
+        title: 'Depfu',
+        previewUri: '/depfu/depfu/example-ruby.svg'
       },
       {
-        title: 'Bitrise',
-        previewUri: '/bitrise/cde737473028420d/master.svg?token=GCIdEzacE4GW32jLVrZb7A',
-        exampleUri: '/bitrise/APP-ID/BRANCH.svg?token=APP-STATUS-BADGE-TOKEN'
-      }
+        title: 'Hackage-Deps',
+        previewUri: '/hackage-deps/v/lens.svg'
+      },
+      {
+        title: 'Requires.io',
+        previewUri: '/requires/github/celery/celery.svg'
+      },
+      {
+        title: 'David',
+        previewUri: '/david/expressjs/express.svg'
+      },
+      {
+        title: 'David',
+        previewUri: '/david/dev/expressjs/express.svg'
+      },
+      {
+        title: 'David',
+        previewUri: '/david/optional/elnounch/byebye.svg'
+      },
+      {
+        title: 'David',
+        previewUri: '/david/peer/webcomponents/generator-element.svg'
+      },
+      {
+        title: 'David (path)',
+        previewUri: '/david/babel/babel.svg?path=packages/babel-core'
+      },
+      {
+        title: 'Libraries.io for releases',
+        previewUri: '/librariesio/release/hex/phoenix/1.0.3.svg'
+      },
+      {
+        title: 'Libraries.io for GitHub',
+        previewUri: '/librariesio/github/phoenixframework/phoenix.svg'
+      },
     ]
   },
   {
@@ -729,6 +829,580 @@ const allBadgeExamples = [
   },
   {
     category: {
+      id: 'funding',
+      name: 'Funding'
+    },
+    examples: [
+      {
+        title: 'Gratipay',
+        previewUri: '/gratipay/project/shields.svg'
+      },
+      {
+        title: 'Liberapay receiving',
+        previewUri: '/liberapay/receives/Changaco.svg'
+      },
+      {
+        title: 'Liberapay giving',
+        previewUri: '/liberapay/gives/Changaco.svg'
+      },
+      {
+        title: 'Liberapay patrons',
+        previewUri: '/liberapay/patrons/Changaco.svg'
+      },
+      {
+        title: 'Liberapay goal progress',
+        previewUri: '/liberapay/goal/Changaco.svg'
+      },
+      {
+        title: 'Bountysource',
+        previewUri: '/bountysource/team/mozilla-core/activity.svg'
+      },
+      {
+        title: 'Beerpay',
+        previewUri: '/beerpay/hashdog/scrapfy-chrome-extension.svg'
+      },
+      {
+        title: 'Codetally',
+        previewUri: '/codetally/triggerman722/colorstrap.svg'
+      },
+      {
+        title: 'Chrome Web Store',
+        previewUri: '/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg',
+        keywords: [
+          'chrome'
+        ]
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'issue-tracking',
+      name: 'Issue Tracking'
+    },
+    examples: [
+      {
+        title: 'Bugzilla bug status',
+        previewUri: '/bugzilla/996038.svg',
+        keywords: [
+          'Bugzilla',
+          'bug'
+        ],
+        documentation: bugzillaDoc,
+      },
+      {
+        title: 'GitHub issues',
+        previewUri: '/github/issues/badges/shields.svg',
+        keywords: [
+          'GitHub',
+          'issue'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issues',
+        previewUri: '/github/issues-raw/badges/shields.svg',
+        keywords: [
+          'GitHub',
+          'issue'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub pull requests',
+        previewUri: '/github/issues-pr/cdnjs/cdnjs.svg',
+        keywords: [
+          'GitHub',
+          'pullrequest',
+          'pr'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub pull requests',
+        previewUri: '/github/issues-pr-raw/cdnjs/cdnjs.svg',
+        keywords: [
+          'GitHub',
+          'pullrequest',
+          'pr'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub closed issues',
+        previewUri: '/github/issues-closed/badges/shields.svg',
+        keywords: [
+          'GitHub',
+          'issue'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub closed issues',
+        previewUri: '/github/issues-closed-raw/badges/shields.svg',
+        keywords: [
+          'GitHub',
+          'issue'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub closed pull requests',
+        previewUri: '/github/issues-pr-closed/cdnjs/cdnjs.svg',
+        keywords: [
+          'GitHub',
+          'pullrequest',
+          'pr'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub closed pull requests',
+        previewUri: '/github/issues-pr-closed-raw/cdnjs/cdnjs.svg',
+        keywords: [
+          'GitHub',
+          'pullrequest',
+          'pr'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issues by-label',
+        previewUri: '/github/issues/badges/shields/service-badge.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'label'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issues by-label',
+        previewUri: '/github/issues-raw/badges/shields/service-badge.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'label'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub pull requests by-label',
+        previewUri: '/github/issues-pr/badges/shields/service-badge.svg',
+        keywords: [
+          'GitHub',
+          'pullrequests',
+          'label'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub pull requests by-label',
+        previewUri: '/github/issues-pr-raw/badges/shields/service-badge.svg',
+        keywords: [
+          'GitHub',
+          'pullrequests',
+          'label'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request state',
+        previewUri: '/github/issues/detail/s/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request title',
+        previewUri: '/github/issues/detail/title/badges/shields/1290.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request author',
+        previewUri: '/github/issues/detail/u/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request label',
+        previewUri: '/github/issues/detail/label/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrqeuest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request comments',
+        previewUri: '/github/issues/detail/comments/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request age',
+        previewUri: '/github/issues/detail/age/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub issue/pull request last update',
+        previewUri: '/github/issues/detail/last-update/badges/shields/979.svg',
+        keywords: [
+          'GitHub',
+          'issue',
+          'pullrequest',
+          'detail'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'Bitbucket issues',
+        previewUri: '/bitbucket/issues/atlassian/python-bitbucket.svg'
+      },
+      {
+        title: 'Bitbucket issues',
+        previewUri: '/bitbucket/issues-raw/atlassian/python-bitbucket.svg',
+        keywords: [
+          'Bitbucket'
+        ]
+      },
+      {
+        title: 'Bitbucket open pull requests',
+        previewUri: '/bitbucket/pr/osrf/gazebo.svg'
+      },
+      {
+        title: 'Bitbucket open pull requests',
+        previewUri: '/bitbucket/pr-raw/osrf/gazebo.svg',
+        keywords: [
+          'Bitbucket'
+        ]
+      },
+      {
+        title: 'JIRA issue',
+        previewUri: '/jira/issue/https/issues.apache.org/jira/KAFKA-2896.svg'
+      },
+      {
+        title: 'JIRA sprint completion',
+        previewUri: '/jira/sprint/https/jira.spring.io/94.svg',
+        documentation: jiraSprintCompletionDoc,
+      },
+      {
+        title: 'Waffle.io',
+        previewUri: '/waffle/label/evancohen/smart-mirror/status%3A%20in%20progress.svg'
+      },
+      {
+        title: 'Issue Stats',
+        previewUri: '/issuestats/i/github/expressjs/express.svg'
+      },
+      {
+        title: 'Issue Stats (long form)',
+        previewUri: '/issuestats/i/long/github/expressjs/express.svg'
+      },
+      {
+        title: 'Pull Request Stats',
+        previewUri: '/issuestats/p/github/expressjs/express.svg'
+      },
+      {
+        title: 'Pull Request Stats (long form)',
+        previewUri: '/issuestats/p/long/github/expressjs/express.svg'
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'license',
+      name: 'License'
+    },
+    examples: [
+      {
+        title: 'AUR',
+        previewUri: '/aur/license/yaourt.svg',
+        keywords: [
+          'aur'
+        ]
+      },
+      {
+        title: 'GitHub',
+        previewUri: '/github/license/mashape/apistatus.svg',
+        keywords: [
+          'GitHub',
+          'license'
+        ],
+        documentation: githubDoc,
+      },
+      {
+        title: 'Crates.io',
+        previewUri: '/crates/l/rustc-serialize.svg',
+        keywords: [
+          'Rust'
+        ]
+      },
+      {
+        title: 'Packagist',
+        previewUri: '/packagist/l/doctrine/orm.svg',
+        keywords: [
+          'PHP'
+        ]
+      },
+      {
+        title: 'npm',
+        previewUri: '/npm/l/express.svg',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'npm (custom registry)',
+        previewUri: '/npm/l/express.svg?registry_uri=https://registry.npmjs.com',
+        keywords: [
+          'node'
+        ]
+      },
+      {
+        title: 'apm',
+        previewUri: '/apm/l/vim-mode.svg',
+        keywords: [
+          'atom'
+        ]
+      },
+      {
+        title: 'Bower',
+        previewUri: '/bower/l/bootstrap.svg'
+      },
+      {
+        title: 'PyPI - License',
+        previewUri: '/pypi/l/Django.svg',
+        keywords: [
+          'python',
+          'pypi'
+        ]
+      },
+      {
+        title: 'Hex.pm',
+        previewUri: '/hexpm/l/plug.svg'
+      },
+      {
+        title: 'CocoaPods',
+        previewUri: '/cocoapods/l/AFNetworking.svg'
+      },
+      {
+        title: 'CPAN',
+        previewUri: '/cpan/l/Config-Augeas.svg',
+        keywords: [
+          'perl'
+        ]
+      },
+      {
+        title: 'CRAN',
+        previewUri: '/cran/l/devtools.svg',
+        keywords: [
+          'R'
+        ]
+      },
+      {
+        title: 'CTAN',
+        previewUri: '/ctan/l/novel.svg',
+        keywords: [
+          'tex'
+        ]
+      },
+      {
+        title: 'DUB',
+        previewUri: '/dub/l/vibe-d.svg',
+        keywords: [
+          'dub'
+        ]
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'rating',
+      name: 'Rating'
+    },
+    examples: [
+      {
+        title: 'Chrome Web Store',
+        previewUri: '/chrome-web-store/rating/nimelepbpejjlbmoobocpfnjhihnpked.svg',
+        keywords: [
+          'chrome'
+        ]
+      },
+      {
+        title: 'Chrome Web Store',
+        previewUri: '/chrome-web-store/stars/nimelepbpejjlbmoobocpfnjhihnpked.svg',
+        keywords: [
+          'chrome'
+        ]
+      },
+      {
+        title: 'Chrome Web Store',
+        previewUri: '/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg',
+        keywords: [
+          'chrome'
+        ]
+      },
+      {
+        title: 'AUR',
+        previewUri: '/aur/votes/yaourt.svg',
+        keywords: [
+          'aur'
+        ]
+      },
+      {
+        title: 'Mozilla Add-on',
+        previewUri: '/amo/rating/dustman.svg',
+        keywords: [
+          'amo',
+          'firefox'
+        ]
+      },
+      {
+        title: 'Mozilla Add-on',
+        previewUri: '/amo/stars/dustman.svg',
+        keywords: [
+          'amo',
+          'firefox'
+        ]
+      },
+      {
+        title: 'Plugin on redmine.org',
+        previewUri: '/redmine/plugin/rating/redmine_xlsx_format_issue_exporter.svg',
+        keywords: [
+          'redmine',
+          'plugin'
+        ]
+      },
+      {
+        title: 'Plugin on redmine.org',
+        previewUri: '/redmine/plugin/stars/redmine_xlsx_format_issue_exporter.svg',
+        keywords: [
+          'redmine',
+          'plugin'
+        ]
+      },
+      {
+        title: 'Vaadin Directory',
+        previewUri: '/vaadin-directory/rating/vaadinvaadin-grid.svg',
+        keywords: [
+          'vaadin-directory',
+          'vaadin directory',
+          'rating'
+        ]
+      },
+      {
+        title: 'Vaadin Directory',
+        previewUri: '/vaadin-directory/stars/vaadinvaadin-grid.svg',
+        keywords: [
+          'vaadin-directory',
+          'vaadin directory',
+          'star', 'stars'
+        ]
+      },
+      {
+        title: 'Vaadin Directory',
+        previewUri: '/vaadin-directory/rating-count/vaadinvaadin-grid.svg',
+        keywords: [
+          'vaadin-directory',
+          'vaadin directory',
+          'rating-count',
+          'rating count'
+        ]
+      },
+      {
+        title: 'WordPress plugin rating',
+        previewUri: '/wordpress/plugin/r/akismet.svg'
+      },
+      {
+        title: 'WordPress theme rating',
+        previewUri: '/wordpress/theme/r/hestia.svg'
+      },
+      {
+        title: 'Visual Studio Marketplace',
+        previewUri: '/vscode-marketplace/r/ritwickdey.LiveServer.svg',
+        keywords: [
+          'vscode-marketplace'
+        ]
+      },
+      {
+        title: 'StackExchange',
+        previewUri: '/stackexchange/tex/r/951.svg'
+      },
+      {
+        title: 'Docker Stars',
+        previewUri: '/docker/stars/_/ubuntu.svg',
+        keywords: [
+          'docker',
+          'stars'
+        ]
+      },
+    ]
+  },
+  {
+    category: {
+      id: 'social',
+      name: 'Social'
+    },
+    examples: [
+      {
+        title: 'GitHub forks',
+        previewUri: '/github/forks/badges/shields.svg?style=social&label=Fork',
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub stars',
+        previewUri: '/github/stars/badges/shields.svg?style=social&label=Stars',
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub watchers',
+        previewUri: '/github/watchers/badges/shields.svg?style=social&label=Watch',
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub followers',
+        previewUri: '/github/followers/espadrine.svg?style=social&label=Follow',
+        documentation: githubDoc,
+      },
+      {
+        title: 'Twitter URL',
+        previewUri: '/twitter/url/http/shields.io.svg?style=social'
+      },
+      {
+        title: 'Twitter Follow',
+        previewUri: '/twitter/follow/espadrine.svg?style=social&label=Follow'
+      }
+    ]
+  },
+  {
+    category: {
       id: 'version',
       name: 'Version'
     },
@@ -829,6 +1503,23 @@ const allBadgeExamples = [
         previewUri: '/pypi/v/nine.svg',
         keywords: [
           'python'
+        ]
+      },
+      {
+        title: 'PyPI - Python Version',
+        previewUri: '/pypi/pyversions/Django.svg',
+        keywords: [
+          'python',
+          'pypi'
+        ]
+      },
+      {
+        title: 'PyPI - Django Version',
+        previewUri: '/pypi/djversions/djangorestframework.svg',
+        keywords: [
+          'python',
+          'pypi',
+          'django'
         ]
       },
       {
@@ -1035,13 +1726,6 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'CRAN',
-        previewUri: '/cran/l/devtools.svg',
-        keywords: [
-          'R'
-        ]
-      },
-      {
         title: 'CTAN',
         previewUri: '/ctan/v/tex.svg',
         keywords: [
@@ -1138,185 +1822,27 @@ const allBadgeExamples = [
         title: 'PHP version from PHP-Eye',
         previewUri: '/php-eye/symfony/symfony.svg',
       },
-    ]
-  },
-  {
-    category: {
-      id: 'social',
-      name: 'Social'
-    },
-    examples: [
       {
-        title: 'GitHub forks',
-        previewUri: '/github/forks/badges/shields.svg?style=social&label=Fork',
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub stars',
-        previewUri: '/github/stars/badges/shields.svg?style=social&label=Stars',
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub watchers',
-        previewUri: '/github/watchers/badges/shields.svg?style=social&label=Watch',
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub followers',
-        previewUri: '/github/followers/espadrine.svg?style=social&label=Follow',
-        documentation: githubDoc,
-      },
-      {
-        title: 'Twitter URL',
-        previewUri: '/twitter/url/http/shields.io.svg?style=social'
-      },
-      {
-        title: 'Twitter Follow',
-        previewUri: '/twitter/follow/espadrine.svg?style=social&label=Follow'
-      }
-    ]
-  },
-  {
-    category: {
-      id: 'funding',
-      name: 'Funding'
-    },
-    examples: [
-      {
-        title: 'Gratipay',
-        previewUri: '/gratipay/project/shields.svg'
-      },
-      {
-        title: 'Liberapay receiving',
-        previewUri: '/liberapay/receives/Changaco.svg'
-      },
-      {
-        title: 'Liberapay giving',
-        previewUri: '/liberapay/gives/Changaco.svg'
-      },
-      {
-        title: 'Liberapay patrons',
-        previewUri: '/liberapay/patrons/Changaco.svg'
-      },
-      {
-        title: 'Liberapay goal progress',
-        previewUri: '/liberapay/goal/Changaco.svg'
-      },
-      {
-        title: 'Bountysource',
-        previewUri: '/bountysource/team/mozilla-core/activity.svg'
-      },
-      {
-        title: 'Beerpay',
-        previewUri: '/beerpay/hashdog/scrapfy-chrome-extension.svg'
-      },
-      {
-        title: 'Codetally',
-        previewUri: '/codetally/triggerman722/colorstrap.svg'
-      }
-    ]
-  },
-  {
-    category: {
-      id: 'miscellaneous',
-      name: 'Miscellaneous'
-    },
-    examples: [
-      {
-        title: 'Bugzilla bug status',
-        previewUri: '/bugzilla/996038.svg',
+        title: 'Vaadin Directory',
+        previewUri: '/vaadin-directory/v/vaadinvaadin-grid.svg',
         keywords: [
-          'Bugzilla',
-          'bug'
-        ],
-        documentation: bugzillaDoc,
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/issues/twbs/bootstrap.svg'
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/maintainability/angular/angular.js.svg'
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/maintainability-percentage/angular/angular.js.svg'
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/coverage/jekyll/jekyll.svg'
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/coverage-letter/jekyll/jekyll.svg'
-      },
-      {
-        title: 'Code Climate',
-        previewUri: '/codeclimate/tech-debt/jekyll/jekyll.svg'
-      },
-      {
-        title: 'Depfu',
-        previewUri: '/depfu/depfu/example-ruby.svg'
-      },
-      {
-        title: 'Hackage-Deps',
-        previewUri: '/hackage-deps/v/lens.svg'
-      },
-      {
-        title: 'Crates.io',
-        previewUri: '/crates/l/rustc-serialize.svg',
-        keywords: [
-          'Rust'
+          'vaadin-directory',
+          'vaadin directory',
+          'version',
+          'latest version'
         ]
       },
-      {
-        title: 'Requires.io',
-        previewUri: '/requires/github/celery/celery.svg'
-      },
+    ]
+  },
+  {
+    category: {
+      id: 'other',
+      name: 'Other'
+    },
+    examples: [
       {
         title: 'VersionEye',
         previewUri: '/versioneye/d/ruby/rails.svg'
-      },
-      {
-        title: 'Packagist',
-        previewUri: '/packagist/l/doctrine/orm.svg',
-        keywords: [
-          'PHP'
-        ]
-      },
-      {
-        title: 'npm',
-        previewUri: '/npm/l/express.svg',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'npm (custom registry)',
-        previewUri: '/npm/l/express.svg?registry_uri=https://registry.npmjs.com',
-        keywords: [
-          'node'
-        ]
-      },
-      {
-        title: 'apm',
-        previewUri: '/apm/l/vim-mode.svg',
-        keywords: [
-          'atom'
-        ]
-      },
-      {
-        title: 'Bower',
-        previewUri: '/bower/l/bootstrap.svg'
-      },
-      {
-        title: 'PyPI - License',
-        previewUri: '/pypi/l/Django.svg',
-        keywords: [
-          'python',
-          'pypi'
-        ]
       },
       {
         title: 'PyPI - Wheel',
@@ -1329,14 +1855,6 @@ const allBadgeExamples = [
       {
         title: 'PyPI - Format',
         previewUri: '/pypi/format/Django.svg',
-        keywords: [
-          'python',
-          'pypi'
-        ]
-      },
-      {
-        title: 'PyPI - Python Version',
-        previewUri: '/pypi/pyversions/Django.svg',
         keywords: [
           'python',
           'pypi'
@@ -1359,232 +1877,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'PyPI - Django Version',
-        previewUri: '/pypi/djversions/djangorestframework.svg',
-        keywords: [
-          'python',
-          'pypi',
-          'django'
-        ]
-      },
-      {
-        title: 'Hex.pm',
-        previewUri: '/hexpm/l/plug.svg'
-      },
-      {
-        title: 'CocoaPods',
-        previewUri: '/cocoapods/l/AFNetworking.svg'
-      },
-      {
-        title: 'CPAN',
-        previewUri: '/cpan/l/Config-Augeas.svg',
-        keywords: [
-          'perl'
-        ]
-      },
-      {
-        title: 'CTAN',
-        previewUri: '/ctan/l/novel.svg',
-        keywords: [
-          'tex'
-        ]
-      },
-      {
         title: 'Wheelmap',
         previewUri: '/wheelmap/a/2323004600.svg'
-      },
-      {
-        title: 'GitHub issues',
-        previewUri: '/github/issues/badges/shields.svg',
-        keywords: [
-          'GitHub',
-          'issue'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issues',
-        previewUri: '/github/issues-raw/badges/shields.svg',
-        keywords: [
-          'GitHub',
-          'issue'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub pull requests',
-        previewUri: '/github/issues-pr/cdnjs/cdnjs.svg',
-        keywords: [
-          'GitHub',
-          'pullrequest',
-          'pr'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub pull requests',
-        previewUri: '/github/issues-pr-raw/cdnjs/cdnjs.svg',
-        keywords: [
-          'GitHub',
-          'pullrequest',
-          'pr'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub closed issues',
-        previewUri: '/github/issues-closed/badges/shields.svg',
-        keywords: [
-          'GitHub',
-          'issue'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub closed issues',
-        previewUri: '/github/issues-closed-raw/badges/shields.svg',
-        keywords: [
-          'GitHub',
-          'issue'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub closed pull requests',
-        previewUri: '/github/issues-pr-closed/cdnjs/cdnjs.svg',
-        keywords: [
-          'GitHub',
-          'pullrequest',
-          'pr'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub closed pull requests',
-        previewUri: '/github/issues-pr-closed-raw/cdnjs/cdnjs.svg',
-        keywords: [
-          'GitHub',
-          'pullrequest',
-          'pr'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issues by-label',
-        previewUri: '/github/issues/badges/shields/service-badge.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'label'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issues by-label',
-        previewUri: '/github/issues-raw/badges/shields/service-badge.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'label'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub pull requests by-label',
-        previewUri: '/github/issues-pr/badges/shields/service-badge.svg',
-        keywords: [
-          'GitHub',
-          'pullrequests',
-          'label'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub pull requests by-label',
-        previewUri: '/github/issues-pr-raw/badges/shields/service-badge.svg',
-        keywords: [
-          'GitHub',
-          'pullrequests',
-          'label'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request state',
-        previewUri: '/github/issues/detail/s/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request title',
-        previewUri: '/github/issues/detail/title/badges/shields/1290.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request author',
-        previewUri: '/github/issues/detail/u/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request label',
-        previewUri: '/github/issues/detail/label/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrqeuest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request comments',
-        previewUri: '/github/issues/detail/comments/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request age',
-        previewUri: '/github/issues/detail/age/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'GitHub issue/pull request last update',
-        previewUri: '/github/issues/detail/last-update/badges/shields/979.svg',
-        keywords: [
-          'GitHub',
-          'issue',
-          'pullrequest',
-          'detail'
-        ],
-        documentation: githubDoc,
       },
       {
         title: 'GitHub Release Date',
@@ -1645,15 +1939,6 @@ const allBadgeExamples = [
         keywords: [
           'GitHub',
           'contributor'
-        ],
-        documentation: githubDoc,
-      },
-      {
-        title: 'license',
-        previewUri: '/github/license/mashape/apistatus.svg',
-        keywords: [
-          'GitHub',
-          'license'
         ],
         documentation: githubDoc,
       },
@@ -1753,52 +2038,6 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'Bitbucket issues',
-        previewUri: '/bitbucket/issues/atlassian/python-bitbucket.svg'
-      },
-      {
-        title: 'Bitbucket issues',
-        previewUri: '/bitbucket/issues-raw/atlassian/python-bitbucket.svg',
-        keywords: [
-          'Bitbucket'
-        ]
-      },
-      {
-        title: 'Bitbucket open pull requests',
-        previewUri: '/bitbucket/pr/osrf/gazebo.svg'
-      },
-      {
-        title: 'Bitbucket open pull requests',
-        previewUri: '/bitbucket/pr-raw/osrf/gazebo.svg',
-        keywords: [
-          'Bitbucket'
-        ]
-      },
-      {
-        title: 'WordPress plugin rating',
-        previewUri: '/wordpress/plugin/r/akismet.svg'
-      },
-      {
-        title: 'WordPress theme rating',
-        previewUri: '/wordpress/theme/r/hestia.svg'
-      },
-      {
-        title: 'Codacy grade',
-        previewUri: '/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg'
-      },
-      {
-        title: 'Codacy branch grade',
-        previewUri: '/codacy/grade/e27821fb6289410b8f58338c7e0bc686/master.svg'
-      },
-      {
-        title: 'Codacy coverage',
-        previewUri: '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd.svg'
-      },
-      {
-        title: 'Codacy branch coverage',
-        previewUri: '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg'
-      },
-      {
         title: 'Libscore',
         previewUri: '/libscore/s/jQuery.svg'
       },
@@ -1817,21 +2056,6 @@ const allBadgeExamples = [
       {
         title: 'Puppet Forge',
         previewUri: '/puppetforge/mc/camptocamp.svg'
-      },
-      {
-        title: 'DUB',
-        previewUri: '/dub/l/vibe-d.svg',
-        keywords: [
-          'dub'
-        ]
-      },
-      {
-        title: 'Docker Stars',
-        previewUri: '/docker/stars/_/ubuntu.svg',
-        keywords: [
-          'docker',
-          'stars'
-        ]
       },
       {
         title: 'Docker Pulls',
@@ -1902,32 +2126,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'Gitter',
-        previewUri: '/gitter/room/nwjs/nw.js.svg'
-      },
-      {
-        title: 'JIRA issue',
-        previewUri: '/jira/issue/https/issues.apache.org/jira/KAFKA-2896.svg'
-      },
-      {
-        title: 'JIRA sprint completion',
-        previewUri: '/jira/sprint/https/jira.spring.io/94.svg',
-        documentation: jiraSprintCompletionDoc,
-      },
-      {
         title: 'Maintenance',
         previewUri: '/maintenance/yes/2017.svg'
-      },
-      {
-        title: 'AUR',
-        previewUri: '/aur/license/yaourt.svg',
-        keywords: [
-          'aur'
-        ]
-      },
-      {
-        title: 'Waffle.io',
-        previewUri: '/waffle/label/evancohen/smart-mirror/status%3A%20in%20progress.svg'
       },
       {
         title: 'Chrome Web Store',
@@ -1937,59 +2137,8 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'Chrome Web Store',
-        previewUri: '/chrome-web-store/price/nimelepbpejjlbmoobocpfnjhihnpked.svg',
-        keywords: [
-          'chrome'
-        ]
-      },
-      {
-        title: 'Chrome Web Store',
-        previewUri: '/chrome-web-store/rating/nimelepbpejjlbmoobocpfnjhihnpked.svg',
-        keywords: [
-          'chrome'
-        ]
-      },
-      {
-        title: 'Chrome Web Store',
-        previewUri: '/chrome-web-store/stars/nimelepbpejjlbmoobocpfnjhihnpked.svg',
-        keywords: [
-          'chrome'
-        ]
-      },
-      {
-        title: 'Chrome Web Store',
-        previewUri: '/chrome-web-store/rating-count/nimelepbpejjlbmoobocpfnjhihnpked.svg',
-        keywords: [
-          'chrome'
-        ]
-      },
-      {
-        title: 'AUR',
-        previewUri: '/aur/votes/yaourt.svg',
-        keywords: [
-          'aur'
-        ]
-      },
-      {
         title: 'Mozilla Add-on',
         previewUri: '/amo/users/dustman.svg',
-        keywords: [
-          'amo',
-          'firefox'
-        ]
-      },
-      {
-        title: 'Mozilla Add-on',
-        previewUri: '/amo/rating/dustman.svg',
-        keywords: [
-          'amo',
-          'firefox'
-        ]
-      },
-      {
-        title: 'Mozilla Add-on',
-        previewUri: '/amo/stars/dustman.svg',
         keywords: [
           'amo',
           'firefox'
@@ -2012,17 +2161,6 @@ const allBadgeExamples = [
         previewUri: '/uptimerobot/ratio/7/m778918918-3e92c097147760ee39d02d36.svg'
       },
       {
-        title: 'Discord',
-        previewUri: '/discord/102860784329052160.svg'
-      },
-      {
-        title: 'Visual Studio Marketplace',
-        previewUri: '/vscode-marketplace/r/ritwickdey.LiveServer.svg',
-        keywords: [
-          'vscode-marketplace'
-        ]
-      },
-      {
         title: 'Eclipse Marketplace',
         previewUri: '/eclipse-marketplace/favorites/notepad4e.svg',
         keywords: [
@@ -2039,66 +2177,12 @@ const allBadgeExamples = [
         ]
       },
       {
-        title: 'Plugin on redmine.org',
-        previewUri: '/redmine/plugin/rating/redmine_xlsx_format_issue_exporter.svg',
-        keywords: [
-          'redmine',
-          'plugin'
-        ]
-      },
-      {
-        title: 'Plugin on redmine.org',
-        previewUri: '/redmine/plugin/stars/redmine_xlsx_format_issue_exporter.svg',
-        keywords: [
-          'redmine',
-          'plugin'
-        ]
-      },
-      {
         title: 'Vaadin Directory',
         previewUri: '/vaadin-directory/status/vaadinvaadin-grid.svg',
         keywords: [
           'vaadin-directory',
           'vaadin directory',
           'status'
-        ]
-      },
-      {
-        title: 'Vaadin Directory',
-        previewUri: '/vaadin-directory/rating/vaadinvaadin-grid.svg',
-        keywords: [
-          'vaadin-directory',
-          'vaadin directory',
-          'rating'
-        ]
-      },
-      {
-        title: 'Vaadin Directory',
-        previewUri: '/vaadin-directory/stars/vaadinvaadin-grid.svg',
-        keywords: [
-          'vaadin-directory',
-          'vaadin directory',
-          'star', 'stars'
-        ]
-      },
-      {
-        title: 'Vaadin Directory',
-        previewUri: '/vaadin-directory/rating-count/vaadinvaadin-grid.svg',
-        keywords: [
-          'vaadin-directory',
-          'vaadin directory',
-          'rating-count',
-          'rating count'
-        ]
-      },
-      {
-        title: 'Vaadin Directory',
-        previewUri: '/vaadin-directory/v/vaadinvaadin-grid.svg',
-        keywords: [
-          'vaadin-directory',
-          'vaadin directory',
-          'version',
-          'latest version'
         ]
       },
       {
@@ -2110,34 +2194,6 @@ const allBadgeExamples = [
           'date',
           'latest release date'
         ]
-      }
-    ]
-  },
-  {
-    category: {
-      id: 'miscellaneous',
-      name: 'Longer Miscellaneous'
-    },
-    examples: [
-      {
-        title: 'David',
-        previewUri: '/david/expressjs/express.svg'
-      },
-      {
-        title: 'David',
-        previewUri: '/david/dev/expressjs/express.svg'
-      },
-      {
-        title: 'David',
-        previewUri: '/david/optional/elnounch/byebye.svg'
-      },
-      {
-        title: 'David',
-        previewUri: '/david/peer/webcomponents/generator-element.svg'
-      },
-      {
-        title: 'David (path)',
-        previewUri: '/david/babel/babel.svg?path=packages/babel-core'
       },
       {
         title: 'CocoaPods',
@@ -2168,35 +2224,7 @@ const allBadgeExamples = [
       },
       {
         title: 'StackExchange',
-        previewUri: '/stackexchange/tex/r/951.svg'
-      },
-      {
-        title: 'StackExchange',
         previewUri: '/stackexchange/stackoverflow/t/augeas.svg'
-      },
-      {
-        title: 'Issue Stats',
-        previewUri: '/issuestats/i/github/expressjs/express.svg'
-      },
-      {
-        title: 'Issue Stats (long form)',
-        previewUri: '/issuestats/i/long/github/expressjs/express.svg'
-      },
-      {
-        title: 'Pull Request Stats',
-        previewUri: '/issuestats/p/github/expressjs/express.svg'
-      },
-      {
-        title: 'Pull Request Stats (long form)',
-        previewUri: '/issuestats/p/long/github/expressjs/express.svg'
-      },
-      {
-        title: 'Libraries.io for releases',
-        previewUri: '/librariesio/release/hex/phoenix/1.0.3.svg'
-      },
-      {
-        title: 'Libraries.io for GitHub',
-        previewUri: '/librariesio/github/phoenixframework/phoenix.svg'
       },
       {
         title: 'NetflixOSS Lifecycle',
@@ -2211,7 +2239,7 @@ const allBadgeExamples = [
         previewUri: '/dependabot/semver/bundler/puma.svg'
       }
     ]
-  }
+  },
 ];
 
 function findCategory(wantedCategory) {

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -211,8 +211,12 @@ const allBadgeExamples = [
         previewUri: '/jenkins/t/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg'
       },
       {
-        title: 'Jenkins coverage',
+        title: 'Jenkins Coverage (Cobertura)',
         previewUri: '/jenkins/c/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
+      },
+      {
+        title: 'Jenkins Coverage (Jacoco)',
+        previewUri: '/jenkins/j/https/jenkins.qa.ubuntu.com/view/Utopic/view/All/job/address-book-service-utopic-i386-ci.svg'
       },
       {
         title: 'Bitbucket Pipelines',
@@ -268,7 +272,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Scrutinizer branch',
-        previewUri: '/scrutinizer/coverage/g/phpmyadmin/phpmyadmin/master.svg'
+        previewUri: '/scrutinizer/coverage/g/doctrine/doctrine2/master.svg'
       },
       {
         title: 'Scrutinizer Build',

--- a/services/gem/gem.js
+++ b/services/gem/gem.js
@@ -203,7 +203,7 @@ class GemOwner extends BaseJsonService {
   }
 
   static get category() {
-    return 'miscellaneous';
+    return 'other';
   }
 
   static get url() {
@@ -267,7 +267,7 @@ class GemRank extends BaseJsonService {
   }
 
   static get category() {
-    return 'miscellaneous';
+    return 'rating';
   }
 
   static get url() {


### PR DESCRIPTION
Following on from https://github.com/badges/shields/pull/1762#issuecomment-406896626 I've extracted the changes to the examples. This re-shuffles the examples into categories:

- Build
- Chat
- Dependencies
- Downloads
- Funding
- Issue Tracking
- License
- Rating
- Social
- Version
- Other

#1762 can be rebased on to this later.