### PR TITLE
allow numeric version for NuGet v2 services [powershellgallery chocolatey resharper]

### DIFF
--- a/services/nuget/nuget-v2-service-family.js
+++ b/services/nuget/nuget-v2-service-family.js
@@ -35,7 +35,7 @@ const xmlSchema = Joi.object({
   feed: Joi.object({
     entry: Joi.object({
       'm:properties': Joi.object({
-        'd:Version': Joi.string(),
+        'd:Version': Joi.alternatives(Joi.string(), Joi.number()),
         'd:NormalizedVersion': Joi.string(),
         'd:DownloadCount': nonNegativeInteger,
         'd:Tags': Joi.string(),


### PR DESCRIPTION
closes #2331

The issue here was that if the version can be expressed as a number e.g: `0.3`, `d:Version` will be a number instead of a string