### PR TITLE
Prevent bad letter spacing when whitespace surrounds badge text

### DIFF
--- a/gh-badges/lib/make-badge.js
+++ b/gh-badges/lib/make-badge.js
@@ -117,8 +117,8 @@ function makeBadge({
   logoWidth,
   links = ['', ''],
 }) {
-  // String coercion.
-  text = text.map(value => `${value}`)
+  // String coercion and whitespace removal.
+  text = text.map(value => `${value}`.trim())
 
   if (format !== 'json') {
     format = 'svg'


### PR DESCRIPTION
This is a little fix I’ve been meaning to make for a while. Normally it manifests in the codetally badge, but that badge isn’t working right now.

Here’s a static example, where the right text is wrapped in spaces:

https://img.shields.io/badge/foo-%20bar%20-blue.svg

The spaces get included in width computation, though I suppose ignored when the svg renders, resulting in bad letter spacing.

With this fix, the spaces are ignored.

production: ![](https://img.shields.io/badge/foo-%20bar%20-blue.svg)
this PR: ![](https://shields-staging-pr-2475.herokuapp.com/badge/foo-%20bar%20-blue.svg)