### PR TITLE
remove duplicate PyPI examples

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1442,16 +1442,6 @@ const allBadgeExamples = [
     },
     examples: [
       {
-        title: 'PyPI - Python Version',
-        previewUrl: '/pypi/pyversions/Django.svg',
-        keywords: ['python', 'pypi'],
-      },
-      {
-        title: 'PyPI - Django Version',
-        previewUrl: '/pypi/djversions/djangorestframework.svg',
-        keywords: ['python', 'pypi', 'django'],
-      },
-      {
         title: 'Conda',
         previewUrl: '/conda/pn/conda-forge/python.svg',
         keywords: ['conda'],


### PR DESCRIPTION
These examples currently appear twice in the index because they are also defined in the service classes:

https://github.com/badges/shields/blob/10e8232ffae70800be65290150d805e1db9aa9fa/services/pypi/pypi-djversions.service.js#L19-L27

https://github.com/badges/shields/blob/10e8232ffae70800be65290150d805e1db9aa9fa/services/pypi/pypi-pyversions.service.js#L19-L27