### PR TITLE
Enforce property shorthand

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,6 +35,7 @@ rules:
   strict: "error"
   arrow-body-style: ["error", "as-needed"]
   no-extension-in-require/main: "error"
+  object-shorthand: ["error", "properties"]
 
   # Mocha-related.
   mocha/no-exclusive-tests: "error"

--- a/frontend/components/examples-page.js
+++ b/frontend/components/examples-page.js
@@ -43,7 +43,7 @@ export default class ExamplesPage extends React.Component {
     this.searchTimeout = window.setTimeout(() => {
       this.setState({
         searchReady: true,
-        query: query,
+        query,
       })
     }, 500)
   }

--- a/lib/badge-cli.js
+++ b/lib/badge-cli.js
@@ -52,7 +52,7 @@ const status = process.argv[3]
 let color = process.argv[4] || ':green'
 const colorA = process.argv[5]
 
-const badgeData = { text: [subject, status], format: format }
+const badgeData = { text: [subject, status], format }
 if (style) {
   badgeData.template = style
 }

--- a/lib/github-auth.js
+++ b/lib/github-auth.js
@@ -129,7 +129,7 @@ function sendTokenToAllServers(token) {
             method: 'POST',
             form: {
               shieldsSecret: serverSecrets.shieldsSecret,
-              token: token,
+              token,
             },
             // We target servers by IP, and we use HTTPS. Assuming that
             // 1. Internet routers aren't hacked, and
@@ -311,7 +311,7 @@ function githubRequest(request, url, query, cb) {
     url += '?' + qs
   }
 
-  request(url, { headers: headers }, (err, res, buffer) => {
+  request(url, { headers }, (err, res, buffer) => {
     if (globalToken !== null && githubToken !== null && err === null) {
       if (res.statusCode === 401) {
         // Unauthorized.

--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -180,7 +180,7 @@ function handleRequest(makeBadge, handlerOptions) {
       if (options && typeof options === 'object') {
         options.uri = uri
       } else if (typeof uri === 'string') {
-        options = { uri: uri }
+        options = { uri }
       } else {
         options = uri
       }
@@ -247,7 +247,7 @@ function handleRequest(makeBadge, handlerOptions) {
               : 1,
             time: +reqTime,
             interval: cacheInterval,
-            data: { format: format, badgeData: badgeData },
+            data: { format, badgeData },
           }
           requestCache.set(cacheIndex, updatedCache)
           if (!cachedVersionSent) {

--- a/lib/suggest.js
+++ b/lib/suggest.js
@@ -63,7 +63,7 @@ function findSuggestions(githubApiProvider, url, cb) {
     })
     .catch(err => {
       // eslint-disable-next-line standard/no-callback-literal
-      cb({ badges: [], err: err })
+      cb({ badges: [], err })
     })
 }
 

--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -127,7 +127,7 @@ class AurVotes extends BaseAurService {
 class AurVersion extends BaseAurService {
   static render({ version, outOfDate }) {
     const color = outOfDate === null ? 'blue' : 'orange'
-    return { message: versionText(version), color: color }
+    return { message: versionText(version), color }
   }
 
   async handle({ pkg }) {

--- a/services/gem/gem-downloads.service.js
+++ b/services/gem/gem-downloads.service.js
@@ -41,7 +41,7 @@ module.exports = class GemDownloads extends BaseJsonService {
 
   static render({ label, downloads }) {
     return {
-      label: label,
+      label,
       message: metric(downloads),
       color: downloadCountColor(downloads),
     }

--- a/services/gem/gem-rank.service.js
+++ b/services/gem/gem-rank.service.js
@@ -41,7 +41,7 @@ module.exports = class GemRank extends BaseJsonService {
     let message = ordinalNumber(rank)
     message += period === 'rt' ? '' : ' daily'
     return {
-      message: message,
+      message,
       color: floorCountColor(count, 10, 50, 100),
     }
   }

--- a/services/hexpm/hexpm.service.js
+++ b/services/hexpm/hexpm.service.js
@@ -162,7 +162,7 @@ function DownloadsForInterval(interval) {
 
     static get url() {
       return {
-        base: base,
+        base,
         format: '(.+)',
         capture: ['pkg'],
       }

--- a/services/imagelayers/imagelayers.service.js
+++ b/services/imagelayers/imagelayers.service.js
@@ -26,7 +26,7 @@ module.exports = class Imagelayers extends LegacyService {
           method: 'POST',
           json: true,
           body: {
-            repos: [{ name: path, tag: tag }],
+            repos: [{ name: path, tag }],
           },
           uri: 'https://imagelayers.io/registry/analyze',
         }

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -43,7 +43,7 @@ class JenkinsPluginInstalls extends BaseJsonService {
 
   static render({ label, installs }) {
     return {
-      label: label,
+      label,
       message: metric(installs),
       color: downloadCountColor(installs),
     }

--- a/services/librariesio/librariesio-dependencies.service.js
+++ b/services/librariesio/librariesio-dependencies.service.js
@@ -28,7 +28,7 @@ module.exports = class LibrariesioDependencies extends LegacyService {
           }
         }
 
-        const options = { method: 'GET', json: true, uri: uri }
+        const options = { method: 'GET', json: true, uri }
         const badgeData = getBadgeData('dependencies', data)
 
         request(options, (err, res, json) => {

--- a/services/requires/requires.service.js
+++ b/services/requires/requires.service.js
@@ -30,7 +30,7 @@ module.exports = class RequiresIo extends BaseJsonService {
     return this._requestJson({
       url,
       schema: statusSchema,
-      options: { qs: { branch: branch } },
+      options: { qs: { branch } },
     })
   }
 

--- a/services/steam/steam-base.js
+++ b/services/steam/steam-base.js
@@ -38,11 +38,11 @@ module.exports = class BaseSteamAPI extends BaseJsonService {
     const url = `https://api.steampowered.com/${interf}/${method}/v${version}/?format=json`
     return this._requestJson({
       url,
-      schema: schema,
+      schema,
       errorMessages: {
         400: 'bad request',
       },
-      options: options,
+      options,
     })
   }
 }

--- a/services/steam/steam-workshop.service.js
+++ b/services/steam/steam-workshop.service.js
@@ -280,7 +280,7 @@ class SteamFileReleaseDate extends SteamFileService {
 
   async onRequest({ response }) {
     const releaseDate = new Date(0).setUTCSeconds(response.time_created)
-    return this.constructor.render({ releaseDate: releaseDate })
+    return this.constructor.render({ releaseDate })
   }
 
   static get defaultBadgeData() {

--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -16,7 +16,7 @@ const validatorSchema = Joi.object()
 
 module.exports = class SwaggerValidatorService extends BaseJsonService {
   static render({ message, clr }) {
-    return { message: message, color: clr }
+    return { message, color: clr }
   }
 
   static get url() {

--- a/services/wercker/wercker.service.js
+++ b/services/wercker/wercker.service.js
@@ -29,7 +29,7 @@ module.exports = class Wercker extends BaseJsonService {
       url: baseUrl,
       options: {
         qs: {
-          branch: branch,
+          branch,
           limit: 1,
         },
       },
@@ -57,7 +57,7 @@ module.exports = class Wercker extends BaseJsonService {
         projectId,
         applicationName,
       }),
-      branch: branch,
+      branch,
     })
     if (json.length === 0) {
       return this.constructor.render({

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -38,7 +38,7 @@ module.exports = class BaseWordpress extends BaseJsonService {
         qs: {
           action: `${this.constructor.extensionType}_information`,
           request: {
-            slug: slug,
+            slug,
             fields: {
               active_installs: 1,
               sections: 0,

--- a/services/wordpress/wordpress-downloads.service.js
+++ b/services/wordpress/wordpress-downloads.service.js
@@ -177,7 +177,7 @@ function DownloadsForInterval(interval) {
         url: `https://api.wordpress.org/stats/plugin/1.0/downloads.php`,
         options: {
           qs: {
-            slug: slug,
+            slug,
             limit: query,
           },
         },

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -69,7 +69,7 @@ class WordpressPluginTestedVersion extends BaseWordpressPlatform {
   static render({ version, color }) {
     return {
       message: `${addv(version)} tested`,
-      color: color,
+      color,
     }
   }
 


### PR DESCRIPTION
I had to track down the right lint rule for this. We have no-useless-rename for destructuring and import/export. The one for object literals is object-shorthand.