### PR TITLE
Fix spec typos and clarify non-promotional guideline

### DIFF
--- a/spec/SPECIFICATION.md
+++ b/spec/SPECIFICATION.md
@@ -5,8 +5,8 @@ This document specifies the visual design of Shields badges.
 ## Guidelines
 
 - **legible**: it should be as easy to read the metadata provided by a badge as it is to read body copy inside of a README file regardless of display resolution
-- **semantic**: the purpose information provided by a badge should be self-evident
-- **non-promotional**: badges should not advertise but instead provide value through information
+- **semantic**: the purpose of the information provided by a badge should be self-evident
+- **non-promotional**: badges should refrain from advertising a service but instead provide value through the badge's information instead
 - **concise**: one descriptive word on the left (the key), one piece of data on the right (the value)
 - **hyperlinked**: badges can link to a third-party website providing more information, either related to the metadata provided by the badge or about the project the badge was used for (e.g. an open source library)
 


### PR DESCRIPTION
Just noticed this typo and that one of the essential parts of the specification 
could be worded more clearly. It seems like the hardest to enforce with SaaS 
companies, so I don't think the explicitness will hurt.