### PR TITLE
Fix intermittent test failures for serverHasBeenUpSinceResourceCached

### DIFF
--- a/services/cache-headers.spec.js
+++ b/services/cache-headers.spec.js
@@ -131,6 +131,14 @@ describe('Cache header functions', function() {
   })
 
   describe('serverHasBeenUpSinceResourceCached', function() {
+    beforeEach(function() {
+      sinon.useFakeTimers({ now: 1545674651924 })
+    })
+
+    afterEach(function() {
+      sinon.restore()
+    })
+
     // The stringified req's are hard to understand. I thought Sazerac
     // provided a way to override the describe message, though I can't find it.
     context('when there is no If-Modified-Since header', function() {
@@ -163,7 +171,7 @@ describe('Cache header functions', function() {
       function() {
         it('returns true', function() {
           const req = httpMocks.createRequest({
-            headers: { 'If-Modified-Since': new Date().toGMTString() },
+            headers: { 'If-Modified-Since': '2018-12-24T23:00:00.000Z' },
           })
           expect(serverHasBeenUpSinceResourceCached(req)).to.equal(true)
         })


### PR DESCRIPTION
Adds fake timers to the cache-headers tests for serverHasBeenUpSinceResourceCached, fixes #2571 