### PR TITLE
Refactor endpoint functions [dynamic endpoint]

### DIFF
--- a/services/dynamic-common.js
+++ b/services/dynamic-common.js
@@ -5,6 +5,10 @@ const validate = require('../core/base-service/validate')
 const { toArray } = require('../lib/badge-data')
 const { InvalidResponse } = require('.')
 
+const errorMessages = {
+  404: 'resource not found',
+}
+
 const individualValueSchema = Joi.alternatives()
   .try(Joi.string(), Joi.number())
   .required()
@@ -47,6 +51,7 @@ function renderDynamicBadge({
 }
 
 module.exports = {
+  errorMessages,
   individualValueSchema,
   transformAndValidate,
   renderDynamicBadge,

--- a/services/dynamic/dynamic-helpers.js
+++ b/services/dynamic/dynamic-helpers.js
@@ -20,12 +20,7 @@ const queryParamSchema = Joi.object({
   .rename('uri', 'url', { ignoreUndefined: true, override: true })
   .required()
 
-const errorMessages = {
-  404: 'resource not found',
-}
-
 module.exports = {
   createRoute,
   queryParamSchema,
-  errorMessages,
 }

--- a/services/dynamic/dynamic-json.service.js
+++ b/services/dynamic/dynamic-json.service.js
@@ -3,12 +3,8 @@
 const Joi = require('joi')
 const jp = require('jsonpath')
 const { BaseJsonService, InvalidResponse } = require('..')
-const { renderDynamicBadge } = require('../dynamic-common')
-const {
-  createRoute,
-  queryParamSchema,
-  errorMessages,
-} = require('./dynamic-helpers')
+const { renderDynamicBadge, errorMessages } = require('../dynamic-common')
+const { createRoute, queryParamSchema } = require('./dynamic-helpers')
 
 module.exports = class DynamicJson extends BaseJsonService {
   static get category() {

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -3,12 +3,8 @@
 const { DOMParser } = require('xmldom')
 const xpath = require('xpath')
 const { BaseService, InvalidResponse } = require('..')
-const { renderDynamicBadge } = require('../dynamic-common')
-const {
-  createRoute,
-  queryParamSchema,
-  errorMessages,
-} = require('./dynamic-helpers')
+const { renderDynamicBadge, errorMessages } = require('../dynamic-common')
+const { createRoute, queryParamSchema } = require('./dynamic-helpers')
 
 // This service extends BaseService because it uses a different XML parser
 // than BaseXmlService which can be used with xpath.

--- a/services/dynamic/dynamic-yaml.service.js
+++ b/services/dynamic/dynamic-yaml.service.js
@@ -3,12 +3,8 @@
 const Joi = require('joi')
 const jp = require('jsonpath')
 const { BaseYamlService, InvalidResponse } = require('..')
-const { renderDynamicBadge } = require('../dynamic-common')
-const {
-  createRoute,
-  queryParamSchema,
-  errorMessages,
-} = require('./dynamic-helpers')
+const { renderDynamicBadge, errorMessages } = require('../dynamic-common')
+const { createRoute, queryParamSchema } = require('./dynamic-helpers')
 
 module.exports = class DynamicYaml extends BaseYamlService {
   static get category() {

--- a/services/endpoint-common.js
+++ b/services/endpoint-common.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const Joi = require('joi')
+const validate = require('../core/base-service/validate')
+const { InvalidResponse } = require('.')
+
+const optionalStringWhenNamedLogoPresent = Joi.alternatives().when(
+  'namedLogo',
+  {
+    is: Joi.string().required(),
+    then: Joi.string(),
+  }
+)
+
+const optionalNumberWhenAnyLogoPresent = Joi.alternatives()
+  .when('namedLogo', { is: Joi.string().required(), then: Joi.number() })
+  .when('logoSvg', { is: Joi.string().required(), then: Joi.number() })
+
+const endpointSchema = Joi.object({
+  schemaVersion: 1,
+  label: Joi.string()
+    .allow('')
+    .required(),
+  message: Joi.string().required(),
+  color: Joi.string(),
+  labelColor: Joi.string(),
+  isError: Joi.boolean().default(false),
+  namedLogo: Joi.string(),
+  logoSvg: Joi.string(),
+  logoColor: optionalStringWhenNamedLogoPresent,
+  logoWidth: optionalNumberWhenAnyLogoPresent,
+  logoPosition: optionalNumberWhenAnyLogoPresent,
+  style: Joi.string(),
+  cacheSeconds: Joi.number()
+    .integer()
+    .min(0),
+})
+  // `namedLogo` or `logoSvg`; not both.
+  .oxor('namedLogo', 'logoSvg')
+  .required()
+
+// Strictly validate according to the endpoint schema. This rejects unknown /
+// invalid keys. Optionally it prints those keys in the message in order to
+// provide detailed feedback.
+function validateEndpointData(
+  data,
+  { prettyErrorMessage = 'invalid response data', includeKeys = false } = {}
+) {
+  return validate(
+    {
+      ErrorClass: InvalidResponse,
+      prettyErrorMessage,
+      includeKeys,
+      traceErrorMessage: 'Response did not match schema',
+      traceSuccessMessage: 'Response after validation',
+      allowAndStripUnknownKeys: false,
+    },
+    data,
+    endpointSchema
+  )
+}
+
+const anySchema = Joi.any()
+
+async function fetchEndpointData(
+  serviceInstance,
+  { url, errorMessages, validationPrettyErrorMessage, includeKeys }
+) {
+  const json = await serviceInstance._requestJson({
+    schema: anySchema,
+    url,
+    errorMessages,
+  })
+  return validateEndpointData(json, {
+    prettyErrorMessage: validationPrettyErrorMessage,
+    includeKeys,
+  })
+}
+
+function renderEndpointBadge(
+  {
+    isError,
+    label,
+    message,
+    color,
+    labelColor,
+    namedLogo,
+    logoSvg,
+    logoColor,
+    logoWidth,
+    logoPosition,
+    style,
+    cacheSeconds,
+  },
+  { allowLogo = false } = {}
+) {
+  const logoProps = {
+    namedLogo,
+    logoSvg,
+    logoColor,
+    logoWidth,
+    logoPosition,
+  }
+  return {
+    isError,
+    label,
+    message,
+    color,
+    labelColor,
+    ...(allowLogo ? logoProps : undefined),
+    style,
+    cacheSeconds,
+  }
+}
+
+module.exports = {
+  validateEndpointData,
+  fetchEndpointData,
+  renderEndpointBadge,
+}


### PR DESCRIPTION
Modularize the endpoint badge functions, making it easier to create a service which pipes an upstream service's endpoint badge data out to a Shields user. It could be useful for the Transifex badge being discussed in #2904 and #497.

Some of this, like moving `errorMessages` from `dynamic-helper` to `dynamic-common` is useful regardless. I think same for the fetch and validate, which we seem likely to use.

Though let's hold off briefly on merging this in case we go in a different direction with formatting / rendering the Transifex badge.