### PR TITLE
replace calls to makeBadge() with BadgeFactory.create()

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -6,11 +6,13 @@ const request = require('request')
 const { makeBadgeData: getBadgeData } = require('./badge-data')
 const log = require('./log')
 const LruCache = require('../gh-badges/lib/lru-cache')
-const makeBadge = require('../gh-badges/lib/make-badge')
+const { BadgeFactory } = require('gh-badges')
 const analytics = require('./analytics')
 const { makeSend } = require('./result-sender')
 const queryString = require('query-string')
 const { Inaccessible } = require('../services/errors')
+
+const bf = new BadgeFactory()
 
 // We avoid calling the vendor's server for computation of the information in a
 // number of badges.
@@ -134,7 +136,7 @@ function handleRequest(handlerOptions) {
       // A request was made not long ago.
       const tooSoon = +reqTime - cached.time < cached.interval
       if (tooSoon || cached.dataChange / cached.reqs <= freqRatioMax) {
-        const svg = makeBadge(cached.data.badgeData)
+        const svg = bf.create(cached.data.badgeData)
         makeSend(cached.data.format, ask.res, end)(svg)
         cachedVersionSent = true
         // We do not wish to call the vendor servers.
@@ -153,7 +155,7 @@ function handleRequest(handlerOptions) {
       }
       if (requestCache.has(cacheIndex)) {
         const cached = requestCache.get(cacheIndex).data
-        const svg = makeBadge(cached.badgeData)
+        const svg = bf.create(cached.badgeData)
         makeSend(cached.format, ask.res, end)(svg)
         return
       }
@@ -166,7 +168,7 @@ function handleRequest(handlerOptions) {
       } catch (e) {
         extension = 'svg'
       }
-      const svg = makeBadge(badgeData)
+      const svg = bf.create(badgeData)
       makeSend(extension, ask.res, end)(svg)
     }, 25000)
 
@@ -250,7 +252,7 @@ function handleRequest(handlerOptions) {
           }
           requestCache.set(cacheIndex, updatedCache)
           if (!cachedVersionSent) {
-            const svg = makeBadge(badgeData)
+            const svg = bf.create(badgeData)
             makeSend(format, ask.res, end)(svg)
           }
         },

--- a/server.js
+++ b/server.js
@@ -19,7 +19,7 @@ const GithubConstellation = require('./services/github/github-constellation')
 const PrometheusMetrics = require('./lib/sys/prometheus-metrics')
 const sysMonitor = require('./lib/sys/monitor')
 const log = require('./lib/log')
-const makeBadge = require('./gh-badges/lib/make-badge')
+const { BadgeFactory } = require('gh-badges')
 const suggest = require('./lib/suggest')
 const {
   makeBadgeData: getBadgeData,
@@ -33,6 +33,7 @@ const { clearRegularUpdateCache } = require('./lib/regular-update')
 const { makeSend } = require('./lib/result-sender')
 
 const serverStartTime = new Date(new Date().toGMTString())
+const bf = new BadgeFactory()
 
 const camp = require('camp').start({
   documentRoot: path.join(__dirname, 'public'),
@@ -91,7 +92,7 @@ camp.notfound(/\.(svg|png|gif|jpg|json)/, (query, match, end, request) => {
   badgeData.colorscheme = 'red'
   // Add format to badge data.
   badgeData.format = format
-  const svg = makeBadge(badgeData)
+  const svg = bf.create(badgeData)
   makeSend(format, request.res, end)(svg)
 })
 
@@ -239,7 +240,7 @@ camp.route(/^\/flip\.svg$/, (data, match, end, ask) => {
   bitFlip = !bitFlip
   badgeData.text[1] = bitFlip ? 'on' : 'off'
   badgeData.colorscheme = bitFlip ? 'brightgreen' : 'red'
-  const svg = makeBadge(badgeData)
+  const svg = bf.create(badgeData)
   makeSend('svg', ask.res, end)(svg)
 })
 
@@ -263,10 +264,10 @@ camp.route(/^\/([^/]+)\/(.+).png$/, (data, match, end, ask) => {
   try {
     const badgeData = { text: [subject, status] }
     badgeData.colorscheme = color
-    const svg = makeBadge(badgeData)
+    const svg = bf.create(badgeData)
     makeSend('png', ask.res, end)(svg)
   } catch (e) {
-    const svg = makeBadge({ text: ['error', 'bad badge'], colorscheme: 'red' })
+    const svg = bf.create({ text: ['error', 'bad badge'], colorscheme: 'red' })
     makeSend('png', ask.res, end)(svg)
   }
 })

--- a/services/base-static.js
+++ b/services/base-static.js
@@ -1,11 +1,12 @@
 'use strict'
 
-const makeBadge = require('../gh-badges/lib/make-badge')
+const { BadgeFactory } = require('gh-badges')
 const { makeSend } = require('../lib/result-sender')
 const analytics = require('../lib/analytics')
 const BaseService = require('./base')
 
 const serverStartTime = new Date(new Date().toGMTString())
+const bf = new BadgeFactory()
 
 module.exports = class BaseStaticService extends BaseService {
   // Note: Since this is a static service, it is not `async`.
@@ -43,7 +44,8 @@ module.exports = class BaseStaticService extends BaseService {
       if (serviceConfig.profiling.makeBadge) {
         console.time('makeBadge total')
       }
-      const svg = makeBadge(badgeData)
+
+      const svg = bf.create(badgeData)
       if (serviceConfig.profiling.makeBadge) {
         console.timeEnd('makeBadge total')
       }

--- a/services/base-svg-scraping.spec.js
+++ b/services/base-svg-scraping.spec.js
@@ -5,15 +5,17 @@ const { expect } = require('chai')
 const sinon = require('sinon')
 const Joi = require('joi')
 const { makeBadgeData } = require('../lib/badge-data')
-const makeBadge = require('../gh-badges/lib/make-badge')
+const { BadgeFactory } = require('gh-badges')
 const BaseSvgScrapingService = require('./base-svg-scraping')
+
+const bf = new BadgeFactory()
 
 chai.use(require('chai-as-promised'))
 
 function makeExampleSvg({ label, message }) {
   const badgeData = makeBadgeData('this is the label', {})
   badgeData.text[1] = 'this is the result!'
-  return makeBadge(badgeData)
+  return bf.create(badgeData)
 }
 
 const schema = Joi.object({


### PR DESCRIPTION
This PR replaces all the calls to `makeBadge()` with `BadgeFactory.create()` and converts the relative imports to package imports so we are depending on the public interface of our package rather than its internals. PR #2311 has also been a big help with this.

There are still some relative imports left for
* `gh-badges/lib/colorscheme.json`
* `gh-badges/lib/lru-cache` and
* `gh-badges/lib/svg-to-img`