### PR TITLE
Remove extra file checked in by mistake

### DIFF
--- a/services/hackage/1.json
+++ b/services/hackage/1.json
@@ -1,1 +1,0 @@
-{ "plugin-repository": "" }


### PR DESCRIPTION
This snuck in on 52ab84c89f41cab5188364235c67b04735650f6d and I missed it in review.