### PR TITLE
Migrate [Coverity] to new service model

### DIFF
--- a/lib/deprecated-services.js
+++ b/lib/deprecated-services.js
@@ -16,6 +16,7 @@ const deprecatedServices = {
   libscore: new Date('2018-09-22'),
   imagelayers: new Date('2018-11-18'),
   nsp: new Date('2018-12-13'),
+  'coverity-on-demand': new Date('2018-12-18'),
 }
 
 module.exports = {

--- a/services/coverity/coverity-on-demand.service.js
+++ b/services/coverity/coverity-on-demand.service.js
@@ -1,77 +1,13 @@
 'use strict'
 
-const LegacyService = require('../legacy-service')
-const { makeBadgeData: getBadgeData } = require('../../lib/badge-data')
+const deprecatedService = require('../deprecated-service')
 
-// For Coverity Code Advisor On Demand.
-module.exports = class CoverityOnDemand extends LegacyService {
-  static get category() {
-    return 'quality'
-  }
-
-  static get route() {
-    return {
-      base: 'coverity/ondemand',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Coverity Code Advisor On Demand Stream',
-        previewUrl: 'streams/STREAM',
-      },
-      {
-        title: 'Coverity Code Advisor On Demand Job',
-        previewUrl: 'jobs/JOB',
-      },
-    ]
-  }
-
-  static registerLegacyRouteHandler({ camp, cache }) {
-    camp.route(
-      /^\/coverity\/ondemand\/(.+)\/(.+)\.(svg|png|gif|jpg|json)$/,
-      cache((data, match, sendBadge, request) => {
-        const badgeType = match[1] // One of the strings "streams" or "jobs"
-        const badgeTypeId = match[2] // streamId or jobId
-        const format = match[3]
-
-        const badgeData = getBadgeData('coverity', data)
-        if (
-          (badgeType === 'jobs' && badgeTypeId === 'JOB') ||
-          (badgeType === 'streams' && badgeTypeId === 'STREAM')
-        ) {
-          // Request is for a static demo badge
-          badgeData.text[1] = 'clean'
-          badgeData.colorscheme = 'green'
-          sendBadge(format, badgeData)
-        } else {
-          //
-          // Request is for a real badge; send request to Coverity On Demand API
-          // server to get the badge
-          //
-          // Example URLs for requests sent to Coverity On Demand are:
-          //
-          // https://api.ondemand.coverity.com/streams/44b25sjc9l3ntc2ngfi29tngro/badge
-          // https://api.ondemand.coverity.com/jobs/p4tmm8031t4i971r0im4s7lckk/badge
-          //
-          const url = `https://api.ondemand.coverity.com/${badgeType}/${badgeTypeId}/badge`
-          request(url, (err, res, buffer) => {
-            if (err != null) {
-              badgeData.text[1] = 'inaccessible'
-              sendBadge(format, badgeData)
-              return
-            }
-            try {
-              const data = JSON.parse(buffer)
-              sendBadge(format, data)
-            } catch (e) {
-              badgeData.text[1] = 'invalid'
-              sendBadge(format, badgeData)
-            }
-          })
-        }
-      })
-    )
-  }
-}
+// coverity on demand integration - deprecated as of December 2018.
+module.exports = deprecatedService({
+  url: {
+    base: 'coverity/ondemand',
+    format: '(?:.+)',
+  },
+  label: 'coverity',
+  category: 'quality',
+})

--- a/services/coverity/coverity-on-demand.tester.js
+++ b/services/coverity/coverity-on-demand.tester.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const ServiceTester = require('../service-tester')
+
+const t = (module.exports = new ServiceTester({
+  id: 'CoverityOnDemand',
+  title: 'Coverity On Demand',
+  pathPrefix: '/coverity/ondemand',
+}))
+
+t.create('no longer available (streams)')
+  .get('/streams/44b25sjc9l3ntc2ngfi29tngro.json')
+  .expectJSON({
+    name: 'coverity',
+    value: 'no longer available',
+  })
+
+t.create('no longer available (jobs)')
+  .get('/jobs/p4tmm8031t4i971r0im4s7lckk.json')
+  .expectJSON({
+    name: 'coverity',
+    value: 'no longer available',
+  })

--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -58,7 +58,6 @@ module.exports = class CoverityScan extends BaseJsonService {
         staticPreview: this.render({
           message: 'passed',
         }),
-        keywords: ['coverity', 'scan'],
       },
     ]
   }

--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -69,6 +69,8 @@ module.exports = class CoverityScan extends BaseJsonService {
       url,
       schema,
       errorMessages: {
+        // At the moment Coverity returns an HTTP 200 with an HTML page
+        // displaying the text 404 when project is not found.
         404: 'project not found',
       },
     })

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
+const { colorScheme } = require('../test-helpers')
 const t = (module.exports = require('../create-service-tester')())
 
 t.create('live: known project id')
@@ -27,7 +28,7 @@ t.create('404 response')
   .expectJSON({ name: 'coverity', value: 'project not found' })
 
 t.create('passed')
-  .get('/2.json')
+  .get('/2.json?style=_shields_test')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -35,10 +36,14 @@ t.create('passed')
         message: 'passed',
       })
   )
-  .expectJSON({ name: 'coverity', value: 'passing' })
+  .expectJSON({
+    name: 'coverity',
+    value: 'passing',
+    colorB: colorScheme.brightgreen,
+  })
 
 t.create('passed with defects')
-  .get('/2.json')
+  .get('/2.json?style=_shields_test')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -46,10 +51,14 @@ t.create('passed with defects')
         message: 'passed 51 new defects',
       })
   )
-  .expectJSON({ name: 'coverity', value: 'passed 51 new defects' })
+  .expectJSON({
+    name: 'coverity',
+    value: 'passed 51 new defects',
+    colorB: colorScheme.yellow,
+  })
 
 t.create('pending')
-  .get('/2.json')
+  .get('/2.json?style=_shields_test')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -57,10 +66,14 @@ t.create('pending')
         message: 'pending',
       })
   )
-  .expectJSON({ name: 'coverity', value: 'pending' })
+  .expectJSON({
+    name: 'coverity',
+    value: 'pending',
+    colorB: colorScheme.orange,
+  })
 
 t.create('failed')
-  .get('/2.json')
+  .get('/2.json?style=_shields_test')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -68,4 +81,8 @@ t.create('failed')
         message: 'failed',
       })
   )
-  .expectJSON({ name: 'coverity', value: 'failed' })
+  .expectJSON({
+    name: 'coverity',
+    value: 'failed',
+    colorB: colorScheme.red,
+  })

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -1,0 +1,71 @@
+'use strict'
+
+const Joi = require('joi')
+const t = (module.exports = require('../create-service-tester')())
+
+t.create('live: known project id')
+  .get('/3997.json')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'coverity',
+      value: Joi.string().regex(/passing|passed .* new defects|pending|failed/),
+    })
+  )
+
+t.create('live: unknown project id')
+  .get('/abc.json')
+  // Coverity actually returns an HTTP 200 status with an HTML page when the project is not found.
+  .expectJSON({ name: 'coverity', value: 'unparseable json response' })
+
+t.create('404 response')
+  .get('/1.json')
+  .intercept(nock =>
+    nock('https://scan.coverity.com/projects/1')
+      .get('/badge.json')
+      .reply(404)
+  )
+  .expectJSON({ name: 'coverity', value: 'project not found' })
+
+t.create('passed')
+  .get('/2.json')
+  .intercept(nock =>
+    nock('https://scan.coverity.com/projects/2')
+      .get('/badge.json')
+      .reply(200, {
+        message: 'passed',
+      })
+  )
+  .expectJSON({ name: 'coverity', value: 'passing' })
+
+t.create('passed with defects')
+  .get('/2.json')
+  .intercept(nock =>
+    nock('https://scan.coverity.com/projects/2')
+      .get('/badge.json')
+      .reply(200, {
+        message: 'passed 51 new defects',
+      })
+  )
+  .expectJSON({ name: 'coverity', value: 'passed 51 new defects' })
+
+t.create('pending')
+  .get('/2.json')
+  .intercept(nock =>
+    nock('https://scan.coverity.com/projects/2')
+      .get('/badge.json')
+      .reply(200, {
+        message: 'pending',
+      })
+  )
+  .expectJSON({ name: 'coverity', value: 'pending' })
+
+t.create('failed')
+  .get('/2.json')
+  .intercept(nock =>
+    nock('https://scan.coverity.com/projects/2')
+      .get('/badge.json')
+      .reply(200, {
+        message: 'failed',
+      })
+  )
+  .expectJSON({ name: 'coverity', value: 'failed' })


### PR DESCRIPTION
* Migrate Coverity Scan to new service model (and adds tests) refs #1358 
* Deprecate Coverity On Demand badges (and adds tests)

Everything I've seen indicates that Coverity On Demand has been decommissioned for a while, although I haven't seen any _official_ announcements from Coverity/Snyopsys. If anyone knows otherwise please let me know, but for now I believe deprecation is the best course of action.

All of the on-demand endpoints are down/inaccessible:
* https://ondemand.coverity.com/ 
* http://ondemand.coverity.com/
* https://api.ondemand.coverity.com
* https://api.ondemand.coverity.com/streams/44b25sjc9l3ntc2ngfi29tngro/badge
* https://api.ondemand.coverity.com/jobs/p4tmm8031t4i971r0im4s7lckk/badge 

And the few online references I have found for Coverity On Demand speak about it in the past tense, like this from the Coverity Wikipedia page:
> Coverity Code Advisor on Demand **_was_** a cloud hosted version of Coverity Code Advisor.