### PR TITLE
add not found tests back in for [depfu hexpm requires]

### DIFF
--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -163,7 +163,7 @@ Once we have multiple tests, sometimes it is useful to run only one test. We can
 npm run test:services -- --only="wercker" --fgrep="Build status (with branch)"
 ```
 
-Having covered the typical and custom cases, we'll move on to errors. We should include tests for any cusom error handling. The Wercker integration defines a couple of custom error conditions:
+Having covered the typical and custom cases, we'll move on to errors. We should include a test for the 'not found' response and also tests for any other cusom error handling. The Wercker integration defines a custom error condition for 401 as well as a custom 404 message:
 
 ```js
 errorMessages: {

--- a/services/depfu/depfu.tester.js
+++ b/services/depfu/depfu.tester.js
@@ -21,3 +21,7 @@ t.create('depfu dependencies (valid)')
       value: isDependencyStatus,
     })
   )
+
+t.create('depfu dependencies (repo not found)')
+  .get('/pyvesb/emptyrepo.json')
+  .expectJSON({ name: 'dependencies', value: 'not found' })

--- a/services/hexpm/hexpm.tester.js
+++ b/services/hexpm/hexpm.tester.js
@@ -26,9 +26,17 @@ t.create('downloads in total')
   .get('/dt/cowboy.json')
   .expectJSONTypes(Joi.object().keys({ name: 'downloads', value: isMetric }))
 
+t.create('downloads (not found)')
+  .get('/dt/this-package-does-not-exist.json')
+  .expectJSON({ name: 'downloads', value: 'not found' })
+
 t.create('version')
   .get('/v/cowboy.json')
   .expectJSONTypes(Joi.object().keys({ name: 'hex', value: isHexpmVersion }))
+
+t.create('version (not found)')
+  .get('/v/this-package-does-not-exist.json')
+  .expectJSON({ name: 'hex', value: 'not found' })
 
 t.create('license')
   .get('/l/cowboy.json?style=_shields_test')
@@ -73,3 +81,7 @@ t.create('license (no license)')
     value: 'Unknown',
     colorB: colorScheme.lightgrey,
   })
+
+t.create('license (not found)')
+  .get('/l/this-package-does-not-exist.json')
+  .expectJSON({ name: 'license', value: 'not found' })

--- a/services/requires/requires.tester.js
+++ b/services/requires/requires.tester.js
@@ -27,3 +27,7 @@ t.create('requirements (valid, with branch)')
       value: isRequireStatus,
     })
   )
+
+t.create('requirements (not found)')
+  .get('/github/PyvesB/EmptyRepo.json')
+  .expectJSON({ name: 'requirements', value: 'not found' })


### PR DESCRIPTION
Follow up from https://github.com/badges/shields/pull/2261#discussion_r230575315

There are a few recent PRs where we removed tests for the 'not found' case. I _think_ I've found all of them here and added them back in. I've also amended the docs on testing.

I suspect there are also some cases where we've accepted new badges or services tests without a test for the 'not found' case, but this replaces the ones we deleted.