### PR TITLE
Update build status list 

### DIFF
--- a/lib/build-status.js
+++ b/lib/build-status.js
@@ -29,6 +29,7 @@ const otherStatuses = [
   'running',
   'scheduled',
   'skipped',
+  'starting',
   'stopped',
   'waiting',
 ]

--- a/lib/build-status.spec.js
+++ b/lib/build-status.spec.js
@@ -76,6 +76,7 @@ test(renderBuildStatusBadge, () => {
     given({ status: 'running' }),
     given({ status: 'scheduled' }),
     given({ status: 'skipped' }),
+    given({ status: 'starting' }),
     given({ status: 'stopped' }),
     given({ status: 'waiting' }),
   ]).assert('should have undefined color', b =>


### PR DESCRIPTION
Fixes #2848 

Appveyor briefly has a status of `starting` before the job begins, so adding `starting` to the list of `otherStatuses` to prevent the Appveyor badges from showing `invalid response data` during that window