### PR TITLE
Add multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,2 +1,0 @@
-<!-- Love Shields? Please consider donating $10 to sustain our activities:
-👉  https://opencollective.com/shields -->

--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -1,0 +1,25 @@
+---
+name: 🐛 Bug Report
+about: Report errors and problems
+
+---
+
+Are you experiencing this issue on shields.io or your own instance?
+ - [ ] shields.io
+ - [ ] My instance
+
+:beetle: **Description**
+<!-- A clear and concise description of the problem. -->
+
+:link: **Link to the badge**
+<!--
+If you are reporting a problem with a specific badge on shields.io,
+provide a link to a badge demonstrating the error
+-->
+
+:bulb: **Possible Solution**
+<!--- Optional: only if you have suggestions on a fix/reason for the bug -->
+
+
+<!-- Love Shields? Please consider donating $10 to sustain our activities:
+👉  https://opencollective.com/shields -->

--- a/.github/ISSUE_TEMPLATE/2_Badge_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Badge_request.md
@@ -1,0 +1,26 @@
+---
+name: 💡 Badge Request
+about: Ideas for new badges
+
+---
+
+:clipboard: **Description**
+<!--
+A clear and concise description of the new feature.
+
+- Which service is this badge for e.g: GitHub, Travis CI
+- What sort of information should this badge show e.g: version, downloads
+-->
+
+:link: **Data**
+<!--
+Where can we get the data from?
+
+- Is there a public API?
+- Does the API requires an API key?
+- Link to the API documentation.
+-->
+
+
+<!-- Love Shields? Please consider donating $10 to sustain our activities:
+👉  https://opencollective.com/shields -->

--- a/.github/ISSUE_TEMPLATE/2_Badge_request.md
+++ b/.github/ISSUE_TEMPLATE/2_Badge_request.md
@@ -6,10 +6,12 @@ about: Ideas for new badges
 
 :clipboard: **Description**
 <!--
-A clear and concise description of the new feature.
+A clear and concise description of the new badge.
 
 - Which service is this badge for e.g: GitHub, Travis CI
-- What sort of information should this badge show e.g: version, downloads
+- What sort of information should this badge show?
+  Provide an example in plain text e.g: "version | v1.01" or as a static badge
+  (static badge generator can be found at https://shields.io)
 -->
 
 :link: **Data**

--- a/.github/ISSUE_TEMPLATE/3_Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_Feature_request.md
@@ -1,0 +1,12 @@
+---
+name: 💡 Feature Request
+about: Ideas for other new features or improvements
+
+---
+
+:clipboard: **Description**
+<!-- A clear and concise description of the new feature. -->
+
+
+<!-- Love Shields? Please consider donating $10 to sustain our activities:
+👉  https://opencollective.com/shields -->

--- a/.github/ISSUE_TEMPLATE/4_Support_question.md
+++ b/.github/ISSUE_TEMPLATE/4_Support_question.md
@@ -1,0 +1,17 @@
+---
+name: ❓ Support Question
+about: Ask a question about shields.io
+
+---
+
+:question: **Question**
+<!--
+Ask your question clearly and concisely.
+
+#support on our [Discord](https://discordapp.com/invite/HjJCwm5)
+is also a great place to ask questions and get help
+-->
+
+
+<!-- Love Shields? Please consider donating $10 to sustain our activities:
+👉  https://opencollective.com/shields -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ the top post.
 If you have a suggestion of your own, [search the open issues][issues]. If you
 don't see it, feel free to [open a new issue][open an issue].
 
-[open an issue]: https://github.com/badges/shields/issues/new
+[open an issue]: https://github.com/badges/shields/issues/new/choose
 
 ### Spreading the word
 

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -37,7 +37,7 @@ and learn about the [Github workflow](http://try.github.io/).
 (3) Open an Issue
 -----------------
 
-Before you want to implement your service, you may want to [open an issue](https://github.com/badges/shields/issues/new) and describe what you have in mind:
+Before you want to implement your service, you may want to [open an issue](https://github.com/badges/shields/issues/new?template=2_Badge_request.md) and describe what you have in mind:
 - What is the badge for?
 - Which API do you want to use?
 


### PR DESCRIPTION
Following up on @platan 's suggestion in #1678 I've had a go at writing some issue templates.

It is a bit hard to review what this will look like when we merge it so to make this easier I've also pushed the templates in this PR up to a test repo. You can preview at https://github.com/chris48s/templates-test/issues/new/choose

closes #1678