### PR TITLE
Coverage: ignore next.config

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -5,6 +5,7 @@
     "**/*.spec.js",
     "**/*.integration.js",
     "dangerfile.js",
+    "next.config.js",
     "services/**/*.tester.js",
     "test-fixtures",
     "scripts",


### PR DESCRIPTION
https://coveralls.io/github/badges/shields is shaping up!

I think it does not make sense to check coverage for `next.config.js`. This file is run by the frontend build, which seems sufficient.

If that file has logic in it that is complex enough to warrant testing, it should be broken out into a separate file.