### PR TITLE
Try to fix recent CircleCI failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ jobs:
   npm-install:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -27,7 +26,6 @@ jobs:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
       - image: redis
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -64,7 +62,6 @@ jobs:
     docker:
       - image: shieldsio/shields-ci-node-latest:0.0.3
       - image: redis
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -100,7 +97,6 @@ jobs:
   danger:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -121,7 +117,6 @@ jobs:
   frontend:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -147,7 +142,6 @@ jobs:
   services-pr:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -187,7 +181,6 @@ jobs:
   services-pr@node-latest:
     docker:
       - image: shieldsio/shields-ci-node-latest:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 
@@ -227,7 +220,6 @@ jobs:
   services-daily:
     docker:
       - image: shieldsio/shields-ci-node-8:0.0.3
-    working_directory: ~/repo
     steps:
       - checkout
 


### PR DESCRIPTION
All the recent circle builds are failing and when I re-ran a build on master, I'm seeing the same failure.

```

npm ERR! path /root/repo/node_modules/gh-badges
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall access
npm ERR! enoent ENOENT: no such file or directory, access '/root/repo/node_modules/gh-badges'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2018-11-12T14_28_41_232Z-debug.log
Exited with code 254
```

After reading https://discuss.circleci.com/t/cant-run-npm-install/19012 I wonder if it's related to the `working_directory` line. That issue suggests not using it. Here goes!