### PR TITLE
Remove dev dep imports in production code

### DIFF
--- a/doc/deprecating-badges.md
+++ b/doc/deprecating-badges.md
@@ -43,7 +43,7 @@ Locate the test file(s) for the service, which can be found in `*.tester.js` fil
 With `DeprecatedService` classes we cannot use `createServiceTester()` so you will need to create the `ServiceTester` class directly. For example:
 
 ```js
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'imagelayers',
@@ -69,7 +69,7 @@ Here is an example of what the final result would look like for a test file:
 ```js
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'imagelayers',

--- a/doc/rewriting-services.md
+++ b/doc/rewriting-services.md
@@ -278,7 +278,7 @@ https://github.com/hapijs/joi/blob/master/API.md
 Switch to `createServiceTester`:
 
 ```js
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 ```
 
 This may require updating the URLs, which will be relative to the service's base

--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -37,14 +37,14 @@ We'll start by adding some boilerplate to our file:
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 ```
 
 1. Import [Joi][] We'll use this to make assertions. This is the same library
    we use to define schema for validation in the main badge class.
 
 2. If our `.service.js` module exports a single class, we can
-   `require('..').createServiceTester()`, which uses convention to create a
+   `require('../tester').createServiceTester()`, which uses convention to create a
    `ServiceTester` object. Calling this inside
    `services/wercker/wercker.tester.js` will create a `ServiceTester` object
    configured for the service exported in `services/wercker/wercker.service.js`.

--- a/services/amo/amo.tester.js
+++ b/services/amo/amo.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isStarRating,

--- a/services/ansible/ansible-quality.tester.js
+++ b/services/ansible/ansible-quality.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('quality score (valid)')
   .get('/432.json')

--- a/services/ansible/ansible-role.tester.js
+++ b/services/ansible/ansible-role.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/apm/apm.tester.js
+++ b/services/apm/apm.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { invalidJSON } = require('../response-fixtures')
 const { isMetric, isVPlusTripleDottedVersion } = require('../test-validators')
 

--- a/services/appveyor/appveyor-ci.tester.js
+++ b/services/appveyor/appveyor-ci.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('CI status')
   .timeout(10000)

--- a/services/appveyor/appveyor-tests.tester.js
+++ b/services/appveyor/appveyor-tests.tester.js
@@ -18,7 +18,7 @@ const isCompactCustomAppveyorTestTotals = Joi.string().regex(
   /^💃 [0-9]+( \| 🤦‍♀️ [0-9]+)?( \| 🤷 [0-9]+)?$/
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Test status')
   .timeout(10000)

--- a/services/aur/aur.tester.js
+++ b/services/aur/aur.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isVPlusDottedVersionNClausesWithOptionalSuffix,
   isMetric,

--- a/services/azure-devops/azure-devops-build.tester.js
+++ b/services/azure-devops/azure-devops-build.tester.js
@@ -6,7 +6,7 @@ const { isBuildStatus } = require('../../lib/build-status')
 // https://dev.azure.com/totodem/Shields.io is a public Azure DevOps project
 // solely created for Shields.io testing.
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('default branch')
   .get(

--- a/services/azure-devops/azure-devops-coverage.tester.js
+++ b/services/azure-devops/azure-devops-coverage.tester.js
@@ -53,7 +53,7 @@ const secondLinesCovStat = {
 const expCoverageSingleReport = '83%'
 const expCoverageMultipleReports = '77%'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('default branch coverage')
   .get(`${uriPrefix}/${linuxDefinitionId}.json`)

--- a/services/azure-devops/azure-devops-release.tester.js
+++ b/services/azure-devops/azure-devops-release.tester.js
@@ -6,7 +6,7 @@ const { isBuildStatus } = require('../../lib/build-status')
 // https://dev.azure.com/totodem/Shields.io is a public Azure DevOps project
 // solely created for Shields.io testing.
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('release status is succeeded')
   .get(

--- a/services/azure-devops/azure-devops-tests.tester.js
+++ b/services/azure-devops/azure-devops-tests.tester.js
@@ -113,7 +113,7 @@ const isCompactCustomAzureDevOpsTestTotals = isAzureDevOpsTestTotals(
   true
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('unknown build definition')
   .get(`${uriPrefix}/${nonExistentDefinitionId}.json`)

--- a/services/beerpay/beerpay.tester.js
+++ b/services/beerpay/beerpay.tester.js
@@ -5,7 +5,7 @@ const { withRegex } = require('../test-validators')
 
 const amountOfMoney = withRegex(/^\$[0-9]+(\.[0-9]+)?/)
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('funding')
   .get('/hashdog/scrapfy-chrome-extension.json')

--- a/services/bintray/bintray.tester.js
+++ b/services/bintray/bintray.tester.js
@@ -5,7 +5,7 @@ const {
   isVPlusDottedVersionNClausesWithOptionalSuffix,
 } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version')
   .get('/asciidoctor/maven/asciidoctorj.json')

--- a/services/bitbucket/bitbucket.tester.js
+++ b/services/bitbucket/bitbucket.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   mockBitbucketCreds,
   mockBitbucketServerCreds,

--- a/services/bithound/bithound.tester.js
+++ b/services/bithound/bithound.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'bithound',

--- a/services/bitrise/bitrise.tester.js
+++ b/services/bitrise/bitrise.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'bitrise',

--- a/services/bountysource/bountysource.tester.js
+++ b/services/bountysource/bountysource.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'bountysource',

--- a/services/bower/bower.tester.js
+++ b/services/bower/bower.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const isBowerPrereleaseVersion = Joi.string().regex(

--- a/services/bstats/bstats-players.tester.js
+++ b/services/bstats/bstats-players.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Players')
   .get('/1.json')

--- a/services/bstats/bstats-servers.tester.js
+++ b/services/bstats/bstats-servers.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Servers')
   .get('/1.json')

--- a/services/bugzilla/bugzilla.tester.js
+++ b/services/bugzilla/bugzilla.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const bzBugStatus = Joi.equal(
   'unconfirmed',

--- a/services/buildkite/buildkite.tester.js
+++ b/services/buildkite/buildkite.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 const { invalidJSON } = require('../response-fixtures')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'buildkite',

--- a/services/bundlephobia/bundlephobia.tester.js
+++ b/services/bundlephobia/bundlephobia.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isFileSize } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'bundlephobia',

--- a/services/cauditor/cauditor.tester.js
+++ b/services/cauditor/cauditor.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'cauditor',

--- a/services/cdnjs/cdnjs.tester.js
+++ b/services/cdnjs/cdnjs.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusTripleDottedVersion } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('cdnjs (valid)')
   .get('/jquery.json')

--- a/services/chocolatey/chocolatey.tester.js
+++ b/services/chocolatey/chocolatey.tester.js
@@ -11,7 +11,7 @@ const {
   nuGetV2VersionJsonFirstCharZero,
   nuGetV2VersionJsonFirstCharNotZero,
 } = require('../nuget-fixtures')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'chocolatey',

--- a/services/chrome-web-store/chrome-web-store.tester.js
+++ b/services/chrome-web-store/chrome-web-store.tester.js
@@ -6,7 +6,7 @@ const {
   isStarRating,
   isMetric,
 } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'chrome-web-store',

--- a/services/cii-best-practices/cii-best-practices.tester.js
+++ b/services/cii-best-practices/cii-best-practices.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { withRegex } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('live: level known project')
   .get(`/level/1.json`)

--- a/services/circleci/circleci.tester.js
+++ b/services/circleci/circleci.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'circleci',

--- a/services/clojars/clojars-downloads.tester.js
+++ b/services/clojars/clojars-downloads.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('clojars downloads (valid)')
   .get('/prismic.json')

--- a/services/clojars/clojars-version.tester.js
+++ b/services/clojars/clojars-version.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('clojars (valid)')
   .get('/prismic.json')

--- a/services/cocoapods/cocoapods-apps.tester.js
+++ b/services/cocoapods/cocoapods-apps.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const t = (module.exports = new ServiceTester({
   id: 'CocoapodsApps',
   title: 'CocoapodsApps',

--- a/services/cocoapods/cocoapods-downloads.tester.js
+++ b/services/cocoapods/cocoapods-downloads.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'CocoapodsDownloads',

--- a/services/cocoapods/cocoapods-license.tester.js
+++ b/services/cocoapods/cocoapods-license.tester.js
@@ -2,7 +2,7 @@
 
 const { invalidJSON } = require('../response-fixtures')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('license (valid)')
   .get('/AFNetworking.json')

--- a/services/cocoapods/cocoapods-metrics.tester.js
+++ b/services/cocoapods/cocoapods-metrics.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { invalidJSON } = require('../response-fixtures')
 const { isIntegerPercentage } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('doc percent (valid)')
   .get('/AFNetworking.json')

--- a/services/cocoapods/cocoapods-platform.tester.js
+++ b/services/cocoapods/cocoapods-platform.tester.js
@@ -7,7 +7,7 @@ const isPlatform = Joi.string().regex(
   /^(osx|ios|tvos|watchos)( \| (osx|ios|tvos|watchos))*$/
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('platform (valid)')
   .get('/AFNetworking.json')

--- a/services/cocoapods/cocoapods-version.tester.js
+++ b/services/cocoapods/cocoapods-version.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 const { invalidJSON } = require('../response-fixtures')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version (valid)')
   .get('/AFNetworking.json')

--- a/services/codacy/codacy-coverage.tester.js
+++ b/services/codacy/codacy-coverage.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isIntegerPercentage } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Coverage')
   .get('/59d607d0e311408885e418004068ea58.json')

--- a/services/codacy/codacy-grade.tester.js
+++ b/services/codacy/codacy-grade.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { codacyGrade } = require('./codacy-helpers')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Code quality')
   .get('/grade/e27821fb6289410b8f58338c7e0bc686.json')

--- a/services/codeclimate/codeclimate.tester.js
+++ b/services/codeclimate/codeclimate.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isIntegerPercentage } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/codecov/codecov.tester.js
+++ b/services/codecov/codecov.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isIntegerPercentage } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/codeship/codeship.tester.js
+++ b/services/codeship/codeship.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'codeship',

--- a/services/codetally/codetally.tester.js
+++ b/services/codetally/codetally.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 // This test will extract the currency value from the
 // string value response from the server.

--- a/services/conda/conda.tester.js
+++ b/services/conda/conda.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusTripleDottedVersion, isMetric } = require('../test-validators')
 
 const isCondaPlatform = Joi.string().regex(/^\w+-[\w\d]+( \| \w+-[\w\d]+)*$/)

--- a/services/continuousphp/continuousphp.tester.js
+++ b/services/continuousphp/continuousphp.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('build status on default branch')
   .get('/git-hub/doctrine/dbal.json')

--- a/services/cookbook/cookbook.tester.js
+++ b/services/cookbook/cookbook.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version')
   .get('/chef-sugar.json')

--- a/services/coveralls/coveralls.tester.js
+++ b/services/coveralls/coveralls.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isIntegerPercentage } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'coveralls',

--- a/services/coverity/coverity-on-demand.tester.js
+++ b/services/coverity/coverity-on-demand.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'CoverityOnDemand',

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'CoverityScan',

--- a/services/cpan/cpan-license.tester.js
+++ b/services/cpan/cpan-license.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('license (valid)')
   .get('/Config-Augeas.json')

--- a/services/cpan/cpan-version.tester.js
+++ b/services/cpan/cpan-version.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version (valid)')
   .get('/Config-Augeas.json')

--- a/services/cran/cran.tester.js
+++ b/services/cran/cran.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusTripleDottedVersion } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/crates/crates-license.tester.js
+++ b/services/crates/crates-license.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'crates',

--- a/services/crates/crates-version.tester.js
+++ b/services/crates/crates-version.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isSemver } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/date/date.tester.js
+++ b/services/date/date.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isRelativeFormattedDate } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { invalidJSON } = require('../response-fixtures')
 
 const isDependencyStatus = Joi.string().valid(

--- a/services/debug/debug.tester.js
+++ b/services/debug/debug.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('start time')
   .get('/starttime.json')

--- a/services/dependabot/dependabot.tester.js
+++ b/services/dependabot/dependabot.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isIntegerPercentage } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('semver stability (valid)')
   .get('/bundler/puma.json')

--- a/services/depfu/depfu.tester.js
+++ b/services/depfu/depfu.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const isDependencyStatus = Joi.string().valid(
   'insecure',

--- a/services/discord/discord.tester.js
+++ b/services/discord/discord.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets status for Reactiflux')
   .get('/102860784329052160.json?style=_shields_test')

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'discourse',

--- a/services/dockbit/dockbit.tester.js
+++ b/services/dockbit/dockbit.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'dockbit',

--- a/services/docker/docker-automated.tester.js
+++ b/services/docker/docker-automated.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { dockerBlue } = require('./docker-helpers')
 const isAutomatedBuildStatus = Joi.string().valid('automated', 'manual')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('docker automated build (valid, library)')
   .get('/_/ubuntu.json')

--- a/services/docker/docker-build.tester.js
+++ b/services/docker/docker-build.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { dockerBlue } = require('./docker-helpers')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('docker build status (valid, user)')
   .get('/jrottenberg/ffmpeg.json')

--- a/services/docker/docker-pulls.tester.js
+++ b/services/docker/docker-pulls.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { dockerBlue } = require('./docker-helpers')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('docker pulls (valid, library)')
   .get('/_/ubuntu.json?style=_shields_test')

--- a/services/docker/docker-stars.tester.js
+++ b/services/docker/docker-stars.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 const { dockerBlue } = require('./docker-helpers')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('docker stars (valid, library)')
   .get('/_/ubuntu.json?style=_shields_test')

--- a/services/dotnetstatus/dotnetstatus.tester.js
+++ b/services/dotnetstatus/dotnetstatus.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'dotnetstatus',

--- a/services/dub/dub-download.tester.js
+++ b/services/dub/dub-download.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 
 const isDownloadsColor = Joi.equal(

--- a/services/dub/dub-license.tester.js
+++ b/services/dub/dub-license.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('license (valid)')
   .get('/vibe-d.json')

--- a/services/dub/dub-version.tester.js
+++ b/services/dub/dub-version.tester.js
@@ -5,7 +5,7 @@ const {
   isVPlusDottedVersionNClausesWithOptionalSuffix,
 } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version (valid)')
   .get('/vibe-d.json?style=_shields_test')

--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { expect } = require('chai')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('No URL specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { expect } = require('chai')
 const { isSemver } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('No URL specified')
   .get('.json?query=//name&label=Package Name&style=_shields_test')

--- a/services/dynamic/dynamic-yaml.tester.js
+++ b/services/dynamic/dynamic-yaml.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('No URL specified')
   .get('.json?query=$.name&label=Package Name&style=_shields_test')

--- a/services/eclipse-marketplace/eclipse-marketplace-downloads.tester.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-downloads.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/eclipse-marketplace/eclipse-marketplace-favorites.tester.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-favorites.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('favorites count')
   .get('/notepad4e.json')

--- a/services/eclipse-marketplace/eclipse-marketplace-license.tester.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-license.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('license')
   .get('/notepad4e.json')

--- a/services/eclipse-marketplace/eclipse-marketplace-update.tester.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-update.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFormattedDate } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('last update date')
   .get('/notepad4e.json')

--- a/services/eclipse-marketplace/eclipse-marketplace-version.tester.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-version.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('marketplace version')
   .get('/notepad4e.json')

--- a/services/elm-package/elm-package.tester.js
+++ b/services/elm-package/elm-package.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isSemver } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets the package version of elm/core')
   .get('/elm/core.json')

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai')
 const { getShieldsIcon } = require('../../lib/logos')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Valid schema (mocked)')
   .get('.json?url=https://example.com/badge')

--- a/services/f-droid/f-droid.tester.js
+++ b/services/f-droid/f-droid.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/flip/flip.tester.js
+++ b/services/flip/flip.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('First request')
   .get('.json')

--- a/services/gem/gem-downloads.tester.js
+++ b/services/gem/gem-downloads.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('total downloads (valid)')
   .get('/dt/rails.json')

--- a/services/gem/gem-owner.tester.js
+++ b/services/gem/gem-owner.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('users (valid)')
   .get('/raphink.json')

--- a/services/gem/gem-rank.tester.js
+++ b/services/gem/gem-rank.tester.js
@@ -7,7 +7,7 @@ const isOrdinalNumberDaily = Joi.string().regex(
   /^[1-9][0-9]*(ᵗʰ|ˢᵗ|ⁿᵈ|ʳᵈ) daily$/
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('total rank (valid)')
   .get('/rt/rspec-puppet-facts.json')

--- a/services/gem/gem-version.tester.js
+++ b/services/gem/gem-version.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('version (valid)')
   .get('/formatador.json')

--- a/services/gemnasium/gemnasium.tester.js
+++ b/services/gemnasium/gemnasium.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'gemnasium',

--- a/services/github/github-commit-activity.tester.js
+++ b/services/github/github-commit-activity.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetricOverTimePeriod } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('commit activity (1 year)')
   .get('/y/eslint/eslint.json')

--- a/services/github/github-commit-status.tester.js
+++ b/services/github/github-commit-status.tester.js
@@ -2,7 +2,7 @@
 
 const { invalidJSON } = require('../response-fixtures')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('commit status - commit in branch')
   .get(

--- a/services/github/github-commits-since.tester.js
+++ b/services/github/github-commits-since.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Commits since')
   .get(

--- a/services/github/github-contributors.tester.js
+++ b/services/github/github-contributors.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 t.create('Contributors')

--- a/services/github/github-downloads.tester.js
+++ b/services/github/github-downloads.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Downloads all releases')
   .get('/downloads/photonstorm/phaser/total.json')

--- a/services/github/github-followers.tester.js
+++ b/services/github/github-followers.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Followers')
   .get('/webcaetano.json')

--- a/services/github/github-forks.tester.js
+++ b/services/github/github-forks.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Forks')
   .get('/badges/shields.json')

--- a/services/github/github-issue-detail.tester.js
+++ b/services/github/github-issue-detail.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFormattedDate } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('github issue state')
   .get('/s/badges/shields/979.json')

--- a/services/github/github-issues.tester.js
+++ b/services/github/github-issues.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric, isMetricOpenIssues } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('GitHub closed pull requests')
   .get('/issues-pr-closed/badges/shields.json')

--- a/services/github/github-languages.tester.js
+++ b/services/github/github-languages.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isFileSize } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/github/github-last-commit.tester.js
+++ b/services/github/github-last-commit.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFormattedDate } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('last commit (recent)')
   .get('/eslint/eslint.json')

--- a/services/github/github-license.tester.js
+++ b/services/github/github-license.tester.js
@@ -7,7 +7,7 @@ const permissiveLicenseColor = licenseToColor('MIT')
 const copyleftLicenseColor = licenseToColor('GPL-3.0')
 const unknownLicenseColor = licenseToColor()
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Public domain license')
   .get('/github/gitignore.json?style=_shields_test')

--- a/services/github/github-manifest.tester.js
+++ b/services/github/github-manifest.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/github/github-package-json.tester.js
+++ b/services/github/github-package-json.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isSemver } = require('../test-validators')
 const { semverRange } = require('../validators')
 

--- a/services/github/github-pull-request-check-state.tester.js
+++ b/services/github/github-pull-request-check-state.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('github pull request check state')
   .get('/s/pulls/badges/shields/1110.json')

--- a/services/github/github-release.tester.js
+++ b/services/github/github-release.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFormattedDate } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Release')
   .get('/release/photonstorm/phaser.json')

--- a/services/github/github-repo-size.tester.js
+++ b/services/github/github-repo-size.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFileSize } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('repository size')
   .get('/badges/shields.json')

--- a/services/github/github-search.tester.js
+++ b/services/github/github-search.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('hit counter')
   .get('/badges/shields/async%20handle.json')

--- a/services/github/github-size.tester.js
+++ b/services/github/github-size.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFileSize } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('File size')
   .get('/webcaetano/craft/build/phaser-craft.min.js.json')

--- a/services/github/github-stars.tester.js
+++ b/services/github/github-stars.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Stars')
   .get('/badges/shields.json')

--- a/services/github/github-tag.tester.js
+++ b/services/github/github-tag.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Tag')
   .get('/tag/photonstorm/phaser.json')

--- a/services/github/github-watchers.tester.js
+++ b/services/github/github-watchers.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Watchers')
   .get('/badges/shields.json')

--- a/services/gitlab/gitlab-pipeline-status.tester.js
+++ b/services/gitlab/gitlab-pipeline-status.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Pipeline status')
   .get('/gitlab-org/gitlab-ce.json')

--- a/services/gitter/gitter.tester.js
+++ b/services/gitter/gitter.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('on gitter')
   .get('/nwjs/nw.js.json')

--- a/services/gratipay/gratipay.tester.js
+++ b/services/gratipay/gratipay.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'gratipay',

--- a/services/hackage/hackage-deps.tester.js
+++ b/services/hackage/hackage-deps.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('hackage deps (valid)')
   .get('/lens.json')

--- a/services/hackage/hackage-version.tester.js
+++ b/services/hackage/hackage-version.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('hackage version (valid)')
   .get('/lens.json')

--- a/services/hexpm/hexpm.tester.js
+++ b/services/hexpm/hexpm.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 
 const isHexpmVersion = Joi.string().regex(/^v\d+.\d+.?\d?$/)

--- a/services/homebrew/homebrew.tester.js
+++ b/services/homebrew/homebrew.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusTripleDottedVersion } = require('../test-validators')
 const { invalidJSON } = require('../response-fixtures')
 

--- a/services/imagelayers/imagelayers.tester.js
+++ b/services/imagelayers/imagelayers.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'imagelayers',

--- a/services/index.js
+++ b/services/index.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const base = require('../core/base-service')
-const createServiceTester = require('../core/service-test-runner/create-service-tester')
-const ServiceTester = require('../core/service-test-runner/service-tester')
+// const createServiceTester = require('../core/service-test-runner/create-service-tester')
+// const ServiceTester = require('../core/service-test-runner/service-tester')
 
 module.exports = {
   ...base,
-  createServiceTester,
-  ServiceTester,
+  // createServiceTester,
+  // ServiceTester,
 }

--- a/services/index.js
+++ b/services/index.js
@@ -1,11 +1,7 @@
 'use strict'
 
 const base = require('../core/base-service')
-// const createServiceTester = require('../core/service-test-runner/create-service-tester')
-// const ServiceTester = require('../core/service-test-runner/service-tester')
 
 module.exports = {
   ...base,
-  // createServiceTester,
-  // ServiceTester,
 }

--- a/services/issuestats/issuestats.tester.js
+++ b/services/issuestats/issuestats.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'issuestats', title: 'Issue Stats' })
 module.exports = t

--- a/services/itunes/itunes.tester.js
+++ b/services/itunes/itunes.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('iTunes version (valid)')
   .get('/324684580.json')

--- a/services/jenkins/jenkins-coverage.tester.js
+++ b/services/jenkins/jenkins-coverage.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isIntegerPercentage } = require('../test-validators')
 
 const t = new ServiceTester({

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 // total installs
 

--- a/services/jenkins/jenkins-plugin-version.tester.js
+++ b/services/jenkins/jenkins-plugin-version.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({
   id: 'jenkins-plugin',

--- a/services/jetbrains/jetbrains.tester.js
+++ b/services/jetbrains/jetbrains.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isVPlusDottedVersionNClauses } = require('../test-validators')
 
 const t = new ServiceTester({ id: 'jetbrains', title: 'JetBrains' })

--- a/services/jira/jira-issue.tester.js
+++ b/services/jira/jira-issue.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { mockJiraCreds, restore, user, pass } = require('./jira-test-helpers')
 
 t.create('live: unknown issue')

--- a/services/jira/jira-sprint.tester.js
+++ b/services/jira/jira-sprint.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { isIntegerPercentage } = require('../test-validators')
 const { mockJiraCreds, restore, user, pass } = require('./jira-test-helpers')
 

--- a/services/jitpack/jitpack.tester.js
+++ b/services/jitpack/jitpack.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 // Github allows versions with chars, etc.
 const isAnyV = Joi.string().regex(/^v.+$/)

--- a/services/leanpub/leanpub-book-summary.tester.js
+++ b/services/leanpub/leanpub-book-summary.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 
 const knownValidBook = 'juice-shop'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('known book pages')
   .get(`/pages/${knownValidBook}.json`)

--- a/services/lgtm/lgtm.tester.js
+++ b/services/lgtm/lgtm.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const t = new ServiceTester({ id: 'lgtm', title: 'LGTM' })
 module.exports = t
 

--- a/services/liberapay/liberapay-gives.tester.js
+++ b/services/liberapay/liberapay-gives.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isCurrencyOverTime } = require('./liberapay-base')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Giving (valid)')
   .get('/Changaco.json')

--- a/services/liberapay/liberapay-goal.tester.js
+++ b/services/liberapay/liberapay-goal.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isIntegerPercentage } = require('../test-validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Goal Progress (valid)')
   .get('/Liberapay.json')

--- a/services/liberapay/liberapay-patrons.tester.js
+++ b/services/liberapay/liberapay-patrons.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Patrons (valid)')
   .get('/Liberapay.json')

--- a/services/liberapay/liberapay-receives.tester.js
+++ b/services/liberapay/liberapay-receives.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isCurrencyOverTime } = require('./liberapay-base')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Receiving (valid)')
   .get('/Changaco.json')

--- a/services/librariesio/librariesio-dependencies.tester.js
+++ b/services/librariesio/librariesio-dependencies.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isDependencyState } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('dependencies for releases')
   .get('/release/hex/phoenix/1.0.3.json')

--- a/services/librariesio/librariesio-dependent-repos.tester.js
+++ b/services/librariesio/librariesio-dependent-repos.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('dependent repo count')
   .get('/npm/got.json')

--- a/services/librariesio/librariesio-dependents.tester.js
+++ b/services/librariesio/librariesio-dependents.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('dependent count')
   .get('/npm/got.json')

--- a/services/librariesio/librariesio-sourcerank.tester.js
+++ b/services/librariesio/librariesio-sourcerank.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { anyInteger } = require('../validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('sourcerank')
   .get('/npm/got.json')

--- a/services/libscore/libscore.tester.js
+++ b/services/libscore/libscore.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'libscore', title: 'libscore' })
 module.exports = t

--- a/services/luarocks/luarocks.tester.js
+++ b/services/luarocks/luarocks.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'luarocks', title: 'LuaRocks' })
 module.exports = t

--- a/services/magnumci/magnumci.tester.js
+++ b/services/magnumci/magnumci.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'magnumci', title: 'Magnum CI' })
 module.exports = t

--- a/services/maintenance/maintenance.tester.js
+++ b/services/maintenance/maintenance.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'maintenance', title: 'Maintenance' })
 module.exports = t

--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('get room state as guest')
   .get('/ALIAS:DUMMY.dumb.json?style=_shields_test')

--- a/services/maven-central/maven-central.tester.js
+++ b/services/maven-central/maven-central.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'maven-central', title: 'Maven Central' })
 module.exports = t

--- a/services/maven-metadata/maven-metadata.tester.js
+++ b/services/maven-metadata/maven-metadata.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/microbadger/microbadger.tester.js
+++ b/services/microbadger/microbadger.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isFileSize } = require('../test-validators')
 const { invalidJSON } = require('../response-fixtures')
 

--- a/services/myget/myget.tester.js
+++ b/services/myget/myget.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isVPlusDottedVersionNClausesWithOptionalSuffix,

--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const {
   isVPlusDottedVersionNClausesWithOptionalSuffix: isVersion,
 } = require('../test-validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const serverSecrets = require('../../lib/server-secrets')
 
 const user = 'admin'

--- a/services/node/node.tester.js
+++ b/services/node/node.tester.js
@@ -4,7 +4,7 @@ const { expect } = require('chai')
 const Joi = require('joi')
 const { Range } = require('semver')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 function expectSemverRange(value) {
   expect(() => new Range(value)).not.to.throw()

--- a/services/npm/npm-collaborators.tester.js
+++ b/services/npm/npm-collaborators.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets the contributor count')
   .get('/prettier.json')

--- a/services/npm/npm-dependency-version.tester.js
+++ b/services/npm/npm-dependency-version.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { semverRange } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets the peer dependency version')
   .get('/react-boxplot/peer/react.json')

--- a/services/npm/npm-downloads.tester.js
+++ b/services/npm/npm-downloads.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric } = require('../test-validators')
 
 const t = new ServiceTester({

--- a/services/npm/npm-license.tester.js
+++ b/services/npm/npm-license.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets the license of express')
   .get('/express.json')

--- a/services/npm/npm-type-definitions.tester.js
+++ b/services/npm/npm-type-definitions.tester.js
@@ -6,7 +6,7 @@ const isTypeDefinition = Joi.string().regex(
   /^((Flow|TypeScript)|(Flow \| TypeScript))$/
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('types (from dev dependencies + files)')
   .get('/chalk.json')

--- a/services/npm/npm-version.tester.js
+++ b/services/npm/npm-version.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isSemver } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('gets the package version of left-pad')
   .get('/left-pad.json')

--- a/services/nsp/nsp.tester.js
+++ b/services/nsp/nsp.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'nsp',

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isVPlusDottedVersionNClauses,

--- a/services/opencollective/opencollective-all.tester.js
+++ b/services/opencollective/opencollective-all.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('renders correctly')
   .get('/shields.json?style=_shields_test')

--- a/services/opencollective/opencollective-backers.tester.js
+++ b/services/opencollective/opencollective-backers.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('renders correctly')
   .get('/shields.json?style=_shields_test')

--- a/services/opencollective/opencollective-by-tier.tester.js
+++ b/services/opencollective/opencollective-by-tier.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('renders correctly')
   .get('/shields/2988.json')

--- a/services/opencollective/opencollective-sponsors.tester.js
+++ b/services/opencollective/opencollective-sponsors.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { nonNegativeInteger } = require('../validators')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('renders correctly')
   .get('/shields.json')

--- a/services/osslifecycle/osslifecycle.tester.js
+++ b/services/osslifecycle/osslifecycle.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'osslifecycle',

--- a/services/packagecontrol/packagecontrol.tester.js
+++ b/services/packagecontrol/packagecontrol.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/packagist/packagist.tester.js
+++ b/services/packagist/packagist.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isComposerVersion,
   isMetric,

--- a/services/php-eye/php-eye-hhvm.tester.js
+++ b/services/php-eye/php-eye-hhvm.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { invalidJSON } = require('../response-fixtures')
 
 const isAllowedStatus = Joi.string().regex(

--- a/services/php-eye/php-eye-php-version.tester.js
+++ b/services/php-eye/php-eye-php-version.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isPhpVersionReduction } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/powershellgallery/powershellgallery.tester.js
+++ b/services/powershellgallery/powershellgallery.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isVPlusDottedVersionNClauses,

--- a/services/pub/pub.tester.js
+++ b/services/pub/pub.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusTripleDottedVersion } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({ id: 'pub', title: 'Pub' }))

--- a/services/puppetforge/puppetforge-modules.tester.js
+++ b/services/puppetforge/puppetforge-modules.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isSemver } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/pypi/pypi.tester.js
+++ b/services/pypi/pypi.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetricOverTimePeriod, isSemver } = require('../test-validators')
 
 const isPsycopg2Version = Joi.string().regex(/^v([0-9][.]?)+$/)

--- a/services/readthedocs/readthedocs.tester.js
+++ b/services/readthedocs/readthedocs.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('build status')
   .get('/pip.json')

--- a/services/redmine/redmine.tester.js
+++ b/services/redmine/redmine.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isStarRating } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/requires/requires.tester.js
+++ b/services/requires/requires.tester.js
@@ -6,7 +6,7 @@ const isRequireStatus = Joi.string().regex(
   /^(up to date|outdated|insecure|unknown)$/
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('requirements (valid, without branch)')
   .get('/github/celery/celery.json')

--- a/services/resharper/resharper.tester.js
+++ b/services/resharper/resharper.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isVPlusDottedVersionNClauses,

--- a/services/scrutinizer/scrutinizer.tester.js
+++ b/services/scrutinizer/scrutinizer.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isIntegerPercentage } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/shippable/shippable.tester.js
+++ b/services/shippable/shippable.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('build status (valid, without branch)')
   .get('/5444c5ecb904a4b21567b0ff.json')

--- a/services/snap-ci/snap-ci.tester.js
+++ b/services/snap-ci/snap-ci.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'snap-ci', title: 'Snap CI' })
 module.exports = t

--- a/services/snyk/snyk-vulnerability-github.tester.js
+++ b/services/snyk/snyk-vulnerability-github.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const {
   twoVulnerabilitiesSvg,
   zeroVulnerabilitiesSvg,

--- a/services/snyk/snyk-vulnerability-npm.tester.js
+++ b/services/snyk/snyk-vulnerability-npm.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const {
   twoVulnerabilitiesSvg,
   zeroVulnerabilitiesSvg,

--- a/services/sonarqube/sonarqube.tester.js
+++ b/services/sonarqube/sonarqube.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isIntegerPercentage } = require('../test-validators')
 
 const t = new ServiceTester({ id: 'sonar', title: 'SonarQube' })

--- a/services/sourceforge/sourceforge.tester.js
+++ b/services/sourceforge/sourceforge.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 
 const t = new ServiceTester({ id: 'sourceforge', title: 'SourceForge' })

--- a/services/sourcegraph/sourcegraph.tester.js
+++ b/services/sourcegraph/sourcegraph.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { withRegex } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 // Matches API responses such as "0 projects", "1 projects", "182 projects", "14.0k projects".
 // There may be other cases not covered by this regex, but hopefully the tested projects won't vary much.

--- a/services/spiget/spiget-download-size.tester.js
+++ b/services/spiget/spiget-download-size.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isFileSize } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('EssentialsX (id 9089)')
   .get('/9089.json')

--- a/services/spiget/spiget-downloads.tester.js
+++ b/services/spiget/spiget-downloads.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('EssentialsX (id 9089)')
   .get('/9089.json')

--- a/services/spiget/spiget-latest-version.tester.js
+++ b/services/spiget/spiget-latest-version.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { withRegex } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 // Note that Spigot versions can be anything (including just a string), so we'll make sure it's not returning 'not found'
 

--- a/services/spiget/spiget-rating.tester.js
+++ b/services/spiget/spiget-rating.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isStarRating, withRegex } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Stars - EssentialsX (id 9089)')
   .get('/stars/9089.json')

--- a/services/spiget/spiget-tested-versions.tester.js
+++ b/services/spiget/spiget-tested-versions.tester.js
@@ -5,7 +5,7 @@ const { withRegex } = require('../test-validators')
 
 const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('EssentialsX - multiple versions supported - (id 9089)')
   .get('/9089.json')

--- a/services/stackexchange/stackexchange-monthlyquestions.tester.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetricOverTimePeriod } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Monthly Questions for StackOverflow Momentjs')
   .get('/stackoverflow/qm/momentjs.json')

--- a/services/stackexchange/stackexchange-reputation.tester.js
+++ b/services/stackexchange/stackexchange-reputation.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Invalid parameters')
   .get('/stackoverflow/r/invalidimage.json')

--- a/services/stackexchange/stackexchange-taginfo.tester.js
+++ b/services/stackexchange/stackexchange-taginfo.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('JavaScript Questions')
   .get('/stackoverflow/t/javascript.json')

--- a/services/static-badge/static-badge.tester.js
+++ b/services/static-badge/static-badge.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Shields colorscheme color')
   .get('/badge/label-message-blue.json?style=_shields_test')

--- a/services/steam/steam-workshop.tester.js
+++ b/services/steam/steam-workshop.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isMetric, isFileSize, isFormattedDate } = require('../test-validators')
 
 const t = new ServiceTester({ id: 'steam', title: 'Steam Workshop Tests' })

--- a/services/swagger/swagger.tester.js
+++ b/services/swagger/swagger.tester.js
@@ -5,7 +5,7 @@ const apiURL = 'http://online.swagger.io'
 const apiGetURL = '/validator/debug'
 const apiGetQueryParams = { url: 'https://example.com/example.json' }
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Valid (mocked)')
   .get(getURL)

--- a/services/symfony/symfony-insight.tester.js
+++ b/services/symfony/symfony-insight.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { withRegex } = require('../test-validators')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 const {
   runningMockResponse,

--- a/services/teamcity/teamcity-build.tester.js
+++ b/services/teamcity/teamcity-build.tester.js
@@ -12,7 +12,7 @@ const {
 const buildStatusValues = Joi.equal('passing', 'failure', 'error').required()
 const buildStatusTextRegex = /^success|failure|error|tests( failed: \d+( \(\d+ new\))?)?(,)?( passed: \d+)?(,)?( ignored: \d+)?(,)?( muted: \d+)?$/
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('live: codebetter unknown build')
   .get('/codebetter/btabc.json')

--- a/services/teamcity/teamcity-coverage.tester.js
+++ b/services/teamcity/teamcity-coverage.tester.js
@@ -9,7 +9,7 @@ const {
   restore,
 } = require('./teamcity-test-helpers')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('live: valid buildId')
   .get('/bt428.json')

--- a/services/tester.js
+++ b/services/tester.js
@@ -1,0 +1,9 @@
+'use strict'
+
+const createServiceTester = require('../core/service-test-runner/create-service-tester')
+const ServiceTester = require('../core/service-test-runner/service-tester')
+
+module.exports = {
+  createServiceTester,
+  ServiceTester,
+}

--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'travis-build',

--- a/services/travis/travis-php-version.tester.js
+++ b/services/travis/travis-php-version.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isPhpVersionReduction } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'travis-php-version',

--- a/services/twitter/twitter.tester.js
+++ b/services/twitter/twitter.tester.js
@@ -2,7 +2,7 @@
 
 const Joi = require('joi')
 const { isMetric } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'twitter',

--- a/services/uptimerobot/uptimerobot-ratio.tester.js
+++ b/services/uptimerobot/uptimerobot-ratio.tester.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { isPercentage } = require('../test-validators')
 const { invalidJSON } = require('../response-fixtures')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Uptime Robot: Percentage (valid)')
   .get('/m778918918-3e92c097147760ee39d02d36.json')

--- a/services/uptimerobot/uptimerobot-status.tester.js
+++ b/services/uptimerobot/uptimerobot-status.tester.js
@@ -11,7 +11,7 @@ const isUptimeStatus = Joi.string().valid(
   'down'
 )
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Uptime Robot: Status (valid)')
   .get('/m778918918-3e92c097147760ee39d02d36.json')

--- a/services/vaadin-directory/vaadin-directory.tester.js
+++ b/services/vaadin-directory/vaadin-directory.tester.js
@@ -6,7 +6,7 @@ const {
   isStarRating,
   isFormattedDate,
 } = require('../test-validators')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
   id: 'vaadin-directory',

--- a/services/versioneye/versioneye.tester.js
+++ b/services/versioneye/versioneye.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const t = new ServiceTester({ id: 'versioneye', title: 'VersionEye' })
 module.exports = t

--- a/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 const mockResponse = {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 const mockResponse = {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { withRegex, isStarRating } = require('../test-validators')
 
 const isVscodeRating = withRegex(/[0-5]\.[0-9]{1}\/5?\s*\([0-9]*\)$/)

--- a/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 const { withRegex } = require('../test-validators')
 
 const isMarketplaceVersion = withRegex(/^v(\d+\.\d+\.\d+)(\.\d+)?$/)

--- a/services/waffle/waffle.tester.js
+++ b/services/waffle/waffle.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { invalidJSON } = require('../response-fixtures')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 const fakeData = [
   {

--- a/services/website/website.tester.js
+++ b/services/website/website.tester.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('status of http://shields.io')
   .get('/website/http/shields.io.json?style=_shields_test')

--- a/services/wercker/wercker.tester.js
+++ b/services/wercker/wercker.tester.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 const { isBuildStatus } = require('../../lib/build-status')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Build status')
   .get('/build/wercker/go-wercker-api.json')

--- a/services/wheelmap/wheelmap.tester.js
+++ b/services/wheelmap/wheelmap.tester.js
@@ -2,7 +2,7 @@
 
 const serverSecrets = require('../../lib/server-secrets')
 
-const t = (module.exports = require('..').createServiceTester())
+const t = (module.exports = require('../tester').createServiceTester())
 
 const noToken = !serverSecrets.wheelmap_token
 function logTokenWarning() {

--- a/services/wordpress/wordpress-downloads.tester.js
+++ b/services/wordpress/wordpress-downloads.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const { isMetric, isMetricOverTimePeriod } = require('../test-validators')
 

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({

--- a/services/wordpress/wordpress-rating.tester.js
+++ b/services/wordpress/wordpress-rating.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 
 const { isStarRating } = require('../test-validators')
 

--- a/services/wordpress/wordpress-version.tester.js
+++ b/services/wordpress/wordpress-version.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { ServiceTester } = require('..')
+const { ServiceTester } = require('../tester')
 const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({


### PR DESCRIPTION
Fixes #2876 with @paulmelnikow's suggestion 

Moved imports of `ServiceTester` and `createServiceTester` to a separate file so that dev dependencies are not imported by service classes 