### PR TITLE
Made [appveyor azuredevopsbuild bitbucket buildkite circleci codeship continuousphp docker readthedocs scrutinizer shippable travis-build wercker] tests use isBuildStatus validator from build-status.js

### DIFF
--- a/services/appveyor/appveyor-ci.tester.js
+++ b/services/appveyor/appveyor-ci.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = require('../create-service-tester')())
 

--- a/services/azure-devops/azure-devops-build.tester.js
+++ b/services/azure-devops/azure-devops-build.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 // https://dev.azure.com/totodem/Shields.io is a public Azure DevOps project
 // solely created for Shields.io testing.

--- a/services/azure-devops/azure-devops-release.tester.js
+++ b/services/azure-devops/azure-devops-release.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 // https://dev.azure.com/totodem/Shields.io is a public Azure DevOps project
 // solely created for Shields.io testing.

--- a/services/bitbucket/bitbucket.tester.js
+++ b/services/bitbucket/bitbucket.tester.js
@@ -9,11 +9,8 @@ const {
   user,
   pass,
 } = require('./bitbucket-test-helpers')
-const {
-  isBuildStatus,
-  isMetric,
-  isMetricOpenIssues,
-} = require('../test-validators')
+const { isMetric, isMetricOpenIssues } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = new ServiceTester({
   id: 'bitbucket',

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
 const { invalidJSON } = require('../response-fixtures')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = new ServiceTester({
   id: 'buildkite',

--- a/services/circleci/circleci.tester.js
+++ b/services/circleci/circleci.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = new ServiceTester({
   id: 'circleci',

--- a/services/codeship/codeship.tester.js
+++ b/services/codeship/codeship.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = new ServiceTester({
   id: 'codeship',

--- a/services/continuousphp/continuousphp.tester.js
+++ b/services/continuousphp/continuousphp.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = require('../create-service-tester')())
 

--- a/services/docker/docker-build.tester.js
+++ b/services/docker/docker-build.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { colorScheme: colorsB } = require('../test-helpers')
 const { dockerBlue } = require('./docker-helpers')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = require('../create-service-tester')())
 

--- a/services/readthedocs/readthedocs.tester.js
+++ b/services/readthedocs/readthedocs.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = require('../create-service-tester')())
 

--- a/services/scrutinizer/scrutinizer.tester.js
+++ b/services/scrutinizer/scrutinizer.tester.js
@@ -2,7 +2,8 @@
 
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
-const { isBuildStatus, isIntegerPercentage } = require('../test-validators')
+const { isIntegerPercentage } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 const { colorScheme } = require('../test-helpers')
 
 const t = new ServiceTester({ id: 'scrutinizer', title: 'Scrutinizer' })

--- a/services/shippable/shippable.tester.js
+++ b/services/shippable/shippable.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = require('../create-service-tester')())
 

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -91,31 +91,6 @@ const isDependencyState = withRegex(
   /^(\d+ out of date|\d+ deprecated|up to date)$/
 )
 
-const isBuildStatus = Joi.equal(
-  'building',
-  'cancelled',
-  'error',
-  'expired',
-  'failed',
-  'failing',
-  'no tests',
-  'not built',
-  'not run',
-  'passed',
-  'passing',
-  'pending',
-  'processing',
-  'queued',
-  'running',
-  'scheduled',
-  'skipped',
-  'stopped',
-  'success',
-  'timeout',
-  'unstable',
-  'waiting'
-)
-
 module.exports = {
   isSemver,
   isVPlusTripleDottedVersion,
@@ -135,6 +110,5 @@ module.exports = {
   isFormattedDate,
   isRelativeFormattedDate,
   isDependencyState,
-  isBuildStatus,
   withRegex,
 }

--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const ServiceTester = require('../service-tester')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 
 const t = (module.exports = new ServiceTester({
   id: 'travis-build',

--- a/services/wercker/wercker.tester.js
+++ b/services/wercker/wercker.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { isBuildStatus } = require('../test-validators')
+const { isBuildStatus } = require('../../lib/build-status')
 const { colorScheme } = require('../test-helpers')
 
 const t = (module.exports = require('../create-service-tester')())


### PR DESCRIPTION
Part of #2706: removing the now duplicated validator in `test-validators.js`.

Sorry for the lengthy pull request title. ^^