### PR TITLE
consistently style Github as GitHub in examples

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -511,7 +511,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'Github file size',
+        title: 'GitHub file size',
         previewUrl:
           '/github/size/webcaetano/craft/build/phaser-craft.min.js.svg',
         keywords: ['GitHub', 'file', 'size'],
@@ -556,37 +556,37 @@ const allBadgeExamples = [
     },
     examples: [
       {
-        title: 'Github All Releases',
+        title: 'GitHub All Releases',
         previewUrl: '/github/downloads/atom/atom/total.svg',
         keywords: ['github'],
         documentation: githubDoc,
       },
       {
-        title: 'Github Releases',
+        title: 'GitHub Releases',
         previewUrl: '/github/downloads/atom/atom/latest/total.svg',
         keywords: ['github'],
         documentation: githubDoc,
       },
       {
-        title: 'Github Pre-Releases',
+        title: 'GitHub Pre-Releases',
         previewUrl: '/github/downloads-pre/atom/atom/latest/total.svg',
         keywords: ['github'],
         documentation: githubDoc,
       },
       {
-        title: 'Github Releases (by Release)',
+        title: 'GitHub Releases (by Release)',
         previewUrl: '/github/downloads/atom/atom/v0.190.0/total.svg',
         keywords: ['github'],
         documentation: githubDoc,
       },
       {
-        title: 'Github Releases (by Asset)',
+        title: 'GitHub Releases (by Asset)',
         previewUrl: '/github/downloads/atom/atom/latest/atom-amd64.deb.svg',
         keywords: ['github'],
         documentation: githubDoc,
       },
       {
-        title: 'Github Pre-Releases (by Asset)',
+        title: 'GitHub Pre-Releases (by Asset)',
         previewUrl: '/github/downloads-pre/atom/atom/latest/atom-amd64.deb.svg',
         keywords: ['github'],
         documentation: githubDoc,
@@ -1283,7 +1283,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'Github commits (since latest release)',
+        title: 'GitHub commits (since latest release)',
         previewUrl:
           '/github/commits-since/SubtitleEdit/subtitleedit/latest.svg',
         keywords: ['GitHub', 'commit'],
@@ -1532,7 +1532,7 @@ const allBadgeExamples = [
         documentation: githubDoc,
       },
       {
-        title: 'Github commit merge status',
+        title: 'GitHub commit merge status',
         previewUrl:
           '/github/commit-status/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.svg',
         keywords: ['GitHub', 'commit', 'branch', 'merge'],


### PR DESCRIPTION
Following on from #2095 this updates the remaining occurrences of "Github" to "GitHub"