### PR TITLE
Fix [packagist] badges

### DIFF
--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -3,26 +3,6 @@
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
 
-const latestVersionSchema = Joi.object({
-  package: Joi.object({
-    versions: Joi.object({
-      'dev-master': Joi.object({
-        license: Joi.array().required(),
-        extra: Joi.object({
-          'branch-alias': Joi.object({
-            'dev-master': Joi.string().required(),
-          }).required(),
-        }),
-      }).required(),
-    }).required(),
-    downloads: Joi.object({
-      total: Joi.number().required(),
-      monthly: Joi.number().required(),
-      daily: Joi.number().required(),
-    }).required(),
-  }).required(),
-}).required()
-
 const allVersionsSchema = Joi.object({
   package: Joi.object({
     versions: Joi.object()
@@ -42,7 +22,7 @@ const allVersionsSchema = Joi.object({
 const keywords = ['PHP']
 
 class BasePackagistService extends BaseJsonService {
-  async fetch({ user, repo, schema = latestVersionSchema }) {
+  async fetch({ user, repo, schema }) {
     const url = `https://packagist.org/packages/${user}/${repo}.json`
 
     return this._requestJson({

--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -12,7 +12,7 @@ const latestVersionSchema = Joi.object({
           'branch-alias': Joi.object({
             'dev-master': Joi.string().required(),
           }).required(),
-        }).required(),
+        }),
       }).required(),
     }).required(),
     downloads: Joi.object({

--- a/services/packagist/packagist-downloads.service.js
+++ b/services/packagist/packagist-downloads.service.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const Joi = require('joi')
 const { metric } = require('../text-formatters')
 const { downloadCount } = require('../color-formatters')
 const { keywords, BasePackagistService } = require('./packagist-base')
@@ -19,6 +20,16 @@ const periodMap = {
   },
 }
 
+const schema = Joi.object({
+  package: Joi.object({
+    downloads: Joi.object({
+      total: Joi.number().required(),
+      monthly: Joi.number().required(),
+      daily: Joi.number().required(),
+    }).required(),
+  }).required(),
+}).required()
+
 module.exports = class PackagistDownloads extends BasePackagistService {
   static get route() {
     return {
@@ -36,7 +47,7 @@ module.exports = class PackagistDownloads extends BasePackagistService {
   async handle({ interval, user, repo }) {
     const {
       package: { downloads },
-    } = await this.fetch({ user, repo })
+    } = await this.fetch({ user, repo, schema })
 
     return this.constructor.render({
       downloads: downloads[periodMap[interval].field],

--- a/services/packagist/packagist-version.spec.js
+++ b/services/packagist/packagist-version.spec.js
@@ -1,20 +1,6 @@
 'use strict'
 
-const { expect } = require('chai')
-const { InvalidResponse } = require('..')
-const PackagistVersion = require('./packagist-version.service')
+// const { expect } = require('chai')
+// const PackagistVersion = require('./packagist-version.service')
 
-describe('PackagistVersion', function() {
-  it('throws InvalidResponse error when extra key is missing for vpre', function() {
-    try {
-      PackagistVersion.prototype.transform({
-        type: 'vpre',
-        json: { package: { versions: { 'dev-master': {} } } },
-      })
-      expect.fail('should have thrown')
-    } catch (e) {
-      expect(e).to.be.an.instanceof(InvalidResponse)
-      expect(e.prettyMessage).to.equal('prerelease version data not available')
-    }
-  })
-})
+describe('PackagistVersion', function() {})

--- a/services/packagist/packagist-version.spec.js
+++ b/services/packagist/packagist-version.spec.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { expect } = require('chai')
+const { InvalidResponse } = require('..')
+const PackagistVersion = require('./packagist-version.service')
+
+describe('PackagistVersion', function() {
+  it('throws InvalidResponse error when extra key is missing for vpre', function() {
+    try {
+      PackagistVersion.prototype.transform({
+        type: 'vpre',
+        json: { package: { versions: { 'dev-master': {} } } },
+      })
+      expect.fail('should have thrown')
+    } catch (e) {
+      expect(e).to.be.an.instanceof(InvalidResponse)
+      expect(e.prettyMessage).to.equal('prerelease version data not available')
+    }
+  })
+})

--- a/services/packagist/packagist-version.tester.js
+++ b/services/packagist/packagist-version.tester.js
@@ -1,6 +1,9 @@
 'use strict'
 
 const Joi = require('joi')
+const {
+  isVPlusDottedVersionNClausesWithOptionalSuffix,
+} = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 /*
@@ -22,3 +25,10 @@ t.create('version (valid)')
 t.create('version (invalid package name)')
   .get('/v/frodo/is-not-a-package.json')
   .expectBadge({ label: 'packagist', message: 'not found' })
+
+t.create('pre-release version (valid)')
+  .get('/vpre/symfony/symfony.json')
+  .expectBadge({
+    label: 'packagist',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+  })


### PR DESCRIPTION
Fix #3238 

- Moved definitions of schemas from base service class to their respective service classes (and simplified them accordingly), save for the one schema used in multiple places
- Updated version badge to re-add the logic used to properly select correct latest/pre version that existed in the legacy service implementation. I believe that when the legacy services were refactored that this was attempted to be handled within the schema, but that won't be able to cover all cases (as evident by the reported bugs)
- Added an additional live/integration test with packagist for a vpre badge

Note: some additional tests should be added in the future to cover some of the re-added logic in the transform function of the version badge service. However, I'd prefer to go ahead and merge this given the prod issues and add those new tests in a follow on