### PR TITLE
Remove `longCache` from static examples

### DIFF
--- a/frontend/components/usage.js
+++ b/frontend/components/usage.js
@@ -8,11 +8,10 @@ import { advertisedStyles, logos } from '../../supported-features.json'
 export default class Usage extends React.PureComponent {
   static propTypes = {
     baseUrl: PropTypes.string.isRequired,
-    longCache: PropTypes.bool.isRequired,
   }
 
   renderColorExamples() {
-    const { baseUrl, longCache } = this.props
+    const { baseUrl } = this.props
     const colors = [
       'brightgreen',
       'green',
@@ -30,9 +29,7 @@ export default class Usage extends React.PureComponent {
           <Fragment key={i}>
             <img
               className="badge-img"
-              src={staticBadgeUrl(baseUrl, 'color', color, color, {
-                longCache,
-              })}
+              src={staticBadgeUrl(baseUrl, 'color', color, color)}
               alt={color}
             />{' '}
             {}
@@ -43,14 +40,13 @@ export default class Usage extends React.PureComponent {
   }
 
   renderStyleExamples() {
-    const { baseUrl, longCache } = this.props
+    const { baseUrl } = this.props
     return (
       <table className="badge-img">
         <tbody>
           {advertisedStyles.map((style, i) => {
             const badgeUrl = staticBadgeUrl(baseUrl, 'style', style, 'green', {
               logo: 'appveyor',
-              longCache,
               style,
             })
             return (


### PR DESCRIPTION
- `longCache` should not be appearing in the displayed URLs for the usage examples.
- `maxAge` is ignored for static badges.