### PR TITLE
render category links correctly on initial page load

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,11 @@ export default class Router extends React.Component {
     } else {
       // server-side rendering
       const context = {}
-      return <StaticRouter context={context}>{router}</StaticRouter>
+      return (
+        <StaticRouter context={context} basename="#">
+          {router}
+        </StaticRouter>
+      )
     }
   }
 }


### PR DESCRIPTION
refs https://github.com/badges/shields/issues/1954#issuecomment-417513823

I don't know if this is objectively the best solution to this, but it does seem to work.