### PR TITLE
improve setup instructions

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -25,14 +25,19 @@ and learn about the [Github workflow](http://try.github.io/).
 2. Clone the fork
    `git clone git@github.com:YOURGITHUBUSERNAME/shields.git`
 3. `cd shields`
-4. Install npm and other required packages (Ubuntu 16.10)
-   `sudo apt-get install npm nodejs-legacy curl imagemagick`
-5. Install all packages
+4. Node 8 or later is required. If you don't already have them,
+   install node and npm: https://nodejs.org/en/download/
+5. Install project dependencies
    `npm install`
 6. Run the server
    `npm start`
 7. Visit the website to check the front-end is loaded:
    [http://127.0.0.1:3000/](http://127.0.0.1:3000/)
+
+You may also want to install
+[ImageMagick](https://www.imagemagick.org/script/download.php).
+This is an optional dependency needed for generating badges in raster format,
+but you can get a dev copy running without it.
 
 (3) Open an Issue
 -----------------


### PR DESCRIPTION
As noted in https://github.com/badges/shields/pull/2579 the install instructions aren't cross-platform and don't get you a compatible version of node js (or a useful version of npm) if you follow them. This updates the instructions based on the suggestions in https://github.com/badges/shields/pull/2579

I've also removed curl as I _think_ the only place we're using that is in https://github.com/badges/shields/blob/master/scripts/benchmark-performance.sh I don't think we need to list it as a dependency to get a dev copy working.