### PR TITLE
fix [circleci] badge for projects that use workflows

### DIFF
--- a/services/circleci/circleci.helpers.js
+++ b/services/circleci/circleci.helpers.js
@@ -1,0 +1,121 @@
+'use strict'
+
+const Joi = require('joi')
+
+const getWorkflowId = function(build) {
+  return build.workflows.workflow_id
+}
+
+// find all the builds with the same workflow id
+const getBuildsForWorkflow = function(builds, workflowId) {
+  return builds.filter(build => getWorkflowId(build) === workflowId)
+}
+
+// find all the builds with the same workflow id which are also complete
+const getCompleteBuildsForWorkflow = function(builds, workflowId) {
+  return builds.filter(
+    build => getWorkflowId(build) === workflowId && build.outcome !== null
+  )
+}
+
+// Find the most recent workflow which contains only complete builds
+// and return all the builds with that workflow id
+const getBuildsForLatestCompleteWorkflow = function(builds) {
+  let allBuilds, completeBuilds
+  for (let i = 0; i < builds.length; i++) {
+    allBuilds = getBuildsForWorkflow(builds, getWorkflowId(builds[i]))
+    completeBuilds = getCompleteBuildsForWorkflow(
+      builds,
+      getWorkflowId(builds[i])
+    )
+    if (allBuilds.length === completeBuilds.length) {
+      return completeBuilds
+    }
+  }
+  throw new Error('No complete workflows found')
+}
+
+const countOutcomes = function(builds) {
+  let total = 0
+  const counts = {
+    canceled: 0,
+    infrastructure_fail: 0,
+    timedout: 0,
+    failed: 0,
+    no_tests: 0,
+    success: 0,
+  }
+  for (let i = 0; i < builds.length; i++) {
+    if (!(builds[i].outcome in counts)) {
+      throw new Error('Found unexpected outcome')
+    }
+    counts[builds[i].outcome]++
+    total++
+  }
+  return { total, counts }
+}
+
+// reduce the outcomes for an array of builds to a single status
+const summarizeBuilds = function(builds) {
+  const { total, counts } = countOutcomes(builds)
+
+  if (total === counts.success) {
+    return 'passing'
+  } else if (counts.no_tests >= 1) {
+    return 'no tests'
+  } else if (counts.infrastructure_fail >= 1) {
+    return 'infrastructure fail'
+  } else if (counts.canceled >= 1) {
+    return 'canceled'
+  } else if (counts.timedout >= 1) {
+    return 'timed out'
+  } else if (counts.failed >= 1) {
+    return 'failed'
+  }
+  throw new Error('Failed to summarize build status')
+}
+
+const summarizeBuildsForLatestCompleteWorkflow = function(builds) {
+  return summarizeBuilds(getBuildsForLatestCompleteWorkflow(builds))
+}
+
+// return the status of the latest complete build
+// we need this if a project doesn't use workflows
+const getLatestCompleteBuildOutcome = function(builds) {
+  for (let i = 0; i < builds.length; i++) {
+    if (builds[i].outcome != null) {
+      return summarizeBuilds([builds[i]])
+    }
+  }
+  throw new Error('No complete builds found')
+}
+
+const populatedArraySchema = Joi.array()
+  .items(
+    Joi.object({
+      // if we have >0 items in our array, every object must have an 'outcome' key
+      outcome: Joi.string()
+        .allow(null)
+        .required(),
+
+      // 'workflows' key is optional - not all projects have workflows
+      workflows: Joi.object({
+        // if there is a 'workflows' key, it must have a string workflow_id
+        workflow_id: Joi.string().required(),
+      }),
+    }).required()
+  )
+  .min(1)
+  .max(100)
+  .required()
+const emptyArraySchema = Joi.array()
+  .min(0)
+  .max(0)
+  .required() // [] is also a valid response from Circle CI
+const circleSchema = Joi.alternatives(populatedArraySchema, emptyArraySchema)
+
+module.exports = {
+  circleSchema,
+  getLatestCompleteBuildOutcome,
+  summarizeBuildsForLatestCompleteWorkflow,
+}

--- a/services/circleci/circleci.helpers.spec.js
+++ b/services/circleci/circleci.helpers.spec.js
@@ -1,0 +1,177 @@
+'use strict'
+
+const Joi = require('joi')
+const { test, given } = require('sazerac')
+const { expect } = require('chai')
+const {
+  circleSchema,
+  getLatestCompleteBuildOutcome,
+  summarizeBuildsForLatestCompleteWorkflow,
+} = require('./circleci.helpers.js')
+
+describe('circleci: getLatestCompleteBuildOutcome() function', function() {
+  test(getLatestCompleteBuildOutcome, () => {
+    given([{ outcome: 'success' }]).expect('passing')
+    given([{ outcome: 'no_tests' }]).expect('no tests')
+    given([{ outcome: 'failed' }]).expect('failed')
+
+    given([{ outcome: 'success' }, { outcome: 'failed' }]).expect('passing')
+    given([{ outcome: null }, { outcome: 'failed' }]).expect('failed')
+
+    expect(() =>
+      getLatestCompleteBuildOutcome([{ outcome: 'cheese' }])
+    ).to.throw(Error, 'Found unexpected outcome')
+    expect(() => getLatestCompleteBuildOutcome([{ outcome: null }])).to.throw(
+      Error,
+      'No complete builds found'
+    )
+    expect(() => getLatestCompleteBuildOutcome([{}])).to.throw(
+      Error,
+      'No complete builds found'
+    )
+    expect(() => getLatestCompleteBuildOutcome([])).to.throw(
+      Error,
+      'No complete builds found'
+    )
+  })
+})
+
+describe('circleci: summarizeBuildsForLatestCompleteWorkflow() function', function() {
+  test(summarizeBuildsForLatestCompleteWorkflow, () => {
+    given([
+      // these 2 successful builds are part of the same workflow
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      // this failed build is part of a different workflow
+      {
+        outcome: 'failed',
+        workflows: { workflow_id: 'bbbbbbbb-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+    ]).expect('passing')
+
+    given([
+      // this workflow contains 3 builds: 2 passing builds and one which failed
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      {
+        outcome: 'failed',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      // we should summarize the status of this build as 'failed'
+    ]).expect('failed')
+
+    given([
+      // not all of the builds in the most recent wokflow are complete
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      {
+        outcome: null,
+        workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      // so we should report the status of this older workflow instead
+      // because all of its builds have finished
+      {
+        outcome: 'failed',
+        workflows: { workflow_id: 'bbbbbbbb-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+      {
+        outcome: 'success',
+        workflows: { workflow_id: 'bbbbbbbb-1111-aaaa-1111-aaaaaaaaaaaa' },
+      },
+    ]).expect('failed')
+
+    expect(() =>
+      summarizeBuildsForLatestCompleteWorkflow([
+        // we have no completed workflows
+        {
+          outcome: null,
+          workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+        },
+        {
+          outcome: null,
+          workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+        },
+      ])
+    ).to.throw(Error, 'No complete workflows found')
+
+    expect(() =>
+      summarizeBuildsForLatestCompleteWorkflow([
+        {
+          outcome: 'failed',
+          workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+        },
+        // this status value is not expected
+        {
+          outcome: 'cheese',
+          workflows: { workflow_id: 'aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa' },
+        },
+      ])
+    ).to.throw(Error, 'Found unexpected outcome')
+
+    expect(() =>
+      summarizeBuildsForLatestCompleteWorkflow([
+        // this response doesn't have workflows
+        { outcome: 'failed' },
+        { outcome: 'success' },
+      ])
+    ).to.throw(Error, "Cannot read property 'workflow_id' of undefined")
+  })
+})
+
+describe('circleci: schema validation', function() {
+  const validate = function(data, schema) {
+    const { error, value } = Joi.validate(data, schema, {
+      allowUnknown: true,
+      stripUnknown: true,
+    })
+    return { error, value }
+  }
+
+  expect(validate([], circleSchema)).to.deep.equal({ error: null, value: [] })
+
+  expect(
+    validate([{ outcome: 'success' }, { outcome: null }], circleSchema)
+  ).to.deep.equal({
+    error: null,
+    value: [{ outcome: 'success' }, { outcome: null }],
+  })
+
+  expect(
+    validate(
+      [
+        { outcome: 'success', workflows: { workflow_id: 'aa111' } },
+        { outcome: null, workflows: { workflow_id: 'bb222' } },
+      ],
+      circleSchema
+    )
+  ).to.deep.equal({
+    error: null,
+    value: [
+      { outcome: 'success', workflows: { workflow_id: 'aa111' } },
+      { outcome: null, workflows: { workflow_id: 'bb222' } },
+    ],
+  })
+
+  // object does not have an 'outcome' key
+  expect(validate([{ foo: 'bar' }], circleSchema).error).to.not.equal(null)
+
+  // 'workflows' key doesn't have a workflow_id
+  expect(
+    validate([{ outcome: 'failed', workflows: { foo: 'bar' } }], circleSchema)
+      .error
+  ).to.not.equal(null)
+})


### PR DESCRIPTION
Well this escalated in complexity quite sharply...

In an attempt to solve #1792 I've had a go at grouping related builds based on `workflow_id`. There are a number of changes in this PR which are useful to discuss 'inline', so I will mark up the diff with specific line comments, but just to give a high-level summary this is how the new approach works:

* Attempt to work out if this project uses workflows
* If it doesn't use workflows, just grab the outcome of the latest build and return that
* If it does use workflows,
  * Find the most recent workflow where all the builds with that workflow_id have finished
  * Grab all the builds with that workflow_id
  * Summarise all the build outcomes into a single outcome for the workflow

In general, this seems to work pretty well. Unfortunately there are 3 edge cases (that I can think of) which could be problematic:

* If a workflow with multiple builds is currently in progress and some builds have finished and some have not yet been started/queued, we might summarise an incomplete build. I'm not sure exactly how likely it is that we would hit this as testing it requires some quite precise timing but even if this is possible I don't think there is any way we could fix or work around it using this API.
* We've hard-coded a limit on the number of builds, but if a project has a large build matrix there could potentially be a situation (e.g: if multiple workflows currently have builds in progress and we have to summarise the third or fourth workflow back in time), we might end up summarising only part of a build because some of the builds in the wrokflow are beyond our hard-coded limit. If this did happen it would fail by producing an incorrect/unexpected value and be very hard to detect. Again, I see no sensible way to fix or work around this using this API.
* If a project has a mix of recent builds that do use workflows and older builds that don't use workflows in its history (I actually have a good example of this: https://circleci.com/api/v1.1/project/github/DemocracyClub/ec2-tag-conditional/tree/master ), we will fail with an `InvalidResponse()` until every build in the build history specified by the limit param either does or doesn't use workflows. This case fails with an error rather than unexpected output (so is less serious). Also it may be possible to account for, but I've not attempted to do so.