### PR TITLE
Increased default BADGE_MAX_AGE_SECONDS

### DIFF
--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -215,7 +215,7 @@ export default class Usage extends React.PureComponent {
               <td>
                 <code>?maxAge=3600</code>
               </td>
-              <td>Set the HTTP cache lifetime in secs (values below the default will be ignored)</td>
+              <td>Set the HTTP cache lifetime in secs (values below the default (currently 120 seconds) will be ignored)</td>
             </tr>
           </tbody>
         </table>

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -81,10 +81,9 @@ function handleRequest (makeBadge, handlerOptions) {
   return (queryParams, match, end, ask) => {
     const reqTime = new Date();
 
-    let maxAge = parseInt(process.env.BADGE_MAX_AGE_SECONDS) || 120;
+    let maxAge = isInt(process.env.BADGE_MAX_AGE_SECONDS) ? parseInt(process.env.BADGE_MAX_AGE_SECONDS) : 120;
     if (
-      queryParams.maxAge !== undefined
-      && /^[0-9]+$/.test(queryParams.maxAge)
+        isInt(queryParams.maxAge)
       && parseInt(queryParams.maxAge) > maxAge
     ) {
       // only queryParams.maxAge to override the default
@@ -234,6 +233,10 @@ function handleRequest (makeBadge, handlerOptions) {
 
 function clearRequestCache() {
   requestCache.clear();
+}
+
+function isInt(number) {
+  return number !== undefined && /^[0-9]+$/.test(number);
 }
 
 module.exports = {

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -81,7 +81,7 @@ function handleRequest (makeBadge, handlerOptions) {
   return (queryParams, match, end, ask) => {
     const reqTime = new Date();
 
-    let maxAge = parseInt(process.env.BADGE_MAX_AGE_SECONDS) || 0;
+    let maxAge = parseInt(process.env.BADGE_MAX_AGE_SECONDS) || 120;
     if (
       queryParams.maxAge !== undefined
       && /^[0-9]+$/.test(queryParams.maxAge)

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -139,11 +139,12 @@ describe('The request handler', function() {
         expect(res.headers.get('cache-control')).to.equal('no-cache, no-store, must-revalidate');
       });
 
-      it('should set Cache-Control: no-cache, no-store, must-revalidate if BADGE_MAX_AGE_SECONDS not set', async function () {
+      it('should set the expires header to current time + 120 if BADGE_MAX_AGE_SECONDS not set', async function () {
         delete process.env.BADGE_MAX_AGE_SECONDS;
         const res = await fetch(`${baseUri}/testing/123.json`);
-        expect(res.headers.get('expires')).to.equal(res.headers.get('date'));
-        expect(res.headers.get('cache-control')).to.equal('no-cache, no-store, must-revalidate');
+        const expectedExpiry = new Date(+(new Date(res.headers.get('date'))) + 120000).toGMTString();
+        expect(res.headers.get('expires')).to.equal(expectedExpiry);
+        expect(res.headers.get('cache-control')).to.equal('max-age=120');
       });
 
       describe('the cache key', function () {


### PR DESCRIPTION
This is related to discussions in #1806. Until that pull request is merged and we have an easy way of configuring the environment variables on the server, we should have a non-0 value in the meantime.

@paulmelnikow suggested 60 seconds whereas @Nyholm was advocating larger values (300, 600), so I've opted for something intermediary, 120 seconds. We can easily change it if need-be and revert it once the other PR is merged.