### PR TITLE
allow badge maxAge to be set by category; affects [discord]

### DIFF
--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -269,8 +269,9 @@ export default class Usage extends React.PureComponent {
                 <code>?maxAge=3600</code>
               </td>
               <td>
-                Set the HTTP cache lifetime in secs (values below the default
-                (currently 120 seconds) will be ignored)
+                Set the HTTP cache lifetime in secs (rules are applied to infer
+                a default value on a per-badge basis, any values specified below
+                the default will be ignored)
               </td>
             </tr>
           </tbody>

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -56,10 +56,29 @@ function flattenQueryParams(queryParams) {
   return Array.from(union).sort()
 }
 
+function getBadgeMaxAge(handlerOptions, queryParams) {
+  let maxAge = isInt(process.env.BADGE_MAX_AGE_SECONDS)
+    ? parseInt(process.env.BADGE_MAX_AGE_SECONDS)
+    : 120
+  if (handlerOptions.cacheLength) {
+    // if we've set a more specific cache length for this badge (or category),
+    // use that instead of env.BADGE_MAX_AGE_SECONDS
+    maxAge = parseInt(handlerOptions.cacheLength)
+  }
+  if (isInt(queryParams.maxAge) && parseInt(queryParams.maxAge) > maxAge) {
+    // only allow queryParams.maxAge to override the default
+    // if it is greater than the default
+    maxAge = parseInt(queryParams.maxAge)
+  }
+  return maxAge
+}
+
 // handlerOptions can contain:
 // - handler: The service's request handler function
 // - queryParams: An array of the field names of any custom query parameters
 //   the service uses
+// - cacheLength: An optional badge or category-specific cache length
+//   (in number of seconds) to be used in preference to the default
 //
 // For safety, the service must declare the query parameters it wants to use.
 // Only the declared parameters (and the global parameters) are provided to
@@ -81,14 +100,7 @@ function handleRequest(makeBadge, handlerOptions) {
   return (queryParams, match, end, ask) => {
     const reqTime = new Date()
 
-    let maxAge = isInt(process.env.BADGE_MAX_AGE_SECONDS)
-      ? parseInt(process.env.BADGE_MAX_AGE_SECONDS)
-      : 120
-    if (isInt(queryParams.maxAge) && parseInt(queryParams.maxAge) > maxAge) {
-      // only queryParams.maxAge to override the default
-      // if it is greater than env.BADGE_MAX_AGE_SECONDS
-      maxAge = parseInt(queryParams.maxAge)
-    }
+    const maxAge = getBadgeMaxAge(handlerOptions, queryParams)
     // send both Cache-Control max-age and Expires
     // in case the client implements HTTP/1.0 but not HTTP/1.1
     if (maxAge === 0) {
@@ -269,4 +281,5 @@ module.exports = {
   clearRequestCache,
   // Expose for testing.
   _requestCache: requestCache,
+  getBadgeMaxAge,
 }

--- a/lib/request-handler.spec.js
+++ b/lib/request-handler.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
+const { test, given } = require('sazerac')
 const fetch = require('node-fetch')
 const config = require('./test-config')
 const Camp = require('camp')
@@ -10,6 +11,7 @@ const {
   makeHandleRequestFn,
   clearRequestCache,
   _requestCache,
+  getBadgeMaxAge,
 } = require('./request-handler')
 const testHelpers = require('./make-badge-test-helpers')
 
@@ -204,6 +206,16 @@ describe('The request handler', function() {
         )
         expect(handlerCallCount).to.equal(2)
       })
+    })
+  })
+
+  describe('getBadgeMaxAge function', function() {
+    process.env.BADGE_MAX_AGE_SECONDS = 120
+    test(getBadgeMaxAge, () => {
+      given({}, {}).expect(120)
+      given({ cacheLength: 900 }, {}).expect(900)
+      given({ cacheLength: 900 }, { maxAge: 1000 }).expect(1000)
+      given({ cacheLength: 900 }, { maxAge: 400 }).expect(900)
     })
   })
 })

--- a/services/base.js
+++ b/services/base.js
@@ -171,9 +171,7 @@ class BaseService {
       license: 3600,
       version: 300,
     }
-    return cacheLengths.hasOwnProperty(this.category)
-      ? cacheLengths[this.category]
-      : undefined
+    return cacheLengths[this.category]
   }
 
   static _namedParamsForMatch(match) {

--- a/services/base.js
+++ b/services/base.js
@@ -165,6 +165,19 @@ class BaseService {
     return new RegExp(fullRegex)
   }
 
+  static get _cacheLength() {
+    if (this.category === 'build') {
+      return 30
+    }
+    if (this.category === 'license') {
+      return 3600
+    }
+    if (this.category === 'version') {
+      return 300
+    }
+    return undefined
+  }
+
   static _namedParamsForMatch(match) {
     const names = this.url.capture || []
 
@@ -315,6 +328,7 @@ class BaseService {
           const format = match.slice(-1)[0]
           sendBadge(format, badgeData)
         },
+        cacheLength: this._cacheLength,
       })
     )
   }

--- a/services/base.js
+++ b/services/base.js
@@ -166,16 +166,14 @@ class BaseService {
   }
 
   static get _cacheLength() {
-    if (this.category === 'build') {
-      return 30
+    const cacheLengths = {
+      build: 30,
+      license: 3600,
+      version: 300,
     }
-    if (this.category === 'license') {
-      return 3600
-    }
-    if (this.category === 'version') {
-      return 300
-    }
-    return undefined
+    return cacheLengths.hasOwnProperty(this.category)
+      ? cacheLengths[this.category]
+      : undefined
   }
 
   static _namedParamsForMatch(match) {

--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -22,6 +22,10 @@ module.exports = class Discord extends BaseJsonService {
     })
   }
 
+  static get _cacheLength() {
+    return 30
+  }
+
   static render({ members }) {
     return {
       message: `${members} online`,


### PR DESCRIPTION
This PR adds the ability for us to override `BADGE_MAX_AGE_SECONDS` with a different value for a category or a specific badge. This will allow us to set a long cache on badges that change infrequently (like license) and a shorter cache on badges that change more frequently (like build status). I've set some values in this PR:

license: 1 hour
version: 5 minutes
build: 30 seconds

as a starting point, but I'm not wedded to them. I'm more interested in feedback on the approach for now.

This only applies to the services we've already refactored, but as we refactor more of the codebase, this becomes an increasingly helpful feature :)

I've also shown an example in fe3552a of how we can use this feature to override the default in a specific badge. 2 mins cache is fine for most of the 'chat' badges, but the discord "how many users are online now" badge shows something more immediate so we might want to set a lower cache time on it.

One downside of this is that it becomes tricky to clearly explain the behaviour of the `maxAge` param:

https://github.com/badges/shields/blob/9df1da137c19d93e0d4e0a0a2526e807cddfbed4/frontend/components/usage.js#L267-L275

as potentially every badge could define its own default (lets not actually do that). That said, as we become better at caching on our side, I wonder if exposing that for users is still a valuable feature? :thinking: