### PR TITLE
Add [JenkinsPluginInstalls] service

### DIFF
--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -110,8 +110,7 @@ class JenkinsPluginInstalls extends BaseJsonService {
         staticExample: this.render({
           label: this._getLabel(),
           installs: 10247,
-        }),
-        keywords: ['jenkins'],
+        })
       },
       {
         title: 'Jenkins Plugin installs',
@@ -120,8 +119,7 @@ class JenkinsPluginInstalls extends BaseJsonService {
         staticExample: this.render({
           label: this._getLabel('1.26'),
           installs: 955,
-        }),
-        keywords: ['jenkins'],
+        })
       },
     ]
   }

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 
 const BaseJsonService = require('../base-json')
-const { NotFound, InvalidParameter } = require('../errors')
+const { NotFound } = require('../errors')
 const {
   downloadCount: downloadCountColor,
 } = require('../../lib/color-formatters')

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -59,27 +59,23 @@ class JenkinsPluginInstalls extends BaseJsonService {
     }
   }
 
-  async handle({ info, plugin, version }) {
+  async handle({ plugin, version }) {
     const label = this.constructor._getLabel(version)
     const json = await this.fetch({ plugin, version })
 
     let installs
-    if (info === 'iv') {
+    if (version) {
       installs = json.installationsPerVersion[version]
       if (!installs) {
         throw new NotFound({
           underlyingError: new Error('non-existent version'),
         })
       }
-    } else if (info === 'i') {
+    } else {
       const latestDate = Object.keys(json.installations)
         .sort()
         .slice(-1)[0]
       installs = json.installations[latestDate]
-    } else {
-      throw new InvalidParameter({
-        underlyingError: new Error('invalid info'),
-      })
     }
 
     return this.constructor.render({ label, installs })
@@ -95,9 +91,9 @@ class JenkinsPluginInstalls extends BaseJsonService {
 
   static get url() {
     return {
-      base: 'jenkins/plugin',
-      format: '(i|iv)/([^/]+)/?([^/]+)?',
-      capture: ['info', 'plugin', 'version'],
+      base: 'jenkins/plugin/i',
+      format: '([^/]+)/?([^/]+)?',
+      capture: ['plugin', 'version'],
     }
   }
 
@@ -105,21 +101,21 @@ class JenkinsPluginInstalls extends BaseJsonService {
     return [
       {
         title: 'Jenkins Plugin installs',
-        exampleUrl: 'i/view-job-filters',
-        urlPattern: 'i/:plugin',
+        exampleUrl: 'view-job-filters',
+        urlPattern: ':plugin',
         staticExample: this.render({
           label: this._getLabel(),
           installs: 10247,
-        })
+        }),
       },
       {
         title: 'Jenkins Plugin installs',
-        exampleUrl: 'iv/view-job-filters/1.26',
-        urlPattern: 'iv/:plugin/:version',
+        exampleUrl: 'view-job-filters/1.26',
+        urlPattern: ':plugin/:version',
         staticExample: this.render({
           label: this._getLabel('1.26'),
           installs: 955,
-        })
+        }),
       },
     ]
   }

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -32,7 +32,13 @@ class JenkinsPluginInstalls extends BaseJsonService {
   async fetch({ plugin, version }) {
     const url = `https://stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`
     const schema = this.constructor._getSchema(version)
-    return this._requestJson({ url, schema })
+    return this._requestJson({
+      url,
+      schema,
+      errorMessages: {
+        404: 'plugin not found',
+      },
+    })
   }
 
   static render({ label, installs }) {
@@ -68,7 +74,7 @@ class JenkinsPluginInstalls extends BaseJsonService {
       installs = json.installationsPerVersion[version]
       if (!installs) {
         throw new NotFound({
-          underlyingError: new Error('non-existent version'),
+          prettyMessage: 'version not found',
         })
       }
     } else {

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const Joi = require('joi')
+
+const BaseJsonService = require('../base-json')
+const { NotFound, InvalidParameter } = require('../errors')
+const {
+  downloadCount: downloadCountColor,
+} = require('../../lib/color-formatters')
+const { metric } = require('../../lib/text-formatters')
+const { nonNegativeInteger } = require('../validators')
+
+const schemaInstallations = Joi.object()
+  .keys({
+    installations: Joi.object()
+      .required()
+      .pattern(nonNegativeInteger, nonNegativeInteger)
+      .min(1),
+  })
+  .required()
+
+const schemaInstallationsPerVersion = Joi.object()
+  .keys({
+    installationsPerVersion: Joi.object()
+      .required()
+      .pattern(Joi.string(), nonNegativeInteger)
+      .min(1),
+  })
+  .required()
+
+class JenkinsPluginInstalls extends BaseJsonService {
+  async fetch({ plugin, version }) {
+    const url = `https://stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`
+    const schema = this.constructor._getSchema(version)
+    return this._requestJson({ url, schema })
+  }
+
+  static render({ label, installs }) {
+    return {
+      label: label,
+      message: metric(installs),
+      color: downloadCountColor(installs),
+    }
+  }
+
+  static _getSchema(version) {
+    if (version) {
+      return schemaInstallationsPerVersion
+    } else {
+      return schemaInstallations
+    }
+  }
+
+  static _getLabel(version) {
+    if (version) {
+      return 'installs@' + version
+    } else {
+      return 'installs'
+    }
+  }
+
+  async handle({ info, plugin, version }) {
+    const label = this.constructor._getLabel(version)
+    const json = await this.fetch({ plugin, version })
+
+    let installs
+    if (info === 'iv') {
+      installs = json.installationsPerVersion[version]
+      if (!installs) {
+        throw new NotFound({
+          underlyingError: new Error('non-existent version'),
+        })
+      }
+    } else if (info === 'i') {
+      const latestDate = Object.keys(json.installations)
+        .sort()
+        .slice(-1)[0]
+      installs = json.installations[latestDate]
+    } else {
+      throw new InvalidParameter({
+        underlyingError: new Error('invalid info'),
+      })
+    }
+
+    return this.constructor.render({ label, installs })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'installs' }
+  }
+
+  static get category() {
+    return 'downloads'
+  }
+
+  static get url() {
+    return {
+      base: 'jenkins/plugin',
+      format: '(i|iv)/([^/]+)/?([^/]+)?',
+      capture: ['info', 'plugin', 'version'],
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Jenkins Plugin installs',
+        exampleUrl: 'i/view-job-filters',
+        urlPattern: 'i/:plugin',
+        staticExample: this.render({
+          label: this._getLabel(),
+          installs: 10247,
+        }),
+        keywords: ['jenkins'],
+      },
+      {
+        title: 'Jenkins Plugin installs',
+        exampleUrl: 'iv/view-job-filters/1.26',
+        urlPattern: 'iv/:plugin/:version',
+        staticExample: this.render({
+          label: this._getLabel('1.26'),
+          installs: 955,
+        }),
+        keywords: ['jenkins'],
+      },
+    ]
+  }
+}
+
+module.exports = JenkinsPluginInstalls

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -46,7 +46,7 @@ t.create('total installs | invalid: non-numeric "installations" key')
 
 t.create('total installs | not found')
   .get('/not-a-plugin.json')
-  .expectJSON({ name: 'installs', value: 'not found' })
+  .expectJSON({ name: 'installs', value: 'plugin not found' })
 
 t.create('total installs | inaccessible: connection error')
   .get('/view-job-filters.json')
@@ -93,11 +93,11 @@ t.create('version installs | invalid: empty "installationsPerVersion" object')
 
 t.create('version installs | not found: non-existent plugin')
   .get('/not-a-plugin/1.26.json')
-  .expectJSON({ name: 'installs', value: 'not found' })
+  .expectJSON({ name: 'installs', value: 'plugin not found' })
 
 t.create('version installs | not found: non-existent version')
   .get('/view-job-filters/1.99.json')
-  .expectJSON({ name: 'installs', value: 'not found' })
+  .expectJSON({ name: 'installs', value: 'version not found' })
 
 t.create('version installs | inaccessible: connection error')
   .get('/view-job-filters/1.26.json')

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -96,7 +96,7 @@ t.create('version installs | not found: non-existent plugin')
   .expectJSON({ name: 'installs', value: 'plugin not found' })
 
 t.create('version installs | not found: non-existent version')
-  .get('/view-job-filters/1.99.json')
+  .get('/view-job-filters/1.1-NOT-FOUND.json')
   .expectJSON({ name: 'installs', value: 'version not found' })
 
 t.create('version installs | inaccessible: connection error')

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const Joi = require('joi')
+const { isMetric } = require('../test-validators')
+
+const createServiceTester = require('../create-service-tester')
+const t = createServiceTester()
+
+// total installs
+
+t.create('total installs | valid')
+  .get('/i/view-job-filters.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs',
+      value: isMetric,
+    })
+  )
+
+t.create('total installs | invalid: no "installations" property')
+  .get('/i/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters' })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | invalid: empty "installations" object')
+  .get('/i/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installations: {} })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | invalid: non-numeric "installations" key')
+  .get('/i/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installations: { abc: 12345 } })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | not found')
+  .get('/i/not-a-plugin.json')
+  .expectJSON({ name: 'installs', value: 'not found' })
+
+t.create('total installs | inaccessible: connection error')
+  .get('/i/view-job-filters.json')
+  .networkOff()
+  .expectJSON({ name: 'installs', value: 'inaccessible' })
+
+// version installs
+
+t.create('version installs | valid: numeric version')
+  .get('/iv/view-job-filters/1.26.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs@1.26',
+      value: isMetric,
+    })
+  )
+
+t.create('version installs | valid: alpha-numeric version')
+  .get('/iv/view-job-filters/1.27-DRE1.00.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs@1.27-DRE1.00',
+      value: isMetric,
+    })
+  )
+
+t.create('version installs | invalid: "installationsPerVersion" missing')
+  .get('/iv/view-job-filters/1.26.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters' })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('version installs | invalid: empty "installationsPerVersion" object')
+  .get('/iv/view-job-filters/1.26.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installationsPerVersion: {} })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('version installs | not found: non-existent plugin')
+  .get('/iv/not-a-plugin/1.26.json')
+  .expectJSON({ name: 'installs', value: 'not found' })
+
+t.create('version installs | not found: non-existent version')
+  .get('/iv/view-job-filters/1.99.json')
+  .expectJSON({ name: 'installs', value: 'not found' })
+
+t.create('version installs | inaccessible: connection error')
+  .get('/iv/view-job-filters/1.26.json')
+  .networkOff()
+  .expectJSON({ name: 'installs', value: 'inaccessible' })
+
+module.exports = t

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -9,7 +9,7 @@ const t = createServiceTester()
 // total installs
 
 t.create('total installs | valid')
-  .get('/i/view-job-filters.json')
+  .get('/view-job-filters.json')
   .expectJSONTypes(
     Joi.object().keys({
       name: 'installs',
@@ -18,7 +18,7 @@ t.create('total installs | valid')
   )
 
 t.create('total installs | invalid: no "installations" property')
-  .get('/i/view-job-filters.json')
+  .get('/view-job-filters.json')
   .intercept(nock =>
     nock('https://stats.jenkins.io')
       .get('/plugin-installation-trend/view-job-filters.stats.json')
@@ -27,7 +27,7 @@ t.create('total installs | invalid: no "installations" property')
   .expectJSON({ name: 'installs', value: 'invalid response data' })
 
 t.create('total installs | invalid: empty "installations" object')
-  .get('/i/view-job-filters.json')
+  .get('/view-job-filters.json')
   .intercept(nock =>
     nock('https://stats.jenkins.io')
       .get('/plugin-installation-trend/view-job-filters.stats.json')
@@ -36,7 +36,7 @@ t.create('total installs | invalid: empty "installations" object')
   .expectJSON({ name: 'installs', value: 'invalid response data' })
 
 t.create('total installs | invalid: non-numeric "installations" key')
-  .get('/i/view-job-filters.json')
+  .get('/view-job-filters.json')
   .intercept(nock =>
     nock('https://stats.jenkins.io')
       .get('/plugin-installation-trend/view-job-filters.stats.json')
@@ -45,18 +45,18 @@ t.create('total installs | invalid: non-numeric "installations" key')
   .expectJSON({ name: 'installs', value: 'invalid response data' })
 
 t.create('total installs | not found')
-  .get('/i/not-a-plugin.json')
+  .get('/not-a-plugin.json')
   .expectJSON({ name: 'installs', value: 'not found' })
 
 t.create('total installs | inaccessible: connection error')
-  .get('/i/view-job-filters.json')
+  .get('/view-job-filters.json')
   .networkOff()
   .expectJSON({ name: 'installs', value: 'inaccessible' })
 
 // version installs
 
 t.create('version installs | valid: numeric version')
-  .get('/iv/view-job-filters/1.26.json')
+  .get('/view-job-filters/1.26.json')
   .expectJSONTypes(
     Joi.object().keys({
       name: 'installs@1.26',
@@ -65,7 +65,7 @@ t.create('version installs | valid: numeric version')
   )
 
 t.create('version installs | valid: alpha-numeric version')
-  .get('/iv/view-job-filters/1.27-DRE1.00.json')
+  .get('/view-job-filters/1.27-DRE1.00.json')
   .expectJSONTypes(
     Joi.object().keys({
       name: 'installs@1.27-DRE1.00',
@@ -74,7 +74,7 @@ t.create('version installs | valid: alpha-numeric version')
   )
 
 t.create('version installs | invalid: "installationsPerVersion" missing')
-  .get('/iv/view-job-filters/1.26.json')
+  .get('/view-job-filters/1.26.json')
   .intercept(nock =>
     nock('https://stats.jenkins.io')
       .get('/plugin-installation-trend/view-job-filters.stats.json')
@@ -83,7 +83,7 @@ t.create('version installs | invalid: "installationsPerVersion" missing')
   .expectJSON({ name: 'installs', value: 'invalid response data' })
 
 t.create('version installs | invalid: empty "installationsPerVersion" object')
-  .get('/iv/view-job-filters/1.26.json')
+  .get('/view-job-filters/1.26.json')
   .intercept(nock =>
     nock('https://stats.jenkins.io')
       .get('/plugin-installation-trend/view-job-filters.stats.json')
@@ -92,15 +92,15 @@ t.create('version installs | invalid: empty "installationsPerVersion" object')
   .expectJSON({ name: 'installs', value: 'invalid response data' })
 
 t.create('version installs | not found: non-existent plugin')
-  .get('/iv/not-a-plugin/1.26.json')
+  .get('/not-a-plugin/1.26.json')
   .expectJSON({ name: 'installs', value: 'not found' })
 
 t.create('version installs | not found: non-existent version')
-  .get('/iv/view-job-filters/1.99.json')
+  .get('/view-job-filters/1.99.json')
   .expectJSON({ name: 'installs', value: 'not found' })
 
 t.create('version installs | inaccessible: connection error')
-  .get('/iv/view-job-filters/1.26.json')
+  .get('/view-job-filters/1.26.json')
   .networkOff()
   .expectJSON({ name: 'installs', value: 'inaccessible' })
 


### PR DESCRIPTION
This adds a badge that shows the number of installations of a particular Jenkins plugin. You can show the total number of installations across all versions or pick a particular version.

The data is retrieved from the [official statistics](https://stats.jenkins.io/) that the Jenkins project provides. For example, the data for the [View Job Filters Plugin](https://plugins.jenkins.io/view-job-filters) can be found here:

https://stats.jenkins.io/plugin-installation-trend/view-job-filters.stats.json

Note that these are actual installs, not downloads (i.e if somebody uninstalls a plugin, the number goes down). I've still added the badge to the downloads category because that's the closest category there is.