### PR TITLE
Add timeout for server test setup/teardown

### DIFF
--- a/lib/server.spec.js
+++ b/lib/server.spec.js
@@ -14,6 +14,7 @@ const { createTestServer } = require('./in-process-server-test-helpers')
 describe('The server', function() {
   let server, baseUrl
   before('Start the server', async function() {
+    // Fixes https://github.com/badges/shields/issues/2611
     this.timeout(10000)
     const port = await portfinder.getPortPromise()
     server = createTestServer({ port })
@@ -21,7 +22,6 @@ describe('The server', function() {
     await server.start()
   })
   after('Shut down the server', async function() {
-    this.timeout(10000)
     if (server) {
       await server.stop()
     }

--- a/lib/server.spec.js
+++ b/lib/server.spec.js
@@ -14,12 +14,14 @@ const { createTestServer } = require('./in-process-server-test-helpers')
 describe('The server', function() {
   let server, baseUrl
   before('Start the server', async function() {
+    this.timeout(10000)
     const port = await portfinder.getPortPromise()
     server = createTestServer({ port })
     baseUrl = server.baseUrl
     await server.start()
   })
   after('Shut down the server', async function() {
+    this.timeout(10000)
     if (server) {
       await server.stop()
     }


### PR DESCRIPTION
Fixes #2611. I added a 10 second to the `before` and `teardown` functions directly so only those functions will be impacted (timeout period for the tests remains the default 2 seconds)  