### PR TITLE
Add [Steam] Service badges WIP

### DIFF
--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -1,0 +1,130 @@
+'use strict'
+
+const Joi = require('joi')
+
+const BaseJsonService = require('../base-json')
+const { NotFound } = require('../errors')
+const {
+  downloadCount: downloadCountColor,
+} = require('../../lib/color-formatters')
+const { metric } = require('../../lib/text-formatters')
+const { nonNegativeInteger } = require('../validators')
+
+const schemaInstallations = Joi.object()
+  .keys({
+    installations: Joi.object()
+      .required()
+      .pattern(nonNegativeInteger, nonNegativeInteger)
+      .min(1),
+  })
+  .required()
+
+const schemaInstallationsPerVersion = Joi.object()
+  .keys({
+    installationsPerVersion: Joi.object()
+      .required()
+      .pattern(Joi.string(), nonNegativeInteger)
+      .min(1),
+  })
+  .required()
+
+class JenkinsPluginInstalls extends BaseJsonService {
+  async fetch({ plugin, version }) {
+    const url = `https://stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`
+    const schema = this.constructor._getSchema(version)
+    return this._requestJson({
+      url,
+      schema,
+      errorMessages: {
+        404: 'plugin not found',
+      },
+    })
+  }
+
+  static render({ label, installs }) {
+    return {
+      label: label,
+      message: metric(installs),
+      color: downloadCountColor(installs),
+    }
+  }
+
+  static _getSchema(version) {
+    if (version) {
+      return schemaInstallationsPerVersion
+    } else {
+      return schemaInstallations
+    }
+  }
+
+  static _getLabel(version) {
+    if (version) {
+      return 'installs@' + version
+    } else {
+      return 'installs'
+    }
+  }
+
+  async handle({ plugin, version }) {
+    const label = this.constructor._getLabel(version)
+    const json = await this.fetch({ plugin, version })
+
+    let installs
+    if (version) {
+      installs = json.installationsPerVersion[version]
+      if (!installs) {
+        throw new NotFound({
+          prettyMessage: 'version not found',
+        })
+      }
+    } else {
+      const latestDate = Object.keys(json.installations)
+        .sort()
+        .slice(-1)[0]
+      installs = json.installations[latestDate]
+    }
+
+    return this.constructor.render({ label, installs })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'installs' }
+  }
+
+  static get category() {
+    return 'downloads'
+  }
+
+  static get url() {
+    return {
+      base: 'jenkins/plugin/i',
+      format: '([^/]+)/?([^/]+)?',
+      capture: ['plugin', 'version'],
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Jenkins Plugin installs',
+        exampleUrl: 'view-job-filters',
+        urlPattern: ':plugin',
+        staticExample: this.render({
+          label: this._getLabel(),
+          installs: 10247,
+        }),
+      },
+      {
+        title: 'Jenkins Plugin installs',
+        exampleUrl: 'view-job-filters/1.26',
+        urlPattern: ':plugin/:version',
+        staticExample: this.render({
+          label: this._getLabel('1.26'),
+          installs: 955,
+        }),
+      },
+    ]
+  }
+}
+
+module.exports = JenkinsPluginInstalls

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const Joi = require('joi')
+const { isMetric } = require('../test-validators')
+
+const createServiceTester = require('../create-service-tester')
+const t = createServiceTester()
+
+// total installs
+
+t.create('total installs | valid')
+  .get('/view-job-filters.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs',
+      value: isMetric,
+    })
+  )
+
+t.create('total installs | invalid: no "installations" property')
+  .get('/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters' })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | invalid: empty "installations" object')
+  .get('/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installations: {} })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | invalid: non-numeric "installations" key')
+  .get('/view-job-filters.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installations: { abc: 12345 } })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('total installs | not found')
+  .get('/not-a-plugin.json')
+  .expectJSON({ name: 'installs', value: 'plugin not found' })
+
+t.create('total installs | inaccessible: connection error')
+  .get('/view-job-filters.json')
+  .networkOff()
+  .expectJSON({ name: 'installs', value: 'inaccessible' })
+
+// version installs
+
+t.create('version installs | valid: numeric version')
+  .get('/view-job-filters/1.26.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs@1.26',
+      value: isMetric,
+    })
+  )
+
+t.create('version installs | valid: alpha-numeric version')
+  .get('/view-job-filters/1.27-DRE1.00.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'installs@1.27-DRE1.00',
+      value: isMetric,
+    })
+  )
+
+t.create('version installs | invalid: "installationsPerVersion" missing')
+  .get('/view-job-filters/1.26.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters' })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('version installs | invalid: empty "installationsPerVersion" object')
+  .get('/view-job-filters/1.26.json')
+  .intercept(nock =>
+    nock('https://stats.jenkins.io')
+      .get('/plugin-installation-trend/view-job-filters.stats.json')
+      .reply(200, { name: 'view-job-filters', installationsPerVersion: {} })
+  )
+  .expectJSON({ name: 'installs', value: 'invalid response data' })
+
+t.create('version installs | not found: non-existent plugin')
+  .get('/not-a-plugin/1.26.json')
+  .expectJSON({ name: 'installs', value: 'plugin not found' })
+
+t.create('version installs | not found: non-existent version')
+  .get('/view-job-filters/1.1-NOT-FOUND.json')
+  .expectJSON({ name: 'installs', value: 'version not found' })
+
+t.create('version installs | inaccessible: connection error')
+  .get('/view-job-filters/1.26.json')
+  .networkOff()
+  .expectJSON({ name: 'installs', value: 'inaccessible' })
+
+module.exports = t

--- a/services/steam/steam.service.js
+++ b/services/steam/steam.service.js
@@ -1,0 +1,357 @@
+'use strict'
+
+const Joi = require('joi')
+const BaseJsonService = require('../base-json')
+const { metric, formatDate } = require('../../lib/text-formatters')
+const { age: ageColor } = require('../../lib/color-formatters')
+const prettyBytes = require('pretty-bytes')
+
+const steamCollectionSchema = Joi.object({
+  response: Joi.object().keys({
+    result: Joi.number().integer().min(1).max(1).required(),
+    resultcount: Joi.number().integer().min(0).max(1).required(),
+    collectiondetails: Joi.array().items(Joi.object({
+      publishedfileid: Joi.string(),
+      result: Joi.number().integer(),
+      children: Joi.array()
+    })).required()
+  }).required(),
+}).required()
+
+const steamFileSchema = Joi.object({
+  response: Joi.object().keys({
+    result: Joi.number().integer().min(1).required(),
+    resultcount: Joi.number().integer().min(0).required(),
+    publishedfiledetails: Joi.array().items(Joi.object({
+      publishedfileid: Joi.string().required(),
+      result: Joi.number().integer().required(),
+      file_size: Joi.number().integer(),
+      time_created: Joi.number().integer(),
+      subscriptions: Joi.number().integer(),
+      favorited: Joi.number().integer(),
+      lifetime_subscriptions: Joi.number().integer(),
+      lifetime_favorited: Joi.number().integer(),
+      views: Joi.number().integer(),
+    }))
+  }).required(),
+}).required()
+
+class SteamCollectionCount extends BaseJsonService {
+  async fetch({collectionId}) {
+    const url = 'https://api.steampowered.com/ISteamRemoteStorage/GetCollectionDetails/v1/?format=json'
+    return this._requestJson({
+      url,
+      schema: steamCollectionSchema,
+      errorMessages: {
+        400: 'bad request'
+      },
+      options: {
+        method: 'POST',
+        form: {
+          collectioncount: '1',
+          'publishedfileids[0]': collectionId
+        }
+      }
+    })
+  }
+
+  static render({ size }) {
+    return { message: metric(size), color: 'green' }
+  }
+
+  async handle({ collectionId }) {
+    const json = await this.fetch({ collectionId })
+    return this.constructor.render({ size: json.response.collectiondetails[0].children.length})
+  }
+
+  static get category() {
+    return 'other'
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'files' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/collection-size',
+      format: '(.+)',
+      capture: ['collectionId'],
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Collection Size',
+        exampleUrl: '16524',
+        urlPattern: ":collection_id",
+        staticExample: this.render({ size: 20 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamFileService extends BaseJsonService {
+
+  async fetch({fileId}) {
+    const url = 'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/?format=json'
+    return this._requestJson({
+      url,
+      schema: steamFileSchema,
+      errorMessages: {
+        400: 'bad request'
+      },
+      options: {
+        method: 'POST',
+        form: {
+          itemcount: 1,
+          'publishedfileids[0]': fileId,
+        }
+      }
+    })
+  }
+
+  async handle({ fileId }) {
+    const json = await this.fetch({ fileId })
+
+    if (json.response.publishedfiledetails[0].result === 1) {
+      return this.onRequest({ response: json.response.publishedfiledetails[0] })
+    } else {
+      return { message: 'file not found', color: 'red' }
+    }
+  }
+
+  async onRequest({response}) {}
+
+  static get defaultBadgeData() {
+    return {label: 'steam'}
+  }
+
+  static get category() {
+    return 'other'
+  }
+}
+
+class SteamFileSize extends SteamFileService {
+  static render({ fileSize }) {
+    return { message: prettyBytes(fileSize), color: 'green' }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ fileSize: response.file_size })
+  }
+
+  static get category() {
+    return 'size'
+  }
+
+  static get defaultBadgeData() {
+    return {label: 'size'}
+  }
+
+  static get url() {
+    return {
+      base: 'steam/size',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam File Size',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ fileSize: 20000 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamReleaseDate extends SteamFileService {
+  static render({ releaseDate }) {
+    return { message: formatDate(releaseDate), color: ageColor(releaseDate) }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ releaseDate: response.time_created })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'release date' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/release-date',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Release Date',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ releaseDate: '12-12-2020' }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamSubscriptions extends SteamFileService {
+  static render({ subscriptions }) {
+    return { message: metric(subscriptions), color: 'lime' }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ subscriptions: response.subscriptions })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'subscriptions' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/subscriptions',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Subscriptions',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ subscriptions: 20124 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamFavorites extends SteamFileService {
+  static render({ favorited }) {
+    return { message: metric(favorited), color: 'lime' }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ favorited: response.favorited })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'favorited' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/favorited',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Favourites',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ favorited: 20124 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamDownloads extends SteamFileService {
+  static render({ downloads }) {
+    return { message: metric(downloads), color: 'lime' }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ downloads: response.lifetime_subscriptions })
+  }
+
+  static get category() {
+    return 'downloads'
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'downloads' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/downloads',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Downloads',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ downloads: 20124 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+class SteamViews extends SteamFileService {
+  static render({ views }) {
+    return { message: metric(views), color: 'lime' }
+  }
+
+  async onRequest({response}) {
+    return this.constructor.render({ views: response.views })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'views' }
+  }
+
+  static get url() {
+    return {
+      base: 'steam/views',
+      format: '(.+)',
+      capture: ['fileId']
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Views',
+        exampleUrl: '100',
+        urlPattern: ':file_id',
+        staticExample: this.render({ views: 20000 }),
+        keywords: ['steam']
+      }
+    ]
+  }
+}
+
+module.exports = {
+  SteamCollectionCount,
+  SteamFileSize,
+  SteamReleaseDate,
+  SteamSubscriptions,
+  SteamFavorites,
+  SteamDownloads,
+  SteamViews
+}

--- a/services/steam/steam.service.js
+++ b/services/steam/steam.service.js
@@ -211,7 +211,8 @@ class SteamReleaseDate extends SteamFileService {
   }
 
   async onRequest({ response }) {
-    return this.constructor.render({ releaseDate: response.time_created })
+    const releaseDate = new Date(0).setUTCSeconds(response.time_created)
+    return this.constructor.render({ releaseDate: releaseDate })
   }
 
   static get defaultBadgeData() {
@@ -232,7 +233,7 @@ class SteamReleaseDate extends SteamFileService {
         title: 'Steam Release Date',
         exampleUrl: '100',
         urlPattern: ':file_id',
-        staticExample: this.render({ releaseDate: '12-12-2020' }),
+        staticExample: this.render({ releaseDate: new Date(0).setUTCSeconds(1538288239) }),
         keywords: ['steam'],
       },
     ]
@@ -274,8 +275,8 @@ class SteamSubscriptions extends SteamFileService {
 }
 
 class SteamFavorites extends SteamFileService {
-  static render({ favorited }) {
-    return { message: metric(favorited), color: 'lime' }
+  static render({ favorites }) {
+    return { message: metric(favorites), color: 'lime' }
   }
 
   async onRequest({ response }) {
@@ -283,12 +284,12 @@ class SteamFavorites extends SteamFileService {
   }
 
   static get defaultBadgeData() {
-    return { label: 'favorited' }
+    return { label: 'favorites' }
   }
 
   static get url() {
     return {
-      base: 'steam/favorited',
+      base: 'steam/favorites',
       format: '(.+)',
       capture: ['fileId'],
     }
@@ -300,7 +301,7 @@ class SteamFavorites extends SteamFileService {
         title: 'Steam Favourites',
         exampleUrl: '100',
         urlPattern: ':file_id',
-        staticExample: this.render({ favorited: 20124 }),
+        staticExample: this.render({ favorites: 20124 }),
         keywords: ['steam'],
       },
     ]

--- a/services/steam/steam.service.js
+++ b/services/steam/steam.service.js
@@ -36,7 +36,7 @@ const steamFileSchema = Joi.object({
   }).required(),
 }).required()
 
-class SteamCollectionCount extends BaseJsonService {
+class SteamCollectionFiles extends BaseJsonService {
   async fetch({collectionId}) {
     const url = 'https://api.steampowered.com/ISteamRemoteStorage/GetCollectionDetails/v1/?format=json'
     return this._requestJson({
@@ -61,7 +61,11 @@ class SteamCollectionCount extends BaseJsonService {
 
   async handle({ collectionId }) {
     const json = await this.fetch({ collectionId })
-    return this.constructor.render({ size: json.response.collectiondetails[0].children.length})
+    if (json.response.collectiondetails[0].result === 1) {
+      return this.constructor.render({ size: json.response.collectiondetails[0].children.length})
+    } else {
+      return { message: 'collection not found', color: 'red' }
+    }
   }
 
   static get category() {
@@ -74,7 +78,7 @@ class SteamCollectionCount extends BaseJsonService {
 
   static get url() {
     return {
-      base: 'steam/collection-size',
+      base: 'steam/collection-files',
       format: '(.+)',
       capture: ['collectionId'],
     }
@@ -83,10 +87,10 @@ class SteamCollectionCount extends BaseJsonService {
   static get examples() {
     return [
       {
-        title: 'Steam Collection Size',
-        exampleUrl: '16524',
+        title: 'Steam Collection Files',
+        exampleUrl: '180077636',
         urlPattern: ":collection_id",
-        staticExample: this.render({ size: 20 }),
+        staticExample: this.render({ size: 32 }),
         keywords: ['steam']
       }
     ]
@@ -347,7 +351,7 @@ class SteamViews extends SteamFileService {
 }
 
 module.exports = {
-  SteamCollectionCount,
+  SteamCollectionFiles,
   SteamFileSize,
   SteamReleaseDate,
   SteamSubscriptions,

--- a/services/steam/steam.service.js
+++ b/services/steam/steam.service.js
@@ -7,51 +7,78 @@ const { age: ageColor } = require('../../lib/color-formatters')
 const prettyBytes = require('pretty-bytes')
 
 const steamCollectionSchema = Joi.object({
-  response: Joi.object().keys({
-    result: Joi.number().integer().min(1).max(1).required(),
-    resultcount: Joi.number().integer().min(0).max(1).required(),
-    collectiondetails: Joi.array().items(Joi.object({
-      publishedfileid: Joi.string(),
-      result: Joi.number().integer(),
-      children: Joi.array()
-    })).required()
-  }).required(),
+  response: Joi.object()
+    .keys({
+      result: Joi.number()
+        .integer()
+        .min(1)
+        .max(1)
+        .required(),
+      resultcount: Joi.number()
+        .integer()
+        .min(0)
+        .max(1)
+        .required(),
+      collectiondetails: Joi.array()
+        .items(
+          Joi.object({
+            publishedfileid: Joi.string(),
+            result: Joi.number().integer(),
+            children: Joi.array(),
+          })
+        )
+        .required(),
+    })
+    .required(),
 }).required()
 
 const steamFileSchema = Joi.object({
-  response: Joi.object().keys({
-    result: Joi.number().integer().min(1).required(),
-    resultcount: Joi.number().integer().min(0).required(),
-    publishedfiledetails: Joi.array().items(Joi.object({
-      publishedfileid: Joi.string().required(),
-      result: Joi.number().integer().required(),
-      file_size: Joi.number().integer(),
-      time_created: Joi.number().integer(),
-      subscriptions: Joi.number().integer(),
-      favorited: Joi.number().integer(),
-      lifetime_subscriptions: Joi.number().integer(),
-      lifetime_favorited: Joi.number().integer(),
-      views: Joi.number().integer(),
-    }))
-  }).required(),
+  response: Joi.object()
+    .keys({
+      result: Joi.number()
+        .integer()
+        .min(1)
+        .required(),
+      resultcount: Joi.number()
+        .integer()
+        .min(0)
+        .required(),
+      publishedfiledetails: Joi.array().items(
+        Joi.object({
+          publishedfileid: Joi.string().required(),
+          result: Joi.number()
+            .integer()
+            .required(),
+          file_size: Joi.number().integer(),
+          time_created: Joi.number().integer(),
+          subscriptions: Joi.number().integer(),
+          favorited: Joi.number().integer(),
+          lifetime_subscriptions: Joi.number().integer(),
+          lifetime_favorited: Joi.number().integer(),
+          views: Joi.number().integer(),
+        })
+      ),
+    })
+    .required(),
 }).required()
 
 class SteamCollectionFiles extends BaseJsonService {
-  async fetch({collectionId}) {
-    const url = 'https://api.steampowered.com/ISteamRemoteStorage/GetCollectionDetails/v1/?format=json'
+  async fetch({ collectionId }) {
+    const url =
+      'https://api.steampowered.com/ISteamRemoteStorage/GetCollectionDetails/v1/?format=json'
     return this._requestJson({
       url,
       schema: steamCollectionSchema,
       errorMessages: {
-        400: 'bad request'
+        400: 'bad request',
       },
       options: {
         method: 'POST',
         form: {
           collectioncount: '1',
-          'publishedfileids[0]': collectionId
-        }
-      }
+          'publishedfileids[0]': collectionId,
+        },
+      },
     })
   }
 
@@ -62,7 +89,9 @@ class SteamCollectionFiles extends BaseJsonService {
   async handle({ collectionId }) {
     const json = await this.fetch({ collectionId })
     if (json.response.collectiondetails[0].result === 1) {
-      return this.constructor.render({ size: json.response.collectiondetails[0].children.length})
+      return this.constructor.render({
+        size: json.response.collectiondetails[0].children.length,
+      })
     } else {
       return { message: 'collection not found', color: 'red' }
     }
@@ -89,31 +118,31 @@ class SteamCollectionFiles extends BaseJsonService {
       {
         title: 'Steam Collection Files',
         exampleUrl: '180077636',
-        urlPattern: ":collection_id",
+        urlPattern: ':collection_id',
         staticExample: this.render({ size: 32 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
 
 class SteamFileService extends BaseJsonService {
-
-  async fetch({fileId}) {
-    const url = 'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/?format=json'
+  async fetch({ fileId }) {
+    const url =
+      'https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/?format=json'
     return this._requestJson({
       url,
       schema: steamFileSchema,
       errorMessages: {
-        400: 'bad request'
+        400: 'bad request',
       },
       options: {
         method: 'POST',
         form: {
           itemcount: 1,
           'publishedfileids[0]': fileId,
-        }
-      }
+        },
+      },
     })
   }
 
@@ -127,10 +156,10 @@ class SteamFileService extends BaseJsonService {
     }
   }
 
-  async onRequest({response}) {}
+  async onRequest({ response }) {}
 
   static get defaultBadgeData() {
-    return {label: 'steam'}
+    return { label: 'steam' }
   }
 
   static get category() {
@@ -143,7 +172,7 @@ class SteamFileSize extends SteamFileService {
     return { message: prettyBytes(fileSize), color: 'green' }
   }
 
-  async onRequest({response}) {
+  async onRequest({ response }) {
     return this.constructor.render({ fileSize: response.file_size })
   }
 
@@ -152,14 +181,14 @@ class SteamFileSize extends SteamFileService {
   }
 
   static get defaultBadgeData() {
-    return {label: 'size'}
+    return { label: 'size' }
   }
 
   static get url() {
     return {
       base: 'steam/size',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -170,8 +199,8 @@ class SteamFileSize extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ fileSize: 20000 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -181,7 +210,7 @@ class SteamReleaseDate extends SteamFileService {
     return { message: formatDate(releaseDate), color: ageColor(releaseDate) }
   }
 
-  async onRequest({response}) {
+  async onRequest({ response }) {
     return this.constructor.render({ releaseDate: response.time_created })
   }
 
@@ -193,7 +222,7 @@ class SteamReleaseDate extends SteamFileService {
     return {
       base: 'steam/release-date',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -204,8 +233,8 @@ class SteamReleaseDate extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ releaseDate: '12-12-2020' }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -215,7 +244,7 @@ class SteamSubscriptions extends SteamFileService {
     return { message: metric(subscriptions), color: 'lime' }
   }
 
-  async onRequest({response}) {
+  async onRequest({ response }) {
     return this.constructor.render({ subscriptions: response.subscriptions })
   }
 
@@ -227,7 +256,7 @@ class SteamSubscriptions extends SteamFileService {
     return {
       base: 'steam/subscriptions',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -238,8 +267,8 @@ class SteamSubscriptions extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ subscriptions: 20124 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -249,7 +278,7 @@ class SteamFavorites extends SteamFileService {
     return { message: metric(favorited), color: 'lime' }
   }
 
-  async onRequest({response}) {
+  async onRequest({ response }) {
     return this.constructor.render({ favorited: response.favorited })
   }
 
@@ -261,7 +290,7 @@ class SteamFavorites extends SteamFileService {
     return {
       base: 'steam/favorited',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -272,8 +301,8 @@ class SteamFavorites extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ favorited: 20124 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -283,8 +312,10 @@ class SteamDownloads extends SteamFileService {
     return { message: metric(downloads), color: 'lime' }
   }
 
-  async onRequest({response}) {
-    return this.constructor.render({ downloads: response.lifetime_subscriptions })
+  async onRequest({ response }) {
+    return this.constructor.render({
+      downloads: response.lifetime_subscriptions,
+    })
   }
 
   static get category() {
@@ -299,7 +330,7 @@ class SteamDownloads extends SteamFileService {
     return {
       base: 'steam/downloads',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -310,8 +341,8 @@ class SteamDownloads extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ downloads: 20124 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -321,7 +352,7 @@ class SteamViews extends SteamFileService {
     return { message: metric(views), color: 'lime' }
   }
 
-  async onRequest({response}) {
+  async onRequest({ response }) {
     return this.constructor.render({ views: response.views })
   }
 
@@ -333,7 +364,7 @@ class SteamViews extends SteamFileService {
     return {
       base: 'steam/views',
       format: '(.+)',
-      capture: ['fileId']
+      capture: ['fileId'],
     }
   }
 
@@ -344,8 +375,8 @@ class SteamViews extends SteamFileService {
         exampleUrl: '100',
         urlPattern: ':file_id',
         staticExample: this.render({ views: 20000 }),
-        keywords: ['steam']
-      }
+        keywords: ['steam'],
+      },
     ]
   }
 }
@@ -357,5 +388,5 @@ module.exports = {
   SteamSubscriptions,
   SteamFavorites,
   SteamDownloads,
-  SteamViews
+  SteamViews,
 }

--- a/services/steam/steam.service.js
+++ b/services/steam/steam.service.js
@@ -233,7 +233,9 @@ class SteamReleaseDate extends SteamFileService {
         title: 'Steam Release Date',
         exampleUrl: '100',
         urlPattern: ':file_id',
-        staticExample: this.render({ releaseDate: new Date(0).setUTCSeconds(1538288239) }),
+        staticExample: this.render({
+          releaseDate: new Date(0).setUTCSeconds(1538288239),
+        }),
         keywords: ['steam'],
       },
     ]

--- a/services/steam/steam.tester.js
+++ b/services/steam/steam.tester.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const Joi = require('joi')
+const ServiceTester = require('../service-tester')
+const { isMetric, isFileSize, isFormattedDate } = require('../test-validators')
+
+const t = new ServiceTester({ id: 'steam', title: 'Steam' })
+module.exports = t
+
+t.create('Collection Files')
+  .get('/collection-files/180077636.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'files', value: isMetric }))
+
+t.create('File Size')
+  .get('/size/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'size', value: isFileSize }))
+
+t.create('Release Date')
+  .get('/release-date/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'release date', value: isFormattedDate }))
+
+t.create('Subscriptions')
+  .get('/subscriptions/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'subscriptions', value: isMetric }))
+
+t.create('Favorites')
+  .get('/favorited/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'favorited', value: isMetric }))
+
+t.create('Downloads')
+  .get('/downloads/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'downloads', value: isMetric }))
+
+t.create('Views')
+  .get('/views/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'views', value: isMetric }))
+
+  t.create('Collection Files | Collection Not Found')
+  .get('/collection-files/1.json')
+  .expectJSON({ name: 'files', value: 'collection not found' })
+
+t.create('File Size | File Not Found')
+  .get('/size/1.json')
+  .expectJSON({ name: 'size', value: 'file not found' })
+
+t.create('Release Date | File Not Found')
+  .get('/release-date/1.json')
+  .expectJSON({ name: 'release date', value: 'file not found' })
+
+t.create('Subscriptions | File Not Found')
+  .get('/subscriptions/1.json')
+  .expectJSON({ name: 'subscriptions', value: 'file not found' })
+
+t.create('Favorites | File Not Found')
+  .get('/favorited/1.json')
+  .expectJSON({ name: 'favorited', value: 'file not found' })
+
+t.create('Downloads | File Not Found')
+  .get('/downloads/1.json')
+  .expectJSON({ name: 'downloads', value: 'file not found' })
+
+t.create('Views | File Not Found')
+  .get('/views/1.json')
+  .expectJSON({ name: 'views', value: 'file not found' })
+
+t.create('Connection Error')
+  .get('/views/100.json')
+  .networkOff()
+  .expectJSON({ name: 'views', value: 'inaccessible' });
+

--- a/services/steam/steam.tester.js
+++ b/services/steam/steam.tester.js
@@ -28,8 +28,8 @@ t.create('Subscriptions')
   )
 
 t.create('Favorites')
-  .get('/favorited/1523924535.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'favorited', value: isMetric }))
+  .get('/favorites/1523924535.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'favorites', value: isMetric }))
 
 t.create('Downloads')
   .get('/downloads/1523924535.json')
@@ -56,8 +56,8 @@ t.create('Subscriptions | File Not Found')
   .expectJSON({ name: 'subscriptions', value: 'file not found' })
 
 t.create('Favorites | File Not Found')
-  .get('/favorited/1.json')
-  .expectJSON({ name: 'favorited', value: 'file not found' })
+  .get('/favorites/1.json')
+  .expectJSON({ name: 'favorites', value: 'file not found' })
 
 t.create('Downloads | File Not Found')
   .get('/downloads/1.json')

--- a/services/steam/steam.tester.js
+++ b/services/steam/steam.tester.js
@@ -17,11 +17,15 @@ t.create('File Size')
 
 t.create('Release Date')
   .get('/release-date/1523924535.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'release date', value: isFormattedDate }))
+  .expectJSONTypes(
+    Joi.object().keys({ name: 'release date', value: isFormattedDate })
+  )
 
 t.create('Subscriptions')
   .get('/subscriptions/1523924535.json')
-  .expectJSONTypes(Joi.object().keys({ name: 'subscriptions', value: isMetric }))
+  .expectJSONTypes(
+    Joi.object().keys({ name: 'subscriptions', value: isMetric })
+  )
 
 t.create('Favorites')
   .get('/favorited/1523924535.json')
@@ -35,7 +39,7 @@ t.create('Views')
   .get('/views/1523924535.json')
   .expectJSONTypes(Joi.object().keys({ name: 'views', value: isMetric }))
 
-  t.create('Collection Files | Collection Not Found')
+t.create('Collection Files | Collection Not Found')
   .get('/collection-files/1.json')
   .expectJSON({ name: 'files', value: 'collection not found' })
 
@@ -66,5 +70,4 @@ t.create('Views | File Not Found')
 t.create('Connection Error')
   .get('/views/100.json')
   .networkOff()
-  .expectJSON({ name: 'views', value: 'inaccessible' });
-
+  .expectJSON({ name: 'views', value: 'inaccessible' })


### PR DESCRIPTION
This adds multiple badges which comes from what data can be fetched by the Steam WEB API

The API documentation can be found [here](https://partner.steamgames.com/doc/webapi/ISteamRemoteStorage) with the import bits being:

1. [GetCollectionDetails](https://partner.steamgames.com/doc/webapi/ISteamRemoteStorage#GetCollectionDetails)
2. [GetPublishedFileDetails](https://partner.steamgames.com/doc/webapi/ISteamRemoteStorage#GetPublishedFileDetails)

Since this is my first request into this repo, I would like for people to tell me where I can improve if possible.

I have run the tests on my local server but I may have not added all the required tests if so do tell, please!

This pull request resolves #2121 