### PR TITLE
Made JSON snapshot test pass on Windows

### DIFF
--- a/__snapshots__/make-badge.spec.js
+++ b/__snapshots__/make-badge.spec.js
@@ -9,6 +9,13 @@ exports['The badge generator JSON should always produce the same JSON (unless we
 }
 `
 
+exports['The badge generator JSON should always produce the same JSON on Windows (unless we have changed something!) 1'] = `
+{
+  "name": "cactus",
+  "value": "grown"
+}
+`
+
 exports['shields GitHub logo default color (#333333) 1'] = `
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="113" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h54v20H0z"/><path fill="#007ec6" d="M54 0h59v20H54z"/><path fill="url(#b)" d="M0 0h113v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"><image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMTIgMTIgNDAgNDAiPg0KPHBhdGggZmlsbD0iIzMzMzMzMyIgZD0iTTMyLDEzLjRjLTEwLjUsMC0xOSw4LjUtMTksMTljMCw4LjQsNS41LDE1LjUsMTMsMThjMSwwLjIsMS4zLTAuNCwxLjMtMC45YzAtMC41LDAtMS43LDAtMy4yIGMtNS4zLDEuMS02LjQtMi42LTYuNC0yLjZDMjAsNDEuNiwxOC44LDQxLDE4LjgsNDFjLTEuNy0xLjIsMC4xLTEuMSwwLjEtMS4xYzEuOSwwLjEsMi45LDIsMi45LDJjMS43LDIuOSw0LjUsMi4xLDUuNSwxLjYgYzAuMi0xLjIsMC43LTIuMSwxLjItMi42Yy00LjItMC41LTguNy0yLjEtOC43LTkuNGMwLTIuMSwwLjctMy43LDItNS4xYy0wLjItMC41LTAuOC0yLjQsMC4yLTVjMCwwLDEuNi0wLjUsNS4yLDIgYzEuNS0wLjQsMy4xLTAuNyw0LjgtMC43YzEuNiwwLDMuMywwLjIsNC43LDAuN2MzLjYtMi40LDUuMi0yLDUuMi0yYzEsMi42LDAuNCw0LjYsMC4yLDVjMS4yLDEuMywyLDMsMiw1LjFjMCw3LjMtNC41LDguOS04LjcsOS40IGMwLjcsMC42LDEuMywxLjcsMS4zLDMuNWMwLDIuNiwwLDQuNiwwLDUuMmMwLDAuNSwwLjQsMS4xLDEuMywwLjljNy41LTIuNiwxMy05LjcsMTMtMTguMUM1MSwyMS45LDQyLjUsMTMuNCwzMiwxMy40eiIvPg0KPC9zdmc+DQo="/> <text x="365" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">label</text><text x="365" y="140" transform="scale(.1)" textLength="270">label</text><text x="825" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">message</text><text x="825" y="140" transform="scale(.1)" textLength="490">message</text></g> </svg>
 `

--- a/__snapshots__/make-badge.spec.js
+++ b/__snapshots__/make-badge.spec.js
@@ -9,13 +9,6 @@ exports['The badge generator JSON should always produce the same JSON (unless we
 }
 `
 
-exports['The badge generator JSON should always produce the same JSON on Windows (unless we have changed something!) 1'] = `
-{
-  "name": "cactus",
-  "value": "grown"
-}
-`
-
 exports['shields GitHub logo default color (#333333) 1'] = `
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="113" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="113" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h54v20H0z"/><path fill="#007ec6" d="M54 0h59v20H54z"/><path fill="url(#b)" d="M0 0h113v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110"><image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgdmlld0JveD0iMTIgMTIgNDAgNDAiPg0KPHBhdGggZmlsbD0iIzMzMzMzMyIgZD0iTTMyLDEzLjRjLTEwLjUsMC0xOSw4LjUtMTksMTljMCw4LjQsNS41LDE1LjUsMTMsMThjMSwwLjIsMS4zLTAuNCwxLjMtMC45YzAtMC41LDAtMS43LDAtMy4yIGMtNS4zLDEuMS02LjQtMi42LTYuNC0yLjZDMjAsNDEuNiwxOC44LDQxLDE4LjgsNDFjLTEuNy0xLjIsMC4xLTEuMSwwLjEtMS4xYzEuOSwwLjEsMi45LDIsMi45LDJjMS43LDIuOSw0LjUsMi4xLDUuNSwxLjYgYzAuMi0xLjIsMC43LTIuMSwxLjItMi42Yy00LjItMC41LTguNy0yLjEtOC43LTkuNGMwLTIuMSwwLjctMy43LDItNS4xYy0wLjItMC41LTAuOC0yLjQsMC4yLTVjMCwwLDEuNi0wLjUsNS4yLDIgYzEuNS0wLjQsMy4xLTAuNyw0LjgtMC43YzEuNiwwLDMuMywwLjIsNC43LDAuN2MzLjYtMi40LDUuMi0yLDUuMi0yYzEsMi42LDAuNCw0LjYsMC4yLDVjMS4yLDEuMywyLDMsMiw1LjFjMCw3LjMtNC41LDguOS04LjcsOS40IGMwLjcsMC42LDEuMywxLjcsMS4zLDMuNWMwLDIuNiwwLDQuNiwwLDUuMmMwLDAuNSwwLjQsMS4xLDEuMywwLjljNy41LTIuNiwxMy05LjcsMTMtMTguMUM1MSwyMS45LDQyLjUsMTMuNCwzMiwxMy40eiIvPg0KPC9zdmc+DQo="/> <text x="365" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">label</text><text x="365" y="140" transform="scale(.1)" textLength="270">label</text><text x="825" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="490">message</text><text x="825" y="140" transform="scale(.1)" textLength="490">message</text></g> </svg>
 `

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -89,17 +89,10 @@ describe('The badge generator', function() {
   })
 
   describe('JSON', function() {
-    if (process.platform === 'win32') {
-      it('should always produce the same JSON on Windows (unless we have changed something!)', function() {
-        const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
-        snapshot(json)
-      })
-    } else {
-      it('should always produce the same JSON (unless we have changed something!)', function() {
-        const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
-        snapshot(json)
-      })
-    }
+    it('should always produce the same JSON (unless we have changed something!)', function() {
+      const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
+      snapshot(json)
+    })
 
     it('should replace unknown json template with "default"', function() {
       const jsonBadgeWithUnknownStyle = makeBadge({

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -89,10 +89,17 @@ describe('The badge generator', function() {
   })
 
   describe('JSON', function() {
-    it('should always produce the same JSON (unless we have changed something!)', function() {
-      const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
-      snapshot(json)
-    })
+    if (process.platform === 'win32') {
+      it('should always produce the same JSON on Windows (unless we have changed something!)', function() {
+        const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
+        snapshot(json)
+      })
+    } else {
+      it('should always produce the same JSON (unless we have changed something!)', function() {
+        const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
+        snapshot(json)
+      })
+    }
 
     it('should replace unknown json template with "default"', function() {
       const jsonBadgeWithUnknownStyle = makeBadge({

--- a/lib/make-badge.spec.js
+++ b/lib/make-badge.spec.js
@@ -3,6 +3,7 @@
 const { test, given, forCases } = require('sazerac')
 const { expect } = require('chai')
 const snapshot = require('snap-shot-it')
+const eol = require('eol')
 const { _badgeKeyWidthCache } = require('./make-badge')
 const isSvg = require('is-svg')
 const testHelpers = require('./make-badge-test-helpers')
@@ -91,7 +92,8 @@ describe('The badge generator', function() {
   describe('JSON', function() {
     it('should always produce the same JSON (unless we have changed something!)', function() {
       const json = makeBadge({ text: ['cactus', 'grown'], format: 'json' })
-      snapshot(json)
+      const jsonWithLFEndings = eol.lf(json)
+      snapshot(jsonWithLFEndings)
     })
 
     it('should replace unknown json template with "default"', function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4478,6 +4478,12 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
+    "eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "danger": "^3.7.13",
     "danger-plugin-no-test-shortcuts": "^2.0.0",
     "dejavu-fonts-ttf": "^2.37.3",
+    "eol": "^0.9.1",
     "eslint": "^5.0.1",
     "eslint-config-prettier": "^3.0.1",
     "eslint-config-standard": "^12.0.0",


### PR DESCRIPTION
The test `should always produce the same JSON (unless we have changed something!)` was systematically failing on my laptop. If my understanding is correct, the snapshot data for the test was generated on a Unix platform and therefore uses Unix line endings (`\n`).

On Windows, when loading and preparing the badge templates, Windows line endings are used (`\r\n`). The comparison with the snapshot was therefore failing.

When run on Windows, the test suite will now use a different snapshot, with the proper line endings.