### PR TITLE
regular-update: Fix a crasher in production

### DIFF
--- a/lib/regular-update.js
+++ b/lib/regular-update.js
@@ -54,9 +54,11 @@ function regularUpdate(
     }
 
     if (res.statusCode < 200 || res.statusCode >= 300) {
-      throw new InvalidResponse({
-        prettyMessage: 'intermediate resource inaccessible',
-      })
+      cb(
+        new InvalidResponse({
+          prettyMessage: 'intermediate resource inaccessible',
+        })
+      )
     }
 
     let reqData


### PR DESCRIPTION
When I deployed 5e99aad2defac71e31e519f4b0460ce1aa33cfce to s0, shortly after Sentry picked up an unhandled error. I'm not sure which of the legacy badges this is in.

The bug was introduced just now, in #2257. Oops!