### PR TITLE
Fix partially succeeded builds on Azure DevOps

### DIFF
--- a/services/azure-devops/azure-devops-helpers.js
+++ b/services/azure-devops/azure-devops-helpers.js
@@ -8,7 +8,7 @@ const keywords = ['vso', 'vsts', 'azure-devops']
 const schema = Joi.object({
   message: Joi.equal(
     'succeeded',
-    'partially suceeded',
+    'partially succeeded',
     'failed',
     'unknown',
     'set up now'


### PR DESCRIPTION
There is a small typo preventing partially succeeded builds from being correctly displayed (i.e. "passing" in orange)