### PR TITLE
Update remaining documentation for expectBadge

### DIFF
--- a/doc/deprecating-badges.md
+++ b/doc/deprecating-badges.md
@@ -49,9 +49,9 @@ Next you will need to replace/refactor the existing tests to validate the new de
 ```js
 t.create('no longer available (previously image size)')
   .get('/image-size/_/ubuntu/latest.json')
-  .expectJSON({
-    name: 'imagelayers',
-    value: 'no longer available',
+  .expectBadge({
+    label: 'imagelayers',
+    message: 'no longer available',
   })
 ```
 
@@ -71,16 +71,16 @@ const t = (module.exports = new ServiceTester({
 
 t.create('no longer available (previously image size)')
   .get('/image-size/_/ubuntu/latest.json')
-  .expectJSON({
-    name: 'imagelayers',
-    value: 'no longer available',
+  .expectBadge({
+    label: 'imagelayers',
+    message: 'no longer available',
   })
 
 t.create('no longer available (previously number of layers)')
   .get('/layers/_/ubuntu/latest.json')
-  .expectJSON({
-    name: 'imagelayers',
-    value: 'no longer available',
+  .expectBadge({
+    label: 'imagelayers',
+    message: 'no longer available',
   })
 ```
 

--- a/doc/rewriting-services.md
+++ b/doc/rewriting-services.md
@@ -124,11 +124,9 @@ class ExampleDownloads extends BaseJsonService {
 t.create('build status')
   .get('/pip.json')
   .only() // Prevent this ServiceTester from running its other tests.
-  .expectJSONTypes(
-    Joi.object().keys({
-      name: 'docs',
-      value: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
-    })
+  .expectBadge(
+    label: 'docs',
+    message: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
   )
 ```
 


### PR DESCRIPTION
I updated the _service-tests.md_ documentation in #3097, but noticed that there were two other pieces of documentation that I had missed out.