### PR TITLE
Add vso keyword to azure badges

### DIFF
--- a/services/azure-devops/azure-devops-build.service.js
+++ b/services/azure-devops/azure-devops-build.service.js
@@ -53,6 +53,7 @@ module.exports = class AzureDevOpsBuild extends BaseSvgService {
         staticExample: render({ status: 'succeeded' }),
         exampleUrl:
           'azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/2',
+        keywords: ['vso'],
         documentation,
       },
       {
@@ -62,6 +63,7 @@ module.exports = class AzureDevOpsBuild extends BaseSvgService {
         staticExample: render({ status: 'succeeded' }),
         exampleUrl:
           'azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/2/master',
+        keywords: ['vso'],
         documentation,
       },
     ]

--- a/services/azure-devops/azure-devops-release.service.js
+++ b/services/azure-devops/azure-devops-release.service.js
@@ -43,6 +43,7 @@ module.exports = class AzureDevOpsRelease extends BaseSvgService {
         staticExample: render({ status: 'succeeded' }),
         exampleUrl:
           'azure-devops/release/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/1/1',
+        keywords: ['vso'],
         documentation,
       },
     ]


### PR DESCRIPTION
While checking out the deployment I suddenly realized the renaming has made these badges harder to find. This should help.