### PR TITLE
Fix color overriding for legacy services

### DIFF
--- a/lib/badge-data.js
+++ b/lib/badge-data.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const coalesce = require('../core/base-service/coalesce')
 const { makeLogo } = require('./logos')
 
 function toArray(val) {
@@ -30,12 +31,15 @@ function makeLabel(defaultLabel, overrides) {
 //   - logo
 //   - logoWidth
 //   - link
-//   - colorA
-//   - colorB
+//   - color and colorB
+//   - labelColor and colorA
 //   - maxAge
 //
 // Note: maxAge is handled by cache(), not this function.
 function makeBadgeData(defaultLabel, overrides) {
+  const colorA = coalesce(overrides.labelColor, overrides.colorA)
+  const colorB = coalesce(overrides.color, overrides.colorB)
+
   return {
     text: [makeLabel(defaultLabel, overrides), 'n/a'],
     colorscheme: 'lightgrey',
@@ -45,14 +49,8 @@ function makeBadgeData(defaultLabel, overrides) {
     logoWidth: +overrides.logoWidth,
     links: toArray(overrides.link),
     // Scoutcamp sometimes turns these into numbers.
-    colorA:
-      typeof overrides.colorA === 'number'
-        ? `${overrides.colorA}`
-        : overrides.colorA,
-    colorB:
-      typeof overrides.colorB === 'number'
-        ? `${overrides.colorB}`
-        : overrides.colorB,
+    colorA: typeof colorA === 'number' ? `${colorA}` : colorA,
+    colorB: typeof colorB === 'number' ? `${colorB}` : colorB,
   }
 }
 


### PR DESCRIPTION
While I was doing #3090 I realized the work in #3012 did not handle legacy services.

I tested this manually with `/librariesio/release/hex/phoenix.svg?color=blue` and it works.

The rewrite is almost done and I don't feel like we ought to invest in automated testing that's going to be thrown away, so I didn't write an automated test.