### PR TITLE
use most permissive license color

### DIFF
--- a/lib/licenses.js
+++ b/lib/licenses.js
@@ -62,8 +62,14 @@ Object.keys(licenseTypes).forEach(licenseType => {
   })
 })
 const defaultLicenseColor = 'lightgrey'
-const licenseToColor = spdxIds => {
-  const licenseType = spdxIds
+const licenseToColor = spdxId => {
+  if (!Array.isArray(spdxId)) {
+    return (
+      (licenseToColorMap[spdxId] && licenseToColorMap[spdxId].color) ||
+      defaultLicenseColor
+    )
+  }
+  const licenseType = spdxId
     .filter(i => licenseToColorMap[i])
     .map(i => licenseToColorMap[i])
     .reduce((a, b) => (a.priority > b.priority ? a : b), {

--- a/lib/licenses.js
+++ b/lib/licenses.js
@@ -23,6 +23,7 @@ const licenseTypes = {
       'Zlib',
     ],
     color: 'green',
+    priority: '2',
   },
   // copyleft licenses require 'Disclose source' (https://choosealicense.com/appendix/#disclose-source)
   // or 'Same license' (https://choosealicense.com/appendix/#same-license)
@@ -43,24 +44,34 @@ const licenseTypes = {
       'OSL-3.0',
     ],
     color: 'orange',
+    priority: '1',
   },
   // public domain licenses do not require 'License and copyright notice' (https://choosealicense.com/appendix/#include-copyright)
   'public-domain': {
     spdxLicenseIds: ['CC0-1.0', 'Unlicense', 'WTFPL'],
     color: '7cd958',
+    priority: '3',
   },
 }
 
 const licenseToColorMap = {}
 Object.keys(licenseTypes).forEach(licenseType => {
-  const { spdxLicenseIds, color } = licenseTypes[licenseType]
+  const { spdxLicenseIds, color, priority } = licenseTypes[licenseType]
   spdxLicenseIds.forEach(license => {
-    licenseToColorMap[license] = color
+    licenseToColorMap[license] = { color, priority }
   })
 })
 const defaultLicenseColor = 'lightgrey'
-const licenseToColor = spdxId =>
-  licenseToColorMap[spdxId] || defaultLicenseColor
+const licenseToColor = spdxIds => {
+  const licenseType = spdxIds
+    .filter(i => licenseToColorMap[i])
+    .map(i => licenseToColorMap[i])
+    .reduce((a, b) => (a.priority > b.priority ? a : b), {
+      color: defaultLicenseColor,
+      priority: 0,
+    })
+  return licenseType.color
+}
 
 function renderLicenseBadge({ license, licenses }) {
   if (licenses === undefined) {
@@ -73,8 +84,6 @@ function renderLicenseBadge({ license, licenses }) {
 
   return {
     message: licenses.join(', '),
-    // TODO This does not provide a color when more than one license is
-    // present. Probably that should be fixed.
     color: licenseToColor(licenses),
   }
 }

--- a/lib/licenses.spec.js
+++ b/lib/licenses.spec.js
@@ -5,11 +5,18 @@ const { licenseToColor, renderLicenseBadge } = require('./licenses')
 
 describe('license helpers', function() {
   test(licenseToColor, () => {
-    given('MIT').expect('green')
-    given('MPL-2.0').expect('orange')
-    given('Unlicense').expect('7cd958')
-    given('unknown-license').expect('lightgrey')
-    given(null).expect('lightgrey')
+    given(['MIT']).expect('green')
+    given(['MPL-2.0']).expect('orange')
+    given(['Unlicense']).expect('7cd958')
+    given(['unknown-license']).expect('lightgrey')
+    given(['CC0-1.0', 'MPL-2.0']).expect('7cd958')
+    given(['MPL-2.0', 'CC0-1.0']).expect('7cd958')
+    given(['MIT', 'MPL-2.0']).expect('green')
+    given(['MPL-2.0', 'MIT']).expect('green')
+    given(['OFL-1.1', 'MPL-2.0']).expect('orange')
+    given(['MPL-2.0', 'OFL-1.1']).expect('orange')
+    given(['CC0-1.0', 'MIT', 'MPL-2.0']).expect('7cd958')
+    given(['UNKNOWN-1.0', 'UNKNOWN-2.0']).expect('lightgrey')
   })
 
   test(renderLicenseBadge, () => {
@@ -30,7 +37,7 @@ describe('license helpers', function() {
     })
     given({ licenses: ['MPL-2.0', 'MIT'] }).expect({
       message: 'MPL-2.0, MIT',
-      color: 'lightgrey',
+      color: 'green',
     })
   })
 })

--- a/lib/licenses.spec.js
+++ b/lib/licenses.spec.js
@@ -5,10 +5,12 @@ const { licenseToColor, renderLicenseBadge } = require('./licenses')
 
 describe('license helpers', function() {
   test(licenseToColor, () => {
-    given(['MIT']).expect('green')
-    given(['MPL-2.0']).expect('orange')
-    given(['Unlicense']).expect('7cd958')
-    given(['unknown-license']).expect('lightgrey')
+    given('MIT').expect('green')
+    given('MPL-2.0').expect('orange')
+    given('Unlicense').expect('7cd958')
+    given('unknown-license').expect('lightgrey')
+    given(null).expect('lightgrey')
+
     given(['CC0-1.0', 'MPL-2.0']).expect('7cd958')
     given(['MPL-2.0', 'CC0-1.0']).expect('7cd958')
     given(['MIT', 'MPL-2.0']).expect('green')
@@ -16,6 +18,7 @@ describe('license helpers', function() {
     given(['OFL-1.1', 'MPL-2.0']).expect('orange')
     given(['MPL-2.0', 'OFL-1.1']).expect('orange')
     given(['CC0-1.0', 'MIT', 'MPL-2.0']).expect('7cd958')
+    given(['UNKNOWN-1.0', 'MIT']).expect('green')
     given(['UNKNOWN-1.0', 'UNKNOWN-2.0']).expect('lightgrey')
   })
 


### PR DESCRIPTION
Hello, I'd like to propose a solution for a TODO left in `lib/licenses.js` 😄 
I think that since something is available under many licenses, it can be obtained under the most permissive one, thus we can set the badge color to that specific one.
What do you think? I'm open for discussion 😃 