### PR TITLE
Static Code Climate examples

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -340,28 +340,52 @@ const allBadgeExamples = [
       },
       {
         title: 'Code Climate',
-        previewUrl: '/codeclimate/issues/twbs/bootstrap.svg',
+        exampleUrl: '/codeclimate/issues/twbs/bootstrap.svg',
+        urlPattern: '/codeclimate/issues/:userRepo.svg',
+        staticExample: { label: 'issues', message: '93', color: 'red' },
       },
       {
         title: 'Code Climate',
-        previewUrl: '/codeclimate/maintainability/angular/angular.js.svg',
+        exampleUrl: '/codeclimate/maintainability/angular/angular.js.svg',
+        urlPattern: '/codeclimate/maintainability/:userRepo.svg',
+        staticExample: { label: 'maintainability', message: 'F', color: 'red' },
       },
       {
         title: 'Code Climate',
-        previewUrl:
+        exampleUrl:
           '/codeclimate/maintainability-percentage/angular/angular.js.svg',
+        urlPattern: '/codeclimate/maintainability-percentage/:userRepo.svg',
+        staticExample: {
+          label: 'maintainability',
+          message: '4.2%',
+          color: 'red',
+        },
       },
       {
         title: 'Code Climate',
-        previewUrl: '/codeclimate/coverage/jekyll/jekyll.svg',
+        exampleUrl: '/codeclimate/coverage/jekyll/jekyll.svg',
+        urlPattern: '/codeclimate/coverage/:userRepo.svg',
+        staticExample: {
+          label: 'coverage',
+          message: '95%',
+          color: 'yellowgreen',
+        },
       },
       {
         title: 'Code Climate',
-        previewUrl: '/codeclimate/coverage-letter/jekyll/jekyll.svg',
+        exampleUrl: '/codeclimate/coverage-letter/jekyll/jekyll.svg',
+        urlPattern: '/codeclimate/coverage-letter/:userRepo.svg',
+        staticExample: { label: 'coverage', message: 'A', color: 'green' },
       },
       {
         title: 'Code Climate',
-        previewUrl: '/codeclimate/tech-debt/jekyll/jekyll.svg',
+        exampleUrl: '/codeclimate/tech-debt/jekyll/jekyll.svg',
+        urlPattern: '/codeclimate/tech-debt/:userRepo.svg',
+        staticExample: {
+          label: 'technical debt',
+          message: '4%',
+          color: 'green',
+        },
       },
       {
         title: 'Codacy grade',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -339,55 +339,6 @@ const allBadgeExamples = [
           '/bitrise/cde737473028420d/master.svg?token=GCIdEzacE4GW32jLVrZb7A',
       },
       {
-        title: 'Code Climate',
-        exampleUrl: '/codeclimate/issues/twbs/bootstrap.svg',
-        urlPattern: '/codeclimate/issues/:userRepo.svg',
-        staticExample: { label: 'issues', message: '89', color: 'red' },
-      },
-      {
-        title: 'Code Climate',
-        exampleUrl: '/codeclimate/maintainability/angular/angular.js.svg',
-        urlPattern: '/codeclimate/maintainability/:userRepo.svg',
-        staticExample: { label: 'maintainability', message: 'F', color: 'red' },
-      },
-      {
-        title: 'Code Climate',
-        exampleUrl:
-          '/codeclimate/maintainability-percentage/angular/angular.js.svg',
-        urlPattern: '/codeclimate/maintainability-percentage/:userRepo.svg',
-        staticExample: {
-          label: 'maintainability',
-          message: '4.6%',
-          color: 'red',
-        },
-      },
-      {
-        title: 'Code Climate',
-        exampleUrl: '/codeclimate/coverage/jekyll/jekyll.svg',
-        urlPattern: '/codeclimate/coverage/:userRepo.svg',
-        staticExample: {
-          label: 'coverage',
-          message: '95%',
-          color: 'yellowgreen',
-        },
-      },
-      {
-        title: 'Code Climate',
-        exampleUrl: '/codeclimate/coverage-letter/jekyll/jekyll.svg',
-        urlPattern: '/codeclimate/coverage-letter/:userRepo.svg',
-        staticExample: { label: 'coverage', message: 'A', color: 'green' },
-      },
-      {
-        title: 'Code Climate',
-        exampleUrl: '/codeclimate/tech-debt/jekyll/jekyll.svg',
-        urlPattern: '/codeclimate/tech-debt/:userRepo.svg',
-        staticExample: {
-          label: 'technical debt',
-          message: '3%',
-          color: 'green',
-        },
-      },
-      {
         title: 'Codacy grade',
         previewUrl: '/codacy/grade/e27821fb6289410b8f58338c7e0bc686.svg',
       },

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -342,7 +342,7 @@ const allBadgeExamples = [
         title: 'Code Climate',
         exampleUrl: '/codeclimate/issues/twbs/bootstrap.svg',
         urlPattern: '/codeclimate/issues/:userRepo.svg',
-        staticExample: { label: 'issues', message: '93', color: 'red' },
+        staticExample: { label: 'issues', message: '89', color: 'red' },
       },
       {
         title: 'Code Climate',
@@ -357,7 +357,7 @@ const allBadgeExamples = [
         urlPattern: '/codeclimate/maintainability-percentage/:userRepo.svg',
         staticExample: {
           label: 'maintainability',
-          message: '4.2%',
+          message: '4.6%',
           color: 'red',
         },
       },
@@ -383,7 +383,7 @@ const allBadgeExamples = [
         urlPattern: '/codeclimate/tech-debt/:userRepo.svg',
         staticExample: {
           label: 'technical debt',
-          message: '4%',
+          message: '3%',
           color: 'green',
         },
       },

--- a/services/codeclimate/codeclimate.service.js
+++ b/services/codeclimate/codeclimate.service.js
@@ -140,7 +140,7 @@ module.exports = class Codeclimate extends LegacyService {
       base: 'codeclimate',
     }
   }
-  
+
   static get category() {
     return 'build'
   }

--- a/services/codeclimate/codeclimate.service.js
+++ b/services/codeclimate/codeclimate.service.js
@@ -140,6 +140,10 @@ module.exports = class Codeclimate extends LegacyService {
       base: 'codeclimate',
     }
   }
+  
+  static get category() {
+    return 'build'
+  }
 
   static get examples() {
     return [

--- a/services/codeclimate/codeclimate.service.js
+++ b/services/codeclimate/codeclimate.service.js
@@ -134,4 +134,63 @@ module.exports = class Codeclimate extends LegacyService {
       })
     )
   }
+
+  static get url() {
+    return {
+      base: 'codeclimate',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Code Climate issues',
+        exampleUrl: 'issues/twbs/bootstrap.svg',
+        urlPattern: 'issues/:userRepo.svg',
+        staticExample: { label: 'issues', message: '89', color: 'red' },
+      },
+      {
+        title: 'Code Climate maintainability',
+        exampleUrl: 'maintainability/angular/angular.js.svg',
+        urlPattern: 'maintainability/:userRepo.svg',
+        staticExample: { label: 'maintainability', message: 'F', color: 'red' },
+      },
+      {
+        title: 'Code Climate maintainability (percentage)',
+        exampleUrl: 'maintainability-percentage/angular/angular.js.svg',
+        urlPattern: 'maintainability-percentage/:userRepo.svg',
+        staticExample: {
+          label: 'maintainability',
+          message: '4.6%',
+          color: 'red',
+        },
+      },
+      {
+        title: 'Code Climate coverage',
+        exampleUrl: 'coverage/jekyll/jekyll.svg',
+        urlPattern: 'coverage/:userRepo.svg',
+        staticExample: {
+          label: 'coverage',
+          message: '95%',
+          color: 'yellowgreen',
+        },
+      },
+      {
+        title: 'Code Climate coverage (letter)',
+        exampleUrl: 'coverage-letter/jekyll/jekyll.svg',
+        urlPattern: 'coverage-letter/:userRepo.svg',
+        staticExample: { label: 'coverage', message: 'A', color: 'green' },
+      },
+      {
+        title: 'Code Climate technical debt',
+        exampleUrl: 'tech-debt/jekyll/jekyll.svg',
+        urlPattern: 'tech-debt/:userRepo.svg',
+        staticExample: {
+          label: 'technical debt',
+          message: '3%',
+          color: 'green',
+        },
+      },
+    ]
+  }
 }

--- a/services/codeclimate/codeclimate.service.js
+++ b/services/codeclimate/codeclimate.service.js
@@ -176,14 +176,18 @@ module.exports = class Codeclimate extends LegacyService {
         staticExample: {
           label: 'coverage',
           message: '95%',
-          color: 'yellowgreen',
+          color: 'green',
         },
       },
       {
         title: 'Code Climate coverage (letter)',
         exampleUrl: 'coverage-letter/jekyll/jekyll',
         urlPattern: 'coverage-letter/:userRepo',
-        staticExample: { label: 'coverage', message: 'A', color: 'green' },
+        staticExample: {
+          label: 'coverage',
+          message: 'A',
+          color: 'brightgreen',
+        },
       },
       {
         title: 'Code Climate technical debt',
@@ -192,7 +196,7 @@ module.exports = class Codeclimate extends LegacyService {
         staticExample: {
           label: 'technical debt',
           message: '3%',
-          color: 'green',
+          color: 'brightgreen',
         },
       },
     ]

--- a/services/codeclimate/codeclimate.service.js
+++ b/services/codeclimate/codeclimate.service.js
@@ -149,20 +149,20 @@ module.exports = class Codeclimate extends LegacyService {
     return [
       {
         title: 'Code Climate issues',
-        exampleUrl: 'issues/twbs/bootstrap.svg',
-        urlPattern: 'issues/:userRepo.svg',
+        exampleUrl: 'issues/twbs/bootstrap',
+        urlPattern: 'issues/:userRepo',
         staticExample: { label: 'issues', message: '89', color: 'red' },
       },
       {
         title: 'Code Climate maintainability',
-        exampleUrl: 'maintainability/angular/angular.js.svg',
-        urlPattern: 'maintainability/:userRepo.svg',
+        exampleUrl: 'maintainability/angular/angular.js',
+        urlPattern: 'maintainability/:userRepo',
         staticExample: { label: 'maintainability', message: 'F', color: 'red' },
       },
       {
         title: 'Code Climate maintainability (percentage)',
-        exampleUrl: 'maintainability-percentage/angular/angular.js.svg',
-        urlPattern: 'maintainability-percentage/:userRepo.svg',
+        exampleUrl: 'maintainability-percentage/angular/angular.js',
+        urlPattern: 'maintainability-percentage/:userRepo',
         staticExample: {
           label: 'maintainability',
           message: '4.6%',
@@ -171,8 +171,8 @@ module.exports = class Codeclimate extends LegacyService {
       },
       {
         title: 'Code Climate coverage',
-        exampleUrl: 'coverage/jekyll/jekyll.svg',
-        urlPattern: 'coverage/:userRepo.svg',
+        exampleUrl: 'coverage/jekyll/jekyll',
+        urlPattern: 'coverage/:userRepo',
         staticExample: {
           label: 'coverage',
           message: '95%',
@@ -181,14 +181,14 @@ module.exports = class Codeclimate extends LegacyService {
       },
       {
         title: 'Code Climate coverage (letter)',
-        exampleUrl: 'coverage-letter/jekyll/jekyll.svg',
-        urlPattern: 'coverage-letter/:userRepo.svg',
+        exampleUrl: 'coverage-letter/jekyll/jekyll',
+        urlPattern: 'coverage-letter/:userRepo',
         staticExample: { label: 'coverage', message: 'A', color: 'green' },
       },
       {
         title: 'Code Climate technical debt',
-        exampleUrl: 'tech-debt/jekyll/jekyll.svg',
-        urlPattern: 'tech-debt/:userRepo.svg',
+        exampleUrl: 'tech-debt/jekyll/jekyll',
+        urlPattern: 'tech-debt/:userRepo',
         staticExample: {
           label: 'technical debt',
           message: '3%',


### PR DESCRIPTION
We've hit a wall in #1518, our Code Climate badges have been unreliable for months now.

This pull request aims at sparing some of our limited API quota by switching to static examples on the homepage.

I'm not willing to migrate the badges to the new service architecture at this point as we've already put in quite a lot of investigation and development effort in these badges. The least we can say is that @CodeClimate have not been very cooperative and have been dragging their feet since one of our users first contacted them back in April.
