### PR TITLE
Prevent queryParams from reaching handle() when no schema is defined

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -276,9 +276,10 @@ module.exports = class BaseService {
 
     let serviceError
     const { queryParamSchema } = this.route
+    let transformedQueryParams
     if (queryParamSchema) {
       try {
-        queryParams = validate(
+        transformedQueryParams = validate(
           {
             ErrorClass: InvalidParameter,
             prettyErrorMessage: 'invalid query parameter',
@@ -298,12 +299,17 @@ module.exports = class BaseService {
       } catch (error) {
         serviceError = error
       }
+    } else {
+      transformedQueryParams = {}
     }
 
     let serviceData
     if (!serviceError) {
       try {
-        serviceData = await serviceInstance.handle(namedParams, queryParams)
+        serviceData = await serviceInstance.handle(
+          namedParams,
+          transformedQueryParams
+        )
         Joi.assert(serviceData, serviceDataSchema)
       } catch (error) {
         serviceError = error


### PR DESCRIPTION
I believe I’ve added all the schemas to the new-style services in #3164, so this should be purely preventive.