### PR TITLE
Consolidate [NpmDownloads] into one service

### DIFF
--- a/services/npm/npm-downloads.spec.js
+++ b/services/npm/npm-downloads.spec.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const { test, given } = require('sazerac')
+const NpmDownloads = require('./npm-downloads.service')
+
+describe('NpmDownloads', function() {
+  test(NpmDownloads._intervalMap.dt.transform, () => {
+    given({
+      downloads: [
+        { downloads: 2, day: '2018-01-01' },
+        { downloads: 3, day: '2018-01-02' },
+      ],
+    }).expect(5)
+  })
+
+  test(NpmDownloads.render, () => {
+    given({
+      interval: 'dt',
+      downloadCount: 0,
+    }).expect({
+      message: '0',
+      color: 'red',
+    })
+  })
+})

--- a/services/npm/npm-downloads.tester.js
+++ b/services/npm/npm-downloads.tester.js
@@ -1,14 +1,19 @@
 'use strict'
 
-const { ServiceTester } = require('../tester')
-const { isMetric } = require('../test-validators')
+const { isMetricOverTimePeriod, isMetric } = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
 
-const t = new ServiceTester({
-  id: 'NpmDownloads',
-  title: 'NpmDownloads',
-  pathPrefix: '/npm',
-})
-module.exports = t
+t.create('weekly downloads of left-pad')
+  .get('/dw/left-pad.json')
+  .expectBadge({
+    label: 'downloads',
+    message: isMetricOverTimePeriod,
+    color: 'brightgreen',
+  })
+
+t.create('weekly downloads of @cycle/core')
+  .get('/dw/@cycle/core.json')
+  .expectBadge({ label: 'downloads', message: isMetricOverTimePeriod })
 
 t.create('total downloads of left-pad')
   .get('/dt/left-pad.json')
@@ -22,32 +27,7 @@ t.create('total downloads of @cycle/core')
   .get('/dt/@cycle/core.json')
   .expectBadge({ label: 'downloads', message: isMetric })
 
-t.create('total downloads of package with zero downloads')
-  .get('/dt/package-no-downloads.json')
-  .intercept(nock =>
-    nock('https://api.npmjs.org')
-      .get('/downloads/range/1000-01-01:3000-01-01/package-no-downloads')
-      .reply(200, {
-        downloads: [{ downloads: 0, day: '2018-01-01' }],
-      })
-  )
-  .expectBadge({ label: 'downloads', message: '0', color: 'red' })
-
-t.create('exact total downloads value')
-  .get('/dt/exact-value.json')
-  .intercept(nock =>
-    nock('https://api.npmjs.org')
-      .get('/downloads/range/1000-01-01:3000-01-01/exact-value')
-      .reply(200, {
-        downloads: [
-          { downloads: 2, day: '2018-01-01' },
-          { downloads: 3, day: '2018-01-02' },
-        ],
-      })
-  )
-  .expectBadge({ label: 'downloads', message: '5' })
-
-t.create('total downloads of unknown package')
+t.create('downloads of unknown package')
   .get('/dt/npm-api-does-not-have-this-package.json')
   .expectBadge({
     label: 'downloads',


### PR DESCRIPTION
This moves the four npm download services into a single class, in line with #3174, and other service implementations we've written in the last couple months. 
1. Change the suffixes from **/m** to **/month** for consistency.
2. Add tests of one of the intervals besides total.
3. Rewrite mocked service tests as unit tests.
4. Use (and work with) the `intervalMap` pattern that I think @calebcartwright started us using.
