### PR TITLE
Fix GitHubFollowers example style

### DIFF
--- a/services/github/github-followers.service.js
+++ b/services/github/github-followers.service.js
@@ -36,6 +36,7 @@ module.exports = class GithubFollowers extends GithubAuthService {
         namedParams: { user: 'espadrine' },
         staticPreview: Object.assign(this.render({ followers: 150 }), {
           label: 'Follow',
+          style: 'social',
         }),
         queryParams: { label: 'Follow' },
         documentation,


### PR DESCRIPTION
Accidentally left the social style off the example in https://github.com/badges/shields/pull/3157#issuecomment-469527123