### PR TITLE
Rename VSTS into Azure DevOps

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -2,39 +2,49 @@
 
 const { loadServiceClasses } = require('../services')
 
-const visualStudioTeamServicesBuildDoc = `
+const azureDevOpsBuildDoc = `
 <p>
-  To obtain your own badge, you will first need to enable badges for your
-  project:
+  To obtain your own badge, you need to get 3 pieces of information:
+  <code>ORGANIZATION</code>, <code>PROJECT_ID</code> and <code>DEFINITION_ID</code>.
+</p>
+<p>
+  First, you need to edit your build definition and look at the url:
 </p>
 <img
-  src="https://cloud.githubusercontent.com/assets/6189336/11894616/be744ab4-a578-11e5-9e44-0c32a7836b3b.png"
-  alt="Go to your builds, click General, then check Badge enabled." />
+  src="https://user-images.githubusercontent.com/3749820/47259976-e2d9ec80-d4b2-11e8-92cc-7c81089a7a2c.png"
+  alt="ORGANIZATION is after the dev.azure.com part, PROJECT_NAME is right after that, DEFINITION_ID is at the end after the id= part." />
 <p>
-  Then, click “Show url…” to reveal the URL of the default badge. In that URL,
-  you will need to extract three pieces of information: <code>TEAM_NAME</code>,
-  <code>PROJECT_ID</code> and <code>BUILD_DEFINITION_ID</code>.
+  Then, you can get the <code>PROJECT_ID</code> from the <code>PROJECT_NAME</code> using Azure DevOps REST API.
+  Just access to: <code>https://dev.azure.com/ORGANIZATION/_apis/projects/PROJECT_NAME</code>.
 </p>
 <img
-  src="https://cloud.githubusercontent.com/assets/6189336/11629345/f4eb0d78-9cf7-11e5-8d83-ca9fd895fcea.png"
-  alt="TEAM_NAME is just after the https:// part, PROJECT_ID is after definitions/, BUILD_DEFINITION_ID is after that.">
+  src="https://user-images.githubusercontent.com/3749820/47266325-1d846900-d535-11e8-9211-2ee72fb91877.png"
+  alt="PROJECT_ID is in the id property of the API response." />
 <p>
-  Your badge will then have the form
-  <code>https://img.shields.io/vso/build/TEAM_NAME/PROJECT_ID/BUILD_DEFINITION_ID</code>.
+  Your badge will then have the form:
+  <code>https://img.shields.io/vso/build/ORGANIZATION/PROJECT_ID/DEFINITION_ID.svg</code>.
 </p>
 <p>
-  Optionally, you can specify a named branch
-  <code>https://img.shields.io/vso/build/TEAM_NAME/PROJECT_ID/BUILD_DEFINITION_ID/NAMED_BRANCH</code>.
+  Optionally, you can specify a named branch:
+  <code>https://img.shields.io/vso/build/ORGANIZATION/PROJECT_ID/DEFINITION_ID/NAMED_BRANCH.svg</code>.
 </p>
 `
 
-const visualStudioTeamServicesReleaseDoc = `
+const azureDevOpsReleaseDoc = `
 <p>
-  To obtain your own badge, you will first need to enable badges on your release definition.
+  To obtain your own badge, you need to get 4 pieces of information:
+  <code>ORGANIZATION</code>, <code>PROJECT_ID</code>, <code>DEFINITION_ID</code> and <code>ENVIRONMENT_ID</code>.
 </p>
 <p>
-  Your badge will then have the form
-  <code>https://img.shields.io/vso/release/TEAM_NAME/PROJECT_ID/RELEASE_DEFINITION_ID/ENVIRONMENT_ID</code>.
+  First, you need to enable badges for each required environments in the options of your release definition.
+  Once you have save the change, look at badge url:
+</p>
+<img
+  src="https://user-images.githubusercontent.com/3749820/47266694-7f939d00-d53a-11e8-9224-c2371dd2d0c9.png"
+  alt="ORGANIZATION is after the dev.azure.com part, PROJECT_ID is after the badge part, DEFINITION_ID and ENVIRONMENT_ID are right after that." />
+<p>
+  Your badge will then have the form:
+  <code>https://img.shields.io/vso/release/ORGANIZATION/PROJECT_ID/DEFINITION_ID/ENVIRONMENT_ID.svg</code>.
 </p>
 `
 
@@ -182,16 +192,16 @@ const allBadgeExamples = [
         previewUrl: '/codeship/d6c1ddd0-16a3-0132-5f85-2e35c05e22b1/master.svg',
       },
       {
-        title: 'Visual Studio Team Services builds',
+        title: 'Azure DevOps builds',
         previewUrl:
-          '/vso/build/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1.svg',
-        documentation: visualStudioTeamServicesBuildDoc,
+          '/vso/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/2.svg',
+        documentation: azureDevOpsBuildDoc,
       },
       {
-        title: 'Visual Studio Team Services releases',
+        title: 'Azure DevOps releases',
         previewUrl:
-          '/vso/release/larsbrinkhoff/953a34b9-5966-4923-a48a-c41874cfb5f5/1/2.svg',
-        documentation: visualStudioTeamServicesReleaseDoc,
+          '/vso/release/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/1/1.svg',
+        documentation: azureDevOpsReleaseDoc,
       },
       {
         title: 'Jenkins',

--- a/services/vso/vso.service.js
+++ b/services/vso/vso.service.js
@@ -33,34 +33,36 @@ const fetchVstsBadge = (request, url, badgeData, sendBadge, format) => {
 
 module.exports = class Vso extends LegacyService {
   static registerLegacyRouteHandler({ camp, cache }) {
-    // For Visual Studio Team Services builds.
+    // For Azure DevOps builds.
     camp.route(
       /^\/vso\/build\/([^/]+)\/([^/]+)\/([^/]+)(?:\/(.+))?\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
-        const name = match[1] // User name
-        const project = match[2] // Project ID, e.g. 953a34b9-5966-4923-a48a-c41874cfb5f5
-        const build = match[3] // Build definition ID, e.g. 1
-        const branch = match[4]
+        // Microsoft documentation: https://docs.microsoft.com/en-us/rest/api/vsts/build/status/get
+        const organization = match[1] // The name (string) of the Azure DevOps organization.
+        const projectId = match[2] // The ID (uuid) of the project.
+        const definitionId = match[3] // The ID (int) of the definition.
+        const branchName = match[4] // The name (string) of the branch.
         const format = match[5]
-        let url = `https://${name}.visualstudio.com/${project}/_apis/build/status/${build}`
-        if (branch != null) {
-          url += `?branchName=${branch}`
+        let url = `https://dev.azure.com/${organization}/${projectId}/_apis/build/status/${definitionId}`
+        if (branchName != null) {
+          url += `?branchName=${branchName}`
         }
         const badgeData = getBadgeData('build', data)
         fetchVstsBadge(request, url, badgeData, sendBadge, format)
       })
     )
 
-    // For Visual Studio Team Services releases.
+    // For Azure DevOps releases.
     camp.route(
       /^\/vso\/release\/([^/]+)\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
-        const name = match[1] // User name
-        const project = match[2] // Project ID, e.g. 953a34b9-5966-4923-a48a-c41874cfb5f5
-        const release = match[3] // Release definition ID, e.g. 1
-        const environment = match[4] // Environment ID, e.g. 1
+        // Microsoft documentation: ?
+        const organization = match[1] // The name (string) of the Azure DevOps organization.
+        const projectId = match[2] // The ID (uuid) of the project.
+        const definitionId = match[3] // The ID (int) of the definition.
+        const environmentId = match[4] // The ID (int) of the release environment.
         const format = match[5]
-        const url = `https://${name}.vsrm.visualstudio.com/_apis/public/release/badge/${project}/${release}/${environment}`
+        const url = `https://vsrm.dev.azure.com/${organization}/_apis/public/Release/badge/${projectId}/${definitionId}/${environmentId}`
         const badgeData = getBadgeData('deployment', data)
         fetchVstsBadge(request, url, badgeData, sendBadge, format)
       })


### PR DESCRIPTION
Per #2082, this PR aims at renaming VSTS into Azure DevOps. I also updated the service documentation so that it is easier to create badges for both builds and releases.