### PR TITLE
Temporarily deprecate [CoverityScan] 

### DIFF
--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -1,78 +1,17 @@
 'use strict'
 
-const Joi = require('joi')
-const BaseJsonService = require('../base-json')
+const deprecatedService = require('../deprecated-service')
 
-const messageRegex = /passed|passed .* new defects|pending|failed/
-const schema = Joi.object({
-  message: Joi.string()
-    .regex(messageRegex)
-    .required(),
-}).required()
-
-module.exports = class CoverityScan extends BaseJsonService {
-  static render({ message }) {
-    let color
-    if (message === 'passed') {
-      color = 'brightgreen'
-      message = 'passing'
-    } else if (/^passed .* new defects$/.test(message)) {
-      color = 'yellow'
-    } else if (message === 'pending') {
-      color = 'orange'
-    } else {
-      color = 'red'
-    }
-
-    return {
-      message,
-      color,
-    }
-  }
-
-  static get category() {
-    return 'analysis'
-  }
-
-  static get defaultBadgeData() {
-    return {
-      label: 'coverity',
-    }
-  }
-
-  static get route() {
-    return {
-      base: 'coverity/scan',
-      pattern: ':projectId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Coverity Scan',
-        pattern: ':projectId',
-        namedParams: {
-          projectId: '3997',
-        },
-        staticPreview: this.render({
-          message: 'passed',
-        }),
-      },
-    ]
-  }
-
-  async handle({ projectId }) {
-    const url = `https://scan.coverity.com/projects/${projectId}/badge.json`
-    const json = await this._requestJson({
-      url,
-      schema,
-      errorMessages: {
-        // At the moment Coverity returns an HTTP 200 with an HTML page
-        // displaying the text 404 when project is not found.
-        404: 'project not found',
-      },
-    })
-    return this.constructor.render({ message: json.message })
-  }
-}
+// coverity scan integration -
+// **temporarily deprecated as of January 2019 due to extended outage**
+// https://community.synopsys.com/s/article/Coverity-Scan-Update
+// https://github.com/badges/shields/issues/2722
+module.exports = deprecatedService({
+  url: {
+    base: 'coverity/scan',
+    format: '(?:.+)',
+  },
+  label: 'coverity',
+  category: 'analysis',
+  message: 'extended downtime',
+})

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -1,88 +1,16 @@
 'use strict'
 
-const Joi = require('joi')
-const { colorScheme } = require('../test-helpers')
-const t = (module.exports = require('../create-service-tester')())
+const ServiceTester = require('../service-tester')
 
-t.create('live: known project id')
+const t = (module.exports = new ServiceTester({
+  id: 'CoverityScan',
+  title: 'Coverity Scan',
+  pathPrefix: '/coverity/scan',
+}))
+
+t.create('extended downtime')
   .get('/3997.json')
-  .expectJSONTypes(
-    Joi.object().keys({
-      name: 'coverity',
-      value: Joi.string().regex(/passing|passed .* new defects|pending|failed/),
-    })
-  )
-
-t.create('live: unknown project id')
-  .get('/abc.json')
-  // Coverity actually returns an HTTP 200 status with an HTML page when the project is not found.
-  .expectJSON({ name: 'coverity', value: 'unparseable json response' })
-
-t.create('404 response')
-  .get('/1.json')
-  .intercept(nock =>
-    nock('https://scan.coverity.com/projects/1')
-      .get('/badge.json')
-      .reply(404)
-  )
-  .expectJSON({ name: 'coverity', value: 'project not found' })
-
-t.create('passed')
-  .get('/2.json?style=_shields_test')
-  .intercept(nock =>
-    nock('https://scan.coverity.com/projects/2')
-      .get('/badge.json')
-      .reply(200, {
-        message: 'passed',
-      })
-  )
   .expectJSON({
     name: 'coverity',
-    value: 'passing',
-    colorB: colorScheme.brightgreen,
-  })
-
-t.create('passed with defects')
-  .get('/2.json?style=_shields_test')
-  .intercept(nock =>
-    nock('https://scan.coverity.com/projects/2')
-      .get('/badge.json')
-      .reply(200, {
-        message: 'passed 51 new defects',
-      })
-  )
-  .expectJSON({
-    name: 'coverity',
-    value: 'passed 51 new defects',
-    colorB: colorScheme.yellow,
-  })
-
-t.create('pending')
-  .get('/2.json?style=_shields_test')
-  .intercept(nock =>
-    nock('https://scan.coverity.com/projects/2')
-      .get('/badge.json')
-      .reply(200, {
-        message: 'pending',
-      })
-  )
-  .expectJSON({
-    name: 'coverity',
-    value: 'pending',
-    colorB: colorScheme.orange,
-  })
-
-t.create('failed')
-  .get('/2.json?style=_shields_test')
-  .intercept(nock =>
-    nock('https://scan.coverity.com/projects/2')
-      .get('/badge.json')
-      .reply(200, {
-        message: 'failed',
-      })
-  )
-  .expectJSON({
-    name: 'coverity',
-    value: 'failed',
-    colorB: colorScheme.red,
+    value: 'extended downtime',
   })

--- a/services/deprecated-service.js
+++ b/services/deprecated-service.js
@@ -4,7 +4,7 @@ const BaseService = require('./base')
 const { Deprecated } = require('./errors')
 
 // Only `url` is required.
-function deprecatedService({ url, label, category, examples = [] }) {
+function deprecatedService({ url, label, category, examples = [], message }) {
   return class DeprecatedService extends BaseService {
     static get category() {
       return category
@@ -27,7 +27,7 @@ function deprecatedService({ url, label, category, examples = [] }) {
     }
 
     async handle() {
-      throw new Deprecated()
+      throw new Deprecated({ prettyMessage: message })
     }
   }
 }

--- a/services/deprecated-service.spec.js
+++ b/services/deprecated-service.spec.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const { expect } = require('chai')
+const deprecatedService = require('./deprecated-service')
+
+describe('DeprecatedService', function() {
+  const url = {
+    base: 'coverity/ondemand',
+    format: '(?:.+)',
+  }
+
+  it('returns true on isDeprecated', function() {
+    const service = deprecatedService({ url })
+    expect(service.isDeprecated).to.be.true
+  })
+
+  it('sets specified route', function() {
+    const service = deprecatedService({ url })
+    expect(service.route).to.deep.equal(url)
+  })
+
+  it('sets specified label', function() {
+    const label = 'coverity'
+    const service = deprecatedService({ url, label })
+    expect(service.defaultBadgeData.label).to.equal(label)
+  })
+
+  it('sets specified category', function() {
+    const category = 'analysis'
+    const service = deprecatedService({ url, category })
+    expect(service.category).to.equal(category)
+  })
+
+  it('sets specified examples', function() {
+    const examples = [
+      {
+        title: 'Not sure we would have examples',
+      },
+    ]
+    const service = deprecatedService({ url, examples })
+    expect(service.examples).to.deep.equal(examples)
+  })
+
+  it('uses default deprecation message when no message specified', async function() {
+    const service = deprecatedService({ url })
+    expect(await service.invoke()).to.deep.equal({
+      isError: true,
+      color: 'lightgray',
+      message: 'no longer available',
+    })
+  })
+
+  it('uses custom deprecation message when specified', async function() {
+    const message = 'extended outage'
+    const service = deprecatedService({ url, message })
+    expect(await service.invoke()).to.deep.equal({
+      isError: true,
+      color: 'lightgray',
+      message,
+    })
+  })
+})


### PR DESCRIPTION
* temporarily deprecates Coverity Scan badges due to extended outage of the service, discussion in #2722 
  * https://community.synopsys.com/s/article/Coverity-Scan-Update
* updates `deprecatedService` function to enable custom deprecation badge messages
* adds unit tests for `DeprecatedService` definition

I did **not** add Coverity Scan to the deprecated services lists given that this is only temporary, but let me know if it needs to be added anyway
