### PR TITLE
Lengthen timeouts on [jsdelivr] tests

### DIFF
--- a/services/jsdelivr/jsdelivr-hits-github.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-github.tester.js
@@ -3,35 +3,40 @@
 const { isMetricOverTimePeriod } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('(live) jquery/jquery hits/day')
+t.create('jquery/jquery hits/day')
+  .timeout(5000)
   .get('/hd/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery/jquery hits/week')
+t.create('jquery/jquery hits/week')
+  .timeout(5000)
   .get('/hw/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery/jquery hits/month')
+t.create('jquery/jquery hits/month')
+  .timeout(5000)
   .get('/hm/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery/jquery hits/year')
+t.create('jquery/jquery hits/year')
+  .timeout(5000)
   .get('/hy/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) fake package')
+t.create('fake package')
+  .timeout(5000)
   .get('/hd/somefakepackage/somefakepackage.json')
   .expectBadge({
     label: 'jsdelivr',

--- a/services/jsdelivr/jsdelivr-hits-npm.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.tester.js
@@ -3,35 +3,40 @@
 const { isMetricOverTimePeriod } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('(live) jquery hits/day')
+t.create('jquery hits/day')
+  .timeout(5000)
   .get('/hd/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery hits/week')
+t.create('jquery hits/week')
+  .timeout(5000)
   .get('/hw/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery hits/month')
+t.create('jquery hits/month')
+  .timeout(5000)
   .get('/hm/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) jquery hits/year')
+t.create('jquery hits/year')
+  .timeout(5000)
   .get('/hy/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
-t.create('(live) fake package')
+t.create('fake package')
+  .timeout(5000)
   .get('/hd/somefakepackage.json')
   .expectBadge({
     label: 'jsdelivr',


### PR DESCRIPTION
These are failing pretty often in CI.