### PR TITLE
tutorial: fix headline

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -224,7 +224,7 @@ Downloads, ...) and add your badge:
 
 Save, run `npm run build`, and you can see it [locally][home].
 
-## (4.4) Write Tests
+### (4.4) Write Tests
 
 When creating a badge for a new service or changing a badge's behavior, tests
 should be included. They serve several purposes:


### PR DESCRIPTION
The headline was one level too high.
Or it should be `(5) Write Tests` instead `(4.4) Write Tests`
![44](https://user-images.githubusercontent.com/9874850/44794537-ffd7fa80-aba8-11e8-97b9-029b8497c337.png)
