### PR TITLE
Add support for private [npm] packages

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -149,6 +149,7 @@ packages by [generating an npm token] and using that for the `npm_token` value.
 
 [github rate limit]: https://developer.github.com/v3/#rate-limiting
 [personal access tokens]: https://github.com/settings/tokens
+[generating an npm token]: https://docs.npmjs.com/getting-started/working_with_tokens
 
 Separate frontend hosting
 -------------------------

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -144,10 +144,11 @@ will have access to your private repositories.
 When a `gh_token` is specified, it is used in place of the Shields token
 rotation logic.
 
+You can also give your self-hosted Shields installation access to private npm
+packages by [generating an npm token] and using that for the `npm_token` value.
 
 [github rate limit]: https://developer.github.com/v3/#rate-limiting
 [personal access tokens]: https://github.com/settings/tokens
-
 
 Separate frontend hosting
 -------------------------
@@ -189,9 +190,9 @@ In order to enable integration with [Sentry](https://sentry.io), you need your o
 ### How to obtain the Sentry DSN
 
 1. [Sign up](https://sentry.io/pricing/) for Sentry
-1. Log in to Sentry
-1. Create a new project for Node.js
-1. You should see [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) for your project. Sentry DSN can be found by navigating to \[Project Name] -> Project Settings -> Client Keys (DSN) as well.
+2. Log in to Sentry
+3. Create a new project for Node.js
+4. You should see [Sentry DSN](https://docs.sentry.io/quickstart/#configure-the-dsn) for your project. Sentry DSN can be found by navigating to \[Project Name] -> Project Settings -> Client Keys (DSN) as well.
 
 Start the server using the Sentry DSN. You can set it:
 - by `SENTRY_DSN` environment variable

--- a/secret.tpl.json
+++ b/secret.tpl.json
@@ -2,5 +2,6 @@
   "gh_client_id": "${GH_CLIENT_ID}",
   "gh_client_secret": "${GH_CLIENT_SECRET}",
   "shieldsIps": [ "${SHIELDS_IP}" ],
-  "gh_token": "${GH_TOKEN}"
+  "gh_token": "${GH_TOKEN}",
+  "npm_token": "${NPM_TOKEN}"
 }

--- a/services/npm/npm-base.js
+++ b/services/npm/npm-base.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const BaseJsonService = require('../base-json')
 const { InvalidResponse, NotFound } = require('../errors')
+const serverSecrets = require('../../lib/server-secrets')
 
 const deprecatedLicenseObjectSchema = Joi.object({
   type: Joi.string().required(),
@@ -64,6 +65,20 @@ module.exports = class NpmBase extends BaseJsonService {
     return `@${encoded}`
   }
 
+  async _requestJson(data) {
+    return super._requestJson({
+      ...data,
+      options: {
+        headers: {
+          // Use a custom Accept header because of this bug:
+          // <https://github.com/npm/npmjs.org/issues/163>
+          Accept: '*/*',
+          Authorization: `Bearer ${serverSecrets.npm_token || ''}`
+        }
+      }
+    })
+  }
+
   async fetchPackageData({ registryUrl, scope, packageName, tag }) {
     registryUrl = registryUrl || this.constructor.defaultRegistryUrl
     let url
@@ -85,9 +100,6 @@ module.exports = class NpmBase extends BaseJsonService {
       // We don't validate here because we need to pluck the desired subkey first.
       schema: Joi.any(),
       url,
-      // Use a custom Accept header because of this bug:
-      // <https://github.com/npm/npmjs.org/issues/163>
-      options: { Accept: '*/*' },
       errorMessages: { 404: 'package not found' },
     })
 

--- a/services/npm/npm-base.js
+++ b/services/npm/npm-base.js
@@ -66,16 +66,15 @@ module.exports = class NpmBase extends BaseJsonService {
   }
 
   async _requestJson(data) {
+    // Use a custom Accept header because of this bug:
+    // <https://github.com/npm/npmjs.org/issues/163>
+    const headers = { Accept: '*/*' }
+    if (serverSecrets.npm_token) {
+      headers.Authorization = `Bearer ${serverSecrets.npm_token}`
+    }
     return super._requestJson({
       ...data,
-      options: {
-        headers: {
-          // Use a custom Accept header because of this bug:
-          // <https://github.com/npm/npmjs.org/issues/163>
-          Accept: '*/*',
-          Authorization: `Bearer ${serverSecrets.npm_token || ''}`,
-        },
-      },
+      options: { headers },
     })
   }
 

--- a/services/npm/npm-base.js
+++ b/services/npm/npm-base.js
@@ -73,9 +73,9 @@ module.exports = class NpmBase extends BaseJsonService {
           // Use a custom Accept header because of this bug:
           // <https://github.com/npm/npmjs.org/issues/163>
           Accept: '*/*',
-          Authorization: `Bearer ${serverSecrets.npm_token || ''}`
-        }
-      }
+          Authorization: `Bearer ${serverSecrets.npm_token || ''}`,
+        },
+      },
     })
   }
 


### PR DESCRIPTION
This PR adds support for private npm packages via an `npm_token` secret.  This allows anyone running their own shields.io service to create badges for their private packages.