### PR TITLE
Allow expectBadge to be called with null color, affects [StaticBadge]

### DIFF
--- a/core/service-test-runner/icedfrisby-shields.js
+++ b/core/service-test-runner/icedfrisby-shields.js
@@ -33,10 +33,10 @@ const factory = superclass =>
 
     expectBadge({ label, message, color }) {
       let expectedBadge
-      if (color) {
-        expectedBadge = { name: label, value: message, color }
-      } else {
+      if (typeof color === 'undefined') {
         expectedBadge = { name: label, value: message }
+      } else {
+        expectedBadge = { name: label, value: message, color }
       }
 
       if (typeof message === 'string') {

--- a/services/static-badge/static-badge.tester.js
+++ b/services/static-badge/static-badge.tester.js
@@ -24,7 +24,7 @@ t.create('All one color')
 
 t.create('Not a valid color')
   .get('/badge/label-message-notacolor.json?style=_shields_test')
-  .expectJSON({ name: 'label', value: 'message', color: null })
+  .expectBadge({ label: 'label', message: 'message', color: null })
 
 t.create('Missing message')
   .get('/badge/label--blue.json?style=_shields_test')


### PR DESCRIPTION
This pull request allows `expectBadge` to be called with a `null` color, which is the value that the static badge returns for invalid input colors. We'll pretty much be done with #2687 after this!