### PR TITLE
Allow handle() to return a numeric message

### DIFF
--- a/services/base.js
+++ b/services/base.js
@@ -23,7 +23,7 @@ const { staticBadgeUrl } = require('../lib/make-badge-url')
 const trace = require('./trace')
 
 function coalesce(...candidates) {
-  return candidates.find(c => typeof c === 'string')
+  return candidates.find(c => c !== undefined)
 }
 
 class BaseService {

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -348,6 +348,21 @@ describe('BaseService', function() {
         expect(badgeData.text).to.deep.equal(['cat', '10k'])
       })
 
+      it('preserves an empty label', function() {
+        const badgeData = DummyService._makeBadgeData(
+          {},
+          { label: '', message: '10k' }
+        )
+        expect(badgeData.text).to.deep.equal(['', '10k'])
+      })
+
+      it('applies a numeric service message', function() {
+        // While a number of badges use this, in the long run we may want
+        // `render()` to always return a string.
+        const badgeData = DummyService._makeBadgeData({}, { message: 10 })
+        expect(badgeData.text).to.deep.equal(['cat', 10])
+      })
+
       it('applies the service color', function() {
         const badgeData = DummyService._makeBadgeData({}, { color: 'red' })
         expect(badgeData.colorscheme).to.equal('red')


### PR DESCRIPTION
This regression from #2284 was causing `{ message: 22 }` to render as `'n/a'`, as in this test run: https://circleci.com/gh/badges/shields/23680

This is a deploy blocker.