### PR TITLE
Add PowerShell Gallery platform support

### DIFF
--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -11,6 +11,10 @@ const {
   renderDownloadBadge,
 } = require('../nuget/nuget-helpers')
 
+const WINDOWS_TAG_NAME = 'windows'
+const MACOS_TAG_NAME = 'macos'
+const LINUX_TAG_NAME = 'linux'
+
 const schema = Joi.object({
   feed: Joi.object({
     entry: Joi.object({
@@ -18,6 +22,7 @@ const schema = Joi.object({
         'd:Version': Joi.string(),
         'd:NormalizedVersion': Joi.string(),
         'd:DownloadCount': nonNegativeInteger,
+        'd:Tags': Joi.string(),
       }),
     }),
   }).required(),
@@ -135,4 +140,78 @@ class PowershellGalleryDownloads extends BaseXmlService {
   }
 }
 
-module.exports = { PowershellGalleryVersion, PowershellGalleryDownloads }
+class PowershellGalleryPlatformSupport extends BaseXmlService {
+  static get category() {
+    return 'platform-support'
+  }
+
+  static get route() {
+    return {
+      base: 'powershellgallery/ps',
+      pattern: ':packageName',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'PowerShell Gallery',
+        namedParams: { packageName: 'Az.Storage' },
+        staticExample: this.render({
+          platforms: ['windows', 'macos', 'linux'],
+        }),
+      },
+    ]
+  }
+
+  static render({ platforms }) {
+    return {
+      label: 'platform',
+      message: platforms.join(' | '),
+    }
+  }
+
+  async handle({ packageName }) {
+    const packageData = await fetch(this, {
+      packageName,
+    })
+    const { 'd:Tags': tagStr } = packageData
+
+    const platforms = new Set()
+    const tagArr = tagStr.split(' ')
+
+    for (const tag of tagArr) {
+      switch (tag.toLowerCase()) {
+        // Look for Windows
+        case WINDOWS_TAG_NAME:
+          platforms.add(WINDOWS_TAG_NAME.toLowerCase())
+          break
+
+        // Look for MacOS
+        case MACOS_TAG_NAME:
+          platforms.add(MACOS_TAG_NAME.toLowerCase())
+          break
+
+        // Look for Linux
+        case LINUX_TAG_NAME:
+          platforms.add(LINUX_TAG_NAME.toLowerCase())
+          break
+
+        default:
+          break
+      }
+    }
+
+    if (platforms.size === 0) {
+      platforms.add('unknown')
+    }
+
+    return this.constructor.render({ platforms: [...platforms] })
+  }
+}
+
+module.exports = {
+  PowershellGalleryVersion,
+  PowershellGalleryDownloads,
+  PowershellGalleryPlatformSupport,
+}

--- a/services/powershellgallery/powershellgallery.tester.js
+++ b/services/powershellgallery/powershellgallery.tester.js
@@ -7,6 +7,9 @@ const {
   isVPlusDottedVersionNClauses,
   isVPlusDottedVersionNClausesWithOptionalSuffix,
 } = require('../test-validators')
+const isPlatform = Joi.string().regex(
+  /^(windows|linux|macos)( \| (windows|linux|macos))*$/
+)
 
 const t = new ServiceTester({
   id: 'powershellgallery',
@@ -52,3 +55,20 @@ t.create('version (pre) (valid)')
 t.create('version (pre) (not found)')
   .get('/vpre/not-a-real-package.json')
   .expectJSON({ name: 'powershell gallery', value: 'not found' })
+
+t.create('platform (valid')
+  .get('/ps/DNS.1.1.1.1.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'platform',
+      value: isPlatform,
+    })
+  )
+
+t.create('platform (no tags)')
+  .get('/ps/ACMESharp.json')
+  .expectJSON({ name: 'platform', value: 'unknown' })
+
+t.create('platform (not found)')
+  .get('/ps/not-a-real-package.json')
+  .expectJSON({ name: 'platform-support', value: 'not found' })


### PR DESCRIPTION
Now that we have [PowerShell Core](https://github.com/powershell/powershell) the cross-plat version of PowerShell... it'd be really cool to have a badge that shows the OS's that your module works on.

On the PowerShell Gallery, users can do this by using the tags `Windows` `MacOS` `Linux`. In this PR, I use the PowerShell Gallery API to grab the tags from that package and display `windows` `macos` `linux` if they exist.

The result is:
![](https://i.imgur.com/auXUkJJ.png)

which align with Conda and Cocoapods

Let me know if there's anything else I need to do! It's been a pleasure working on this - the dev experience is incredible!