### PR TITLE
Update from RawGit to local path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://cdn.jsdelivr.net/gh/badges/shields@master/frontend/images/logo.svg"
+    <img src="./frontend/images/logo.svg"
         height="130">
 </p>
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://rawgit.com/badges/shields/master/frontend/images/logo.svg"
+    <img src="https://cdn.jsdelivr.net/gh/badges/shields@master/frontend/images/logo.svg"
         height="130">
 </p>
 <p align="center">


### PR DESCRIPTION
As per RawGit's index, the service is being shut down in October 2019. They mention:

>If you're currently using RawGit, please stop using it as soon as you can.

They recommend using jsDelivr or a few other CDNs going forward. jsDelivr has an easy [transfer page](https://www.jsdelivr.com/rawgit) available

See [rawgit.com](https://rawgit.com) for details on the sunset phase.