### PR TITLE
bump simple-icons version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "redis": "~2.8.0",
     "request": "~2.88.0",
     "semver": "~5.6.0",
-    "simple-icons": "^1.7.1",
+    "simple-icons": "~1.9.9",
     "svgo": "~1.1.1",
     "xml2js": "~0.4.16",
     "xmldom": "~0.1.27",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "redis": "~2.8.0",
     "request": "~2.88.0",
     "semver": "~5.6.0",
-    "simple-icons": "~1.9.9",
+    "simple-icons": "1.9.9",
     "svgo": "~1.1.1",
     "xml2js": "~0.4.16",
     "xmldom": "~0.1.27",


### PR DESCRIPTION
This PR attempts to fix #2223 
>The production server runs `npm install` every deploy, though it doesn’t respect package-lock.

I've changed the required version to `1.9.9` (removed the `^` char) as i assume dependabot will update the required version in `package.json` if it doesn't match the current pattern?

Another option could be `latest`?
But this could cause problems if/when `simple-icons` moves to `2.0.0`.

**Note:**
I was going to change it to use `~1.9.9`, but figured we would still end up behind every patch, and only end up updating every minor version, so removed the tilde aswell.