### PR TITLE
Example command for starting server with SENTRY_DSN after sudo

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -192,7 +192,7 @@ In order to enable integration with [Sentry](https://sentry.io), you need your o
 Start the server using the Sentry DSN. You can set it:
 - by `SENTRY_DSN` environment variable
 ```
-SENTRY_DSN=https://xxx:yyy@sentry.io/zzz sudo node server
+sudo SENTRY_DSN=https://xxx:yyy@sentry.io/zzz node server
 ```
 
 - or by `sentry_dsn` secret property defined in `private/secret.json`


### PR DESCRIPTION
Env variable set before sudo is not visible for node command (alternatively we can use `SENTRY_DSN=https://xxx:yyy@sentry.io/zzz sudo -E node server`). 

Before:
```bash
SENTRY_DSN=https://abc@sentry.io/123 sudo node server

raven@2.4.2 alert: no DSN provided, error reporting disabled
0817203057 Server is starting up: http://[::]:80/
```
After:
```bash
sudo SENTRY_DSN=https://abc@sentry.io/123 node server

0817203112 Server is starting up: http://[::]:80/
```