### PR TITLE
Fix orange statuses, run tests for [AppveyorCi AzureDevOps Bitbucket CircleCi Gitlab Readthedocs Shippable Wercker]

### DIFF
--- a/lib/build-status.js
+++ b/lib/build-status.js
@@ -47,6 +47,7 @@ function renderBuildStatusBadge({ label, status }) {
     message = 'passing'
     color = 'brightgreen'
   } else if (orangeStatuses.includes(status)) {
+    message = status === 'partially succeeded' ? 'passing' : status
     color = 'orange'
   } else if (redStatuses.includes(status)) {
     message = status === 'failed' ? 'failing' : status

--- a/lib/build-status.spec.js
+++ b/lib/build-status.spec.js
@@ -15,6 +15,11 @@ test(renderBuildStatusBadge, () => {
     message: 'passing',
     color: 'brightgreen',
   })
+  given({ label: 'build', status: 'partially succeeded' }).expect({
+    label: 'build',
+    message: 'passing',
+    color: 'orange',
+  })
   given({ label: 'build', status: 'failed' }).expect({
     label: 'build',
     message: 'failing',

--- a/services/azure-devops/azure-devops-build.tester.js
+++ b/services/azure-devops/azure-devops-build.tester.js
@@ -44,13 +44,9 @@ t.create('unknown user')
   .get('/azure-devops/build/notarealuser/foo/515.json')
   .expectJSON({ name: 'build', value: 'user or project not found' })
 
+// The following build definition has always a partially succeeded status
 t.create('partially succeeded build')
   .get(
-    '/azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/4.json'
+    '/azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/4.json?style=_shields_test'
   )
-  .expectJSONTypes(
-    Joi.object().keys({
-      name: 'build',
-      value: isBuildStatus,
-    })
-  )
+  .expectJSON({ name: 'build', value: 'passing', color: 'orange' })

--- a/services/azure-devops/azure-devops-build.tester.js
+++ b/services/azure-devops/azure-devops-build.tester.js
@@ -43,3 +43,14 @@ t.create('unknown project')
 t.create('unknown user')
   .get('/azure-devops/build/notarealuser/foo/515.json')
   .expectJSON({ name: 'build', value: 'user or project not found' })
+
+t.create('partially succeeded build')
+  .get(
+    '/azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/4.json'
+  )
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'build',
+      value: isBuildStatus,
+    })
+  )


### PR DESCRIPTION
I guess because of the missing message, I just get a `vendor unresponsive` badge.