### PR TITLE
npm install -> npm ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - save_cache:
           paths:
@@ -37,7 +37,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - save_cache:
           paths:
@@ -88,7 +88,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Linter
@@ -135,7 +135,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Integration tests
@@ -164,7 +164,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Integration tests
@@ -191,7 +191,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Danger
@@ -215,7 +215,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Prepare frontend tests
@@ -250,7 +250,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Identify services tagged in the PR title
@@ -280,7 +280,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: npm ci
 
       - run:
           name: Identify services tagged in the PR title

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 ports:
   - port: 8080
 tasks:
-  - init: npm install && npm run build
+  - init: npm ci && npm run build
     command: node server 8080 0.0.0.0

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ package.json
 package-lock.json
 /__snapshots__
 /.next
+/.cache
 /build
 /public
 /coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.9.4-alpine
+FROM node:8-alpine
 
 RUN apk add --no-cache gettext imagemagick librsvg git
 
@@ -10,9 +10,9 @@ ARG NODE_ENV
 ENV NODE_ENV $NODE_ENV
 
 COPY package.json package-lock.json /usr/src/app/
-# Without the gh-badges package.json and CLI script in place, `npm install` will fail.
+# Without the gh-badges package.json and CLI script in place, `npm ci` will fail.
 COPY gh-badges /usr/src/app/gh-badges/
-RUN npm install
+RUN npm ci
 
 COPY . /usr/src/app
 RUN npm run build

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can read a [tutorial on how to add a badge][tutorial].
 1. Install Node 8 or later. You can use the [package manager][] of your choice.
    Tests need to pass in Node 8 and 9.
 2. Clone this repository.
-3. Run `npm install` to install the dependencies.
+3. Run `npm ci` to install the dependencies.
 4. Run `npm start` to start the server.
 5. Open `http://localhost:3000/` to view the frontend.
 

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -37,7 +37,7 @@ install node and npm: https://nodejs.org/en/download/
    `git clone git@github.com:YOURGITHUBUSERNAME/shields.git`
 3. `cd shields`
 4. Install project dependencies
-   `npm install`
+   `npm ci`
 5. Run the server
    `npm start`
 6. Visit the website to check the front-end is loaded:

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -14,7 +14,7 @@ curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -; sudo apt-get ins
 ```sh
 git clone https://github.com/badges/shields.git
 cd shields
-npm install  # You may need sudo for this.
+npm ci  # You may need sudo for this.
 ```
 
 [package manager]: https://nodejs.org/en/download/package-manager/


### PR DESCRIPTION
[npm ci](https://medium.com/better-things-digital/npm-ci-a-command-you-should-know-d8d67847884c) provides clean installs of packages, using the exact resolution in the lockfile. It's faster, and reliably produces results matching the lockfile.

The only time you really need `npm install` is when you're actually changing the dependencies, which doesn't apply to CI (where Dependabot writes the lockfile), or to any of the cases documented here.

For a while I thought `npm ci` was for **continuous improvement**, as in what you want to use in your CI server, though it seems that it actually means **clean install**.