### PR TITLE
Add pdk badge for puppet forge

### DIFF
--- a/services/puppetforge/puppetforge-modules.service.js
+++ b/services/puppetforge/puppetforge-modules.service.js
@@ -17,7 +17,7 @@ module.exports = class PuppetforgeModules extends LegacyService {
     camp.route(
       /^\/puppetforge\/([^/]+)\/([^/]+)\/([^/]+)\.(svg|png|gif|jpg|json)$/,
       cache((data, match, sendBadge, request) => {
-        const info = match[1] // either `v`, `dt`, `e` or `f`
+        const info = match[1] // either `v`, `dt`, `e`, `f`, or `p`
         const user = match[2]
         const module = match[3]
         const format = match[4]
@@ -71,6 +71,16 @@ module.exports = class PuppetforgeModules extends LegacyService {
                 badgeData.colorscheme = coveragePercentageColor(feedback)
               } else {
                 badgeData.text[1] = 'unknown'
+                badgeData.colorscheme = 'lightgrey'
+              }
+            } else if (info === 'p') {
+              badgeData.text[0] = 'pdk version'
+              if (json.current_release.pdk) {
+                const pdkVersion = json.current_release.metadata['pdk-version']
+                badgeData.text[1] = versionText(pdkVersion)
+                badgeData.colorscheme = versionColor(pdkVersion)
+              } else {
+                badgeData.text[1] = 'none'
                 badgeData.colorscheme = 'lightgrey'
               }
             }


### PR DESCRIPTION
This adds a badge that can be used to show whether or not a module was developing using the puppet development kit (pdk) and if so what version it's currently using.

Before this gets merged i would love to get some feedback first from some key puppet employees in order to make adjustments if needed.

/cc @davids @scotje

Closes #2255