### PR TITLE
allow localhost as domain for http

### DIFF
--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -109,7 +109,7 @@ module.exports = class Endpoint extends BaseJsonService {
     )
 
     const { protocol, hostname } = new URL(url)
-    if (protocol !== 'https:') {
+    if (protocol !== 'https:' && hostname !== 'localhost') {
       throw new InvalidParameter({ prettyMessage: 'please use https' })
     }
     if (blockedDomains.some(domain => hostname.endsWith(domain))) {

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -258,6 +258,25 @@ t.create('Bad scheme')
   .get('.json?url=http://example.com/badge')
   .expectJSON({ name: 'custom badge', value: 'please use https' })
 
+t.create('Bad scheme localhost')
+  .get('.json?url=http://localhost.example.com/badge')
+  .expectJSON({ name: 'custom badge', value: 'please use https' })
+
+;['', ':80', ':8080'].forEach(port => {
+  t.create(`localhost allows http at port "${port}"`)
+    .get(`.json?url=http://localhost${port}/badge123`)
+    .intercept(nock =>
+      nock(`http://localhost${port}/`)
+        .get('/badge123')
+        .reply(200, {
+          schemaVersion: 1,
+          label: 'http',
+          message: 'http works',
+        })
+    )
+    .expectJSON({ name: 'http', value: 'http works' })
+})
+
 t.create('Blocked domain')
   .get('.json?url=https://img.shields.io/badge/foo-bar-blue.json')
   .expectJSON({ name: 'custom badge', value: 'domain is blocked' })

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -261,7 +261,6 @@ t.create('Bad scheme')
 t.create('Bad scheme localhost')
   .get('.json?url=http://localhost.example.com/badge')
   .expectJSON({ name: 'custom badge', value: 'please use https' })
-
 ;['', ':80', ':8080'].forEach(port => {
   t.create(`localhost allows http at port "${port}"`)
     .get(`.json?url=http://localhost${port}/badge123`)


### PR DESCRIPTION
- fixes https://github.com/badges/shields/issues/2891
This is a proposal.
This may allow portscans on localhost for servers connected to the Internet. I do not think this is wanted.

Questions:
- https://github.com/niccokunzmann/shields/pull/new/endpoint-allow-http-for-localhost proposes to make this configurable.
  I still would need to look into how a test can be run with a specific configuration.
- Should it be forbidden in general to connect to localhost? 