### PR TITLE
[Dub] downloads badge with available version

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -703,7 +703,7 @@ const allBadgeExamples = [
       },
       {
         title: 'DUB',
-        previewUrl: '/dub/dt/vibe-d/0.7.23.svg',
+        previewUrl: '/dub/dt/vibe-d/0.8.4.svg',
         keywords: ['dub'],
       },
       {

--- a/services/dub/dub.tester.js
+++ b/services/dub/dub.tester.js
@@ -35,11 +35,11 @@ t.create('total downloads (valid)')
   )
 
 t.create('total downloads, specific version (valid)')
-  .get('/dt/vibe-d/0.7.27.json?style=_shields_test')
+  .get('/dt/vibe-d/0.8.4.json?style=_shields_test')
   .expectJSONTypes(
     Joi.object().keys({
       name: 'downloads',
-      value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.7.27$/),
+      value: Joi.string().regex(/^[1-9][0-9]*[kMGTPEZY]? v0.8.4$/),
       colorB: isVersionColor,
     })
   )


### PR DESCRIPTION
Before:
![obraz](https://user-images.githubusercontent.com/1526000/46249313-45e1e180-c427-11e8-8d11-dae110b6043c.png)
after:
![obraz](https://user-images.githubusercontent.com/1526000/46249320-627e1980-c427-11e8-8ff7-982e1a123b12.png)
Version `0.7.23` is not available anymore: https://code.dlang.org/packages/vibe-d/versions
I've updated example and service test with the newest one `0.8.4`. 