### PR TITLE
Optimize diffing in Danger

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -118,35 +118,34 @@ if (capitals.created || underscores.created) {
 
 const allFiles = danger.git.created_files.concat(danger.git.modified_files)
 
-allFiles.forEach(file => {
-  // eslint-disable-next-line promise/prefer-await-to-then
-  danger.git.diffForFile(file).then(diff => {
-    if (/\+.*assert[(.]/.test(diff.diff)) {
-      warn(
-        [
-          `Found 'assert' statement added in \`${file}\`. <br>`,
-          'Please ensure tests are written using Chai ',
-          '[expect syntax](http://chaijs.com/guide/styles/#expect)',
-        ].join('')
-      )
-    }
-  })
-})
+if (allFiles.length > 100) {
+  warn("Lots 'o changes. Skipping diff-based checks.")
+} else {
+  allFiles.forEach(file => {
+    // eslint-disable-next-line promise/prefer-await-to-then
+    danger.git.diffForFile(file).then(({ diff }) => {
+      if (/serverSecrets/.test(diff) && !secretsDocs.modified) {
+        warn(
+          [
+            `:books: Remember to ensure any changes to \`serverSecrets\` `,
+            `in \`${file}\` are reflected in the [server secrets documentation]`,
+            '(https://github.com/badges/shields/blob/master/doc/server-secrets.md)',
+          ].join('')
+        )
+      }
 
-allFiles.forEach(file => {
-  // eslint-disable-next-line promise/prefer-await-to-then
-  danger.git.diffForFile(file).then(diff => {
-    if (/serverSecrets/.test(diff.diff) && !secretsDocs.modified) {
-      warn(
-        [
-          `:books: Remember to ensure any changes to \`serverSecrets\` `,
-          `in \`${file}\` are reflected in the [server secrets documentation]`,
-          '(https://github.com/badges/shields/blob/master/doc/server-secrets.md)',
-        ].join('')
-      )
-    }
+      if (/\+.*assert[(.]/.test(diff)) {
+        warn(
+          [
+            `Found 'assert' statement added in \`${file}\`. <br>`,
+            'Please ensure tests are written using Chai ',
+            '[expect syntax](http://chaijs.com/guide/styles/#expect)',
+          ].join('')
+        )
+      }
+    })
   })
-})
+}
 
 function onlyUnique(value, index, self) {
   return self.indexOf(value) === index


### PR DESCRIPTION
This avoids making lots of parallel API calls on big PRs and getting us abuse-limited.

- https://twitter.com/orta/status/1087439065321033735
- https://github.com/badges/shields/pull/2823#issuecomment-456182984

Combining the loops cuts our calls in half. I picked the cutoff of 100 without much information; we could choose a smaller number, too.

Close #2826