### PR TITLE
[aur packagist php-eye travis vaadin-directory github david jitpack twitter] Enforced lowercase badge labels

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ There are three places to get help:
 Badge guidelines
 ----------------
 
-- The left-hand side of a badge should not advertise. It should be a *noun*
+- The left-hand side of a badge should not advertise. It should be a lowercase *noun*
   succinctly describing the meaning of the right-hand side.
 - Query parameters must be *declared by the service*. See `request-handler.js`.
 - Except for badges using the `social` style, logos should be *turned off by

--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -69,7 +69,10 @@ function setBadgeColor(badgeData, color) {
 
 function makeLabel(defaultLabel, overrides) {
   return (
-    '' + (overrides.label === undefined ? defaultLabel || '' : overrides.label)
+    '' +
+    (overrides.label === undefined
+      ? (defaultLabel || '').toLowerCase()
+      : overrides.label)
   )
 }
 

--- a/lib/badge-data.spec.js
+++ b/lib/badge-data.spec.js
@@ -28,7 +28,9 @@ describe('Badge data helpers', function() {
 
   test(makeLabel, () => {
     given('my badge', {}).expect('my badge')
+    given('My bAdge', {}).expect('my badge')
     given('my badge', { label: 'no, my badge' }).expect('no, my badge')
+    given('my badge', { label: 'no, MY badge' }).expect('no, MY badge')
     given('my badge', { label: false }).expect('false')
     given('my badge', { label: 0 }).expect('0')
     given('my badge', { label: '' }).expect('')

--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -19,7 +19,7 @@ module.exports = class Aur extends LegacyService {
         const pkg = match[2]
         const format = match[3]
         const apiUrl = 'https://aur.archlinux.org/rpc.php?type=info&arg=' + pkg
-        const badgeData = getBadgeData('AUR', data)
+        const badgeData = getBadgeData('aur', data)
         request(apiUrl, (err, res, buffer) => {
           if (checkErrorResponse(badgeData, err, res)) {
             sendBadge(format, badgeData)

--- a/services/aur/aur.tester.js
+++ b/services/aur/aur.tester.js
@@ -16,7 +16,7 @@ t.create('version (valid)')
   .get('/version/yaourt.json?style=_shields_test')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'AUR',
+      name: 'aur',
       value: isVPlusDottedVersionNClausesWithOptionalSuffix,
       colorB: '#007ec6',
     })
@@ -26,7 +26,7 @@ t.create('version (valid, out of date)')
   .get('/version/gog-gemini-rue.json?style=_shields_test')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'AUR',
+      name: 'aur',
       value: isVPlusDottedVersionNClausesWithOptionalSuffix,
       colorB: '#fe7d37',
     })
@@ -34,12 +34,12 @@ t.create('version (valid, out of date)')
 
 t.create('version (not found)')
   .get('/version/not-a-package.json')
-  .expectJSON({ name: 'AUR', value: 'not found' })
+  .expectJSON({ name: 'aur', value: 'not found' })
 
 t.create('version (connection error)')
   .get('/version/yaourt.json')
   .networkOff()
-  .expectJSON({ name: 'AUR', value: 'inaccessible' })
+  .expectJSON({ name: 'aur', value: 'inaccessible' })
 
 t.create('version (unexpected response)')
   .get('/version/yaourt.json')
@@ -48,7 +48,7 @@ t.create('version (unexpected response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(invalidJSON)
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })
 
 t.create('version (error response)')
   .get('/version/yaourt.json')
@@ -57,7 +57,7 @@ t.create('version (error response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(500, '{"error":"oh noes!!"}')
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })
 
 // votes tests
 
@@ -72,12 +72,12 @@ t.create('votes (valid)')
 
 t.create('votes (not found)')
   .get('/votes/not-a-package.json')
-  .expectJSON({ name: 'AUR', value: 'not found' })
+  .expectJSON({ name: 'aur', value: 'not found' })
 
 t.create('votes (connection error)')
   .get('/votes/yaourt.json')
   .networkOff()
-  .expectJSON({ name: 'AUR', value: 'inaccessible' })
+  .expectJSON({ name: 'aur', value: 'inaccessible' })
 
 t.create('votes (unexpected response)')
   .get('/votes/yaourt.json')
@@ -86,7 +86,7 @@ t.create('votes (unexpected response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(invalidJSON)
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })
 
 t.create('votes (error response)')
   .get('/votes/yaourt.json')
@@ -95,7 +95,7 @@ t.create('votes (error response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(500, '{"error":"oh noes!!"}')
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })
 
 // license tests
 
@@ -105,12 +105,12 @@ t.create('license (valid)')
 
 t.create('license (not found)')
   .get('/license/not-a-package.json')
-  .expectJSON({ name: 'AUR', value: 'not found' })
+  .expectJSON({ name: 'aur', value: 'not found' })
 
 t.create('license (connection error)')
   .get('/license/yaourt.json')
   .networkOff()
-  .expectJSON({ name: 'AUR', value: 'inaccessible' })
+  .expectJSON({ name: 'aur', value: 'inaccessible' })
 
 t.create('license (unexpected response)')
   .get('/license/yaourt.json')
@@ -119,7 +119,7 @@ t.create('license (unexpected response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(invalidJSON)
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })
 
 t.create('license (error response)')
   .get('/license/yaourt.json')
@@ -128,4 +128,4 @@ t.create('license (error response)')
       .get('/rpc.php?type=info&arg=yaourt')
       .reply(500, '{"error":"oh noes!!"}')
   )
-  .expectJSON({ name: 'AUR', value: 'invalid' })
+  .expectJSON({ name: 'aur', value: 'invalid' })

--- a/services/david/david.service.js
+++ b/services/david/david.service.js
@@ -28,7 +28,7 @@ module.exports = class David extends LegacyService {
             options += '?path=' + data.path
           }
           const badgeData = getBadgeData(
-            (dev ? dev + 'D' : 'd') + 'ependencies',
+            (dev ? dev + ' ' : '') + 'dependencies',
             data
           )
           request(options, (err, res, buffer) => {

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -25,7 +25,7 @@ t.create('david dev dependencies (valid)')
   .get('/dev/expressjs/express.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'devDependencies',
+      name: 'dev dependencies',
       value: isDependencyStatus,
     })
   )
@@ -34,7 +34,7 @@ t.create('david optional dependencies (valid)')
   .get('/optional/elnounch/byebye.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'optionalDependencies',
+      name: 'optional dependencies',
       value: isDependencyStatus,
     })
   )
@@ -43,7 +43,7 @@ t.create('david peer dependencies (valid)')
   .get('/peer/webcomponents/generator-element.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'peerDependencies',
+      name: 'peer dependencies',
       value: isDependencyStatus,
     })
   )
@@ -59,7 +59,7 @@ t.create('david dependencies with path (valid)')
 
 t.create('david dependencies (none)')
   .get('/peer/expressjs/express.json') // express does not specify peer dependencies
-  .expectJSON({ name: 'peerDependencies', value: 'none' })
+  .expectJSON({ name: 'peer dependencies', value: 'none' })
 
 t.create('david dependencies (repo not found)')
   .get('/pyvesb/emptyrepo.json')

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -716,7 +716,7 @@ t.create('top language')
   .get('/languages/top/badges/shields.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'JavaScript',
+      name: 'javascript',
       value: Joi.string().regex(/^([1-9]?[0-9]\.[0-9]|100\.0)%$/),
     })
   )

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -201,7 +201,7 @@ t.create('GitHub open issues by multi-word label is > zero')
   .get('/issues/Cockatrice/Cockatrice/App%20-%20Cockatrice.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: '"App - Cockatrice" issues',
+      name: '"app - cockatrice" issues',
       value: isMetricOpenIssues,
     })
   )

--- a/services/jitpack/jitpack.service.js
+++ b/services/jitpack/jitpack.service.js
@@ -13,12 +13,11 @@ module.exports = class Jitpack extends LegacyService {
         const groupId = 'com.github.' + match[1] // github user
         const artifactId = match[2] // the project's name
         const format = match[3] // "svg"
-        const name = 'JitPack'
 
         const pkg = groupId + '/' + artifactId + '/latest'
         const apiUrl = 'https://jitpack.io/api/builds/' + pkg
 
-        const badgeData = getBadgeData(name, data)
+        const badgeData = getBadgeData('jitpack', data)
 
         request(apiUrl, (err, res, buffer) => {
           if (err != null) {

--- a/services/jitpack/jitpack.tester.js
+++ b/services/jitpack/jitpack.tester.js
@@ -11,11 +11,11 @@ module.exports = t
 
 t.create('version')
   .get('/v/jitpack/maven-simple.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'JitPack', value: isAnyV }))
+  .expectJSONTypes(Joi.object().keys({ name: 'jitpack', value: isAnyV }))
 
 t.create('unknown package')
   .get('/v/some-bogus-user/project.json')
-  .expectJSON({ name: 'JitPack', value: 'invalid' })
+  .expectJSON({ name: 'jitpack', value: 'invalid' })
 
 t.create('unknown info')
   .get('/z/devtools.json')
@@ -25,4 +25,4 @@ t.create('unknown info')
 t.create('connection error')
   .get('/v/jitpack/maven-simple.json')
   .networkOff()
-  .expectJSON({ name: 'JitPack', value: 'inaccessible' })
+  .expectJSON({ name: 'jitpack', value: 'inaccessible' })

--- a/services/osstracker/osstracker.service.js
+++ b/services/osstracker/osstracker.service.js
@@ -23,7 +23,7 @@ module.exports = class OssTracker extends LegacyService {
           method: 'GET',
           uri: url,
         }
-        const badgeData = getBadgeData('OSS Lifecycle', data)
+        const badgeData = getBadgeData('oss lifecycle', data)
         request(options, (err, res, body) => {
           if (err != null) {
             log.error('NetflixOSS error: ' + err.stack)

--- a/services/packagist/packagist-php-version.service.js
+++ b/services/packagist/packagist-php-version.service.js
@@ -16,7 +16,7 @@ module.exports = class PackagistPhpVersion extends LegacyService {
           method: 'GET',
           uri: 'https://packagist.org/p/' + userRepo + '.json',
         }
-        const badgeData = getBadgeData('PHP', data)
+        const badgeData = getBadgeData('php', data)
         request(options, (err, res, buffer) => {
           if (err !== null) {
             log.error('Packagist error: ' + err.stack)

--- a/services/packagist/packagist.tester.js
+++ b/services/packagist/packagist.tester.js
@@ -27,15 +27,15 @@ module.exports = t
 
 t.create('gets the package version of symfony')
   .get('/php-v/symfony/symfony.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'PHP', value: isComposerVersion }))
+  .expectJSONTypes(Joi.object().keys({ name: 'php', value: isComposerVersion }))
 
 t.create('gets the package version of symfony 2.8')
   .get('/php-v/symfony/symfony/v2.8.0.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'PHP', value: isComposerVersion }))
+  .expectJSONTypes(Joi.object().keys({ name: 'php', value: isComposerVersion }))
 
 t.create('invalid package name')
   .get('/php-v/frodo/is-not-a-package.json')
-  .expectJSON({ name: 'PHP', value: 'invalid' })
+  .expectJSON({ name: 'php', value: 'invalid' })
 
 // tests for download stats endpoints
 

--- a/services/php-eye/php-eye-php-version.service.js
+++ b/services/php-eye/php-eye-php-version.service.js
@@ -20,7 +20,7 @@ module.exports = class PhpEyePhpVersion extends LegacyService {
           method: 'GET',
           uri: 'https://php-eye.com/api/v1/package/' + userRepo + '.json',
         }
-        const badgeData = getBadgeData('PHP tested', data)
+        const badgeData = getBadgeData('php tested', data)
         getPhpReleases(githubApiProvider, (err, phpReleases) => {
           if (err != null) {
             badgeData.text[1] = 'invalid'

--- a/services/php-eye/php-eye.tester.js
+++ b/services/php-eye/php-eye.tester.js
@@ -13,17 +13,17 @@ module.exports = t
 t.create('gets the package version of symfony')
   .get('/symfony/symfony.json')
   .expectJSONTypes(
-    Joi.object().keys({ name: 'PHP tested', value: isPhpVersionReduction })
+    Joi.object().keys({ name: 'php tested', value: isPhpVersionReduction })
   )
 
 t.create('gets the package version of symfony 2.8')
   .get('/symfony/symfony/v2.8.0.json')
-  .expectJSON({ name: 'PHP tested', value: '5.3 - 7.0, HHVM' })
+  .expectJSON({ name: 'php tested', value: '5.3 - 7.0, HHVM' })
 
 t.create('gets the package version of yii')
   .get('/yiisoft/yii.json')
-  .expectJSON({ name: 'PHP tested', value: '5.3 - 7.1' })
+  .expectJSON({ name: 'php tested', value: '5.3 - 7.1' })
 
 t.create('invalid package name')
   .get('/frodo/is-not-a-package.json')
-  .expectJSON({ name: 'PHP tested', value: 'invalid' })
+  .expectJSON({ name: 'php tested', value: 'invalid' })

--- a/services/travis/travis-php-version.service.js
+++ b/services/travis/travis-php-version.service.js
@@ -21,7 +21,7 @@ module.exports = class TravisPhpVersion extends LegacyService {
           method: 'GET',
           uri: `https://api.travis-ci.org/repos/${userRepo}/branches/${version}`,
         }
-        const badgeData = getBadgeData('PHP', data)
+        const badgeData = getBadgeData('php', data)
         getPhpReleases(githubApiProvider, (err, phpReleases) => {
           if (err != null) {
             badgeData.text[1] = 'invalid'

--- a/services/travis/travis.tester.js
+++ b/services/travis/travis.tester.js
@@ -86,26 +86,26 @@ t.create('connection error')
   .networkOff()
   .expectJSON({ name: 'build', value: 'inaccessible' })
 
-// PHP version from .travis.yml
+// php version from .travis.yml
 
 t.create('gets the package version of symfony')
   .get('/php-v/symfony/symfony.json')
   .expectJSONTypes(
-    Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction })
+    Joi.object().keys({ name: 'php', value: isPhpVersionReduction })
   )
 
 t.create('gets the package version of symfony 2.8')
   .get('/php-v/symfony/symfony/2.8.json')
   .expectJSONTypes(
-    Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction })
+    Joi.object().keys({ name: 'php', value: isPhpVersionReduction })
   )
 
 t.create('gets the package version of yii')
   .get('/php-v/yiisoft/yii.json')
   .expectJSONTypes(
-    Joi.object().keys({ name: 'PHP', value: isPhpVersionReduction })
+    Joi.object().keys({ name: 'php', value: isPhpVersionReduction })
   )
 
 t.create('invalid package name')
   .get('/php-v/frodo/is-not-a-package.json')
-  .expectJSON({ name: 'PHP', value: 'invalid' })
+  .expectJSON({ name: 'php', value: 'invalid' })

--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -45,7 +45,7 @@ module.exports = class Twitter extends LegacyService {
             'http://cdn.syndication.twimg.com/widgets/followbutton/info.json?screen_names=' +
             user,
         }
-        const badgeData = getBadgeData('Follow @' + user, data)
+        const badgeData = getBadgeData('follow @' + user, data)
 
         badgeData.colorscheme = null
         badgeData.colorB = '#55ACEE'

--- a/services/twitter/twitter.tester.js
+++ b/services/twitter/twitter.tester.js
@@ -12,7 +12,7 @@ t.create('Followers')
   .get('/follow/shields_io.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'Follow @shields_io',
+      name: 'follow @shields_io',
       value: isMetric,
     })
   )

--- a/services/vaadin-directory/vaadin-directory.service.js
+++ b/services/vaadin-directory/vaadin-directory.service.js
@@ -26,7 +26,7 @@ module.exports = class VaadinDirectory extends LegacyService {
           urlIdentifier
 
         // Set left-side text to 'Vaadin-Directory' by default
-        const badgeData = getBadgeData('Vaadin Directory', data)
+        const badgeData = getBadgeData('vaadin directory', data)
         request(apiUrl, (err, res, buffer) => {
           if (checkErrorResponse(badgeData, err, res)) {
             sendBadge(format, badgeData)

--- a/services/vaadin-directory/vaadin-directory.tester.js
+++ b/services/vaadin-directory/vaadin-directory.tester.js
@@ -12,7 +12,7 @@ const {
 
 const t = new ServiceTester({
   id: 'vaadin-directory',
-  title: 'Vaadin Directory',
+  title: 'vaadin directory',
 })
 module.exports = t
 
@@ -38,7 +38,7 @@ t.create('publish status of the component')
   .get('/status/vaadinvaadin-grid.json')
   .expectJSONTypes(
     Joi.object().keys({
-      name: 'Vaadin Directory',
+      name: 'vaadin directory',
       value: Joi.equal(
         'published',
         'unpublished',
@@ -116,7 +116,7 @@ t.create('latest release date of the component (format: yyyy-mm-dd)')
 t.create('Invalid addon')
   .get('/stars/404.json')
   .expectJSON({
-    name: 'Vaadin Directory',
+    name: 'vaadin directory',
     value: 'not found',
   })
 
@@ -124,6 +124,6 @@ t.create('No connection')
   .get('/stars/vaadinvaadin-grid.json')
   .networkOff()
   .expectJSON({
-    name: 'Vaadin Directory',
+    name: 'vaadin directory',
     value: 'inaccessible',
   })


### PR DESCRIPTION
This pull request addresses issue #1997.

I implemented lower casing of the left-handside of badges in the `makeLabel` function, but only for `defaultLabel`. If the user specifies a label override, he can use upper case characters freely.

Note that when the function was called with hardcoded sting values (e.g. `getBadgeData('AUR', data)`), I lower cased the strings at the point of call (`getBadgeData('aur', data)`) as well to avoid any confusion in the code.

Query parameters specifying special styles are not affected (i.e. capitalisation for social badges, full upper casing for for-the-badge).