### PR TITLE
increase timeout for `colorscheme PNG badge` test

### DIFF
--- a/server.spec.js
+++ b/server.spec.js
@@ -33,6 +33,7 @@ describe('The server', function () {
   });
 
   it('should produce colorscheme PNG badges', async function () {
+    this.timeout(5000);
     const res = await fetch(`${baseUri}/:fruit-apple-green.png`);
     expect(res.ok).to.be.true;
     expect(await res.buffer()).to.satisfy(isPng);


### PR DESCRIPTION
increase timeout from `2000ms` → `5000ms` for `colorscheme PNG badge` test.
As this test is often [failing with](https://circleci.com/gh/badges/shields/7231):
```console
  1) The server
       should produce colorscheme PNG badges:
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```
