### PR TITLE
In CI, run e2e tests on the build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,11 +313,15 @@ jobs:
           command: npm ci
 
       - run:
+          name: Frontend build
+          command: npm run build
+
+      - run:
           name: Run tests
           environment:
             CYPRESS_REPORTER: junit
             MOCHA_FILE: junit/e2e/results.xml
-          command: npm run e2e
+          command: npm run e2e-on-build
 
       - store_test_results:
           path: junit

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "prestart": "run-s --silent depcheck defs features",
     "start": "concurrently --names server,frontend \"npm run start:server\" \"cross-env GATSBY_BASE_URL=http://localhost:8080 gatsby develop --port 3000\"",
     "e2e": "start-server-and-test start http://localhost:3000 test:e2e",
+    "e2e-on-build": "CYPRESS_baseUrl=http://localhost:8080 start-server-and-test start:server http://localhost:8080 test:e2e",
     "refactoring-report": "node scripts/refactoring-cli.js",
     "badge": "cross-env NODE_CONFIG_ENV=test TRACE_SERVICES=true node scripts/badge-cli.js"
   },


### PR DESCRIPTION
Fixes https://github.com/badges/shields/issues/3267

`npm run e2e` still starts server using `npm run start`, which is convenient for development. 