### PR TITLE
eslint enable comma-dangle always-multiline

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,3 +27,4 @@ rules:
   no-trailing-spaces: "error"
   eol-last: "error"
   object-curly-spacing: ["error", "always"]
+  comma-dangle: ["error", "always-multiline"]

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -35,7 +35,7 @@ const targetBranch = danger.github.pr.base.ref;
 
 message([
   ':sparkles: Thanks for your contribution to Shields, ',
-  `@${danger.github.pr.user.login}!`
+  `@${danger.github.pr.user.login}!`,
 ].join(''));
 
 if (targetBranch != 'master') {
@@ -47,7 +47,7 @@ if (targetBranch != 'master') {
 if (documentation.createdOrModified) {
   message([
     'Thanks for contributing to our documentation. ',
-    'We :heart: our [documentarians](http://www.writethedocs.org/)!'
+    'We :heart: our [documentarians](http://www.writethedocs.org/)!',
   ].join(''));
 }
 
@@ -81,7 +81,7 @@ if (logos.created) {
     ':art: Thanks for submitting a logo. ',
     'Please ensure your contribution follows our ',
     '[guidance](https://github.com/badges/shields/blob/master/CONTRIBUTING.md#logos) ',
-    'for logo submissions.'
+    'for logo submissions.',
   ].join(''));
 }
 
@@ -100,7 +100,7 @@ all_files.forEach(function(file) {
       warn([
         `Found 'assert' statement added in ${file}. `,
         'Please ensure tests are written using Chai ',
-        '[expect syntax](http://chaijs.com/guide/styles/#expect)'
+        '[expect syntax](http://chaijs.com/guide/styles/#expect)',
       ].join(''));
     }
   });

--- a/server.js
+++ b/server.js
@@ -49,7 +49,7 @@ const {
   omitv,
   addv: versionText,
   maybePluralize,
-  formatDate
+  formatDate,
 } = require('./lib/text-formatters');
 const {
   coveragePercentage: coveragePercentageColor,
@@ -58,62 +58,62 @@ const {
   letterScore: letterScoreColor,
   version: versionColor,
   age: ageColor,
-  colorScale
+  colorScale,
 } = require('./lib/color-formatters');
 const {
   makeColorB,
   makeLabel: getLabel,
   makeLogo: getLogo,
   makeBadgeData: getBadgeData,
-  setBadgeColor
+  setBadgeColor,
 } = require('./lib/badge-data');
 const {
   makeHandleRequestFn,
-  clearRequestCache
+  clearRequestCache,
 } = require('./lib/request-handler');
 const {
   regularUpdate,
-  clearRegularUpdateCache
+  clearRegularUpdateCache,
 } = require('./lib/regular-update');
 const { makeSend } = require('./lib/result-sender');
 const { fetchFromSvg } = require('./lib/svg-badge-parser');
 const {
   escapeFormat,
-  escapeFormatSlashes
+  escapeFormatSlashes,
 } = require('./lib/path-helpers');
 const {
-  isSnapshotVersion: isNexusSnapshotVersion
+  isSnapshotVersion: isNexusSnapshotVersion,
 } = require('./lib/nexus-version');
 const {
-  mapNpmDownloads
+  mapNpmDownloads,
 } = require('./lib/npm-provider');
 const {
   defaultNpmRegistryUri,
   makePackageDataUrl: makeNpmPackageDataUrl,
 } = require('./lib/npm-badge-helpers');
 const {
-  teamcityBadge
+  teamcityBadge,
 } = require('./lib/teamcity-badge-helpers');
 const {
   mapNugetFeedv2,
-  mapNugetFeed
+  mapNugetFeed,
 } = require('./lib/nuget-provider');
 const {
   getVscodeApiReqOptions,
-  getVscodeStatistic
+  getVscodeStatistic,
 } = require('./lib/vscode-badge-helpers');
 const {
   stateColor: githubStateColor,
   checkStateColor: githubCheckStateColor,
-  commentsColor: githubCommentsColor
+  commentsColor: githubCommentsColor,
 } = require('./lib/github-helpers');
 const {
   mapGithubCommitsSince,
-  mapGithubReleaseDate
+  mapGithubReleaseDate,
 } = require('./lib/github-provider');
 const {
   sortDjangoVersions,
-  parseClassifiers
+  parseClassifiers,
 } = require('./lib/pypi-helpers.js');
 
 const serverStartTime = new Date((new Date()).toGMTString());
@@ -146,7 +146,7 @@ function stop(callback) {
 module.exports = {
   camp,
   reset,
-  stop
+  stop,
 };
 
 log(`Server is starting up: ${config.baseUri}`);
@@ -217,12 +217,12 @@ cache(function (data, match, sendBadge, request) {
     method: 'GET',
     json: true,
     uri: protocol + '://' + host + '/rest/api/2/issue/' +
-      encodeURIComponent(issueKey)
+      encodeURIComponent(issueKey),
   };
   if (serverSecrets && serverSecrets.jira_username) {
     options.auth = {
       user: serverSecrets.jira_username,
-      pass: serverSecrets.jira_password
+      pass: serverSecrets.jira_password,
     };
   }
 
@@ -233,7 +233,7 @@ cache(function (data, match, sendBadge, request) {
     'yellow': 'yellow',
     'brown': 'orange',
     'warm-red': 'red',
-    'blue-gray': 'blue'
+    'blue-gray': 'blue',
   };
 
   var badgeData = getBadgeData(issueKey, data);
@@ -274,12 +274,12 @@ cache(function (data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     json: true,
-    uri: protocol + '://' + host + '/rest/api/2/search?jql=sprint='+sprintId+'%20AND%20type%20IN%20(Bug,Improvement,Story,"Technical%20task")&fields=resolution&maxResults=500'
+    uri: protocol + '://' + host + '/rest/api/2/search?jql=sprint='+sprintId+'%20AND%20type%20IN%20(Bug,Improvement,Story,"Technical%20task")&fields=resolution&maxResults=500',
   };
   if (serverSecrets && serverSecrets.jira_username) {
     options.auth = {
       user: serverSecrets.jira_username,
-      pass: serverSecrets.jira_password
+      pass: serverSecrets.jira_password,
     };
   }
 
@@ -439,8 +439,8 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     uri: 'https://status.continuousphp.com/' + provider + '/' + userRepo + '/status-info',
     headers: {
-      'Accept': 'application/json'
-    }
+      'Accept': 'application/json',
+    },
   };
 
   if (branch != null) {
@@ -502,7 +502,7 @@ camp.route(/^\/osslifecycle?\/([^/]+\/[^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$
     }
     var options = {
       method: 'GET',
-      uri: url
+      uri: url,
     };
     var badgeData = getBadgeData('OSS Lifecycle', data);
     request(options, function(err, res, body) {
@@ -559,7 +559,7 @@ cache(function (data, match, sendBadge, request) {
   const url = 'https://api.shippable.com/projects/' + project + '/branchRunStatus';
   const options = {
     method: 'GET',
-    uri: url
+    uri: url,
   };
 
   const badgeData = getBadgeData('build', data);
@@ -596,7 +596,7 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     json: true,
-    uri: 'https://app.wercker.com/getbuilds/' + projectId + '?limit=1'
+    uri: 'https://app.wercker.com/getbuilds/' + projectId + '?limit=1',
   };
   var badgeData = getBadgeData('build', data);
   request(options, function(err, res, json) {
@@ -637,7 +637,7 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     json: true,
-    uri: 'https://app.wercker.com/api/v3/applications/' + owner + '/' + application + '/builds?limit=1'
+    uri: 'https://app.wercker.com/api/v3/applications/' + owner + '/' + application + '/builds?limit=1',
   };
   var badgeData = getBadgeData('build', data);
   request(options, function(err, res, json) {
@@ -685,7 +685,7 @@ cache(function (data, match, sendBadge, request) {
         version = data.version && data.version.num;
         badgeData.text[1] = metric(downloads) + (version? ' version ' + version: '');
         badgeData.colorscheme = downloadCountColor(downloads);
-      }
+      },
     },
     'dv': {
       name: 'downloads',
@@ -695,7 +695,7 @@ cache(function (data, match, sendBadge, request) {
         version = data.version && data.version.num;
         badgeData.text[1] = metric(downloads) + (version? ' version ' + version: ' latest version');
         badgeData.colorscheme = downloadCountColor(downloads);
-      }
+      },
     },
     'v': {
       name: 'crates.io',
@@ -704,7 +704,7 @@ cache(function (data, match, sendBadge, request) {
         version = data.version? data.version.num: data.crate.max_version;
         badgeData.text[1] = versionText(version);
         badgeData.colorscheme = versionColor(version);
-      }
+      },
     },
     'l': {
       name: 'license',
@@ -712,8 +712,8 @@ cache(function (data, match, sendBadge, request) {
       process: function (data, badgeData) {
         badgeData.text[1] = data.versions[0].license;
         badgeData.colorscheme = 'blue';
-      }
-    }
+      },
+    },
   };
   var behavior = modes[mode];
   var apiUrl = 'https://crates.io/api/v1/crates/' + crate;
@@ -880,12 +880,12 @@ camp.route(/^\/sonar\/?([0-9.]+)?\/(http|https)\/(.*)\/(.*)\/(.*)\.(svg|png|gif|
       var options = {
         uri,
         headers: {
-          Accept: 'application/json'
-        }
+          Accept: 'application/json',
+        },
       };
       if (serverSecrets && serverSecrets.sonarqube_token) {
         options.auth = {
-          user: serverSecrets.sonarqube_token
+          user: serverSecrets.sonarqube_token,
         };
       }
 
@@ -1407,14 +1407,14 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     uri: 'https://insight.sensiolabs.com/api/projects/' + projectUuid,
     headers: {
-      Accept: 'application/vnd.com.sensiolabs.insight+xml'
-    }
+      Accept: 'application/vnd.com.sensiolabs.insight+xml',
+    },
   };
 
   if (serverSecrets && serverSecrets.sl_insight_userUuid) {
     options.auth = {
       user: serverSecrets.sl_insight_userUuid,
-      pass: serverSecrets.sl_insight_apiToken
+      pass: serverSecrets.sl_insight_apiToken,
     };
   }
 
@@ -1785,7 +1785,7 @@ cache({
         sendBadge(format, badgeData);
       }
     });
-  }
+  },
 }));
 
 // npm license integration.
@@ -1839,7 +1839,7 @@ cache({
         sendBadge(format, badgeData);
       }
     });
-  }
+  },
 }));
 
 // npm node version integration.
@@ -1914,7 +1914,7 @@ cache({
         sendBadge(format, badgeData);
       }
     });
-  }
+  },
 }));
 
 // Anaconda Cloud / conda package manager integration
@@ -1928,7 +1928,7 @@ cache(function(queryData, match, sendBadge, request) {
   const labels = {
     'd': 'downloads',
     'p': 'platform',
-    'v': channel
+    'v': channel,
   };
   const modes = {
     // downloads - 'd'
@@ -1947,7 +1947,7 @@ cache(function(queryData, match, sendBadge, request) {
     'p': function(data, badgeData) {
       const platforms = data.conda_platforms.join(' | ');
       badgeData.text[1] = platforms;
-    }
+    },
   };
   const variants = {
     // default use `conda|{channelname}` as label
@@ -1956,7 +1956,7 @@ cache(function(queryData, match, sendBadge, request) {
     },
     // skip `conda|` prefix
     'n': function(queryData, badgeData) {
-    }
+    },
   };
 
   const update = modes[mode.charAt(0)];
@@ -1993,14 +1993,14 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     uri: 'https://bintray.com/api/v1/packages/' + path + '/versions/_latest',
     headers: {
-      Accept: 'application/json'
-    }
+      Accept: 'application/json',
+    },
   };
 
   if (serverSecrets && serverSecrets.bintray_user) {
     options.auth = {
       user: serverSecrets.bintray_user,
-      pass: serverSecrets.bintray_apikey
+      pass: serverSecrets.bintray_apikey,
     };
   }
 
@@ -2495,7 +2495,7 @@ cache(function(data, match, sendBadge, request) {
   request({
       method: 'GET',
       uri: `https://api.codeclimate.com/v1/repos?github_slug=${userRepo}`,
-      json: true
+      json: true,
   }, function (err, res, body) {
     const badgeData = getBadgeData(type, data);
     if (err != null) {
@@ -2696,7 +2696,7 @@ cache({
         return;
       }
     });
-  }
+  },
 }));
 
 // dotnet-status integration - deprecated as of April 2018.
@@ -2874,8 +2874,8 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     uri: url,
     headers: {
-      'Accept': 'application/json'
-    }
+      'Accept': 'application/json',
+    },
   };
 
   var badgeData = getBadgeData('discourse', data);
@@ -3137,7 +3137,7 @@ cache(function(data, match, sendBadge, request) {
 
       var platforms = Object.keys(parsedData.platforms || {
         'ios' : '5.0',
-        'osx' : '10.7'
+        'osx' : '10.7',
       }).join(' | ');
       if (type === 'v') {
         badgeData.text[1] = versionText(version);
@@ -3837,7 +3837,7 @@ cache(function(data, match, sendBadge, request) {
   // https://developer.github.com/v3/licenses/
   var customHeaders = {
     'User-Agent': 'Shields.io',
-    'Accept': 'application/vnd.github.drax-preview+json'
+    'Accept': 'application/vnd.github.drax-preview+json',
   };
   request(apiUrl, { headers: customHeaders }, function(err, res, buffer) {
     if (res && res.statusCode === 404) {
@@ -4330,7 +4330,7 @@ cache(function(data, match, sendBadge, request) {
 mapNugetFeedv2({ camp, cache }, 'resharper', 0, function(match) {
   return {
     site: 'resharper',
-    feed: 'https://resharper-plugins.jetbrains.com/api/v2'
+    feed: 'https://resharper-plugins.jetbrains.com/api/v2',
   };
 });
 
@@ -4338,7 +4338,7 @@ mapNugetFeedv2({ camp, cache }, 'resharper', 0, function(match) {
 mapNugetFeedv2({ camp, cache }, 'chocolatey', 0, function(match) {
   return {
     site: 'chocolatey',
-    feed: 'https://www.chocolatey.org/api/v2'
+    feed: 'https://www.chocolatey.org/api/v2',
   };
 });
 
@@ -4346,7 +4346,7 @@ mapNugetFeedv2({ camp, cache }, 'chocolatey', 0, function(match) {
 mapNugetFeedv2({ camp, cache }, 'powershellgallery', 0, function(match) {
   return {
     site: 'powershellgallery',
-    feed: 'https://www.powershellgallery.com/api/v2'
+    feed: 'https://www.powershellgallery.com/api/v2',
   };
 });
 
@@ -4354,7 +4354,7 @@ mapNugetFeedv2({ camp, cache }, 'powershellgallery', 0, function(match) {
 mapNugetFeed({ camp, cache }, 'nuget', 0, function(match) {
   return {
     site: 'nuget',
-    feed: 'https://api.nuget.org/v3'
+    feed: 'https://api.nuget.org/v3',
   };
 });
 
@@ -4364,7 +4364,7 @@ mapNugetFeed({ camp, cache }, '(.+\\.)?myget\\/(.*)', 2, function(match) {
   var feed = match[2];
   return {
     site: feed,
-    feed: 'https://' + tenant + 'myget.org/F/' + feed + '/api/v3'
+    feed: 'https://' + tenant + 'myget.org/F/' + feed + '/api/v3',
   };
 });
 
@@ -4377,7 +4377,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[4];
   var options = {
     json: true,
-    uri: 'https://forgeapi.puppetlabs.com/v3/modules/' + user + '-' + module
+    uri: 'https://forgeapi.puppetlabs.com/v3/modules/' + user + '-' + module,
   };
   var badgeData = getBadgeData('puppetforge', data);
   request(options, function dealWithData(err, res, json) {
@@ -4443,7 +4443,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[3];
   var options = {
     json: true,
-    uri: 'https://forgeapi.puppetlabs.com/v3/users/' + user
+    uri: 'https://forgeapi.puppetlabs.com/v3/users/' + user,
   };
   var badgeData = getBadgeData('puppetforge', data);
   request(options, function dealWithData(err, res, json) {
@@ -4482,7 +4482,7 @@ cache(function(data, match, sendBadge, request) {
   var format = match[4];
   var options = {
     json: true,
-    uri: scheme + '://' + host + '/job/' + job + '/api/json?tree=color'
+    uri: scheme + '://' + host + '/job/' + job + '/api/json?tree=color',
   };
   if (job.indexOf('/') > -1 ) {
     options.uri = scheme + '://' + host + '/' + job + '/api/json?tree=color';
@@ -4491,7 +4491,7 @@ cache(function(data, match, sendBadge, request) {
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
       user: serverSecrets.jenkins_user,
-      pass: serverSecrets.jenkins_pass
+      pass: serverSecrets.jenkins_pass,
     };
   }
 
@@ -4539,7 +4539,7 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     json: true,
     uri: scheme + '://' + host + '/job/' + job
-      + '/lastBuild/api/json?tree=' + encodeURIComponent('actions[failCount,skipCount,totalCount]')
+      + '/lastBuild/api/json?tree=' + encodeURIComponent('actions[failCount,skipCount,totalCount]'),
   };
   if (job.indexOf('/') > -1 ) {
     options.uri = scheme + '://' + host + '/' + job
@@ -4549,7 +4549,7 @@ cache(function(data, match, sendBadge, request) {
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
       user: serverSecrets.jenkins_user,
-      pass: serverSecrets.jenkins_pass
+      pass: serverSecrets.jenkins_pass,
     };
   }
 
@@ -4599,7 +4599,7 @@ cache(function(data, match, sendBadge, request) {
   const format = match[5];
   const options = {
     json: true,
-    uri: `${scheme}://${host}/job/${job}/`
+    uri: `${scheme}://${host}/job/${job}/`,
   };
 
   if (job.indexOf('/') > -1 ) {
@@ -4618,7 +4618,7 @@ cache(function(data, match, sendBadge, request) {
   if (serverSecrets && serverSecrets.jenkins_user) {
     options.auth = {
       user: serverSecrets.jenkins_user,
-      pass: serverSecrets.jenkins_pass
+      pass: serverSecrets.jenkins_pass,
     };
   }
 
@@ -4728,7 +4728,7 @@ cache(function(data, match, sendBadge, request) {
   var branch = match[2];
   var options = {
     method: 'GET',
-    uri: 'https://codeship.com/projects/' + projectId + '/status' + (branch != null ? '?branch=' + branch : '')
+    uri: 'https://codeship.com/projects/' + projectId + '/status' + (branch != null ? '?branch=' + branch : ''),
   };
   var badgeData = getBadgeData('build', data);
   request(options, function(err, res) {
@@ -4999,7 +4999,7 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     json: true,
-    uri: 'http://wheelmap.org/nodes/' + nodeId + '.json'
+    uri: 'http://wheelmap.org/nodes/' + nodeId + '.json',
   };
   var badgeData = getBadgeData('wheelmap', data);
   request(options, function(err, res, json) {
@@ -5178,7 +5178,7 @@ camp.route(/^\/wordpress\/theme\/r\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var queryParams = {
     'action': 'theme_information',
-    'request[slug]': match[1]  // eg, `hestia`.
+    'request[slug]': match[1],  // eg, `hestia`.
   };
   var format = match[2];
   var apiUrl = 'https://api.wordpress.org/themes/info/1.1/?' + queryString.stringify(queryParams);
@@ -5218,7 +5218,7 @@ camp.route(/^\/wordpress\/theme\/dt\/(.*)\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var queryParams = {
     'action': 'theme_information',
-    'request[slug]': match[1] // eg, `hestia`.
+    'request[slug]': match[1], // eg, `hestia`.
   };
   var format = match[2];
   var apiUrl = 'https://api.wordpress.org/themes/info/1.1/?' + queryString.stringify(queryParams);
@@ -5304,7 +5304,7 @@ cache(function(data, match, sendBadge, request) {
   }
   var options = {
     method: 'GET',
-    uri: uri
+    uri: uri,
   };
   var badgeData = getBadgeData('requirements', data);
   request(options, function(err, res, buffer) {
@@ -5471,7 +5471,7 @@ cache({
       error:    '#F55C51',
       working:  '#FCBC41',
       pending:  '#CFD0D7',
-      rejected: '#CFD0D7'
+      rejected: '#CFD0D7',
     };
 
     request(apiUrl, { json: true }, function(err, res, data) {
@@ -5518,7 +5518,7 @@ cache({
     const statusColorScheme = {
       success: 'brightgreen',
       error: 'red',
-      unknown: 'lightgrey'
+      unknown: 'lightgrey',
     };
 
     request(apiUrl, { json: true }, function(err, res, data) {
@@ -6050,7 +6050,7 @@ cache(function(data, match, sendBadge, request) {
   var user = match[1]; // eg, shields_io
   var format = match[2];
   var options = {
-    url: 'http://cdn.syndication.twimg.com/widgets/followbutton/info.json?screen_names=' + user
+    url: 'http://cdn.syndication.twimg.com/widgets/followbutton/info.json?screen_names=' + user,
   };
   var badgeData = getBadgeData('Follow @' + user, data);
 
@@ -6061,7 +6061,7 @@ cache(function(data, match, sendBadge, request) {
   }
   badgeData.links = [
     'https://twitter.com/intent/follow?screen_name=' + user,
-    'https://twitter.com/' + user + '/followers'
+    'https://twitter.com/' + user + '/followers',
   ];
   badgeData.text[1] = '';
   request(options, function(err, res, buffer) {
@@ -6142,9 +6142,9 @@ cache(function(data, match, sendBadge, request) {
     method: 'POST',
     json: true,
     body: {
-      "repos": [{ "name": path, "tag": tag }]
+      "repos": [{ "name": path, "tag": tag }],
     },
-    uri: 'https://imagelayers.io/registry/analyze'
+    uri: 'https://imagelayers.io/registry/analyze',
   };
   request(options, function(err, res, buffer) {
     if (err != null) {
@@ -6192,8 +6192,8 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     uri: url,
     headers: {
-      'Accept': 'application/json'
-    }
+      'Accept': 'application/json',
+    },
   };
   request(options, function(err, res, buffer) {
     if (res && res.statusCode === 404) {
@@ -6301,7 +6301,7 @@ cache(function(data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     uri: 'https://api.stackexchange.com/2.2/' + path + '?site=' + site,
-    gzip: true
+    gzip: true,
   };
   var badgeData = getBadgeData(site, data);
   request(options, function (err, res, buffer) {
@@ -6730,7 +6730,7 @@ cache(function(data, match, sendBadge, request) {
   // Maps type name from URL to JSON property name prefix for badge data
   var typeToPropPrefix = {
     i: 'issue',
-    p: 'pr'
+    p: 'pr',
   };
   var typePropPrefix = typeToPropPrefix[type];
   if (typePropPrefix === undefined) {
@@ -6749,7 +6749,7 @@ cache(function(data, match, sendBadge, request) {
     url: url,
     qs: qs,
     gzip: true,
-    json: true
+    json: true,
   };
   request(options, function(err, res, json) {
     if (err != null || res.statusCode >= 500) {
@@ -6914,7 +6914,7 @@ cache(function(data, match, sendBadge, request) {
     method: 'GET',
     url: url,
     gzip: true,
-    json: true
+    json: true,
   };
   request(options, function(err, res, json) {
     try {
@@ -6960,9 +6960,9 @@ cache(function(data, match, sendBadge, request) {
     json: true,
     body: {
       "api_key": monitorApiKey,
-      "format": "json"
+      "format": "json",
     },
-    uri: 'https://api.uptimerobot.com/v2/getMonitors'
+    uri: 'https://api.uptimerobot.com/v2/getMonitors',
   };
   // A monitor API key must start with "m"
   if (monitorApiKey.substring(0, "m".length) !== "m") {
@@ -7033,9 +7033,9 @@ cache(function(data, match, sendBadge, request) {
     body: {
       "api_key": monitorApiKey,
       "custom_uptime_ratios": numberOfDays,
-      "format": "json"
+      "format": "json",
     },
-    uri: 'https://api.uptimerobot.com/v2/getMonitors'
+    uri: 'https://api.uptimerobot.com/v2/getMonitors',
   };
   // A monitor API key must start with "m"
   if (monitorApiKey.substring(0, "m".length) !== "m") {
@@ -7189,23 +7189,23 @@ cache({
       case 'json':
         requestOptions = {
           headers: {
-            Accept: 'application/json'
+            Accept: 'application/json',
           },
-          json: true
+          json: true,
         };
         break;
       case 'xml':
         requestOptions = {
           headers: {
-            Accept: 'application/xml, text/xml'
-          }
+            Accept: 'application/xml, text/xml',
+          },
         };
         break;
       case 'yaml':
         requestOptions = {
           headers: {
-            Accept: 'text/x-yaml,  text/yaml, application/x-yaml, application/yaml, text/plain'
-          }
+            Accept: 'text/x-yaml,  text/yaml, application/x-yaml, application/yaml, text/plain',
+          },
         };
         break;
     }
@@ -7255,7 +7255,7 @@ cache({
         sendBadge(format, badgeData);
       }
     });
-  }
+  },
 }));
 
 // nsp for npm packages
@@ -7276,10 +7276,10 @@ camp.route(/^\/nsp\/npm\/(?:@([^/]+)?\/)?([^/]+)?(?:\/([^/]+)?)?\.(svg|png|gif|j
       body: {
         package: {
           name: null,
-          version: packageVersion
-        }
+          version: packageVersion,
+        },
       },
-      json: true
+      json: true,
     };
 
     if (typeof scopeWithoutAtSign === 'string') {
@@ -7309,9 +7309,9 @@ camp.route(/^\/nsp\/npm\/(?:@([^/]+)?\/)?([^/]+)?(?:\/([^/]+)?)?\.(svg|png|gif|j
     // https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#getpackageversion
     const npmRequestOptions = {
       headers: {
-        Accept: '*/*'
+        Accept: '*/*',
       },
-      json: true
+      json: true,
     };
     let npmURL = null;
 
@@ -7644,7 +7644,7 @@ cache(function (data, match, sendBadge, request) {
   var options = {
     method: 'GET',
     json: true,
-    uri: 'https://bugzilla.mozilla.org/rest/bug/' + bugNumber
+    uri: 'https://bugzilla.mozilla.org/rest/bug/' + bugNumber,
   };
   var badgeData = getBadgeData('bug ' + bugNumber, data);
   request(options, function (err, res, json) {
@@ -7711,7 +7711,7 @@ cache(function(data, match, sendBadge, request) {
   const options = {
     method: 'GET',
     headers: { 'Accept': 'application/json' },
-    uri: `https://api.dependabot.com/badges/compatibility_score?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`
+    uri: `https://api.dependabot.com/badges/compatibility_score?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`,
   };
   const badgeData = getBadgeData('semver stability', data);
   badgeData.links = [`https://dependabot.com/compatibility-score.html?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`];


### PR DESCRIPTION
https://eslint.org/docs/rules/comma-dangle#always-multiline

Also worth noting that all lib/service files are currently following this rule.

:-1: Examples of incorrect code for this rule with the "always-multiline" option:
```javascript
var foo = {
    bar: "baz",
    qux: "quux"
};

var foo = { bar: "baz", qux: "quux", };

var arr = [1,2,];

var arr = [1,
    2,];

var arr = [
    1,
    2
];

foo({
  bar: "baz",
  qux: "quux"
});
```
:+1: Examples of correct code for this rule with the "always-multiline" option:
```javascript
var foo = {
    bar: "baz",
    qux: "quux",
};

var foo = {bar: "baz", qux: "quux"};
var arr = [1,2];

var arr = [1,
    2];

var arr = [
    1,
    2,
];

foo({
  bar: "baz",
  qux: "quux",
});
```