### PR TITLE
Fix [circleci] urls with token (for private projects)

### DIFF
--- a/services/circleci/circleci.service.js
+++ b/services/circleci/circleci.service.js
@@ -57,7 +57,7 @@ module.exports = class CircleCi extends BaseJsonService {
     return {
       base: 'circleci',
       format:
-        '(?:token/(w+))?[+/]?project/(?:(github|bitbucket)/)?([^/]+/[^/]+)(?:/(.*))?',
+        '(?:token/(\\w+)/)?project/(?:(github|bitbucket)/)?([^/]+/[^/]+)(?:/(.*))?',
       capture: ['token', 'vcsType', 'userRepo', 'branch'],
     }
   }

--- a/services/circleci/circleci.tester.js
+++ b/services/circleci/circleci.tester.js
@@ -25,6 +25,17 @@ t.create('circle ci (valid, with branch)')
     })
   )
 
+t.create('circle ci (valid, with token)')
+  .get(
+    '/token/b90b5c49e59a4c67ba3a92f7992587ac7a0408c2/project/github/RedSparr0w/node-csgo-parser/master.json'
+  )
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'build',
+      value: isBuildStatus,
+    })
+  )
+
 t.create('circle ci (not found)')
   .get('/project/github/PyvesB/EmptyRepo.json')
   .expectJSON({ name: 'build', value: 'project not found' })


### PR DESCRIPTION
* Add tests for urls with token (just basic one that the server can handle such urls).
* Fix URL to make the test passed.

## The problem

Urls like `/circleci/:token/project/:vcsType/:owner/:repo/:branch.svg` don't work, but we need them to let the server fetch data from CircleCI API by passing token.