### PR TITLE
Fixed JaCoCo example

### DIFF
--- a/services/jenkins/jenkins-coverage.service.js
+++ b/services/jenkins/jenkins-coverage.service.js
@@ -113,8 +113,8 @@ class JacocoJenkinsCoverage extends BaseJenkinsCoverage {
         pattern: ':scheme/:host/:job+',
         namedParams: {
           scheme: 'https',
-          host: 'ci.eclipse.org',
-          job: 'ecp/job/gerrit',
+          host: 'builds.apache.org',
+          job: 'job/Derby-JaCoCo',
         },
         staticPreview: this.render({
           coverage: 96,


### PR DESCRIPTION
This small pull request closes #2648. The previous project targeted by the example no longer seems to be using the Jacoco plugin, so I've hunted down another one:
https://img.shields.io/jenkins/j/https/builds.apache.org/job/Derby-JaCoCo.svg 
![](https://img.shields.io/jenkins/j/https/builds.apache.org/job/Derby-JaCoCo.svg)