### PR TITLE
Remove unused parameter in [jsdelivr]

### DIFF
--- a/services/jsdelivr/jsdelivr-hits-github.service.js
+++ b/services/jsdelivr/jsdelivr-hits-github.service.js
@@ -21,16 +21,11 @@ module.exports = class jsDelivrHitsGitHub extends BaseJsDelivrService {
   }
 
   async fetch({ period, user, repo }) {
-    const url = `https://data.jsdelivr.com/v1/package/gh/${user}/${repo}/stats/date/${
-      periodMap[period]
-    }`
-
     return this._requestJson({
       schema,
-      url,
-      headers: {
-        'User-Agent': 'Shields.io',
-      },
+      url: `https://data.jsdelivr.com/v1/package/gh/${user}/${repo}/stats/date/${
+        periodMap[period]
+      }`,
     })
   }
 

--- a/services/jsdelivr/jsdelivr-hits-npm.service.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.service.js
@@ -21,16 +21,11 @@ module.exports = class jsDelivrHitsNPM extends BaseJsDelivrService {
   }
 
   async fetch({ period, pkg }) {
-    const url = `https://data.jsdelivr.com/v1/package/npm/${pkg}/stats/date/${
-      periodMap[period]
-    }`
-
     return this._requestJson({
       schema,
-      url,
-      headers: {
-        'User-Agent': 'Shields.io',
-      },
+      url: `https://data.jsdelivr.com/v1/package/npm/${pkg}/stats/date/${
+        periodMap[period]
+      }`,
     })
   }
 


### PR DESCRIPTION
`headers` is not destructured; it needs to go in `options`.

`Shields.io` is set as the `User-Agent` by code in `legacy-request-handler.js`.