### PR TITLE
[pypi] Improve formatting of trove-based licenses

### DIFF
--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -57,12 +57,18 @@ function getLicenses(packageData) {
   if (license) {
     return [license]
   } else {
-    const acronymRegex = /\(([^)]+)\)/
+    const parenthesizedAcronymRegex = /\(([^)]+)\)/
+    const bareAcronymRegex = /^[a-z0-9]+$/
     let licenses = parseClassifiers(packageData, /^License :: (.+)$/)
       .map(classifier => classifier.split(' :: ').pop())
+      .map(license => license.replace(' license', ''))
       .map(license => {
-        const match = license.match(acronymRegex)
+        const match = license.match(parenthesizedAcronymRegex)
         return match ? match[1].toUpperCase() : license
+      })
+      .map(license => {
+        const match = license.match(bareAcronymRegex)
+        return match ? license.toUpperCase() : license
       })
     if (licenses.length > 1) {
       licenses = licenses.filter(l => l !== 'dfsg approved')

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -121,7 +121,7 @@ describe('PyPI helpers', function() {
           ],
         },
       }),
-    ]).expect(['mit license'])
+    ]).expect(['MIT'])
     given({
       info: {
         license: '',

--- a/services/pypi/pypi-license.tester.js
+++ b/services/pypi/pypi-license.tester.js
@@ -1,0 +1,55 @@
+'use strict'
+
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('license (valid, package version in request)')
+  .get('/requests/2.18.4.json')
+  .expectBadge({ label: 'license', message: 'Apache 2.0' })
+
+t.create('license (valid, no package version specified)')
+  .get('/requests.json')
+  .expectBadge({ label: 'license', message: 'Apache 2.0' })
+
+t.create('license (invalid)')
+  .get('/not-a-package.json')
+  .expectBadge({ label: 'license', message: 'package or version not found' })
+
+t.create('license (from trove classifier)')
+  .get('/mapi.json')
+  .intercept(nock =>
+    nock('https://pypi.org')
+      .get('/pypi/mapi/json')
+      .reply(200, {
+        info: {
+          version: '1.2.3',
+          license: '',
+          classifiers: ['License :: OSI Approved :: MIT License'],
+        },
+        releases: {},
+      })
+  )
+  .expectBadge({
+    label: 'license',
+    message: 'MIT',
+  })
+
+t.create('license (as acronym from trove classifier)')
+  .get('/magma.json')
+  .intercept(nock =>
+    nock('https://pypi.org')
+      .get('/pypi/magma/json')
+      .reply(200, {
+        info: {
+          version: '1.2.3',
+          license: '',
+          classifiers: [
+            'License :: OSI Approved :: GNU General Public License (GPL)',
+          ],
+        },
+        releases: {},
+      })
+  )
+  .expectBadge({
+    label: 'license',
+    message: 'GPL',
+  })

--- a/services/pypi/pypi.tester.js
+++ b/services/pypi/pypi.tester.js
@@ -97,60 +97,6 @@ t.create('no trove classifiers')
     message: 'v1.2.3',
   })
 
-// tests for license endpoint
-
-t.create('license (valid, package version in request)')
-  .get('/l/requests/2.18.4.json')
-  .expectBadge({ label: 'license', message: 'Apache 2.0' })
-
-t.create('license (valid, no package version specified)')
-  .get('/l/requests.json')
-  .expectBadge({ label: 'license', message: 'Apache 2.0' })
-
-t.create('license (invalid)')
-  .get('/l/not-a-package.json')
-  .expectBadge({ label: 'license', message: 'package or version not found' })
-
-t.create('license (from trove classifier)')
-  .get('/l/mapi.json')
-  .intercept(nock =>
-    nock('https://pypi.org')
-      .get('/pypi/mapi/json')
-      .reply(200, {
-        info: {
-          version: '1.2.3',
-          license: '',
-          classifiers: ['License :: OSI Approved :: MIT License'],
-        },
-        releases: {},
-      })
-  )
-  .expectBadge({
-    label: 'license',
-    message: 'mit license',
-  })
-
-t.create('license (as acronym from trove classifier)')
-  .get('/l/magma.json')
-  .intercept(nock =>
-    nock('https://pypi.org')
-      .get('/pypi/magma/json')
-      .reply(200, {
-        info: {
-          version: '1.2.3',
-          license: '',
-          classifiers: [
-            'License :: OSI Approved :: GNU General Public License (GPL)',
-          ],
-        },
-        releases: {},
-      })
-  )
-  .expectBadge({
-    label: 'license',
-    message: 'GPL',
-  })
-
 // tests for wheel endpoint
 
 t.create('wheel (has wheel, package version in request)')


### PR DESCRIPTION
Currently the trove-based license classifiers generate different formatting than the legacy license classifiers. This brings them into alignment.

Production:

![](https://img.shields.io/pypi/l/vg.svg?style=flat-square)

This PR:

![](https://img.shields.io/badge/license-BSD-lightgray.svg?style=flat-square)

Think this is a good improvement; more consistent with most other badges, and will look better on readmes (see https://github.com/lace/vg for an example).