### PR TITLE
add strictSSL query param toggle to [coverity]

### DIFF
--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -10,10 +10,6 @@ const schema = Joi.object({
     .required(),
 }).required()
 
-const queryParamSchema = Joi.object({
-  disableStrictSSL: Joi.equal(''),
-}).required()
-
 module.exports = class CoverityScan extends BaseJsonService {
   static render({ message }) {
     let color
@@ -48,7 +44,6 @@ module.exports = class CoverityScan extends BaseJsonService {
     return {
       base: 'coverity/scan',
       pattern: ':projectId',
-      queryParamSchema,
     }
   }
 
@@ -66,13 +61,13 @@ module.exports = class CoverityScan extends BaseJsonService {
     ]
   }
 
-  async handle({ projectId }, { disableStrictSSL }) {
+  async handle({ projectId }) {
     const url = `https://scan.coverity.com/projects/${projectId}/badge.json`
     const json = await this._requestJson({
       url,
       schema,
       options: {
-        strictSSL: disableStrictSSL === undefined,
+        strictSSL: false,
       },
       errorMessages: {
         // At the moment Coverity returns an HTTP 200 with an HTML page

--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -10,6 +10,10 @@ const schema = Joi.object({
     .required(),
 }).required()
 
+const queryParamSchema = Joi.object({
+  disableStrictSSL: Joi.equal(''),
+}).required()
+
 module.exports = class CoverityScan extends BaseJsonService {
   static render({ message }) {
     let color
@@ -44,6 +48,7 @@ module.exports = class CoverityScan extends BaseJsonService {
     return {
       base: 'coverity/scan',
       pattern: ':projectId',
+      queryParamSchema,
     }
   }
 
@@ -61,11 +66,14 @@ module.exports = class CoverityScan extends BaseJsonService {
     ]
   }
 
-  async handle({ projectId }) {
+  async handle({ projectId }, { disableStrictSSL }) {
     const url = `https://scan.coverity.com/projects/${projectId}/badge.json`
     const json = await this._requestJson({
       url,
       schema,
+      options: {
+        strictSSL: disableStrictSSL === undefined,
+      },
       errorMessages: {
         // At the moment Coverity returns an HTTP 200 with an HTML page
         // displaying the text 404 when project is not found.

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -4,19 +4,19 @@ const Joi = require('joi')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('live: known project id')
-  .get('/3997.json?disableStrictSSL')
+  .get('/3997.json')
   .expectBadge({
     label: 'coverity',
     message: Joi.string().regex(/passing|passed .* new defects|pending|failed/),
   })
 
 t.create('live: unknown project id')
-  .get('/abc.json?disableStrictSSL')
+  .get('/abc.json')
   // Coverity actually returns an HTTP 200 status with an HTML page when the project is not found.
   .expectBadge({ label: 'coverity', message: 'unparseable json response' })
 
 t.create('404 response')
-  .get('/1.json?disableStrictSSL')
+  .get('/1.json')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/1')
       .get('/badge.json')
@@ -25,7 +25,7 @@ t.create('404 response')
   .expectBadge({ label: 'coverity', message: 'project not found' })
 
 t.create('passed')
-  .get('/2.json?disableStrictSSL')
+  .get('/2.json')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -40,7 +40,7 @@ t.create('passed')
   })
 
 t.create('passed with defects')
-  .get('/2.json?disableStrictSSL')
+  .get('/2.json')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -55,7 +55,7 @@ t.create('passed with defects')
   })
 
 t.create('pending')
-  .get('/2.json?disableStrictSSL')
+  .get('/2.json')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -70,7 +70,7 @@ t.create('pending')
   })
 
 t.create('failed')
-  .get('/2.json?disableStrictSSL')
+  .get('/2.json')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -4,19 +4,19 @@ const Joi = require('joi')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('live: known project id')
-  .get('/3997.json')
+  .get('/3997.json?disableStrictSSL')
   .expectBadge({
     label: 'coverity',
     message: Joi.string().regex(/passing|passed .* new defects|pending|failed/),
   })
 
 t.create('live: unknown project id')
-  .get('/abc.json')
+  .get('/abc.json?disableStrictSSL')
   // Coverity actually returns an HTTP 200 status with an HTML page when the project is not found.
   .expectBadge({ label: 'coverity', message: 'unparseable json response' })
 
 t.create('404 response')
-  .get('/1.json')
+  .get('/1.json?disableStrictSSL')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/1')
       .get('/badge.json')
@@ -25,7 +25,7 @@ t.create('404 response')
   .expectBadge({ label: 'coverity', message: 'project not found' })
 
 t.create('passed')
-  .get('/2.json')
+  .get('/2.json?disableStrictSSL')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -40,7 +40,7 @@ t.create('passed')
   })
 
 t.create('passed with defects')
-  .get('/2.json')
+  .get('/2.json?disableStrictSSL')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -55,7 +55,7 @@ t.create('passed with defects')
   })
 
 t.create('pending')
-  .get('/2.json')
+  .get('/2.json?disableStrictSSL')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')
@@ -70,7 +70,7 @@ t.create('pending')
   })
 
 t.create('failed')
-  .get('/2.json')
+  .get('/2.json?disableStrictSSL')
   .intercept(nock =>
     nock('https://scan.coverity.com/projects/2')
       .get('/badge.json')


### PR DESCRIPTION
Close #3334 

As detailed in #3334, Coverity has a cert chain issue which prevents us from being able to render our Coverity badges (internally, we get `Inaccessible: unable to verify the first certificate` errors on cert chain issues, the badges render as `inaccessible`). We've seen this with a couple other services (or instances of self-hosted tools, like #1956)

Ideally the upstream providers would resolve, but our Coverity badge users have expressed understandable concern around the timeframe for if/when Coverity (Synopsys) would be able to resolve this. We receive the cert verification error on both Node 8.x and 10.x so I believe it's an issue that we'll need to address. 

This proposed solution adds a new a new query param `disableStrictSSL` that will allow the user to opt-in to disabling the strict ssl check, thus re-enabling Coverity badges. It's the same solution we seem to be going with for [Jenkins](https://github.com/badges/shields/pull/3302#discussion_r276838069)

Default behavior (strict ssl check enabled per `request`'s defaults):
https://shields-staging-pr-3336.herokuapp.com/coverity/scan/3997.svg
![](https://shields-staging-pr-3336.herokuapp.com/coverity/scan/3997.svg)

https://shields-staging-pr-3336.herokuapp.com/coverity/scan/3997.svg?disableStrictSSL
![](https://shields-staging-pr-3336.herokuapp.com/coverity/scan/3997.svg?disableStrictSSL)