### PR TITLE
npm downloads: Better experience for new projects

### DIFF
--- a/services/npm/npm-downloads.service.js
+++ b/services/npm/npm-downloads.service.js
@@ -79,7 +79,7 @@ function DownloadsForInterval(interval) {
       let { downloads } = await this._requestJson({
         schema,
         url: `https://api.npmjs.org/downloads/${query}/${packageName}`,
-        notFoundMessage: 'project not found',
+        notFoundMessage: 'package not found or too new',
       })
       if (isRange) {
         downloads = downloads

--- a/services/npm/npm.tester.js
+++ b/services/npm/npm.tester.js
@@ -66,7 +66,7 @@ t.create('total downloads of unknown package')
   .get('/dt/npm-api-does-not-have-this-package.json?style=_shields_test')
   .expectJSON({
     name: 'downloads',
-    value: 'project not found',
+    value: 'package not found or too new',
     colorB: colorsB.red,
   })
 


### PR DESCRIPTION
When a new project is created, the download badge shows “project not found” as reported in #1882. This gives a more informative message in that case.