### PR TITLE
Fix unparseable json in [circleci uptimerobot]

### DIFF
--- a/services/base-json.js
+++ b/services/base-json.js
@@ -46,7 +46,7 @@ class BaseJsonService extends BaseHTTPService {
       ...{ headers: { Accept: 'application/json' } },
       ...options,
     }
-    return this._requestHTTP({ url, mergedOptions, errorMessages })
+    return this._requestHTTP({ url, options: mergedOptions, errorMessages })
       .then(asJson)
       .then(json => {
         logTrace(emojic.dart, 'Response JSON (before validation)', json, {


### PR DESCRIPTION
The fix beef866 was simple. This adds two failing tests.

Issues like this is a good reason to be careful about unit testing base functionality, even when it is used by many services!

Fixes #2034 #2030