### PR TITLE
Rewrite GitHub commit status

### DIFF
--- a/core/base-service/errors.js
+++ b/core/base-service/errors.js
@@ -34,6 +34,7 @@ class NotFound extends ShieldsRuntimeError {
         ? 'Not Found'
         : `Not Found: ${prettyMessage}`
     super(props, message)
+    this.response = props.response
   }
 }
 
@@ -50,6 +51,7 @@ class InvalidResponse extends ShieldsRuntimeError {
       ? `Invalid Response: ${props.underlyingError.message}`
       : 'Invalid Response'
     super(props, message)
+    this.response = props.response
   }
 }
 
@@ -66,6 +68,7 @@ class Inaccessible extends ShieldsRuntimeError {
       ? `Inaccessible: ${props.underlyingError.message}`
       : 'Inaccessible'
     super(props, message)
+    this.response = props.response
   }
 }
 
@@ -82,6 +85,7 @@ class InvalidParameter extends ShieldsRuntimeError {
       ? `Invalid Parameter: ${props.underlyingError.message}`
       : 'Invalid Parameter'
     super(props, message)
+    this.response = props.response
   }
 }
 

--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -52,8 +52,9 @@ checkErrorResponse.asPromise = function(errorMessages = {}) {
       error.response = res
       error.buffer = buffer
       throw error
+    } else {
+      return { buffer, res }
     }
-    return { buffer, res }
   }
 }
 

--- a/lib/error-helper.js
+++ b/lib/error-helper.js
@@ -30,9 +30,10 @@ function checkErrorResponse(badgeData, err, res, errorMessages = {}) {
 
 checkErrorResponse.asPromise = function(errorMessages = {}) {
   return async function({ buffer, res }) {
+    let error
     errorMessages = { ...defaultErrorMessages, ...errorMessages }
     if (res.statusCode === 404) {
-      throw new NotFound({ prettyMessage: errorMessages[404] })
+      error = new NotFound({ prettyMessage: errorMessages[404] })
     } else if (res.statusCode !== 200) {
       const underlying = Error(
         `Got status code ${res.statusCode} (expected 200)`
@@ -42,9 +43,15 @@ checkErrorResponse.asPromise = function(errorMessages = {}) {
         props.prettyMessage = errorMessages[res.statusCode]
       }
       if (res.statusCode >= 500) {
-        throw new Inaccessible(props)
+        error = new Inaccessible(props)
+      } else {
+        error = new InvalidResponse(props)
       }
-      throw new InvalidResponse(props)
+    }
+    if (error) {
+      error.response = res
+      error.buffer = buffer
+      throw error
     }
     return { buffer, res }
   }

--- a/lib/error-helper.spec.js
+++ b/lib/error-helper.spec.js
@@ -52,31 +52,40 @@ describe('Standard Error Handler', function() {
 })
 
 describe('async error handler', function() {
+  const buffer = Buffer.from('some stuff')
+
   context('when status is 200', function() {
     it('passes through the inputs', async function() {
-      const args = { buffer: 'buffer', res: { statusCode: 200 } }
-      expect(await checkErrorResponse.asPromise()(args)).to.deep.equal(args)
+      const res = { statusCode: 200 }
+      expect(
+        await checkErrorResponse.asPromise()({ res, buffer })
+      ).to.deep.equal({ res, buffer })
     })
   })
 
   context('when status is 404', function() {
+    const buffer = Buffer.from('some stuff')
     const res = { statusCode: 404 }
 
     it('throws NotFound', async function() {
       try {
-        await checkErrorResponse.asPromise()({ res })
+        await checkErrorResponse.asPromise()({ res, buffer })
         expect.fail('Expected to throw')
       } catch (e) {
         expect(e).to.be.an.instanceof(NotFound)
         expect(e.message).to.equal('Not Found')
         expect(e.prettyMessage).to.equal('not found')
+        expect(e.response).to.equal(res)
+        expect(e.buffer).to.equal(buffer)
       }
     })
 
     it('displays the custom not found message', async function() {
       const notFoundMessage = 'no goblins found'
       try {
-        await checkErrorResponse.asPromise({ 404: notFoundMessage })({ res })
+        await checkErrorResponse.asPromise({
+          404: notFoundMessage,
+        })({ res, buffer })
         expect.fail('Expected to throw')
       } catch (e) {
         expect(e).to.be.an.instanceof(NotFound)
@@ -90,7 +99,7 @@ describe('async error handler', function() {
     it('throws InvalidResponse', async function() {
       const res = { statusCode: 499 }
       try {
-        await checkErrorResponse.asPromise()({ res })
+        await checkErrorResponse.asPromise()({ res, buffer })
         expect.fail('Expected to throw')
       } catch (e) {
         expect(e).to.be.an.instanceof(InvalidResponse)
@@ -98,6 +107,8 @@ describe('async error handler', function() {
           'Invalid Response: Got status code 499 (expected 200)'
         )
         expect(e.prettyMessage).to.equal('invalid')
+        expect(e.response).to.equal(res)
+        expect(e.buffer).to.equal(buffer)
       }
     })
 
@@ -122,7 +133,7 @@ describe('async error handler', function() {
     it('throws Inaccessible', async function() {
       const res = { statusCode: 503 }
       try {
-        await checkErrorResponse.asPromise()({ res })
+        await checkErrorResponse.asPromise()({ res, buffer })
         expect.fail('Expected to throw')
       } catch (e) {
         expect(e).to.be.an.instanceof(Inaccessible)
@@ -130,6 +141,8 @@ describe('async error handler', function() {
           'Inaccessible: Got status code 503 (expected 200)'
         )
         expect(e.prettyMessage).to.equal('inaccessible')
+        expect(e.response).to.equal(res)
+        expect(e.buffer).to.equal(buffer)
       }
     })
 
@@ -138,7 +151,7 @@ describe('async error handler', function() {
       try {
         await checkErrorResponse.asPromise({
           500: 'server overloaded',
-        })({ res })
+        })({ res, buffer })
         expect.fail('Expected to throw')
       } catch (e) {
         expect(e).to.be.an.instanceof(Inaccessible)

--- a/services/github/github-commit-status.service.js
+++ b/services/github/github-commit-status.service.js
@@ -5,6 +5,11 @@ const { NotFound, InvalidParameter } = require('..')
 const { GithubAuthService } = require('./github-auth-service')
 const { documentation, errorMessagesFor } = require('./github-helpers')
 
+const schema = Joi.object({
+  // https://stackoverflow.com/a/23969867/893113
+  status: Joi.equal('identical', 'ahead', 'behind', 'diverged'),
+}).required()
+
 module.exports = class GithubCommitStatus extends GithubAuthService {
   static get category() {
     return 'issue-tracking'
@@ -64,7 +69,7 @@ module.exports = class GithubCommitStatus extends GithubAuthService {
       ;({ status } = await this._requestJson({
         url: `/repos/${user}/${repo}/compare/${branch}...${commit}`,
         errorMessages: errorMessagesFor('commit or branch not found'),
-        schema: Joi.object().required(),
+        schema,
       }))
     } catch (e) {
       if (e instanceof NotFound) {

--- a/services/github/github-commit-status.tester.js
+++ b/services/github/github-commit-status.tester.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { invalidJSON } = require('../response-fixtures')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('commit status - commit in branch')
@@ -69,5 +68,5 @@ t.create('commit status - no common ancestor between commit and branch')
   .expectBadge({
     label: 'commit status',
     message: 'no common ancestor',
-    color: 'lightgrey',
+    color: 'red',
   })

--- a/services/github/github-commit-status.tester.js
+++ b/services/github/github-commit-status.tester.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const { invalidJSON } = require('../response-fixtures')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('commit status - commit in branch')
@@ -69,4 +70,23 @@ t.create('commit status - no common ancestor between commit and branch')
     label: 'commit status',
     message: 'no common ancestor',
     color: 'red',
+  })
+
+// Since the service is responsible for parsing its error response, this tests
+// the service, not BaseJsonService.
+t.create('commit status - 404 with invalid JSON form github')
+  .get(
+    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
+  )
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get(
+        '/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c'
+      )
+      .reply(404, invalidJSON)
+  )
+  .expectBadge({
+    label: 'commit status',
+    message: 'unparseable json response',
+    color: 'lightgrey',
   })

--- a/services/github/github-commit-status.tester.js
+++ b/services/github/github-commit-status.tester.js
@@ -39,7 +39,7 @@ t.create('commit status - commit not in branch')
   .expectBadge({
     label: 'commit status',
     message: 'commit or branch not found',
-    color: 'lightgrey',
+    color: 'red',
   })
 
 t.create('commit status - unknown commit id')
@@ -59,7 +59,7 @@ t.create('commit status - unknown branch')
   .expectBadge({
     label: 'commit status',
     message: 'commit or branch not found',
-    color: 'lightgrey',
+    color: 'red',
   })
 
 t.create('commit status - no common ancestor between commit and branch')
@@ -69,84 +69,5 @@ t.create('commit status - no common ancestor between commit and branch')
   .expectBadge({
     label: 'commit status',
     message: 'no common ancestor',
-    color: 'lightgrey',
-  })
-
-t.create('commit status - invalid JSON')
-  .get(
-    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
-  )
-  .intercept(nock =>
-    nock('https://api.github.com')
-      .get(
-        '/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c'
-      )
-      .reply(invalidJSON)
-  )
-  .expectBadge({
-    label: 'commit status',
-    message: 'invalid',
-    color: 'lightgrey',
-  })
-
-t.create('commit status - network error')
-  .get(
-    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
-  )
-  .networkOff()
-  .expectBadge({
-    label: 'commit status',
-    message: 'inaccessible',
-    color: 'red',
-  })
-
-t.create('commit status - github server error')
-  .get(
-    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
-  )
-  .intercept(nock =>
-    nock('https://api.github.com')
-      .get(
-        '/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c'
-      )
-      .reply(500)
-  )
-  .expectBadge({
-    label: 'commit status',
-    message: 'invalid',
-    color: 'lightgrey',
-  })
-
-t.create('commit status - 404 with empty JSON form github')
-  .get(
-    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
-  )
-  .intercept(nock =>
-    nock('https://api.github.com')
-      .get(
-        '/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c'
-      )
-      .reply(404, {})
-  )
-  .expectBadge({
-    label: 'commit status',
-    message: 'invalid',
-    color: 'lightgrey',
-  })
-
-t.create('commit status - 404 with invalid JSON form github')
-  .get(
-    '/badges/shields/master/5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c.json?style=_shields_test'
-  )
-  .intercept(nock =>
-    nock('https://api.github.com')
-      .get(
-        '/repos/badges/shields/compare/master...5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c'
-      )
-      .reply(404, invalidJSON)
-  )
-  .expectBadge({
-    label: 'commit status',
-    message: 'invalid',
     color: 'lightgrey',
   })


### PR DESCRIPTION
This decorates response errors with the response and response buffer, to make it easy for a service to parse an error response when it needs to. Since this is needed so rarely, I didn't put the error-parsing functionality in BaseJsonService, to save resources in the vast majority of cases.