### PR TITLE
Fix bug in server-config on allowedOrigin

### DIFF
--- a/lib/server-config.js
+++ b/lib/server-config.js
@@ -11,7 +11,9 @@ function envArray(envVar, defaultValue, delimiter) {
   if (envVar) {
     return envVar.split(delimiter)
   } else {
-    return defaultValue
+    return Array.isArray(defaultValue)
+      ? defaultValue
+      : defaultValue.split(delimiter)
   }
 }
 


### PR DESCRIPTION
Fixes a bug in server-config where allowedOrigin is set to a string when default value is not an array

Refs: https://github.com/badges/shields/pull/2601#issuecomment-450585612