### PR TITLE
Fix console error before applying a frontend route redirect

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,16 +1,2 @@
-import React from 'react'
 import Main from '../components/main'
-import redirectLegacyRoutes from '../lib/redirect-legacy-routes'
-
-export default class IndexPage extends React.Component {
-  render() {
-    // It seems like putting this in `componentDidMount()` should work.
-    // however, that does not seem to be called often enough, resulting in the
-    // redirect sometimes not occurring.
-    if (typeof window !== 'undefined') {
-      redirectLegacyRoutes()
-    }
-
-    return <Main {...this.props} />
-  }
-}
+export default Main

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,6 @@
-// Adapted from https://github.com/gatsbyjs/gatsby/issues/8413
+import redirectLegacyRoutes from './frontend/lib/redirect-legacy-routes'
 
+// Adapted from https://github.com/gatsbyjs/gatsby/issues/8413
 function scrollToElementId(id) {
   const el = document.querySelector(id)
   if (el) {
@@ -11,6 +12,8 @@ function scrollToElementId(id) {
 
 export function onRouteUpdate({ location: { hash } }) {
   if (hash) {
-    window.setTimeout(() => scrollToElementId(hash), 10)
+    if (!redirectLegacyRoutes()) {
+      window.setTimeout(() => scrollToElementId(hash), 10)
+    }
   }
 }


### PR DESCRIPTION
The error was generated in the `onRouteUpdate` handler, which is invoked before the component. This moves redirecting responsibility to the handler, which seems like a better place for it anyway.