### PR TITLE
[GitHubRelease] Get releases using semver (similar logic to tags)

### DIFF
--- a/services/github/github-release.tester.js
+++ b/services/github/github-release.tester.js
@@ -19,9 +19,14 @@ t.create('Prerelease (repo not found)')
   .get('/release-pre/badges/helmets.json')
   .expectBadge({ label: 'release', message: 'no releases or repo not found' })
 
+t.create('Latest Release')
+  .get('/release-latest/photonstorm/phaser.json')
+  .expectBadge({ label: 'release', message: isVPlusTripleDottedVersion })
+
+t.create('Latest Release (repo not found)')
+  .get('/release-latest/badges/helmets.json')
+  .expectBadge({ label: 'release', message: 'no releases or repo not found' })
+
 t.create('No releases')
   .get('/release/badges/daily-tests.json')
-  .expectBadge({
-    label: 'release',
-    message: 'no releases or repo not found',
-  })
+  .expectBadge({ label: 'release', message: 'no releases or repo not found' })


### PR DESCRIPTION
Closes #3080

This PR updates the GitHub releases badge to use our `latestVersion` function instead of using the most recent release by date (similar to the tag badge).

You can still get the latest release using `/release-latest/:user/:repo`
_(although this excludes pre-releases)_