### PR TITLE
Fix production crash

### DIFF
--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -12,7 +12,7 @@ const {
   Inaccessible,
   InvalidResponse,
   ShieldsRuntimeError,
-} = require('../../services')
+} = require('../../services/errors')
 const { setCacheHeaders } = require('../../services/cache-headers')
 const { makeBadgeData: getBadgeData } = require('../../lib/badge-data')
 const { makeSend } = require('./legacy-result-sender')


### PR DESCRIPTION
`ShieldsRuntimeError` is in `services/errors.js` but not `services/index.js`. Oops!

Close #2834 