### PR TITLE
Fix whitespace in mocked Codetally test

### DIFF
--- a/services/codetally/codetally.tester.js
+++ b/services/codetally/codetally.tester.js
@@ -36,4 +36,4 @@ t.create('Empty')
         currency_abbreviation: 'CAD',
       })
   )
-  .expectJSON({ name: 'codetally', value: ' $0.00 ' })
+  .expectJSON({ name: 'codetally', value: '$0.00' })


### PR DESCRIPTION
This was caused by #2475 and fixes the mocked test. It's not related to #2480 which is causing the other one to fail.

Not running the [Codetally] tests in CI because they're failing.