### PR TITLE
Better support for VSTS build badges

### DIFF
--- a/services/vso/vso.service.js
+++ b/services/vso/vso.service.js
@@ -42,7 +42,7 @@ module.exports = class Vso extends LegacyService {
         const build = match[3] // Build definition ID, e.g. 1
         const branch = match[4]
         const format = match[5]
-        let url = `https://${name}.visualstudio.com/_apis/public/build/definitions/${project}/${build}/badge`
+        let url = `https://${name}.visualstudio.com/${project}/_apis/build/status/${build}`
         if (branch != null) {
           url += `?branchName=${branch}`
         }


### PR DESCRIPTION
Newly created build definitions on VSTS does not support old badge endpoint. Instead, a new one has been provided and supports all build definitions.