### PR TITLE
Add a "pill" style

### DIFF
--- a/gh-badges/lib/make-badge.js
+++ b/gh-badges/lib/make-badge.js
@@ -169,8 +169,9 @@ function makeBadge({
     logoPadding = logo ? 3 : 0
   }
 
+  let containerPadding = 0
   if (template === 'pill') {
-    logoPadding += 2
+    containerPadding = 2
   }
 
   const context = {
@@ -185,6 +186,7 @@ function makeBadge({
     colorA,
     colorB,
     escapeXml,
+    containerPadding,
   }
 
   const templateFn = templates[`${template}-${format}`]

--- a/gh-badges/lib/make-badge.js
+++ b/gh-badges/lib/make-badge.js
@@ -169,6 +169,10 @@ function makeBadge({
     logoPadding = logo ? 3 : 0
   }
 
+  if (template === 'pill') {
+    logoPadding += 2
+  }
+
   const context = {
     text: [left, right],
     escapedText: text.map(escapeXml),

--- a/gh-badges/templates/pill-template.svg
+++ b/gh-badges/templates/pill-template.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=(it.widths[0] -= it.text[0].length ? 0 : (it.logo ? (it.colorA ? 0 : 7) : 11))+it.widths[1]}}" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+
+  <clipPath id="round">
+    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" rx="10" fill="#fff"/>
+  </clipPath>
+
+  <g clip-path="url(#round)">
+    <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.text[0].length || it.logo && it.colorA ? (it.colorA||"#555") : (it.colorB||"#4c1"))}}"/>
+    <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
+    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
+  </g>
+
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
+    {{?it.logo}}
+      <image x="7" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
+    {{?}}
+    {{?it.text[0].length}}
+        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
+        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
+    {{?}}
+    <text x="{{=(it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
+    <text x="{{=(it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
+  </g>
+
+  {{?(it.links[0] && it.links[0].length)}}
+    <a target="_blank" xlink:href="{{=it.links[0]}}">
+      <rect width="{{=it.widths[0]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
+  {{?(it.links[0] && it.links[0].length || it.links[1] && it.links[1].length)}}
+    <a target="_blank" xlink:href="{{=it.links[1] || it.links[0]}}">
+      <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="rgba(0,0,0,0)"/>
+    </a>
+  {{?}}
+</svg>

--- a/gh-badges/templates/pill-template.svg
+++ b/gh-badges/templates/pill-template.svg
@@ -1,29 +1,29 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=(it.widths[0] -= it.text[0].length ? 0 : (it.logo ? (it.colorA ? 0 : 7) : 11))+it.widths[1]}}" height="20">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="{{=(it.widths[0] -= it.text[0].length ? 0 : (it.logo ? (it.colorA ? 0 : 7) : 11))+it.widths[1]+(it.containerPadding*2)}}" height="20">
   <linearGradient id="smooth" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
 
   <clipPath id="round">
-    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" rx="10" fill="#fff"/>
+    <rect width="{{=it.widths[0]+it.widths[1]+(it.containerPadding*2)}}" height="20" rx="10" fill="#fff"/>
   </clipPath>
 
   <g clip-path="url(#round)">
-    <rect width="{{=it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.text[0].length || it.logo && it.colorA ? (it.colorA||"#555") : (it.colorB||"#4c1"))}}"/>
-    <rect x="{{=it.widths[0]}}" width="{{=it.widths[1]}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
-    <rect width="{{=it.widths[0]+it.widths[1]}}" height="20" fill="url(#smooth)"/>
+    <rect width="{{=it.containerPadding+it.widths[0]}}" height="20" fill="{{=it.escapeXml(it.text[0].length || it.logo && it.colorA ? (it.colorA||"#555") : (it.colorB||"#4c1"))}}"/>
+    <rect x="{{=it.containerPadding+it.widths[0]}}" width="{{=it.widths[1]+it.containerPadding}}" height="20" fill="{{=it.escapeXml(it.colorB||"#4c1")}}"/>
+    <rect width="{{=it.widths[0]+it.widths[1]+(it.containerPadding*2)}}" height="20" fill="url(#smooth)"/>
   </g>
 
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
     {{?it.logo}}
-      <image x="7" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
+      <image x="{{=5+it.containerPadding}}" y="3" width="{{=it.logoWidth}}" height="14" xlink:href="{{=it.logo}}"/>
     {{?}}
     {{?it.text[0].length}}
-        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
-        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
+        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1+it.containerPadding)*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
+        <text x="{{=(((it.widths[0]+it.logoWidth+it.logoPadding)/2)+1+it.containerPadding)*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[0]-(10+it.logoWidth+it.logoPadding))*10}}" lengthAdjust="spacing">{{=it.escapedText[0]}}</text>
     {{?}}
-    <text x="{{=(it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
-    <text x="{{=(it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
+    <text x="{{=(it.containerPadding+it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="150" fill="#010101" fill-opacity=".3" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
+    <text x="{{=(it.containerPadding+it.widths[0]+it.widths[1]/2-(it.text[0].length ? 1 : 0 ))*10}}" y="140" transform="scale(0.1)" textLength="{{=(it.widths[1]-10)*10}}" lengthAdjust="spacing">{{=it.escapedText[1]}}</text>
   </g>
 
   {{?(it.links[0] && it.links[0].length)}}

--- a/scripts/export-supported-features-cli.js
+++ b/scripts/export-supported-features-cli.js
@@ -11,6 +11,7 @@ const supportedFeatures = {
     'plastic',
     'flat',
     'flat-square',
+    'pill',
     'for-the-badge',
     'popout',
     'popout-square',


### PR DESCRIPTION
I had a look at the theme selection of [cms.js](https://github.com/chrisdiana/cms.js) earlier. When I saw  the author pill in [the middle one in the top row](https://github.com/chrisdiana/cms.js/blob/d20f1ca80065a2855af0b2a033afd5eef868a753/img/themes.png) I thought to myself "hmmm, couldn't we do that with `gh-pages`?"

Since there currently is no such thing as a `pill` style, I added it!

### What does it look like?
The styles section of the front page would yield this:

![style-pill-green](https://user-images.githubusercontent.com/5056880/48986732-c74cac00-f118-11e8-8995-63a0a461bb2b.png)

I added two pixels of padding (as variable `containerPadding`*) to the left and right so that the more intense rounding doesn't affect the readability of the badge or makes the logo or text seem too close to the borders.

*the logic here may be debatable as it should probably also be applied for other styles(?)

### Why not make the corner radius in `flat` configurable?
I considered this as a solution better than adding a whole new svg template. Maybe it actually makes more sense, but I think that would be something that should be discussed before.