### PR TITLE
RFC add a menu to category pages

### DIFF
--- a/frontend/components/examples-page.js
+++ b/frontend/components/examples-page.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Menu from './menu';
 import Meta from './meta';
 import Header from './header';
 import SuggestionAndSearch from './suggestion-and-search';
@@ -22,6 +23,10 @@ export default class ExamplesPage extends React.Component {
     this.searchTimeout = 0;
     this.renderSearchResults = this.renderSearchResults.bind(this);
     this.searchQueryChanged = this.searchQueryChanged.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({category: nextProps.match.params.id});
   }
 
   static propTypes = {
@@ -86,6 +91,7 @@ export default class ExamplesPage extends React.Component {
             href="https://opencollective.com/shields">
             donate
           </a>
+          { this.state.category && <Menu /> }
         </section>
         { this.renderSearchResults() }
         <Usage

--- a/frontend/components/menu.js
+++ b/frontend/components/menu.js
@@ -1,0 +1,31 @@
+import { NavLink } from "react-router-dom";
+import React from 'react';
+import { getCategoryHeadings } from '../lib/prepare-examples';
+
+export default class Menu extends React.Component {
+
+  renderMenu() {
+    return getCategoryHeadings().map(function(category) {
+      return (
+        <li key={category.id}>
+          <NavLink
+            to={'/examples/' + category.id}
+            activeClassName='active'>
+            { category.name }
+          </NavLink>
+        </li>
+      )
+    });
+  }
+
+  render() {
+    return (
+      <nav id="nav">
+        <ul>
+          { this.renderMenu() }
+        </ul>
+      </nav>
+    );
+  }
+
+}

--- a/frontend/components/search-results.js
+++ b/frontend/components/search-results.js
@@ -3,7 +3,11 @@ import { Link } from "react-router-dom";
 import PropTypes from 'prop-types';
 import { BadgeExamples } from './badge-examples';
 import badgeExampleData from '../../badge-examples.json';
-import { prepareExamples, predicateFromQuery } from '../lib/prepare-examples';
+import {
+  getCategoryHeadings,
+  prepareExamples,
+  predicateFromQuery
+} from '../lib/prepare-examples';
 import { baseUri, longCache } from '../constants';
 
 
@@ -31,10 +35,10 @@ export default class SearchResults extends React.Component {
   }
 
   renderCategoryHeadings() {
-    return this.preparedExamples.map(function(category, i) {
+    return getCategoryHeadings().map(function(category) {
       return (
-        <Link to={'/examples/' + category.category.id} key={category.category.id}>
-          <h3 id={category.category.id}>{ category.category.name }</h3>
+        <Link to={'/examples/' + category.id} key={category.id}>
+          <h3 id={category.id}>{ category.name }</h3>
         </Link>
       )
     });

--- a/frontend/lib/prepare-examples.js
+++ b/frontend/lib/prepare-examples.js
@@ -1,4 +1,6 @@
 import escapeStringRegexp from 'escape-string-regexp';
+import badgeExampleData from '../../badge-examples.json';
+
 
 export function exampleMatchesRegex(example, regex) {
   const { title, keywords } = example;
@@ -33,4 +35,10 @@ export function prepareExamples(categories, predicateProvider) {
     // Assign each example a unique ID.
     key: nextKey++,
   }, example)));
+}
+
+export function getCategoryHeadings() {
+  return badgeExampleData.map(function(category) {
+    return category.category;
+  });
 }

--- a/static/main.css
+++ b/static/main.css
@@ -115,3 +115,29 @@ hr.spacing {
   min-height: 20px;
   vertical-align: middle;
 }
+
+nav ul {
+    padding-top: 30px;
+    min-width: 50%;
+    margin: auto;
+    list-style-type: none;
+    overflow: hidden;
+}
+
+nav li {
+    float: left;
+}
+
+nav li a {
+    display: block;
+    padding: 16px;
+}
+
+li a.active {
+    font-weight: 900;
+}
+
+nav ul {display: block;}
+@media screen and (max-width: 768px) {
+    nav ul {display: none;}
+}


### PR DESCRIPTION
Based on @tooomm 's https://github.com/badges/shields/pull/1808#issuecomment-409732290 on the new front-end design, I have put together a rough implementation based on that screenshot. This isn't intended as ready-to-merge, but it gives me a way to deploy something to staging so we can test something and move the conversation on.

A horizontal menu is probably not great for mobile users, so I've hidden it at low-res for now. In general I'd like to move towards a more mobile-friendly front-end although I'm aware that right now we are rendering most of our content in tables.

Something like this is probably OK as long as we have a relatively small number of categories (we've just increased to 11), but as discussed in https://github.com/badges/shields/pull/1762#issuecomment-403583651 I can see a case for moving to a situation where we might have a much larger number of menu items. I wonder if anyone has any ideas about how we could present this, particularly if we had many more 'categories' or 'headings' (more than you'd want on a single row).

Feedback generally welcome. Also probably worth keeping en eye on the issues as more users see the new layout.