### PR TITLE
add a smoke test for BadgeFactory

### DIFF
--- a/gh-badges/lib/index.spec.js
+++ b/gh-badges/lib/index.spec.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { expect } = require('chai')
+const { BadgeFactory } = require('./index')
+const isSvg = require('is-svg')
+
+const bf = new BadgeFactory()
+
+describe('BadgeFactory class', function() {
+  it('should produce badge with valid input', function() {
+    expect(
+      bf.create({
+        text: ['build', 'passed'],
+        format: 'svg',
+        colorscheme: 'green',
+        template: 'flat',
+      })
+    ).to.satisfy(isSvg)
+  })
+})


### PR DESCRIPTION
The detailed functionality should be covered by the tests for `makeBadge` but it is helpful to have something which checks the public interface isn't broken.