### PR TITLE
[Node] tests improvements

### DIFF
--- a/services/node/node.tester.js
+++ b/services/node/node.tester.js
@@ -1,47 +1,46 @@
 'use strict'
 
 const { expect } = require('chai')
-const Joi = require('joi')
 const { Range } = require('semver')
 const t = (module.exports = require('../tester').createServiceTester())
 
-function expectSemverRange(value) {
-  expect(() => new Range(value)).not.to.throw()
+function expectSemverRange(message) {
+  expect(() => new Range(message)).not.to.throw()
 }
 
 t.create('gets the node version of passport')
   .get('/passport.json')
-  .expectBadge({ label: 'node', message: Joi.string() })
+  .expectBadge({ label: 'node' })
   .afterJSON(json => {
-    expectSemverRange(json.value)
+    expectSemverRange(json.message)
   })
 
 t.create('gets the node version of @stdlib/stdlib')
   .get('/@stdlib/stdlib.json')
-  .expectBadge({ label: 'node', message: Joi.string() })
+  .expectBadge({ label: 'node' })
   .afterJSON(json => {
-    expectSemverRange(json.value)
+    expectSemverRange(json.message)
   })
 
 t.create("gets the tagged release's node version version of ionic")
   .get('/ionic/next.json')
-  .expectBadge({ label: 'node@next', message: Joi.string() })
+  .expectBadge({ label: 'node@next' })
   .afterJSON(json => {
-    expectSemverRange(json.value)
+    expectSemverRange(json.message)
   })
 
 t.create('gets the node version of passport from a custom registry')
   .get('/passport.json?registry_uri=https://registry.npmjs.com')
-  .expectBadge({ label: 'node', message: Joi.string() })
+  .expectBadge({ label: 'node' })
   .afterJSON(json => {
-    expectSemverRange(json.value)
+    expectSemverRange(json.message)
   })
 
 t.create("gets the tagged release's node version of @cycle/core")
   .get('/@cycle/core/canary.json')
-  .expectBadge({ label: 'node@canary', message: Joi.string() })
+  .expectBadge({ label: 'node@canary' })
   .afterJSON(json => {
-    expectSemverRange(json.value)
+    expectSemverRange(json.message)
   })
 
 t.create('invalid package name')


### PR DESCRIPTION
Nothing much going on here:
* made the tests check for the `message` field rather than the deprecated `value` one.
* removed the useless _Joi.string()_ checks. I added them in 1f29c22d3dd47794da72254d2b8527dc0232fea2 due to the limitations of `expectBadge` at the time, but the helper now supports omitting any of the fields in the input.