### PR TITLE
remove react-warning-keys warning in renderNamedLogos

### DIFF
--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -70,7 +70,11 @@ export default class Usage extends React.PureComponent {
   }
 
   static renderNamedLogos() {
-    const renderLogo = logo => <span className="nowrap">{logo}</span>
+    const renderLogo = logo => (
+      <span className="nowrap" key={logo}>
+        {logo}
+      </span>
+    )
     const [first, ...rest] = logos
     return [renderLogo(first)].concat(
       rest.reduce((result, logo) => result.concat([', ', renderLogo(logo)]), [])


### PR DESCRIPTION
Fix for a warning shown below. Warning can be reproduced by starting (`npm run start`) shields locally.

```
[frontend] Check the top-level render call using <td>. See https://fb.me/react-warning-keys for more information.
[frontend]     in span (at usage.js:73)
[frontend]     in Usage (at examples-page.js:97)
[frontend]     in div (at examples-page.js:73)
[frontend]     in ExamplesPage
[frontend]     in Route (at pages/index.js:9)
[frontend]     in div (at pages/index.js:8)
[frontend]     in Router
[frontend]     in StaticRouter (at pages/index.js:21)
[frontend]     in Router
[frontend]     in AppContainer
[frontend]     in Container
[frontend]     in App
```

`logos` array contains unique values, so it can be used as keys.