### PR TITLE
require exampleUrl and urlPattern if using staticExample

### DIFF
--- a/services/base.js
+++ b/services/base.js
@@ -127,6 +127,12 @@ class BaseService {
             } is missing required previewUrl or staticExample`
           )
         }
+        if (staticExample && !urlPattern) {
+          throw new Error('Must declare a urlPattern if using staticExample')
+        }
+        if (staticExample && !exampleUrl) {
+          throw new Error('Must declare an exampleUrl if using staticExample')
+        }
 
         const stringified = queryString.stringify(query)
         const suffix = stringified ? `?${stringified}` : ''


### PR DESCRIPTION
Adds a couple of sanity checks. All our current badges pass them
closes #1994