### PR TITLE
Refactor [AzureDevOpsCoverage AzureDevOpsTests] to only report on completed builds; test all [azuredevops]

### DIFF
--- a/services/azure-devops/azure-devops-base.js
+++ b/services/azure-devops/azure-devops-base.js
@@ -25,7 +25,7 @@ module.exports = class BaseAzureDevOpsService extends BaseJsonService {
     })
   }
 
-  async getLatestBuildId(
+  async getLatestCompletedBuildId(
     organization,
     project,
     definitionId,
@@ -39,6 +39,7 @@ module.exports = class BaseAzureDevOpsService extends BaseJsonService {
       qs: {
         definitions: definitionId,
         $top: 1,
+        statusFilter: 'completed',
         'api-version': '5.0-preview.4',
       },
       headers,

--- a/services/azure-devops/azure-devops-base.js
+++ b/services/azure-devops/azure-devops-base.js
@@ -15,7 +15,7 @@ const latestBuildSchema = Joi.object({
     .required(),
 }).required()
 
-module.exports = class BaseAzureDevOpsService extends BaseJsonService {
+module.exports = class AzureDevOpsBase extends BaseJsonService {
   async fetch({ url, options, schema, errorMessages }) {
     return this._requestJson({
       schema,

--- a/services/azure-devops/azure-devops-coverage.service.js
+++ b/services/azure-devops/azure-devops-coverage.service.js
@@ -106,7 +106,7 @@ module.exports = class AzureDevOpsCoverage extends BaseAzureDevOpsService {
     const errorMessages = {
       404: 'build pipeline or coverage not found',
     }
-    const buildId = await this.getLatestBuildId(
+    const buildId = await this.getLatestCompletedBuildId(
       organization,
       project,
       definitionId,

--- a/services/azure-devops/azure-devops-coverage.service.js
+++ b/services/azure-devops/azure-devops-coverage.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const BaseAzureDevOpsService = require('./azure-devops-base')
+const AzureDevOpsBase = require('./azure-devops-base')
 const { keywords, getHeaders } = require('./azure-devops-helpers')
 
 const documentation = `
@@ -47,7 +47,7 @@ const buildCodeCoverageSchema = Joi.object({
     .required(),
 }).required()
 
-module.exports = class AzureDevOpsCoverage extends BaseAzureDevOpsService {
+module.exports = class AzureDevOpsCoverage extends AzureDevOpsBase {
   static render({ coverage }) {
     return {
       message: `${coverage.toFixed(0)}%`,

--- a/services/azure-devops/azure-devops-coverage.tester.js
+++ b/services/azure-devops/azure-devops-coverage.tester.js
@@ -13,7 +13,7 @@ const buildId = 946
 const uriPrefix = `/${org}/${project}`
 const azureDevOpsApiBaseUri = `https://dev.azure.com/${org}/${project}/_apis`
 const mockBadgeUriPath = `${uriPrefix}/${macDefinitionId}.json`
-const mockLatestBuildApiUriPath = `/build/builds?definitions=${macDefinitionId}&%24top=1&api-version=5.0-preview.4`
+const mockLatestBuildApiUriPath = `/build/builds?definitions=${macDefinitionId}&%24top=1&statusFilter=completed&api-version=5.0-preview.4`
 const mockCodeCoverageApiUriPath = `/test/codecoverage?buildId=${buildId}&api-version=5.0-preview.1`
 const latestBuildResponse = {
   count: 1,
@@ -94,7 +94,7 @@ t.create('no build response')
   .intercept(nock =>
     nock(azureDevOpsApiBaseUri)
       .get(
-        `/build/builds?definitions=${nonExistentDefinitionId}&%24top=1&api-version=5.0-preview.4`
+        `/build/builds?definitions=${nonExistentDefinitionId}&%24top=1&statusFilter=completed&api-version=5.0-preview.4`
       )
       .reply(200, {
         count: 0,

--- a/services/azure-devops/azure-devops-tests.service.js
+++ b/services/azure-devops/azure-devops-tests.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const BaseAzureDevOpsService = require('./azure-devops-base')
+const AzureDevOpsBase = require('./azure-devops-base')
 const { getHeaders } = require('./azure-devops-helpers')
 const { renderTestResultBadge } = require('../../lib/text-formatters')
 
@@ -56,7 +56,7 @@ const buildTestResultSummarySchema = Joi.object({
   }).required(),
 }).required()
 
-module.exports = class AzureDevOpsTests extends BaseAzureDevOpsService {
+module.exports = class AzureDevOpsTests extends AzureDevOpsBase {
   static render({
     passed,
     failed,

--- a/services/azure-devops/azure-devops-tests.service.js
+++ b/services/azure-devops/azure-devops-tests.service.js
@@ -200,7 +200,7 @@ module.exports = class AzureDevOpsTests extends BaseAzureDevOpsService {
     const errorMessages = {
       404: 'build pipeline or test result summary not found',
     }
-    const buildId = await this.getLatestBuildId(
+    const buildId = await this.getLatestCompletedBuildId(
       organization,
       project,
       definitionId,

--- a/services/azure-devops/azure-devops-tests.tester.js
+++ b/services/azure-devops/azure-devops-tests.tester.js
@@ -12,9 +12,9 @@ const azureDevOpsApiBaseUri = `https://dev.azure.com/${org}/${project}/_apis`
 const mockBadgeUriPath = `${uriPrefix}/${definitionId}`
 const mockBadgeUri = `${mockBadgeUriPath}.json`
 const mockBranchBadgeUri = `${mockBadgeUriPath}/master.json`
-const mockLatestBuildApiUriPath = `/build/builds?definitions=${definitionId}&%24top=1&api-version=5.0-preview.4`
-const mockLatestBranchBuildApiUriPath = `/build/builds?definitions=${definitionId}&%24top=1&api-version=5.0-preview.4&branch=master`
-const mockNonExistentBuildApiUriPath = `/build/builds?definitions=${nonExistentDefinitionId}&%24top=1&api-version=5.0-preview.4`
+const mockLatestBuildApiUriPath = `/build/builds?definitions=${definitionId}&%24top=1&statusFilter=completed&api-version=5.0-preview.4`
+const mockLatestBranchBuildApiUriPath = `/build/builds?definitions=${definitionId}&%24top=1&statusFilter=completed&api-version=5.0-preview.4&branch=master`
+const mockNonExistentBuildApiUriPath = `/build/builds?definitions=${nonExistentDefinitionId}&%24top=1&statusFilter=completed&api-version=5.0-preview.4`
 const mockTestResultSummaryApiUriPath = `/test/ResultSummaryByBuild?buildId=${buildId}`
 const latestBuildResponse = {
   count: 1,


### PR DESCRIPTION
This is in response to [this conversation](https://github.com/badges/shields/issues/2237#issuecomment-446812796). The change turned out being even easier than I had anticipated because the [API supports a buildStatus filter](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.0#buildstatus). I did quite a bit of local testing to make sure this is solid. I also ran tests and checked coverage.

One thing I thought might be slightly odd is the [name of this class](https://github.com/badges/shields/blob/master/services/azure-devops/azure-devops-base.js#L18) doesn't match the file name. Not an issue and I'm not sure if it's intentional, but figured it was worth noting.