### PR TITLE
Fix: keywords not found when searching examples

### DIFF
--- a/lib/all-badge-examples.spec.js
+++ b/lib/all-badge-examples.spec.js
@@ -19,6 +19,7 @@ describe('The badge examples', function() {
         previewUrl: '/badge/build-passing-brightgreen.svg',
         urlPattern: '/appveyor/ci/:user/:repo.svg',
         documentation: undefined,
+        keywords: undefined,
       },
       {
         title: 'AppVeyor branch',
@@ -26,6 +27,7 @@ describe('The badge examples', function() {
         previewUrl: '/badge/build-passing-brightgreen.svg',
         urlPattern: '/appveyor/ci/:user/:repo/:branch.svg',
         documentation: undefined,
+        keywords: undefined,
       },
     ])
   })

--- a/services/base.js
+++ b/services/base.js
@@ -119,6 +119,7 @@ class BaseService {
         urlPattern,
         staticExample,
         documentation,
+        keywords,
       }) => {
         if (!previewUrl && !staticExample) {
           throw Error(
@@ -149,6 +150,7 @@ class BaseService {
             ? `${this._makeFullUrl(urlPattern, query)}.svg${suffix}`
             : undefined,
           documentation,
+          keywords,
         }
       }
     )

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -40,6 +40,7 @@ class DummyService extends BaseService {
         urlPattern: ':world',
         exampleUrl: 'World',
         staticExample: this.render({ namedParamA: 'foo', queryParamA: 'bar' }),
+        keywords: ['hello'],
       },
     ]
   }
@@ -375,6 +376,7 @@ describe('BaseService', function() {
         previewUrl: '/foo/World.svg',
         urlPattern: undefined,
         documentation: undefined,
+        keywords: undefined,
       })
       expect(second).to.deep.equal({
         title: 'DummyService',
@@ -382,6 +384,7 @@ describe('BaseService', function() {
         previewUrl: '/foo/World.svg?queryParamA=%21%21%21',
         urlPattern: undefined,
         documentation: undefined,
+        keywords: undefined,
       })
       expect(third).to.deep.equal({
         title: 'DummyService',
@@ -390,6 +393,7 @@ describe('BaseService', function() {
           '/badge/cat-Hello%20namedParamA%3A%20foo%20with%20queryParamA%3A%20bar-lightgrey.svg',
         urlPattern: '/foo/:world.svg',
         documentation: undefined,
+        keywords: ['hello'],
       })
     })
   })


### PR DESCRIPTION
**How to reproduce**

Go to [shields.io](https://shields.io/) and search for `ruby`. There will be 0 results.

**Expected result**

There should be 8 badge examples being found:

* 4 from [`GemDownloads`](https://github.com/badges/shields/blob/362db466bb551154897b415a76305ae04262f2d5/services/gem/gem-downloads.service.js#L121-L164)
* 1 from [`GemOwner`](https://github.com/badges/shields/blob/362db466bb551154897b415a76305ae04262f2d5/services/gem/gem-owner.service.js#L48-L58)
* 2 from [`GemRank`](https://github.com/badges/shields/blob/362db466bb551154897b415a76305ae04262f2d5/services/gem/gem-rank.service.js#L72-L89)
* 1 from [`GemVersion`](https://github.com/badges/shields/blob/362db466bb551154897b415a76305ae04262f2d5/services/gem/gem-version.service.js#L50-L60)

All of these specify the `ruby` keyword as part of their examples.

**Proposed fix**

This issue only affects newer services that extend `BaseService`. Older legacy services aren't affected (e.g. searching for `documentation` does find the ReadTheDocs example badges).

The actual root cause is that `BaseService` forgets to include the `keywords` property when preparing the example data, so keywords don't end up in `badge-examples.json` when you run `npm run examples`.

Including the `keywords` property in `BaseService.prepareExamples()` fixes the problem.