### PR TITLE
don't try to run greenkeeper-lockfile-upload in CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,14 +23,6 @@ jobs:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
 
-      - run:
-          name: Update Greenkeeper lockfile
-          environment:
-            # https://github.com/greenkeeperio/greenkeeper-lockfile/issues/58
-            CI_PULL_REQUEST: ''
-          command: |
-            greenkeeper-lockfile-update
-
   main:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
@@ -55,13 +47,6 @@ jobs:
           name: Danger
           when: always
           command: npm run danger ci
-
-      - run:
-          name: Upload Greenkeeper lockfile
-          environment:
-            # https://github.com/greenkeeperio/greenkeeper-lockfile/issues/58
-            CI_PULL_REQUEST: ''
-          command: greenkeeper-lockfile-upload
 
   main@node-latest:
     docker:


### PR DESCRIPTION
refs #1415
maybe wait till we actually go ahead with swapping out greenkeeper for dependabot