### PR TITLE
Allow [GitHub] tag badge to sort by date

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1242,8 +1242,18 @@ const allBadgeExamples = [
         previewUrl: '/hexpm/v/plug.svg',
       },
       {
-        title: 'GitHub tag',
+        title: 'GitHub tag (latest SemVer)',
         previewUrl: '/github/tag/expressjs/express.svg',
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub tag (latest SemVer pre-release)',
+        previewUrl: '/github/tag-pre/expressjs/express.svg',
+        documentation: githubDoc,
+      },
+      {
+        title: 'GitHub tag (latest by date)',
+        previewUrl: '/github/tag-date/expressjs/express.svg',
         documentation: githubDoc,
       },
       {

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1263,7 +1263,7 @@ const allBadgeExamples = [
       },
       {
         title: 'GitHub (pre-)release',
-        previewUrl: '/github/release/qubyte/rubidium/all.svg',
+        previewUrl: '/github/release-pre/qubyte/rubidium.svg',
         documentation: githubDoc,
       },
       {

--- a/services/github/github-license.service.js
+++ b/services/github/github-license.service.js
@@ -38,7 +38,11 @@ module.exports = class GithubLicense extends LegacyService {
             const body = JSON.parse(buffer)
             const license = body.license
             if (license != null) {
-              badgeData.text[1] = license.spdx_id || 'unknown'
+              if (!license.spdx_id || license.spdx_id === 'NOASSERTION') {
+                badgeData.text[1] = 'unknown'
+              } else {
+                badgeData.text[1] = license.spdx_id
+              }
               setBadgeColor(badgeData, licenseToColor(license.spdx_id))
               sendBadge(format, badgeData)
             } else {

--- a/services/github/github-release.service.js
+++ b/services/github/github-release.service.js
@@ -13,13 +13,13 @@ const {
 module.exports = class GithubRelease extends LegacyService {
   static registerLegacyRouteHandler({ camp, cache, githubApiProvider }) {
     camp.route(
-      /^\/github\/release\/([^/]+\/[^/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
+      /^\/github\/release(-?pre)?\/([^/]+\/[^/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
-        const userRepo = match[1] // eg, qubyte/rubidium
-        const allReleases = match[2]
-        const format = match[3]
+        const includePre = Boolean(match[1]) || match[3] === 'all'
+        const userRepo = match[2] // eg, qubyte/rubidium
+        const format = match[4]
         let apiUrl = `/repos/${userRepo}/releases`
-        if (allReleases === undefined) {
+        if (!includePre) {
           apiUrl = apiUrl + '/latest'
         }
         const badgeData = getBadgeData('release', data)
@@ -33,7 +33,7 @@ module.exports = class GithubRelease extends LegacyService {
           }
           try {
             let data = JSON.parse(buffer)
-            if (allReleases === 'all') {
+            if (includePre) {
               data = data[0]
             }
             const version = data.tag_name

--- a/services/github/github-release.service.js
+++ b/services/github/github-release.service.js
@@ -13,7 +13,7 @@ const {
 module.exports = class GithubRelease extends LegacyService {
   static registerLegacyRouteHandler({ camp, cache, githubApiProvider }) {
     camp.route(
-      /^\/github\/release(-?pre)?\/([^/]+\/[^/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
+      /^\/github\/release(-pre)?\/([^/]+\/[^/]+)(?:\/(all))?\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
         const includePre = Boolean(match[1]) || match[3] === 'all'
         const userRepo = match[2] // eg, qubyte/rubidium

--- a/services/github/github-tag.service.js
+++ b/services/github/github-tag.service.js
@@ -15,9 +15,10 @@ const {
 module.exports = class GithubTag extends LegacyService {
   static registerLegacyRouteHandler({ camp, cache, githubApiProvider }) {
     camp.route(
-      /^\/github\/tag(-?pre)?\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
+      /^\/github\/(tag-?pre|tag-date|tag)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
-        const includePre = Boolean(match[1])
+        const includePre = match[1].includes('pre')
+        const sortOrder = match[1] === 'tag-date' ? 'date' : 'semver'
         const user = match[2] // eg, expressjs/express
         const repo = match[3]
         const format = match[4]
@@ -34,9 +35,13 @@ module.exports = class GithubTag extends LegacyService {
           try {
             const data = JSON.parse(buffer)
             const versions = data.map(e => e.name)
-            const tag = latestVersion(versions, { pre: includePre })
+            const tag =
+              sortOrder === 'date'
+                ? versions[0]
+                : latestVersion(versions, { pre: includePre })
             badgeData.text[1] = versionText(tag)
-            badgeData.colorscheme = versionColor(tag)
+            badgeData.colorscheme =
+              sortOrder === 'date' ? 'blue' : versionColor(tag)
             sendBadge(format, badgeData)
           } catch (e) {
             badgeData.text[1] = 'none'

--- a/services/github/github-tag.service.js
+++ b/services/github/github-tag.service.js
@@ -15,7 +15,7 @@ const {
 module.exports = class GithubTag extends LegacyService {
   static registerLegacyRouteHandler({ camp, cache, githubApiProvider }) {
     camp.route(
-      /^\/github\/(tag-?pre|tag-date|tag)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
+      /^\/github\/(tag-pre|tag-date|tag)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
         const includePre = match[1].includes('pre')
         const sortOrder = match[1] === 'tag-date' ? 'date' : 'semver'

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -347,6 +347,10 @@ t.create('Release (repo not found)')
   .expectJSON({ name: 'release', value: 'repo not found' })
 
 t.create('(pre-)Release')
+  .get('/release-pre/photonstorm/phaser.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'release', value: Joi.string() }))
+
+t.create('(pre-)Release (for legacy compatibility)')
   .get('/release/photonstorm/phaser/all.json')
   .expectJSONTypes(Joi.object().keys({ name: 'release', value: Joi.string() }))
 

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -402,6 +402,10 @@ t.create('Tag')
   .get('/tag/photonstorm/phaser.json')
   .expectJSONTypes(Joi.object().keys({ name: 'tag', value: Joi.string() }))
 
+t.create('Tag (inc pre-release)')
+  .get('/tag-pre/photonstorm/phaser.json')
+  .expectJSONTypes(Joi.object().keys({ name: 'tag', value: Joi.string() }))
+
 t.create('Tag (repo not found)')
   .get('/tag/badges/helmets.json')
   .expectJSON({ name: 'tag', value: 'repo not found' })

--- a/services/github/github.tester.js
+++ b/services/github/github.tester.js
@@ -414,6 +414,39 @@ t.create('Tag (repo not found)')
   .get('/tag/badges/helmets.json')
   .expectJSON({ name: 'tag', value: 'repo not found' })
 
+const tagsFixture = [
+  { name: 'cheese' }, // any old string
+  { name: 'v1.3-beta3' }, // semver pre-release
+  { name: 'v1.2' }, // semver release
+]
+
+t.create('Tag (mocked response, no pre-releases, semver ordering)')
+  .get('/tag/foo/bar.json?style=_shields_test')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/foo/bar/tags')
+      .reply(200, tagsFixture)
+  )
+  .expectJSON({ name: 'tag', value: 'v1.2', colorB: colorsB.blue })
+
+t.create('Tag (mocked response, include pre-releases, semver ordering)')
+  .get('/tag-pre/foo/bar.json?style=_shields_test')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/foo/bar/tags')
+      .reply(200, tagsFixture)
+  )
+  .expectJSON({ name: 'tag', value: 'v1.3-beta3', colorB: colorsB.orange })
+
+t.create('Tag (mocked response, date ordering)')
+  .get('/tag-date/foo/bar.json?style=_shields_test')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/foo/bar/tags')
+      .reply(200, tagsFixture)
+  )
+  .expectJSON({ name: 'tag', value: 'cheese', colorB: colorsB.blue })
+
 t.create('Package version')
   .get('/package-json/v/badges/shields.json')
   .expectJSONTypes(


### PR DESCRIPTION
Following on from https://github.com/badges/shields/issues/2117#issuecomment-425558353

* I've modified the `/release` badge so we can use `/release-pre` and changed the home pages example. The legacy `/all` suffix will still work (for backwards-compatibility) but its not documented.
* I haven't changed anything else on `/release`. Looking into it, we're using the `prerelease` key there rather than assuming semver so we don't have the same issue there that we do with tags.
* I've added a `tag-date` endpoint. I changed my mind and decided not to go with `sort=semver/sort=date` for 2 reasons:
    * It allows `/tag-pre/username/repo.svg?sort=date` which is a bit odd/unclear
    * We don't really have a good way to get the querystring in `BaseJsonService`. This is going to be a problem with a few other services which we need to deal with when we port them, but on reflection I'd prefer not make this problem bigger.

This PR won't change the behaviour for anyone already using these badges but improves consistency and provides a way for projects that don't use SemVer (for whatever reason) to use the `/tag` badge with sensible expected behaviour.

Does this seem reasonable?