### PR TITLE
Fix numeric colorB [static githublanguages]

### DIFF
--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -106,8 +106,9 @@ function makeBadgeData(defaultLabel, overrides) {
     logoPosition: +overrides.logoPosition,
     logoWidth: +overrides.logoWidth,
     links: toArray(overrides.link),
-    colorA: overrides.colorA,
-    colorB: overrides.colorB,
+    // Scoutcamp sometimes turns these into numbers.
+    colorA: `${overrides.colorA}`,
+    colorB: `${overrides.colorB}`,
   }
 }
 

--- a/services/base.js
+++ b/services/base.js
@@ -334,9 +334,15 @@ class BaseService {
       logoColor: overrideLogoColor,
       logoWidth: overrideLogoWidth,
       link: overrideLink,
-      colorA: overrideLabelColor,
-      colorB: overrideColor,
     } = overrides
+    // Scoutcamp converts numeric query params to numbers. Convert them back.
+    let { colorB: overrideColor, colorA: overrideLabelColor } = overrides
+    if (typeof overrideColor === 'number') {
+      overrideColor = `${overrideColor}`
+    }
+    if (typeof overrideLabelColor === 'number') {
+      overrideLabelColor = `${overrideLabelColor}`
+    }
 
     const {
       isError,

--- a/services/base.spec.js
+++ b/services/base.spec.js
@@ -396,6 +396,15 @@ describe('BaseService', function() {
         expect(badgeData.color).to.equal('10ADED')
       })
 
+      it('converts a query-string numeric color to a string', function() {
+        const badgeData = DummyService._makeBadgeData(
+          // Scoutcamp converts numeric query params to numbers.
+          { colorB: 123 },
+          { color: 'green' }
+        )
+        expect(badgeData.color).to.equal('123')
+      })
+
       it('does not override the color in case of an error', function() {
         const badgeData = DummyService._makeBadgeData(
           { colorB: '10ADED' },

--- a/services/github/github-languages.tester.js
+++ b/services/github/github-languages.tester.js
@@ -19,6 +19,16 @@ t.create('top language')
     })
   )
 
+t.create('top language')
+  .get('/top/badges/shields.json?colorB=123&format=_shields_test')
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'javascript',
+      value: Joi.string().regex(/^([1-9]?[0-9]\.[0-9]|100\.0)%$/),
+      color: '#123',
+    })
+  )
+
 t.create('top language with empty repository')
   .get('/top/pyvesb/emptyrepo.json')
   .expectJSON({ name: 'language', value: 'none' })

--- a/services/static-badge/static-badge.tester.js
+++ b/services/static-badge/static-badge.tester.js
@@ -42,6 +42,10 @@ t.create('Override colorB')
   .get('/badge/label-message-blue.json?style=_shields_test&colorB=yellow')
   .expectJSON({ name: 'label', value: 'message', color: 'yellow' })
 
+t.create('Override colorB with a number')
+  .get('/badge/label-message-blue.json?style=_shields_test&colorB=123')
+  .expectJSON({ name: 'label', value: 'message', color: '#123' })
+
 t.create('Override label')
   .get('/badge/label-message-blue.json?style=_shields_test&label=mylabel')
   .expectJSON({ name: 'mylabel', value: 'message', color: 'blue' })


### PR DESCRIPTION
Numeric colors weren't properly being handled by `makeBadge` after #2742.

Since this function really does not need to be accepting colors as strings, rather than make the function more lenient to work with Scoutcamp, I coerced the types of the colors on the way in.

Two tests cover the functionality in the modern service. I don't feel strongly that the legacy version needs coverage at this point, though I've added one for the moment on the github languages badge where this manifested.

Fix #2778