### PR TITLE
Removed no longer available [PyPI] examples and cleaned up code

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -615,21 +615,6 @@ const allBadgeExamples = [
         previewUri: '/powershellgallery/dt/ACMESharp.svg',
       },
       {
-        title: 'PyPI',
-        previewUri: '/pypi/dm/Django.svg',
-        keywords: ['python'],
-      },
-      {
-        title: 'PyPI',
-        previewUri: '/pypi/dw/Django.svg',
-        keywords: ['python'],
-      },
-      {
-        title: 'PyPI',
-        previewUri: '/pypi/dd/Django.svg',
-        keywords: ['python'],
-      },
-      {
         title: 'Conda',
         previewUri: '/conda/dn/conda-forge/python.svg',
         keywords: ['conda'],

--- a/server.js
+++ b/server.js
@@ -1607,24 +1607,7 @@ cache(function(data, match, sendBadge, request) {
       var parsedData = JSON.parse(buffer);
       if (info === 'dm' || info === 'dw' || info ==='dd') {
         // See #716 for the details of the loss of service.
-        badgeData.text[0] = getLabel('downloads', data);
-        badgeData.text[1] = 'no longer available';
-        //var downloads;
-        //switch (info.charAt(1)) {
-        //  case 'm':
-        //    downloads = data.info.downloads.last_month;
-        //    badgeData.text[1] = metric(downloads) + '/month';
-        //    break;
-        //  case 'w':
-        //    downloads = parsedData.info.downloads.last_week;
-        //    badgeData.text[1] = metric(downloads) + '/week';
-        //    break;
-        //  case 'd':
-        //    downloads = parsedData.info.downloads.last_day;
-        //    badgeData.text[1] = metric(downloads) + '/day';
-        //    break;
-        //}
-        //badgeData.colorscheme = downloadCountColor(downloads);
+        const badgeData = getDeprecatedBadge('downloads', data);
         sendBadge(format, badgeData);
       } else if (info === 'v') {
         var version = parsedData.info.version;


### PR DESCRIPTION
See #716 for more details.

The downloads badges are no longer available, so I removed the examples from the homepage. Also switched to our `getDeprecatedBadge` helper and removed the commented code.