### PR TITLE
Tweak [maintenance] badge in UI; remove caching

### DIFF
--- a/services/maintenance/maintenance.service.js
+++ b/services/maintenance/maintenance.service.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const { BaseService } = require('..')
+const { NonMemoryCachingBaseService } = require('..')
 
-module.exports = class Maintenance extends BaseService {
+module.exports = class Maintenance extends NonMemoryCachingBaseService {
   static get route() {
     return {
       base: 'maintenance',
@@ -51,11 +51,12 @@ module.exports = class Maintenance extends BaseService {
   static get category() {
     return 'other'
   }
+
   static get examples() {
     return [
       {
         title: 'Maintenance',
-        pattern: ':maintained/:year',
+        pattern: ':maintained(yes|no)/:year',
         namedParams: {
           maintained: 'yes',
           year: '2019',


### PR DESCRIPTION
As I mentioned at https://github.com/badges/shields/pull/3005/files#r257553498 this should use NonMemoryCachingBaseService as it doesn't fetch anything. It's a waste of the cache to store these values when they can be computed on the fly without taking up any space.

Added `(yes|no)` for the dropdown.