### PR TITLE
[pypi]: Fix broken badges

### DIFF
--- a/services/pypi/pypi-base.js
+++ b/services/pypi/pypi-base.js
@@ -6,9 +6,10 @@ const BaseJsonService = require('../base-json')
 const schema = Joi.object({
   info: Joi.object({
     version: Joi.string().required(),
-    license: Joi.string().required(),
+    // https://github.com/badges/shields/issues/2022
+    license: Joi.string().allow(''),
     classifiers: Joi.array()
-      .items(Joi.string().required())
+      .items(Joi.string())
       .required(),
   }).required(),
   releases: Joi.object()

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -50,6 +50,28 @@ const parseClassifiers = function(parsedData, pattern) {
   return results
 }
 
+function getLicenses(packageData) {
+  const {
+    info: { license, classifiers },
+  } = packageData
+  if (license.length > 0) {
+    return [license]
+  } else {
+    console.log('yololo')
+    const acronymRegex = /\([^\)+]\)/
+    let licenses = parseClassifiers(packageData, /^License :: (.+)$/)
+      .map(classifier => classifier.split(' :: ').pop())
+      .map(license => {
+        const match = license.match(acronymRegex)
+        return match ? match[1] : license
+      })
+    if (licenses.length > 1) {
+      licenses = licenses.filter(l => l !== 'dfsg approved')
+    }
+    return licenses
+  }
+}
+
 function getPackageFormats(packageData) {
   const {
     info: { version },
@@ -70,5 +92,6 @@ module.exports = {
   parseClassifiers,
   parseDjangoVersionString,
   sortDjangoVersions,
+  getLicenses,
   getPackageFormats,
 }

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -52,13 +52,12 @@ const parseClassifiers = function(parsedData, pattern) {
 
 function getLicenses(packageData) {
   const {
-    info: { license, classifiers },
+    info: { license },
   } = packageData
-  if (license.length > 0) {
+  if (license) {
     return [license]
   } else {
-    console.log('yololo')
-    const acronymRegex = /\([^\)+]\)/
+    const acronymRegex = /\([^)+]\)/
     let licenses = parseClassifiers(packageData, /^License :: (.+)$/)
       .map(classifier => classifier.split(' :: ').pop())
       .map(license => {

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -57,12 +57,12 @@ function getLicenses(packageData) {
   if (license) {
     return [license]
   } else {
-    const acronymRegex = /\([^)+]\)/
+    const acronymRegex = /\(([^)]+)\)/
     let licenses = parseClassifiers(packageData, /^License :: (.+)$/)
       .map(classifier => classifier.split(' :: ').pop())
       .map(license => {
         const match = license.match(acronymRegex)
-        return match ? match[1] : license
+        return match ? match[1].toUpperCase() : license
       })
     if (licenses.length > 1) {
       licenses = licenses.filter(l => l !== 'dfsg approved')

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -1,10 +1,11 @@
 'use strict'
 
-const { test, given } = require('sazerac')
+const { test, given, forCases } = require('sazerac')
 const {
   parseClassifiers,
   parseDjangoVersionString,
   sortDjangoVersions,
+  getLicenses,
   getPackageFormats,
 } = require('./pypi-helpers.js')
 
@@ -98,6 +99,29 @@ describe('PyPI helpers', function() {
       '2.11',
       '10',
     ])
+  })
+
+  test(getLicenses, () => {
+    forCases([given({ info: { license: 'MIT', classifiers: [] } })]).expect([
+      'MIT',
+    ])
+    forCases([
+      given({
+        info: {
+          license: '',
+          classifiers: ['License :: OSI Approved :: MIT License'],
+        },
+      }),
+      given({
+        info: {
+          license: '',
+          classifiers: [
+            'License :: OSI Approved :: MIT License',
+            'License :: DFSG approved',
+          ],
+        },
+      }),
+    ]).expect(['mit license'])
   })
 
   test(getPackageFormats, () => {

--- a/services/pypi/pypi-license.service.js
+++ b/services/pypi/pypi-license.service.js
@@ -2,6 +2,7 @@
 
 const { renderLicenseBadge } = require('../../lib/licenses')
 const PypiBase = require('./pypi-base')
+const { getLicenses } = require('./pypi-helpers')
 
 module.exports = class PypiLicense extends PypiBase {
   static get category() {
@@ -22,14 +23,13 @@ module.exports = class PypiLicense extends PypiBase {
     ]
   }
 
-  static render({ license }) {
-    return renderLicenseBadge({ license })
+  static render({ licenses }) {
+    return renderLicenseBadge({ licenses })
   }
 
   async handle({ egg }) {
-    const {
-      info: { license },
-    } = await this.fetch({ egg })
-    return this.constructor.render({ license })
+    const packageData = await this.fetch({ egg })
+    const licenses = getLicenses(packageData)
+    return this.constructor.render({ licenses })
   }
 }

--- a/services/pypi/pypi.tester.js
+++ b/services/pypi/pypi.tester.js
@@ -136,6 +136,27 @@ t.create('license (from trove classifier)')
     value: 'mit license',
   })
 
+t.create('license (as acronym from trove classifier)')
+  .get('/l/magma.json')
+  .intercept(nock =>
+    nock('https://pypi.org')
+      .get('/pypi/magma/json')
+      .reply(200, {
+        info: {
+          version: '1.2.3',
+          license: '',
+          classifiers: [
+            'License :: OSI Approved :: GNU General Public License (GPL)',
+          ],
+        },
+        releases: {},
+      })
+  )
+  .expectJSON({
+    name: 'license',
+    value: 'GPL',
+  })
+
 // tests for wheel endpoint
 
 t.create('wheel (has wheel, package version in request)')

--- a/services/pypi/pypi.tester.js
+++ b/services/pypi/pypi.tester.js
@@ -84,6 +84,25 @@ t.create('version (invalid)')
   .get('/v/not-a-package.json')
   .expectJSON({ name: 'pypi', value: 'package or version not found' })
 
+t.create('no trove classifiers')
+  .get('/v/mapi.json')
+  .intercept(nock =>
+    nock('https://pypi.org')
+      .get('/pypi/mapi/json')
+      .reply(200, {
+        info: {
+          version: '1.2.3',
+          license: 'foo',
+          classifiers: [],
+        },
+        releases: {},
+      })
+  )
+  .expectJSON({
+    name: 'pypi',
+    value: 'v1.2.3',
+  })
+
 // tests for license endpoint
 
 t.create('license (valid, package version in request)')
@@ -97,6 +116,25 @@ t.create('license (valid, no package version specified)')
 t.create('license (invalid)')
   .get('/l/not-a-package.json')
   .expectJSON({ name: 'license', value: 'package or version not found' })
+
+t.create('license (from trove classifier)')
+  .get('/l/mapi.json')
+  .intercept(nock =>
+    nock('https://pypi.org')
+      .get('/pypi/mapi/json')
+      .reply(200, {
+        info: {
+          version: '1.2.3',
+          license: '',
+          classifiers: ['License :: OSI Approved :: MIT License'],
+        },
+        releases: {},
+      })
+  )
+  .expectJSON({
+    name: 'license',
+    value: 'mit license',
+  })
 
 // tests for wheel endpoint
 


### PR DESCRIPTION
- When license is empty, get license from trove classifiers
- Allow empty classifiers array

Closes #2022