### PR TITLE
Add a script used for backing up the production GitHub tokens

### DIFF
--- a/scripts/github_token_backup.fish
+++ b/scripts/github_token_backup.fish
@@ -1,0 +1,19 @@
+#!/usr/bin/env fish
+#
+# Back up the GitHub tokens from each production server.
+#
+
+if test (count $argv) -lt 1
+  echo Usage: (basename (status -f)) shields_secret
+end
+
+set shields_secret $argv[1]
+
+function do_backup
+  set server $argv[1]
+  curl --insecure -u ":$shields_secret" "https://$server.shields-server.com/\$github-auth/tokens" > "$server""_tokens.json"
+end
+
+for server in s0 s1 s2
+  do_backup $server
+end


### PR DESCRIPTION
Seems better to have this checked in here than sitting on my dev machine.