### PR TITLE
Fixed [Codacy] coverage examples and improved unknown coverage handling

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -383,12 +383,12 @@ const allBadgeExamples = [
       },
       {
         title: 'Codacy coverage',
-        previewUrl: '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd.svg',
+        previewUrl: '/codacy/coverage/59d607d0e311408885e418004068ea58.svg',
       },
       {
         title: 'Codacy branch coverage',
         previewUrl:
-          '/codacy/coverage/c44df2d9c89a4809896914fd1a40bedd/master.svg',
+          '/codacy/coverage/59d607d0e311408885e418004068ea58/master.svg',
       },
       {
         title: 'Docker Automated build',

--- a/services/codacy/codacy-coverage.service.js
+++ b/services/codacy/codacy-coverage.service.js
@@ -39,8 +39,13 @@ module.exports = class CodacyCoverage extends LegacyService {
               return
             }
             try {
-              badgeData.text[1] = res
-              badgeData.colorscheme = coveragePercentageColor(parseInt(res))
+              const coverage = parseInt(res)
+              if (isNaN(coverage)) {
+                badgeData.text[1] = 'unknown'
+              } else {
+                badgeData.text[1] = res
+                badgeData.colorscheme = coveragePercentageColor(coverage)
+              }
               sendBadge(format, badgeData)
             } catch (e) {
               badgeData.text[1] = 'invalid'

--- a/services/codacy/codacy-coverage.service.js
+++ b/services/codacy/codacy-coverage.service.js
@@ -40,7 +40,7 @@ module.exports = class CodacyCoverage extends LegacyService {
             }
             try {
               const coverage = parseInt(res)
-              if (isNaN(coverage)) {
+              if (Number.isNaN(coverage)) {
                 badgeData.text[1] = 'unknown'
               } else {
                 badgeData.text[1] = res

--- a/services/codacy/codacy.tester.js
+++ b/services/codacy/codacy.tester.js
@@ -17,6 +17,13 @@ t.create('Coverage')
     })
   )
 
+t.create('Coverage unknown')
+  .get('/coverage/e27821fb6289410b8f58338c7e0bc686.json')
+  .expectJSON({
+    name: 'coverage',
+    value: 'unknown',
+  })
+
 t.create('Coverage on branch')
   .get('/coverage/59d607d0e311408885e418004068ea58/master.json')
   .expectJSONTypes(


### PR DESCRIPTION
The project used on the homepage doesn't have any relevant coverage data: ![](https://img.shields.io/codacy/coverage/e27821fb6289410b8f58338c7e0bc686.svg)

I've switched it to one that does: ![](https://img.shields.io/codacy/coverage/59d607d0e311408885e418004068ea58.svg)

As you can see above the unknown coverage case is handled pretty poorly, with the exclamation mark and the bright green colour. From now on, such a badge would render as: ![](https://img.shields.io/badge/coverage-unknown-lightgrey.svg)