### PR TITLE
The last of the badge examples

### DIFF
--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -38,10 +38,6 @@ const allBadgeExamples = [
     },
     examples: [
       {
-        title: 'Chocolatey',
-        previewUrl: '/chocolatey/dt/scriptcs.svg',
-      },
-      {
         title: 'NuGet',
         previewUrl: '/nuget/dt/Microsoft.AspNetCore.Mvc.svg',
       },
@@ -53,11 +49,6 @@ const allBadgeExamples = [
         title: 'MyGet tenant',
         previewUrl:
           '/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg',
-      },
-      {
-        title: 'JetBrains ReSharper plugins',
-        previewUrl: '/resharper/dt/ReSharper.Nuke.svg',
-        keywords: ['jetbrains', 'plugin'],
       },
     ],
   },
@@ -122,18 +113,6 @@ const allBadgeExamples = [
         title: 'MyGet tenant',
         previewUrl:
           '/dotnet.myget/dotnet-coreclr/v/Microsoft.DotNet.CoreCLR.svg',
-      },
-      {
-        title: 'Chocolatey',
-        previewUrl: '/chocolatey/v/git.svg',
-      },
-      {
-        title: 'JetBrains ReSharper Plugins',
-        previewUrl: '/resharper/v/ReSharper.Nuke.svg',
-      },
-      {
-        title: 'JetBrains ReSharper Plugins Pre-release',
-        previewUrl: '/resharper/vpre/ReSharper.Nuke.svg',
       },
     ],
   },

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -55,10 +55,6 @@ const allBadgeExamples = [
           '/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg',
       },
       {
-        title: 'PowerShell Gallery',
-        previewUrl: '/powershellgallery/dt/ACMESharp.svg',
-      },
-      {
         title: 'JetBrains ReSharper plugins',
         previewUrl: '/resharper/dt/ReSharper.Nuke.svg',
         keywords: ['jetbrains', 'plugin'],
@@ -130,10 +126,6 @@ const allBadgeExamples = [
       {
         title: 'Chocolatey',
         previewUrl: '/chocolatey/v/git.svg',
-      },
-      {
-        title: 'PowerShell Gallery',
-        previewUrl: '/powershellgallery/v/Zyborg.Vault.svg',
       },
       {
         title: 'JetBrains ReSharper Plugins',

--- a/lib/all-badge-examples.js
+++ b/lib/all-badge-examples.js
@@ -36,21 +36,7 @@ const allBadgeExamples = [
       id: 'downloads',
       name: 'Downloads',
     },
-    examples: [
-      {
-        title: 'NuGet',
-        previewUrl: '/nuget/dt/Microsoft.AspNetCore.Mvc.svg',
-      },
-      {
-        title: 'MyGet',
-        previewUrl: '/myget/mongodb/dt/MongoDB.Driver.Core.svg',
-      },
-      {
-        title: 'MyGet tenant',
-        previewUrl:
-          '/dotnet.myget/dotnet-coreclr/dt/Microsoft.DotNet.CoreCLR.svg',
-      },
-    ],
+    examples: [],
   },
   {
     category: {
@@ -92,29 +78,7 @@ const allBadgeExamples = [
       id: 'version',
       name: 'Version',
     },
-    examples: [
-      {
-        title: 'NuGet',
-        previewUrl: '/nuget/v/Nuget.Core.svg',
-      },
-      {
-        title: 'NuGet Pre Release',
-        previewUrl: '/nuget/vpre/Microsoft.AspNet.Mvc.svg',
-      },
-      {
-        title: 'MyGet',
-        previewUrl: '/myget/mongodb/v/MongoDB.Driver.Core.svg',
-      },
-      {
-        title: 'MyGet Pre Release',
-        previewUrl: '/myget/yolodev/vpre/YoloDev.Dnx.FSharp.svg',
-      },
-      {
-        title: 'MyGet tenant',
-        previewUrl:
-          '/dotnet.myget/dotnet-coreclr/v/Microsoft.DotNet.CoreCLR.svg',
-      },
-    ],
+    examples: [],
   },
   {
     category: {

--- a/services/chocolatey/chocolatey.service.js
+++ b/services/chocolatey/chocolatey.service.js
@@ -6,4 +6,9 @@ module.exports = createServiceFamily({
   defaultLabel: 'chocolatey',
   serviceBaseUrl: 'chocolatey',
   apiBaseUrl: 'https://www.chocolatey.org/api/v2',
+  title: 'Chocolatey',
+  examplePackageName: 'git',
+  exampleVersion: '2.19.2',
+  examplePrereleaseVersion: '2.19.2',
+  exampleDownloadCount: 2.2e6,
 })

--- a/services/myget/myget.service.js
+++ b/services/myget/myget.service.js
@@ -2,8 +2,68 @@
 
 const { createServiceFamily } = require('../nuget/nuget-v3-service-family')
 
-module.exports = createServiceFamily({
+const {
+  NugetVersionService: Version,
+  NugetDownloadService: Downloads,
+} = createServiceFamily({
   defaultLabel: 'myget',
   serviceBaseUrl: 'myget',
   apiDomain: 'myget.org',
 })
+
+class MyGetVersionService extends Version {
+  static get examples() {
+    return [
+      {
+        title: 'MyGet',
+        pattern: 'myget/:feed/v/:packageName',
+        namedParams: { feed: 'mongodb', packageName: 'MongoDB.Driver.Core' },
+        staticExample: this.render({ version: '2.6.1' }),
+      },
+      {
+        title: 'MyGet (with prereleases)',
+        pattern: 'myget/:feed/vpre/:packageName',
+        namedParams: { feed: 'mongodb', packageName: 'MongoDB.Driver.Core' },
+        staticExample: this.render({ version: '2.7.0-beta0001' }),
+      },
+      {
+        title: 'MyGet tenant',
+        pattern: ':tenant.myget/:feed/v/:packageName',
+        namedParams: {
+          tenant: 'dotnet',
+          feed: 'dotnet-coreclr',
+          packageName: 'Microsoft.DotNet.CoreCLR',
+        },
+        staticExample: this.render({ version: '1.0.2-prerelease' }),
+      },
+    ]
+  }
+}
+
+class MyGetDownloadService extends Downloads {
+  static get examples() {
+    return [
+      {
+        title: 'MyGet',
+        pattern: 'myget/:feed/dt/:packageName',
+        namedParams: { feed: 'mongodb', packageName: 'MongoDB.Driver.Core' },
+        staticExample: this.render({ downloads: 419 }),
+      },
+      {
+        title: 'MyGet tenant',
+        pattern: ':tenant.myget/:feed/dt/:packageName',
+        namedParams: {
+          tenant: 'dotnet',
+          feed: 'dotnet-coreclr',
+          packageName: 'Microsoft.DotNet.CoreCLR',
+        },
+        staticExample: this.render({ downloads: 9748 }),
+      },
+    ]
+  }
+}
+
+module.exports = {
+  MyGetVersionService,
+  MyGetDownloadService,
+}

--- a/services/nuget/nuget-v2-service-family.js
+++ b/services/nuget/nuget-v2-service-family.js
@@ -65,7 +65,16 @@ async function fetch(
  * serviceBaseUrl: The base URL for the Shields service, e.g. chocolatey, resharper
  * apiBaseUrl: The complete base URL of the API, e.g. https://api.example.com/api/v2
  */
-function createServiceFamily({ defaultLabel, serviceBaseUrl, apiBaseUrl }) {
+function createServiceFamily({
+  defaultLabel,
+  serviceBaseUrl,
+  apiBaseUrl,
+  title,
+  examplePackageName,
+  exampleVersion,
+  examplePrereleaseVersion,
+  exampleDownloadCount,
+}) {
   class NugetVersionService extends BaseJsonService {
     static get category() {
       return 'version'
@@ -79,7 +88,22 @@ function createServiceFamily({ defaultLabel, serviceBaseUrl, apiBaseUrl }) {
     }
 
     static get examples() {
-      return []
+      if (!title) return []
+
+      return [
+        {
+          title,
+          pattern: 'v/:packageName',
+          namedParams: { which: 'v', packageName: examplePackageName },
+          staticExample: this.render({ version: exampleVersion }),
+        },
+        {
+          title: `${title} (with prereleases)`,
+          pattern: 'vpre/:packageName',
+          namedParams: { which: 'vpre', packageName: examplePackageName },
+          staticExample: this.render({ version: examplePrereleaseVersion }),
+        },
+      ]
     }
 
     static get defaultBadgeData() {
@@ -116,7 +140,15 @@ function createServiceFamily({ defaultLabel, serviceBaseUrl, apiBaseUrl }) {
     }
 
     static get examples() {
-      return []
+      if (!title) return []
+
+      return [
+        {
+          title,
+          namedParams: { packageName: examplePackageName },
+          staticExample: this.render({ downloads: exampleDownloadCount }),
+        },
+      ]
     }
 
     static render(props) {

--- a/services/nuget/nuget.service.js
+++ b/services/nuget/nuget.service.js
@@ -2,10 +2,47 @@
 
 const { createServiceFamily } = require('./nuget-v3-service-family')
 
-module.exports = createServiceFamily({
+const {
+  NugetVersionService: Version,
+  NugetDownloadService: Downloads,
+} = createServiceFamily({
   defaultLabel: 'nuget',
   serviceBaseUrl: 'nuget',
   apiBaseUrl: 'https://api.nuget.org/v3',
   withTenant: false,
   withFeed: false,
 })
+
+class NugetVersionService extends Version {
+  static get examples() {
+    return [
+      {
+        title: 'Nuget',
+        pattern: 'v/:packageName',
+        namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+        staticExample: this.render({ version: '5.2.4' }),
+      },
+      {
+        title: 'Nuget (with prereleases)',
+        pattern: 'vpre/:packageName',
+        namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+        staticExample: this.render({ version: '5.2.5-preview1' }),
+      },
+    ]
+  }
+}
+
+class NugetDownloadService extends Downloads {
+  static get examples() {
+    return [
+      {
+        title: 'Nuget',
+        pattern: 'dt/:packageName',
+        namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+        staticExample: this.render({ downloads: 49e6 }),
+      },
+    ]
+  }
+}
+
+module.exports = { NugetVersionService, NugetDownloadService }

--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -63,7 +63,20 @@ class PowershellGalleryVersion extends BaseXmlService {
   }
 
   static get examples() {
-    return []
+    return [
+      {
+        title: 'PowerShell Gallery',
+        pattern: 'v/:packageName',
+        namedParams: { which: 'v', packageName: 'Azure.Storage' },
+        staticExample: this.render({ version: '4.4.0' }),
+      },
+      {
+        title: 'PowerShell Gallery (with prereleases)',
+        pattern: 'vpre/:packageName',
+        namedParams: { which: 'vpre', packageName: 'Azure.Storage' },
+        staticExample: this.render({ version: '4.4.1-preview' }),
+      },
+    ]
   }
 
   static get defaultBadgeData() {
@@ -94,13 +107,19 @@ class PowershellGalleryDownloads extends BaseXmlService {
 
   static get route() {
     return {
-      base: 'powershellgallery',
-      pattern: 'dt/:packageName',
+      base: 'powershellgallery/dt',
+      pattern: ':packageName',
     }
   }
 
   static get examples() {
-    return []
+    return [
+      {
+        title: 'PowerShell Gallery',
+        namedParams: { packageName: 'Azure.Storage' },
+        staticExample: this.render({ downloads: 1.2e7 }),
+      },
+    ]
   }
 
   static render(props) {

--- a/services/resharper/resharper.service.js
+++ b/services/resharper/resharper.service.js
@@ -6,4 +6,9 @@ module.exports = createServiceFamily({
   defaultLabel: 'resharper',
   serviceBaseUrl: 'resharper',
   apiBaseUrl: 'https://resharper-plugins.jetbrains.com/api/v2',
+  title: 'JetBrains ReSharper plugins',
+  examplePackageName: 'StyleCop.StyleCop',
+  exampleVersion: '2017.2.0',
+  examplePrereleaseVersion: '2017.3.0-pre0001',
+  exampleDownloadCount: 9e4,
 })


### PR DESCRIPTION
With the v3 services, I extended the services after exporting them. With the v2 services, a simpler approach seemed possible so I went with that. PowerShell is an independent badge, so that one was straightforward.

Blocking further refactoring work on badge examples.