### PR TITLE
Fix hex colors in static examples

### DIFF
--- a/services/base.js
+++ b/services/base.js
@@ -94,7 +94,7 @@ class BaseService {
     return staticBadgeUrl({
       label: badgeData.text[0],
       message: `${badgeData.text[1]}`,
-      color: badgeData.colorscheme,
+      color: badgeData.colorscheme || badgeData.colorB,
     })
   }
 

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -415,6 +415,25 @@ describe('BaseService', function() {
     })
   })
 
+  describe('_makeStaticExampleUrl', function() {
+    test(
+      serviceData => DummyService._makeStaticExampleUrl(serviceData),
+      () => {
+        given({
+          message: 'hello',
+          color: 'dcdc00',
+        }).expect('/badge/cat-hello-%23dcdc00.svg')
+        given({
+          message: 'hello',
+          color: 'red',
+        }).expect('/badge/cat-hello-red.svg')
+        given({
+          message: 'hello',
+        }).expect('/badge/cat-hello-lightgrey.svg')
+      }
+    )
+  })
+
   describe('prepareExamples', function() {
     it('returns the expected result', function() {
       const [first, second, third] = DummyService.prepareExamples()


### PR DESCRIPTION
Fix a regression from #2240 which was noticed here:

https://github.com/badges/shields/pull/2253#issuecomment-437415722