### PR TITLE
[ctan] refactor service

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -1009,11 +1009,6 @@ const allBadgeExamples = [
         keywords: ['R'],
       },
       {
-        title: 'CTAN',
-        previewUrl: '/ctan/l/novel.svg',
-        keywords: ['tex'],
-      },
-      {
         title: 'DUB',
         previewUrl: '/dub/l/vibe-d.svg',
         keywords: ['dub'],
@@ -1351,11 +1346,6 @@ const allBadgeExamples = [
         title: 'CRAN',
         previewUrl: '/cran/v/devtools.svg',
         keywords: ['R'],
-      },
-      {
-        title: 'CTAN',
-        previewUrl: '/ctan/v/tex.svg',
-        keywords: ['tex'],
       },
       {
         title: 'DUB',

--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -1,65 +1,77 @@
 'use strict'
 
-const LegacyService = require('../legacy-service')
-const {
-  makeBadgeData: getBadgeData,
-  makeLabel: getLabel,
-} = require('../../lib/badge-data')
-const { addv: versionText } = require('../../lib/text-formatters')
-const { version: versionColor } = require('../../lib/color-formatters')
+const Joi = require('joi')
+const BaseJsonService = require('../base-json')
+const { renderLicenseBadge } = require('../../lib/licenses')
+const { renderVersionBadge } = require('../../lib/version')
 
-module.exports = class Ctan extends LegacyService {
+const schema = Joi.object({
+  license: Joi.array()
+    .items(Joi.string())
+    .single(),
+  version: Joi.object({
+    number: Joi.string().required(),
+  }).required(),
+}).required()
+
+class BaseCtanService extends BaseJsonService {
+  async fetch({ library }) {
+    const url = `http://www.ctan.org/json/pkg/${library}`
+    return this._requestJson({
+      schema,
+      url,
+    })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'ctan' }
+  }
+}
+
+class CtanLicense extends BaseCtanService {
+  static get defaultBadgeData() {
+    return { label: 'license' }
+  }
+
+  static get category() {
+    return 'license'
+  }
+
+  async handle({ library }) {
+    const json = await this.fetch({ library })
+    // when present, API returns licenses inconsistently ordered, so fix the order
+    return renderLicenseBadge({ licenses: json.license && json.license.sort() })
+  }
+
   static get url() {
-    return { base: 'ctan' }
+    return {
+      base: 'ctan/l',
+      format: '(.+)',
+      capture: ['library'],
+    }
   }
-  static registerLegacyRouteHandler({ camp, cache }) {
-    camp.route(
-      /^\/ctan\/([vl])\/([^/]+)\.(svg|png|gif|jpg|json)$/,
-      cache((data, match, sendBadge, request) => {
-        const info = match[1] // either `v` or `l`
-        const pkg = match[2] // eg, tex
-        const format = match[3]
-        const url = 'http://www.ctan.org/json/pkg/' + pkg
-        const badgeData = getBadgeData('ctan', data)
-        request(url, (err, res, buffer) => {
-          if (err != null) {
-            badgeData.text[1] = 'inaccessible'
-            sendBadge(format, badgeData)
-            return
-          }
-          if (res.statusCode === 404) {
-            badgeData.text[1] = 'not found'
-            sendBadge(format, badgeData)
-            return
-          }
-          try {
-            const parsedData = JSON.parse(buffer)
+}
 
-            if (info === 'v') {
-              const version = parsedData.version.number
-              badgeData.text[1] = versionText(version)
-              badgeData.colorscheme = versionColor(version)
-              sendBadge(format, badgeData)
-            } else if (info === 'l') {
-              badgeData.text[0] = getLabel('license', data)
-              const license = parsedData.license
-              if (Array.isArray(license) && license.length > 0) {
-                // API returns licenses inconsistently ordered, so fix the order.
-                badgeData.text[1] = license.sort().join(',')
-                badgeData.colorscheme = 'blue'
-              } else {
-                badgeData.text[1] = 'unknown'
-              }
-              sendBadge(format, badgeData)
-            } else {
-              throw Error('Unreachable due to regex')
-            }
-          } catch (e) {
-            badgeData.text[1] = 'invalid'
-            sendBadge(format, badgeData)
-          }
-        })
-      })
-    )
+class CtanVersion extends BaseCtanService {
+  static get category() {
+    return 'version'
   }
+
+  async handle({ library }) {
+    const json = await this.fetch({ library })
+    return renderVersionBadge({ version: json.version.number })
+  }
+
+  static get url() {
+    return {
+      base: 'ctan/v',
+      format: '(.+)',
+      capture: ['library'],
+    }
+  }
+}
+
+module.exports = {
+  CtanLicense,
+  CtanVersion,
 }

--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -43,12 +43,28 @@ class CtanLicense extends BaseCtanService {
     return renderLicenseBadge({ licenses: json.license && json.license.sort() })
   }
 
+  static render({ licenses }) {
+    return renderLicenseBadge({ licenses })
+  }
+
   static get url() {
     return {
       base: 'ctan/l',
       format: '(.+)',
       capture: ['library'],
     }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'CTAN',
+        exampleUrl: 'novel',
+        urlPattern: ':library',
+        staticExample: this.render({ licenses: ['ppl1.3c', 'ofl'] }),
+        keywords: ['tex'],
+      },
+    ]
   }
 }
 
@@ -62,12 +78,28 @@ class CtanVersion extends BaseCtanService {
     return renderVersionBadge({ version: json.version.number })
   }
 
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
   static get url() {
     return {
       base: 'ctan/v',
       format: '(.+)',
       capture: ['library'],
     }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'CTAN',
+        exampleUrl: 'tex',
+        urlPattern: ':library',
+        staticExample: this.render({ version: '3.14159265' }),
+        keywords: ['tex'],
+      },
+    ]
   }
 }
 

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -5,7 +5,7 @@ const ServiceTester = require('../service-tester')
 const { colorScheme } = require('../test-helpers')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = new ServiceTester({ id: 'ctan', title: 'ctan' })
+const t = new ServiceTester({ id: 'ctan', title: 'Comprehensive TEX Archive Network' })
 module.exports = t
 
 t.create('license')

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -34,6 +34,23 @@ t.create('license missing')
     value: 'missing',
   })
 
+t.create('single license')
+  .get('/l/tex.json')
+  .intercept(nock =>
+    nock('http://www.ctan.org')
+      .get('/json/pkg/tex')
+      .reply(200, {
+        license: 'knuth',
+        version: {
+          number: 'notRelevant',
+        },
+      })
+  )
+  .expectJSON({
+    name: 'license',
+    value: 'knuth',
+  })
+
 t.create('version')
   .get('/v/novel.json')
   .expectJSONTypes(

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -5,7 +5,10 @@ const ServiceTester = require('../service-tester')
 const { colorScheme } = require('../test-helpers')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = new ServiceTester({ id: 'ctan', title: 'Comprehensive TEX Archive Network' })
+const t = new ServiceTester({
+  id: 'ctan',
+  title: 'Comprehensive TEX Archive Network',
+})
 module.exports = t
 
 t.create('license')

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -1,19 +1,34 @@
 'use strict'
 
 const Joi = require('joi')
-const createServiceTester = require('../create-service-tester')
+const ServiceTester = require('../service-tester')
 const { colorScheme } = require('../test-helpers')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = createServiceTester()
-
+const t = new ServiceTester({ id: 'ctan', title: 'ctan' })
 module.exports = t
 
 t.create('license')
   .get('/l/novel.json')
   .expectJSON({
     name: 'license',
-    value: 'lppl1.3c,ofl',
+    value: 'lppl1.3c, ofl',
+  })
+
+t.create('license missing')
+  .get('/l/novel.json')
+  .intercept(nock =>
+    nock('http://www.ctan.org')
+      .get('/json/pkg/novel')
+      .reply(200, {
+        version: {
+          number: 'notRelevant',
+        },
+      })
+  )
+  .expectJSON({
+    name: 'license',
+    value: 'missing',
   })
 
 t.create('version')


### PR DESCRIPTION
Refactor ctan service, fixing single licenses along the way (ie. https://img.shields.io/ctan/l/tex.svg from unknown -> knuth)