### PR TITLE
add examples for documentation contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,10 @@ maybe you'd like to open a pull request to address one of them:
 
 You can help by improving the project's usage and developer instructions.
 
+- When you read the documentation, you can fix mistakes and add your own thoughts.
+- When your pull request follows the documentation but the practice changed,
+  consider pointing this out and change the documentation for the next person.
+
 ### Helping others
 
 You can help with code review, which reduces bugs, and over time has a


### PR DESCRIPTION
The section for documentation contribution is quite short.
This adds examples of when to make a contribution.