### PR TITLE
Fix github auth again

### DIFF
--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -81,7 +81,7 @@ class GithubApiProvider {
       return
     }
 
-    const reserve = this.reserveFraction * rateLimit
+    const reserve = Math.ceil(this.reserveFraction * rateLimit)
     const usesRemaining = totalUsesRemaining - reserve
 
     token.update(usesRemaining, nextReset)

--- a/services/github/github-api-provider.spec.js
+++ b/services/github/github-api-provider.spec.js
@@ -77,11 +77,12 @@ describe('Github API provider', function() {
     it('should update the token with the expected values', function(done) {
       provider.request(mockRequest, '/foo', {}, (err, res, buffer) => {
         expect(err).to.equal(null)
-        const expectedUsesRemaining = remaining - reserveFraction * rateLimit
-        expect(
-          mockStandardToken.update.withArgs(expectedUsesRemaining, nextReset)
-            .calledOnce
-        ).to.be.true
+        const expectedUsesRemaining =
+          remaining - Math.ceil(reserveFraction * rateLimit)
+        expect(mockStandardToken.update).to.have.been.calledWith(
+          expectedUsesRemaining,
+          nextReset
+        )
         expect(mockStandardToken.invalidate).not.to.have.been.called
         done()
       })


### PR DESCRIPTION
This code isn't being run during tests, though let's fix that later as part of #2733. Specifically:

> However _the pool itself_ could be used all the time; there's not a big advantage in turning that off when it doesn't need to be used.

Fix #2728