### PR TITLE
Support for custom names on maven-metadata badges

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -275,4 +275,4 @@ These files can also be of help for creating your own badge.
 [docker-example]: https://github.com/badges/shields/blob/b126b4ebdc64015a3d6e845d9c051f69ad81c4ea/server.js#L6275
 [travis-example]: https://github.com/badges/shields/blob/b126b4ebdc64015a3d6e845d9c051f69ad81c4ea/server.js#L403
 [regex]: https://www.w3schools.com/jsref/jsref_obj_regexp.asp
-[tests-tutorial]: ../service-tests/#readme
+[tests-tutorial]: service-tests.md

--- a/server.js
+++ b/server.js
@@ -7124,12 +7124,12 @@ cache((data, match, sendBadge, request) => {
 }));
 
 // Maven metadata versioning integration.
-camp.route(/^\/maven-metadata\/v\/(https?)\/(.+\.xml)\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/(?:(\w*)-)?maven-metadata\/v\/(https?)\/(.+\.xml)\.(svg|png|gif|jpg|json)$/,
   cache(function (data, match, sendBadge, request) {
-    const [, scheme, hostAndPath, format] = match;
+    const [, name, scheme, hostAndPath, format] = match;
     const metadataUri = `${scheme}://${hostAndPath}`;
     request(metadataUri, (error, response, body) => {
-      const badge = getBadgeData('maven', data);
+      const badge = getBadgeData(!name ? 'maven' : name, data);
       if (!error && response.statusCode >= 200 && response.statusCode < 300) {
         try {
           xml2js.parseString(body, (err, result) => {

--- a/services/maven-metadata/gradle-maven-metadata.tester.js
+++ b/services/maven-metadata/gradle-maven-metadata.tester.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const Joi = require('joi');
+const ServiceTester = require('../service-tester');
+const { isVPlusDottedVersionAtLeastOne } = require('../test-validators');
+
+const t = new ServiceTester({ id: 'gradle-maven-metadata', title: 'maven-metadata badge' });
+module.exports = t;
+
+t.create('valid maven-metadata.xml uri with custom name')
+  .get('/v/http/central.maven.org/maven2/com/google/code/gson/gson/maven-metadata.xml.json')
+  .expectJSONTypes(Joi.object().keys({
+    name: 'gradle',
+    value: isVPlusDottedVersionAtLeastOne
+  }));


### PR DESCRIPTION
- This adds support for the gradle plugin repository by leveraging
maven-metadata.xml in plugins.gradle.org/m2
- users can use custom names by specifying them before the
"maven-metadata" type. For example "gradle-maven-metadata" will be
handled by the "maven-metadata" handle and return a result with
"name = gradle"
- Also fixes link to testing page in tutorial

Fixes #1839, but I'm not a node developer, and I'm not sure what exactly the cost of this regular expression will be on the server. Would it better to limit this naming to just `gradle` instead of matching anything?