### PR TITLE
WIP refactor [dependabot] semver stability service

### DIFF
--- a/services/dependabot/dependabot.service.js
+++ b/services/dependabot/dependabot.service.js
@@ -1,13 +1,23 @@
 'use strict'
 
-const LegacyService = require('../legacy-service')
-const {
-  makeBadgeData: getBadgeData,
-  makeLogo: getLogo,
-} = require('../../lib/badge-data')
-const { checkErrorResponse } = require('../../lib/error-helper')
+const BaseJsonService = require('../base-json')
+const Joi = require('joi')
 
-module.exports = class DependabotSemverCompatibility extends LegacyService {
+const schema = Joi.object({
+  status: Joi.string().required(),
+  colour: Joi.string().required(),
+})
+
+module.exports = class DependabotSemverCompatibility extends BaseJsonService {
+  async fetch({ packageManager, dependencyName }) {
+    const url = `https://api.dependabot.com/badges/compatibility_score?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`
+    return this._requestJson({ schema, url })
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'semver stability' }
+  }
+
   static get category() {
     return 'other'
   }
@@ -15,52 +25,33 @@ module.exports = class DependabotSemverCompatibility extends LegacyService {
   static get route() {
     return {
       base: 'dependabot/semver',
+      pattern: ':packageManager/:dependencyName',
     }
+  }
+
+  static _getLink({ packageManager, dependencyName }) {
+    return `https://dependabot.com/compatibility-score.html?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`
   }
 
   static get examples() {
     return [
       {
-        title: 'SemVer Compatibility',
-        previewUrl: 'bundler/puma',
+        title: 'Dependabot SemVer Compatibility',
+        namedParams: { packageManager: 'bundler', dependencyName: 'puma' },
+        staticExample: {
+          color: 'green',
+          message: '98%',
+        },
       },
     ]
   }
 
-  static registerLegacyRouteHandler({ camp, cache }) {
-    camp.route(
-      /^\/dependabot\/semver\/([^/]+)\/(.+)\.(svg|png|gif|jpg|json)$/,
-      cache((data, match, sendBadge, request) => {
-        const packageManager = match[1]
-        const dependencyName = match[2]
-        const format = match[3]
-        const options = {
-          method: 'GET',
-          headers: { Accept: 'application/json' },
-          uri: `https://api.dependabot.com/badges/compatibility_score?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`,
-        }
-        const badgeData = getBadgeData('semver stability', data)
-        badgeData.links = [
-          `https://dependabot.com/compatibility-score.html?package-manager=${packageManager}&dependency-name=${dependencyName}&version-scheme=semver`,
-        ]
-        badgeData.logo = getLogo('dependabot', data)
-        request(options, (err, res) => {
-          if (checkErrorResponse(badgeData, err, res)) {
-            sendBadge(format, badgeData)
-            return
-          }
-          try {
-            const dependabotData = JSON.parse(res['body'])
-            badgeData.text[1] = dependabotData.status
-            badgeData.colorscheme = dependabotData.colour
-            sendBadge(format, badgeData)
-          } catch (e) {
-            badgeData.text[1] = 'invalid'
-            badgeData.colorscheme = 'red'
-            sendBadge(format, badgeData)
-          }
-        })
-      })
-    )
+  async handle({ packageManager, dependencyName }) {
+    const json = await this.fetch({ packageManager, dependencyName })
+    return {
+      color: json.colour,
+      message: json.status,
+      link: this.constructor._getLink({ packageManager, dependencyName }),
+    }
   }
 }

--- a/services/dependabot/dependabot.tester.js
+++ b/services/dependabot/dependabot.tester.js
@@ -3,7 +3,6 @@
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
 const { isIntegerPercentage } = require('../test-validators')
-const { invalidJSON } = require('../response-fixtures')
 const { colorScheme: colorsB } = require('../test-helpers')
 
 const t = (module.exports = new ServiceTester({
@@ -22,35 +21,12 @@ t.create('semver stability (valid)')
     })
   )
 
-t.create('semver stability (connection error)')
-  .get('/semver/bundler/puma.json?style=_shields_test')
-  .networkOff()
-  .expectJSON({
-    name: 'semver stability',
-    value: 'inaccessible',
-    colorB: colorsB.red,
-  })
-
 t.create('semver stability (invalid error)')
   .get('/semver/invalid-manager/puma.json?style=_shields_test')
   .expectJSON({
     name: 'semver stability',
     value: 'invalid',
     colorB: colorsB.lightgrey,
-  })
-
-t.create('semver stability (invalid JSON response)')
-  .get('/semver/bundler/puma.json')
-  .intercept(nock =>
-    nock('https://api.dependabot.com')
-      .get(
-        '/badges/compatibility_score?package-manager=bundler&dependency-name=puma&version-scheme=semver'
-      )
-      .reply(invalidJSON)
-  )
-  .expectJSON({
-    name: 'semver stability',
-    value: 'invalid',
   })
 
 t.create('semver stability (missing dependency)')


### PR DESCRIPTION
Dependabot has an unusual characteristic in that we currently show a logo by default on this badge.

We don't do this on any other badges and our contribution guidelines say we only accept badges that do this if they use the 'social' style:
https://github.com/badges/shields/blob/master/CONTRIBUTING.md#badge-guidelines

This means we can't port the dependabot badge to the new service layout exactly as it stands because we now enforce this rule in the base class - only a social badge may use default logo:
https://github.com/badges/shields/blob/b08a941490f943bd33507c62ccaf42961c7001ff/services/base.js#L336

My instinct on this one is we just change this badge to bring it into line with everything else (which is what I've proposed in this PR)

This isn't a breaking change for @dependabot. The badges they use in their PRs are served from their own servers, not shields.io e.g:

![](https://api.dependabot.com/badges/compatibility_score?package-manager=bundler&dependency-name=puma&version-scheme=semver) - https://api.dependabot.com/badges/compatibility_score?package-manager=bundler&dependency-name=puma&version-scheme=semver

Does that seem reasonable?