### PR TITLE
Fixed [Codacy] badges (affects [vso readthedocs])

### DIFF
--- a/lib/svg-badge-parser.js
+++ b/lib/svg-badge-parser.js
@@ -3,14 +3,13 @@
 const nodeifySync = require('./nodeify-sync')
 
 const leadingWhitespace = /(?:\r\n\s*|\r\s*|\n\s*)/g
-const getValue = />([^<>]+)<\/text><\/g>/
 
-function valueFromSvgBadge(svg) {
+function valueFromSvgBadge(svg, valueMatcher) {
   if (typeof svg !== 'string') {
     throw TypeError('Parameter should be a string')
   }
   const stripped = svg.replace(leadingWhitespace, '')
-  const match = getValue.exec(stripped)
+  const match = valueMatcher.exec(stripped)
   if (match) {
     return match[1]
   } else {
@@ -20,12 +19,12 @@ function valueFromSvgBadge(svg) {
 
 // Get data from a svg-style badge.
 // cb: function(err, string)
-function fetchFromSvg(request, url, cb) {
+function fetchFromSvg(request, url, valueMatcher, cb) {
   request(url, (err, res, buffer) => {
     if (err !== null) {
       cb(err)
     } else {
-      nodeifySync(() => valueFromSvgBadge(buffer), cb)
+      nodeifySync(() => valueFromSvgBadge(buffer, valueMatcher), cb)
     }
   })
 }

--- a/lib/svg-badge-parser.spec.js
+++ b/lib/svg-badge-parser.spec.js
@@ -14,6 +14,8 @@ describe('The SVG badge parser', function() {
 
     const exampleSvg = makeBadge(badgeData)
 
-    expect(valueFromSvgBadge(exampleSvg, />([^<>]+)<\/text><\/g>/)).to.equal('this is the result!')
+    expect(valueFromSvgBadge(exampleSvg, />([^<>]+)<\/text><\/g>/)).to.equal(
+      'this is the result!'
+    )
   })
 })

--- a/lib/svg-badge-parser.spec.js
+++ b/lib/svg-badge-parser.spec.js
@@ -14,6 +14,6 @@ describe('The SVG badge parser', function() {
 
     const exampleSvg = makeBadge(badgeData)
 
-    expect(valueFromSvgBadge(exampleSvg)).to.equal('this is the result!')
+    expect(valueFromSvgBadge(exampleSvg, />([^<>]+)<\/text><\/g>/)).to.equal('this is the result!')
   })
 })

--- a/services/codacy/codacy-coverage.service.js
+++ b/services/codacy/codacy-coverage.service.js
@@ -28,7 +28,7 @@ module.exports = class CodacyCoverage extends LegacyService {
           '?' +
           query
         const badgeData = getBadgeData('coverage', data)
-        fetchFromSvg(request, url, (err, res) => {
+        fetchFromSvg(request, url, /text-anchor="middle">([^<>]+)<\/text>/, (err, res) => {
           if (err != null) {
             badgeData.text[1] = 'inaccessible'
             sendBadge(format, badgeData)

--- a/services/codacy/codacy-coverage.service.js
+++ b/services/codacy/codacy-coverage.service.js
@@ -28,21 +28,26 @@ module.exports = class CodacyCoverage extends LegacyService {
           '?' +
           query
         const badgeData = getBadgeData('coverage', data)
-        fetchFromSvg(request, url, /text-anchor="middle">([^<>]+)<\/text>/, (err, res) => {
-          if (err != null) {
-            badgeData.text[1] = 'inaccessible'
-            sendBadge(format, badgeData)
-            return
+        fetchFromSvg(
+          request,
+          url,
+          /text-anchor="middle">([^<>]+)<\/text>/,
+          (err, res) => {
+            if (err != null) {
+              badgeData.text[1] = 'inaccessible'
+              sendBadge(format, badgeData)
+              return
+            }
+            try {
+              badgeData.text[1] = res
+              badgeData.colorscheme = coveragePercentageColor(parseInt(res))
+              sendBadge(format, badgeData)
+            } catch (e) {
+              badgeData.text[1] = 'invalid'
+              sendBadge(format, badgeData)
+            }
           }
-          try {
-            badgeData.text[1] = res
-            badgeData.colorscheme = coveragePercentageColor(parseInt(res))
-            sendBadge(format, badgeData)
-          } catch (e) {
-            badgeData.text[1] = 'invalid'
-            sendBadge(format, badgeData)
-          }
-        })
+        )
       })
     )
   }

--- a/services/codacy/codacy-grade.service.js
+++ b/services/codacy/codacy-grade.service.js
@@ -25,7 +25,7 @@ module.exports = class CodacyGrade extends LegacyService {
           '?' +
           query
         const badgeData = getBadgeData('code quality', data)
-        fetchFromSvg(request, url, (err, res) => {
+        fetchFromSvg(request, url, /visibility="hidden">([^<>]+)<\/text>/, (err, res) => {
           if (err != null) {
             badgeData.text[1] = 'inaccessible'
             sendBadge(format, badgeData)

--- a/services/codacy/codacy-grade.service.js
+++ b/services/codacy/codacy-grade.service.js
@@ -25,38 +25,43 @@ module.exports = class CodacyGrade extends LegacyService {
           '?' +
           query
         const badgeData = getBadgeData('code quality', data)
-        fetchFromSvg(request, url, /visibility="hidden">([^<>]+)<\/text>/, (err, res) => {
-          if (err != null) {
-            badgeData.text[1] = 'inaccessible'
-            sendBadge(format, badgeData)
-            return
-          }
-          try {
-            badgeData.text[1] = res
-            if (res === 'A') {
-              badgeData.colorscheme = 'brightgreen'
-            } else if (res === 'B') {
-              badgeData.colorscheme = 'green'
-            } else if (res === 'C') {
-              badgeData.colorscheme = 'yellowgreen'
-            } else if (res === 'D') {
-              badgeData.colorscheme = 'yellow'
-            } else if (res === 'E') {
-              badgeData.colorscheme = 'orange'
-            } else if (res === 'F') {
-              badgeData.colorscheme = 'red'
-            } else if (res === 'X') {
-              badgeData.text[1] = 'invalid'
-              badgeData.colorscheme = 'lightgrey'
-            } else {
-              badgeData.colorscheme = 'red'
+        fetchFromSvg(
+          request,
+          url,
+          /visibility="hidden">([^<>]+)<\/text>/,
+          (err, res) => {
+            if (err != null) {
+              badgeData.text[1] = 'inaccessible'
+              sendBadge(format, badgeData)
+              return
             }
-            sendBadge(format, badgeData)
-          } catch (e) {
-            badgeData.text[1] = 'invalid'
-            sendBadge(format, badgeData)
+            try {
+              badgeData.text[1] = res
+              if (res === 'A') {
+                badgeData.colorscheme = 'brightgreen'
+              } else if (res === 'B') {
+                badgeData.colorscheme = 'green'
+              } else if (res === 'C') {
+                badgeData.colorscheme = 'yellowgreen'
+              } else if (res === 'D') {
+                badgeData.colorscheme = 'yellow'
+              } else if (res === 'E') {
+                badgeData.colorscheme = 'orange'
+              } else if (res === 'F') {
+                badgeData.colorscheme = 'red'
+              } else if (res === 'X') {
+                badgeData.text[1] = 'invalid'
+                badgeData.colorscheme = 'lightgrey'
+              } else {
+                badgeData.colorscheme = 'red'
+              }
+              sendBadge(format, badgeData)
+            } catch (e) {
+              badgeData.text[1] = 'invalid'
+              sendBadge(format, badgeData)
+            }
           }
-        })
+        )
       })
     )
   }

--- a/services/codacy/codacy.tester.js
+++ b/services/codacy/codacy.tester.js
@@ -3,14 +3,7 @@
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
 const { isIntegerPercentage } = require('../test-validators')
-const isCodacyGrade = Joi.equal(
-  'A',
-  'B',
-  'C',
-  'D',
-  'E',
-  'F',
-)
+const isCodacyGrade = Joi.equal('A', 'B', 'C', 'D', 'E', 'F')
 
 const t = new ServiceTester({ id: 'codacy', title: 'Codacy' })
 module.exports = t
@@ -23,7 +16,7 @@ t.create('Coverage')
       value: isIntegerPercentage,
     })
   )
-  
+
 t.create('Coverage on branch')
   .get('/coverage/59d607d0e311408885e418004068ea58/master.json')
   .expectJSONTypes(
@@ -32,7 +25,7 @@ t.create('Coverage on branch')
       value: isIntegerPercentage,
     })
   )
-  
+
 t.create('Code qualiy')
   .get('/grade/e27821fb6289410b8f58338c7e0bc686.json')
   .expectJSONTypes(
@@ -41,7 +34,7 @@ t.create('Code qualiy')
       value: isCodacyGrade,
     })
   )
-  
+
 t.create('Code qualiy on branch')
   .get('/grade/e27821fb6289410b8f58338c7e0bc686/master.json')
   .expectJSONTypes(

--- a/services/codacy/codacy.tester.js
+++ b/services/codacy/codacy.tester.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const Joi = require('joi')
+const ServiceTester = require('../service-tester')
+const { isIntegerPercentage } = require('../test-validators')
+const isCodacyGrade = Joi.equal(
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+)
+
+const t = new ServiceTester({ id: 'codacy', title: 'Codacy' })
+module.exports = t
+
+t.create('Coverage')
+  .get('/coverage/59d607d0e311408885e418004068ea58.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'coverage',
+      value: isIntegerPercentage,
+    })
+  )
+  
+t.create('Coverage on branch')
+  .get('/coverage/59d607d0e311408885e418004068ea58/master.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'coverage',
+      value: isIntegerPercentage,
+    })
+  )
+  
+t.create('Code qualiy')
+  .get('/grade/e27821fb6289410b8f58338c7e0bc686.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'code quality',
+      value: isCodacyGrade,
+    })
+  )
+  
+t.create('Code qualiy on branch')
+  .get('/grade/e27821fb6289410b8f58338c7e0bc686/master.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'code quality',
+      value: isCodacyGrade,
+    })
+  )

--- a/services/readthedocs/readthedocs.service.js
+++ b/services/readthedocs/readthedocs.service.js
@@ -20,7 +20,7 @@ module.exports = class ReadTheDocs extends LegacyService {
         if (version != null) {
           url += '?version=' + encodeURIComponent(version)
         }
-        fetchFromSvg(request, url, (err, res) => {
+        fetchFromSvg(request, url, />([^<>]+)<\/text><\/g>/, (err, res) => {
           if (err != null) {
             badgeData.text[1] = 'inaccessible'
             sendBadge(format, badgeData)

--- a/services/vso/vso.service.js
+++ b/services/vso/vso.service.js
@@ -5,7 +5,7 @@ const { fetchFromSvg } = require('../../lib/svg-badge-parser')
 const { makeBadgeData: getBadgeData } = require('../../lib/badge-data')
 
 const fetchVstsBadge = (request, url, badgeData, sendBadge, format) => {
-  fetchFromSvg(request, url, (err, res) => {
+  fetchFromSvg(request, url, />([^<>]+)<\/text><\/g>/, (err, res) => {
     if (err != null) {
       badgeData.text[1] = 'inaccessible'
       sendBadge(format, badgeData)


### PR DESCRIPTION
This pull request addresses #1985.

The current `getValue` regex in _svg-badge-parser.js_ was no longer properly parsing Codacy's SVG badges, and that service's coverage and grade badges were also inconsistent with one another. The proposed solution is to make the regex customisable on a per service basis.

If we implement a _BaseSvgService_ in #2031, we could implement a function returning a regex which can be overriden by implementations.

