### PR TITLE
[elm-package] Fix old package name

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1198,7 +1198,7 @@ const allBadgeExamples = [
       },
       {
         title: 'Elm package',
-        previewUrl: '/elm-package/v/elm-lang/core.svg',
+        previewUrl: '/elm-package/v/elm/core.svg',
         keywords: ['Elm'],
       },
       {
@@ -1696,7 +1696,7 @@ function loadExamples() {
     if (category === undefined) {
       throw Error(
         `Unknown category ${ServiceClass.category} referenced in ${
-          ServiceClass.name
+        ServiceClass.name
         }`
       )
     }

--- a/services/elm-package/elm-package.tester.js
+++ b/services/elm-package/elm-package.tester.js
@@ -7,8 +7,8 @@ const { isSemver } = require('../test-validators')
 const t = new ServiceTester({ id: 'elm-package', title: 'ELM PACKAGE' })
 module.exports = t
 
-t.create('gets the package version of elm-lang/core')
-  .get('/v/elm-lang/core.json')
+t.create('gets the package version of elm/core')
+  .get('/v/elm/core.json')
   .expectJSONTypes(Joi.object().keys({ name: 'elm package', value: isSemver }))
 
 t.create('invalid package name')


### PR DESCRIPTION
With the Elm 0.19.0 update, many packages were renamed. This also concerns `elm-lang/core` which was used as the preview badge. The package is now called `elm/core`.

This PR fixes the preview and the test to use the new package name.

Note that the old package name works. The preview in the search results (at least for me) shows an `invalid` "error". This is simply due to caching with `?maxAge`. When you click it, the preview which uses the same old package name, but without caching, is correct.