### PR TITLE
Allow plus in semver [Nexus aur bintray chocolatey dubversion myget nuget powershellgallery resharper] 

### DIFF
--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -94,7 +94,7 @@ t.create('search snapshot version with + in version')
     nock('https://repository.jboss.org/nexus')
       .get('/service/local/lucene/search')
       .query({ g: 'com.progress.fuse', a: 'fusehq' })
-      .reply(200, { data: [{ version: '7.0.1+METADATA-SNAPSHOT' }] })
+      .reply(200, { data: [{ version: '7.0.1+METADATA-abcdef-SNAPSHOT' }] })
   )
   .expectJSON({
     name: 'nexus',

--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -86,6 +86,21 @@ t.create('live: repository version of an inexistent artifact')
     value: 'artifact not found',
   })
 
+t.create('search snapshot version with + in version')
+  .get(
+    '/s/https/repository.jboss.org/nexus/com.progress.fuse/fusehq.json?style=_shields_test'
+  )
+  .intercept(nock =>
+    nock('https://repository.jboss.org/nexus')
+      .get('/service/local/lucene/search')
+      .query({ g: 'com.progress.fuse', a: 'fusehq' })
+      .reply(200, { data: [{ version: '7.0.1+METADATA-SNAPSHOT' }] })
+  )
+  .expectJSON({
+    name: 'nexus',
+    color: isVersion,
+  })
+
 t.create('search snapshot version not in latestSnapshot')
   .get(
     '/s/https/repository.jboss.org/nexus/com.progress.fuse/fusehq.json?style=_shields_test'

--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -86,7 +86,7 @@ t.create('live: repository version of an inexistent artifact')
     value: 'artifact not found',
   })
 
-t.create('search snapshot version with + in version')
+t.create('snapshot version with + in version')
   .get(
     '/s/https/repository.jboss.org/nexus/com.progress.fuse/fusehq.json?style=_shields_test'
   )
@@ -94,12 +94,15 @@ t.create('search snapshot version with + in version')
     nock('https://repository.jboss.org/nexus')
       .get('/service/local/lucene/search')
       .query({ g: 'com.progress.fuse', a: 'fusehq' })
-      .reply(200, { data: [{ version: '7.0.1+METADATA-abcdef-SNAPSHOT' }] })
+      .reply(200, { data: [{ version: '7.0.1+19-8844c122-SNAPSHOT' }] })
   )
-  .expectJSON({
-    name: 'nexus',
-    color: isVersion,
-  })
+  .expectJSONTypes(
+    Joi.object().keys({
+      name: 'nexus',
+      color: 'orange',
+      value: isVersion,
+    })
+  )
 
 t.create('search snapshot version not in latestSnapshot')
   .get(

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -21,9 +21,9 @@ const isVPlusDottedVersionNClauses = withRegex(/^v\d+(\.\d+)*$/)
 
 // matches a version number with N 'clauses'
 // and an optional text suffix
-// e.g: -beta, -preview1, -release-candidate etc
+// e.g: -beta, -preview1, -release-candidate, +beta etc
 const isVPlusDottedVersionNClausesWithOptionalSuffix = withRegex(
-  /^v\d+(\.\d+)*(-.*)?$/
+  /^v\d+(\.\d+)*([-+].*)?$/
 )
 
 // Simple regex for test Composer versions rule

--- a/services/validators.js
+++ b/services/validators.js
@@ -21,7 +21,7 @@ module.exports = {
     .required(),
 
   optionalDottedVersionNClausesWithOptionalSuffix: Joi.string().regex(
-    /^\d+(\.\d+)*(-.*)?$/
+    /^\d+(\.\d+)*([-+].*)?$/
   ),
 
   // TODO This accepts URLs with query strings and fragments, which for some


### PR DESCRIPTION
Fixes #2978 

Changes the regex to allow a + in semver for the validator used in Nexus, following [semver guidelines](https://semver.org/#spec-item-10)