### PR TITLE
Unwanted title removed

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -17,10 +17,7 @@ export default class MyDocument extends Document {
   render() {
     return (
       <html>
-        <Head>
-          <title>My page</title>
-          {this.props.styleTags}
-        </Head>
+        <Head>{this.props.styleTags}</Head>
         <body>
           <Main />
           <NextScript />


### PR DESCRIPTION
Currently HTML code of shields.io contains two `<title>` elements. This PR removes an extra title element. 

Before change:
```bash
> curl https://shields.io -s | egrep "<title.*/title>" -o 
<title class="next-head">Shields.io: Quality metadata badges for open source projects</title>
<title>My page</title>
```

After change:
```bash
> curl http://localhost:8080 -s | egrep "<title.*/title>" -o
<title class="next-head">Shields.io: Quality metadata badges for open source projects</title>
```