### PR TITLE
[GitHub] support issues tags with "/" character

### DIFF
--- a/server.js
+++ b/server.js
@@ -3295,7 +3295,7 @@ cache(function(data, match, sendBadge, request) {
 }));
 
 // GitHub issues integration.
-camp.route(/^\/github\/issues(-pr)?(-closed)?(-raw)?\/([^/]+)\/([^/]+)\/?([^/]+)?\.(svg|png|gif|jpg|json)$/,
+camp.route(/^\/github\/issues(-pr)?(-closed)?(-raw)?\/([^/]+)\/([^/]+)\/?(.+)?\.(svg|png|gif|jpg|json)$/,
 cache(function(data, match, sendBadge, request) {
   var isPR = !!match[1];
   var isClosed = !!match[2];


### PR DESCRIPTION
Closes #1870 

Regex was looking for all characters upto `/` but that should not be needed for the last parameter.