### PR TITLE
Add InvalidParameter runtime error and return inaccessible for 5xx errors

### DIFF
--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -1,6 +1,10 @@
 'use strict'
 
-const { NotFound, InvalidResponse } = require('../services/errors')
+const {
+  NotFound,
+  InvalidResponse,
+  Inaccessible,
+} = require('../services/errors')
 
 const checkErrorResponse = function(
   badgeData,
@@ -29,6 +33,8 @@ checkErrorResponse.asPromise = function({ notFoundMessage } = {}) {
   return async function({ buffer, res }) {
     if (res.statusCode === 404) {
       throw new NotFound({ prettyMessage: notFoundMessage })
+    } else if (res.statusCode >= 500) {
+      throw new Inaccessible()
     } else if (res.statusCode !== 200) {
       const underlying = Error(
         `Got status code ${res.statusCode} (expected 200)`

--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -31,15 +31,15 @@ const checkErrorResponse = function(
 
 checkErrorResponse.asPromise = function({ notFoundMessage } = {}) {
   return async function({ buffer, res }) {
+    const underlyingError = Error(
+      `Got status code ${res.statusCode} (expected 200)`
+    )
     if (res.statusCode === 404) {
       throw new NotFound({ prettyMessage: notFoundMessage })
     } else if (res.statusCode >= 500) {
-      throw new Inaccessible()
+      throw new Inaccessible({ underlyingError })
     } else if (res.statusCode !== 200) {
-      const underlying = Error(
-        `Got status code ${res.statusCode} (expected 200)`
-      )
-      throw new InvalidResponse({ underlyingError: underlying })
+      throw new InvalidResponse({ underlyingError })
     }
     return { buffer, res }
   }

--- a/lib/error-helper.spec.js
+++ b/lib/error-helper.spec.js
@@ -3,7 +3,11 @@
 const chai = require('chai')
 const { assert, expect } = chai
 const { checkErrorResponse } = require('./error-helper')
-const { NotFound, InvalidResponse } = require('../services/errors')
+const {
+  NotFound,
+  InvalidResponse,
+  Inaccessible,
+} = require('../services/errors')
 
 chai.use(require('chai-as-promised'))
 
@@ -86,8 +90,8 @@ describe('async error handler', function() {
     })
   })
 
-  context('when status is 500', function() {
-    const res = { statusCode: 500 }
+  context('when status is 499', function() {
+    const res = { statusCode: 499 }
 
     it('throws InvalidResponse', async function() {
       try {
@@ -96,9 +100,26 @@ describe('async error handler', function() {
       } catch (e) {
         expect(e).to.be.an.instanceof(InvalidResponse)
         expect(e.message).to.equal(
-          'Invalid Response: Got status code 500 (expected 200)'
+          'Invalid Response: Got status code 499 (expected 200)'
         )
         expect(e.prettyMessage).to.equal('invalid')
+      }
+    })
+  })
+
+  context('when status is 5xx', function() {
+    const res = { statusCode: 503 }
+
+    it('throws Inaccessible', async function() {
+      try {
+        await checkErrorResponse.asPromise()({ res })
+        expect.fail('Expected to throw')
+      } catch (e) {
+        expect(e).to.be.an.instanceof(Inaccessible)
+        expect(e.message).to.equal(
+          'Inaccessible: Got status code 503 (expected 200)'
+        )
+        expect(e.prettyMessage).to.equal('inaccessible')
       }
     })
   })

--- a/lib/error-helper.spec.js
+++ b/lib/error-helper.spec.js
@@ -90,7 +90,7 @@ describe('async error handler', function() {
     })
   })
 
-  context('when status is 499', function() {
+  context('when status is 4xx', function() {
     const res = { statusCode: 499 }
 
     it('throws InvalidResponse', async function() {

--- a/services/base.js
+++ b/services/base.js
@@ -4,7 +4,12 @@ const Joi = require('joi')
 // See available emoji at http://emoji.muan.co/
 const emojic = require('emojic')
 const chalk = require('chalk')
-const { NotFound, InvalidResponse, Inaccessible } = require('./errors')
+const {
+  NotFound,
+  InvalidResponse,
+  Inaccessible,
+  InvalidParameter,
+} = require('./errors')
 const queryString = require('query-string')
 const {
   makeLogo,
@@ -164,7 +169,7 @@ class BaseService {
     try {
       return await this.handle(namedParams, queryParams)
     } catch (error) {
-      if (error instanceof NotFound) {
+      if (error instanceof NotFound || error instanceof InvalidParameter) {
         logTrace('outbound', emojic.noGoodWoman, 'Handled error', error)
         return {
           message: error.prettyMessage,

--- a/services/errors.js
+++ b/services/errors.js
@@ -69,8 +69,23 @@ class Inaccessible extends ShieldsRuntimeError {
   }
 }
 
+class InvalidParameter extends ShieldsRuntimeError {
+  get name() {
+    return 'InvalidParameter'
+  }
+  get defaultPrettyMessage() {
+    return 'invalid parameter'
+  }
+
+  constructor(props) {
+    const message = 'Invalid Parameter'
+    super(props, message)
+  }
+}
+
 module.exports = {
   NotFound,
   InvalidResponse,
   Inaccessible,
+  InvalidParameter,
 }


### PR DESCRIPTION
This came up while I was rewriting uptimerobot, which for usability reasons has some internal validation of one of its parameters.

https://github.com/badges/shields/blob/09be682963da4c3643e7c80a44d9f2ad39a46fd8/server.js#L6773-L6777

Also it seems that the shields error message for a 5xx error is **inaccessible**, not **invalid**.