### PR TITLE
[WIP] Rewrite [vso] badges

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -2,28 +2,6 @@
 
 const { loadServiceClasses } = require('../services')
 
-const visualStudioTeamServicesDoc = `
-<p>
-  To obtain your own badge, you will first need to enable badges for your
-  project:
-</p>
-<img
-  src="https://cloud.githubusercontent.com/assets/6189336/11894616/be744ab4-a578-11e5-9e44-0c32a7836b3b.png"
-  alt="Go to your builds, click General, then check Badge enabled." />
-<p>
-  Then, click “Show url…” to reveal the URL of the default badge. In that URL,
-  you will need to extract three pieces of information: <code>TEAM_NAME</code>,
-  <code>PROJECT_ID</code> and <code>BUILD_DEFINITION_ID</code>.
-</p>
-<img
-  src="https://cloud.githubusercontent.com/assets/6189336/11629345/f4eb0d78-9cf7-11e5-8d83-ca9fd895fcea.png"
-  alt="TEAM_NAME is just after the https:// part, PROJECT_ID is after definitions/, BUILD_DEFINITION_ID is after that.">
-<p>
-  Your badge will then have the form
-  <code>https://img.shields.io/vso/build/TEAM_NAME/PROJECT_ID/BUILD_DEFINITION_ID</code>.
-</p>
-`
-
 const websiteDoc = `
 <p>
   The badge is of the form
@@ -168,12 +146,6 @@ const allBadgeExamples = [
         previewUrl: '/codeship/d6c1ddd0-16a3-0132-5f85-2e35c05e22b1/master.svg',
       },
       {
-        title: 'Visual Studio Team services',
-        previewUrl:
-          '/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg',
-        documentation: visualStudioTeamServicesDoc,
-      },
-      {
         title: 'Jenkins',
         previewUrl:
           '/jenkins/s/https/jenkins.qa.ubuntu.com/view/Precise/view/All%20Precise/job/precise-desktop-amd64_default.svg',
@@ -308,16 +280,6 @@ const allBadgeExamples = [
       {
         title: 'continuousphp',
         previewUrl: '/continuousphp/git-hub/doctrine/dbal/master.svg',
-      },
-      {
-        title: 'Read the Docs',
-        previewUrl: '/readthedocs/pip.svg',
-        keywords: ['documentation'],
-      },
-      {
-        title: 'Read the Docs (version)',
-        previewUrl: '/readthedocs/pip/stable.svg',
-        keywords: ['documentation'],
       },
       {
         title: 'Bitrise',

--- a/lib/svg-badge-parser.js
+++ b/lib/svg-badge-parser.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { InvalidResponse } = require('../services/errors')
 const nodeifySync = require('./nodeify-sync')
 
 const leadingWhitespace = /(?:\r\n\s*|\r\s*|\n\s*)/g
@@ -14,7 +15,10 @@ function valueFromSvgBadge(svg) {
   if (match) {
     return match[1]
   } else {
-    throw Error(`Can't get value from SVG:\n${svg}`)
+    throw new InvalidResponse({
+      prettyMessage: 'unparseable svg response',
+      underlyingError: Error(`Can't get value from SVG:\n${svg}`),
+    })
   }
 }
 
@@ -30,7 +34,13 @@ function fetchFromSvg(request, url, cb) {
   })
 }
 
+async function fetchFromSvgAsPromise(serviceInstance, requestOptions) {
+  const { buffer } = await serviceInstance._requestHTTP(requestOptions)
+  return valueFromSvgBadge(buffer)
+}
+
 module.exports = {
   valueFromSvgBadge,
   fetchFromSvg,
+  fetchFromSvgAsPromise,
 }

--- a/services/readthedocs/readthedocs.service.js
+++ b/services/readthedocs/readthedocs.service.js
@@ -63,7 +63,7 @@ module.exports = class ReadTheDocs extends BaseHTTPService {
       )}/badge/`,
     })
 
-    if (status == 'unknown') {
+    if (status === 'unknown') {
       throw new NotFound({ prettyMessage: 'project or build not found' })
     }
 

--- a/services/readthedocs/readthedocs.tester.js
+++ b/services/readthedocs/readthedocs.tester.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const Joi = require('joi')
-const ServiceTester = require('../service-tester')
+const createServiceTester = require('../create-service-tester')
 const { isBuildStatus } = require('../test-validators')
 
-const t = new ServiceTester({ id: 'readthedocs', title: 'Read the Docs' })
+const t = createServiceTester()
 module.exports = t
 
 t.create('build status')
@@ -36,9 +36,5 @@ t.create('build status for named semantic version')
 
 t.create('unknown project')
   .get('/this-repo/does-not-exist.json')
-  .expectJSON({ name: 'docs', value: 'unknown' })
+  .expectJSON({ name: 'docs', value: 'project or build not found' })
 
-t.create('connection error')
-  .get('/pip.json')
-  .networkOff()
-  .expectJSON({ name: 'docs', value: 'inaccessible' })

--- a/services/readthedocs/readthedocs.tester.js
+++ b/services/readthedocs/readthedocs.tester.js
@@ -37,4 +37,3 @@ t.create('build status for named semantic version')
 t.create('unknown project')
   .get('/this-repo/does-not-exist.json')
   .expectJSON({ name: 'docs', value: 'project or build not found' })
-

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -96,6 +96,7 @@ const isBuildStatus = Joi.equal(
   'failing',
   'no tests',
   'not built',
+  'never built',
   'not run',
   'passing',
   'pending',

--- a/services/vso/vso.service.js
+++ b/services/vso/vso.service.js
@@ -1,50 +1,86 @@
 'use strict'
 
-const LegacyService = require('../legacy-service')
-const { fetchFromSvg } = require('../../lib/svg-badge-parser')
-const { makeBadgeData: getBadgeData } = require('../../lib/badge-data')
+const { fetchFromSvgAsPromise } = require('../../lib/svg-badge-parser')
+const BaseHTTPService = require('../base-http')
+
+const documentation = `
+<p>
+  To obtain your own badge, you will first need to enable badges for your
+  project:
+</p>
+<img
+  src="https://cloud.githubusercontent.com/assets/6189336/11894616/be744ab4-a578-11e5-9e44-0c32a7836b3b.png"
+  alt="Go to your builds, click General, then check Badge enabled." />
+<p>
+  Then, click “Show url…” to reveal the URL of the default badge. In that URL,
+  you will need to extract three pieces of information: <code>TEAM_NAME</code>,
+  <code>PROJECT_ID</code> and <code>BUILD_DEFINITION_ID</code>.
+</p>
+<img
+  src="https://cloud.githubusercontent.com/assets/6189336/11629345/f4eb0d78-9cf7-11e5-8d83-ca9fd895fcea.png"
+  alt="TEAM_NAME is just after the https:// part, PROJECT_ID is after definitions/, BUILD_DEFINITION_ID is after that.">
+<p>
+  Your badge will then have the form
+  <code>https://img.shields.io/vso/build/:team/:project/:buildDefinitionId.svg</code>.
+</p>
+`
 
 // For Visual Studio Team Services build.
-module.exports = class Vso extends LegacyService {
-  static registerLegacyRouteHandler({ camp, cache }) {
-    camp.route(
-      /^\/vso\/build\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
-      cache((data, match, sendBadge, request) => {
-        const name = match[1] // User name
-        const project = match[2] // Project ID, e.g. 953a34b9-5966-4923-a48a-c41874cfb5f5
-        const build = match[3] // Build definition ID, e.g. 1
-        const format = match[4]
-        const url =
-          'https://' +
-          name +
-          '.visualstudio.com/DefaultCollection/_apis/public/build/definitions/' +
-          project +
-          '/' +
-          build +
-          '/badge'
-        const badgeData = getBadgeData('build', data)
-        fetchFromSvg(request, url, (err, res) => {
-          if (err != null) {
-            badgeData.text[1] = 'inaccessible'
-            sendBadge(format, badgeData)
-            return
-          }
-          try {
-            badgeData.text[1] = res.toLowerCase()
-            if (res === 'succeeded') {
-              badgeData.colorscheme = 'brightgreen'
-              badgeData.text[1] = 'passing'
-            } else if (res === 'failed') {
-              badgeData.colorscheme = 'red'
-              badgeData.text[1] = 'failing'
-            }
-            sendBadge(format, badgeData)
-          } catch (e) {
-            badgeData.text[1] = 'invalid'
-            sendBadge(format, badgeData)
-          }
-        })
-      })
-    )
+module.exports = class Vso extends BaseHTTPService {
+  static get category() {
+    return 'build'
+  }
+
+  static get url() {
+    return {
+      base: 'vso/build',
+      format: '([^/]+)/([^/]+)/([^/]+)',
+      capture: [
+        'team',
+        'project', // Project ID, e.g. 953a34b9-5966-4923-a48a-c41874cfb5f5
+        'buildDefinitionId', // Build definition ID, e.g. 1
+      ],
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Visual Studio Team services',
+        previewUrl: 'larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1',
+        documentation,
+        keywords: ['vso'],
+      },
+    ]
+  }
+
+  static render({ status }) {
+    if (status === 'succeeded') {
+      return {
+        message: 'passing',
+        color: 'brightgreen',
+      }
+    } else if (status === 'failed') {
+      return {
+        message: 'failing',
+        color: 'red',
+      }
+    } else {
+      return { message: status.toLowerCase() }
+    }
+  }
+
+  async handle({ team, project, buildDefinitionId }) {
+    const status = await fetchFromSvgAsPromise(this, {
+      url:
+        `https://${team}.visualstudio.com` +
+        '/DefaultCollection/_apis/public/build/definitions' +
+        `/${project}/${buildDefinitionId}/badge`,
+      errorMessages: {
+        400: 'project not found',
+        404: 'user or build not found',
+      },
+    })
+    return this.constructor.render({ status })
   }
 }

--- a/services/vso/vso.tester.js
+++ b/services/vso/vso.tester.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const Joi = require('joi')
+const createServiceTester = require('../create-service-tester')
+const { isBuildStatus } = require('../test-validators')
+
+const t = createServiceTester()
+module.exports = t
+
+t.create('build status')
+  .get('/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'build',
+      value: isBuildStatus,
+    })
+  )
+
+t.create('unknown user')
+  .get('/notarealuser/foo/515.json')
+  .expectJSON({ name: 'build', value: 'user or build not found' })
+
+t.create('unknown project')
+  .get('/larsbrinkhoff/foo/515.json')
+  .expectJSON({ name: 'build', value: 'project not found' })
+
+t.create('unknown build')
+  .get('/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/515.json')
+  .expectJSON({ name: 'build', value: 'user or build not found' })


### PR DESCRIPTION
This tackles two of the services using `fetchFromSvg`. The others are in codacy, which are broken right now; see #1985.

There’s a design decision to make here about how to structure the shared code. One is with a subclass, and the other with a function.

After working on a few service families, I noticed a pattern. First I could code the first service. Then I would start to code the second, and  begin to separate out the shared code into an abstract superclass.

This involved a lot of typing:

- `require` statements would be moved into the module containing the base class
- new `require` statements would be added to the module with the subclass
- The `extends` line would change
- All the shared code would move

The current arrangement also produced base service code which couldn’t be tested without creating a subclass, which has meant that tests of `fetch` end up being written as service tests, though probably they would be more clearly expressed as unit tests with intercepted http calls.

I also dislike deep inheritance hierarchies because they make it harder for new developers to understand what is happening. They are also difficult to change, on account of all the implicit dependencies.

It would be inconceivable to create a base class for a single service, based on the possibility of writing more services someday. This means going from n=1 to 2 is services per family is (relatively) hard, while going from n >=2 to n+1 is easy.

This led me to want to experiment with composition; hence taking the “function” approach here.

Ref: #1358 #1565