### PR TITLE
Unify order of properties and methods in services

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,6 +17,7 @@ overrides:
     parserOptions:
       sourceType: 'module'
   - files:
+      - 'core/base-service/**/*.js'
       - 'services/**/*.js'
     rules:
       sort-class-members/sort-class-members:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -12,10 +12,33 @@ parserOptions:
   sourceType: 'script'
 
 overrides:
-  files:
-    - gatsby-browser.js
-  parserOptions:
-    sourceType: 'module'
+  - files:
+      - gatsby-browser.js
+    parserOptions:
+      sourceType: 'module'
+  - files:
+      - 'services/**/*.js'
+    rules:
+      sort-class-members/sort-class-members:
+        [
+          'warn',
+          {
+            order:
+              [
+                'name',
+                'category',
+                'isDeprecated',
+                'route',
+                'examples',
+                'defaultBadgeData',
+                'render',
+                'constructor',
+                'fetch',
+                'transform',
+                'handle',
+              ],
+          },
+        ]
 
 plugins:
   - mocha
@@ -48,26 +71,6 @@ rules:
   func-style: ['error', 'declaration', { 'allowArrowFunctions': true }]
   new-cap: ['error', { 'capIsNew': true }]
   import/order: ['error', { 'newlines-between': 'never' }]
-  sort-class-members/sort-class-members:
-    [
-      'warn',
-      {
-        order:
-          [
-            'name',
-            'category',
-            'isDeprecated',
-            'route',
-            'examples',
-            'defaultBadgeData',
-            'render',
-            'constructor',
-            'fetch',
-            'transform',
-            'handle',
-          ],
-      },
-    ]
 
   # Mocha-related.
   mocha/no-exclusive-tests: 'error'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -20,7 +20,8 @@ overrides:
 plugins:
   - mocha
   - no-extension-in-require
-  - 'chai-friendly'
+  - chai-friendly
+  - sort-class-members
 
 rules:
   # Disable some rules from eslint:recommended.
@@ -47,6 +48,26 @@ rules:
   func-style: ['error', 'declaration', { 'allowArrowFunctions': true }]
   new-cap: ['error', { 'capIsNew': true }]
   import/order: ['error', { 'newlines-between': 'never' }]
+  sort-class-members/sort-class-members:
+    [
+      'warn',
+      {
+        order:
+          [
+            'name',
+            'category',
+            'isDeprecated',
+            'route',
+            'examples',
+            'defaultBadgeData',
+            'render',
+            'constructor',
+            'fetch',
+            'transform',
+            'handle',
+          ],
+      },
+    ]
 
   # Mocha-related.
   mocha/no-exclusive-tests: 'error'

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -25,22 +25,16 @@ const queryParamSchema = Joi.object({
   .required()
 
 class DummyService extends BaseService {
-  static render({ namedParamA, queryParamA }) {
-    return {
-      message: `Hello namedParamA: ${namedParamA} with queryParamA: ${queryParamA}`,
-    }
-  }
-
-  async handle({ namedParamA }, { queryParamA }) {
-    return this.constructor.render({ namedParamA, queryParamA })
-  }
-
   static get category() {
     return 'other'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'cat', namedLogo: 'appveyor' }
+  static get route() {
+    return {
+      base: 'foo',
+      pattern: ':namedParamA',
+      queryParamSchema,
+    }
   }
 
   static get examples() {
@@ -54,12 +48,18 @@ class DummyService extends BaseService {
     ]
   }
 
-  static get route() {
+  static get defaultBadgeData() {
+    return { label: 'cat', namedLogo: 'appveyor' }
+  }
+
+  static render({ namedParamA, queryParamA }) {
     return {
-      base: 'foo',
-      pattern: ':namedParamA',
-      queryParamSchema,
+      message: `Hello namedParamA: ${namedParamA} with queryParamA: ${queryParamA}`,
     }
+  }
+
+  async handle({ namedParamA }, { queryParamA }) {
+    return this.constructor.render({ namedParamA, queryParamA })
   }
 }
 

--- a/core/base-service/deprecated-service.js
+++ b/core/base-service/deprecated-service.js
@@ -38,20 +38,20 @@ function deprecatedService(attrs) {
       return category
     }
 
-    static get route() {
-      return route
-    }
-
     static get isDeprecated() {
       return true
     }
 
-    static get defaultBadgeData() {
-      return { label }
+    static get route() {
+      return route
     }
 
     static get examples() {
       return examples
+    }
+
+    static get defaultBadgeData() {
+      return { label }
     }
 
     async handle() {

--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -40,18 +40,6 @@ module.exports = function redirector(attrs) {
   } = Joi.attempt(attrs, attrSchema, `Redirector for ${attrs.route.base}`)
 
   return class Redirector extends BaseService {
-    static get category() {
-      return category
-    }
-
-    static get route() {
-      return route
-    }
-
-    static get isDeprecated() {
-      return true
-    }
-
     static get name() {
       if (name) {
         return name
@@ -60,6 +48,18 @@ module.exports = function redirector(attrs) {
           pascalCase: true,
         })}Redirect`
       }
+    }
+
+    static get category() {
+      return category
+    }
+
+    static get isDeprecated() {
+      return true
+    }
+
+    static get route() {
+      return route
     }
 
     static register({ camp, requestCounter }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8977,6 +8977,12 @@
       "integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
       "dev": true
     },
+    "eslint-plugin-sort-class-members": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.4.0.tgz",
+      "integrity": "sha512-FQG6d4Cy2vYmG9gr6J138E91WaltqwOk/b/7GCssPqnUmizrcgOeN91bV5eOTuoS4RSH1Jdn4ukWEtyWLwV8ig==",
+      "dev": true
+    },
     "eslint-plugin-standard": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "eslint-plugin-promise": "^4.1.1",
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
+    "eslint-plugin-sort-class-members": "^1.4.0",
     "eslint-plugin-standard": "^4.0.0",
     "fetch-ponyfill": "^6.0.0",
     "fs-readfile-promise": "^3.0.1",

--- a/services/amo/amo-base.js
+++ b/services/amo/amo-base.js
@@ -18,15 +18,15 @@ const schema = Joi.object({
 }).required()
 
 class BaseAmoService extends BaseJsonService {
+  static get defaultBadgeData() {
+    return { label: 'mozilla add-on' }
+  }
+
   async fetch({ addonId }) {
     return this._requestJson({
       schema,
       url: `https://addons.mozilla.org/api/v3/addons/addon/${addonId}`,
     })
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'mozilla add-on' }
   }
 }
 

--- a/services/conda/conda-base.js
+++ b/services/conda/conda-base.js
@@ -19,14 +19,14 @@ const condaSchema = Joi.object({
 }).required()
 
 module.exports = class BaseCondaService extends BaseJsonService {
+  static get defaultBadgeData() {
+    return { label: 'conda' }
+  }
+
   async fetch({ channel, pkg }) {
     return this._requestJson({
       schema: condaSchema,
       url: `https://api.anaconda.org/package/${channel}/${pkg}`,
     })
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'conda' }
   }
 }

--- a/services/github/github-downloads.service.js
+++ b/services/github/github-downloads.service.js
@@ -1,21 +1,30 @@
 'use strict'
 
-const LegacyService = require('../legacy-service')
-const { makeBadgeData: getBadgeData } = require('../../lib/badge-data')
-const { makeLogo: getLogo } = require('../../lib/logos')
+const Joi = require('joi')
+const { NotFound } = require('..')
 const { metric } = require('../text-formatters')
-const {
-  documentation,
-  checkErrorResponse: githubCheckErrorResponse,
-} = require('./github-helpers')
+const { nonNegativeInteger } = require('../validators')
+const { downloadCount: downloadCountColor } = require('../color-formatters')
+const { GithubAuthService } = require('./github-auth-service')
+const { documentation, errorMessagesFor } = require('./github-helpers')
 
-// This legacy service should be rewritten to use e.g. BaseJsonService.
-//
-// Tips for rewriting:
-// https://github.com/badges/shields/blob/master/doc/rewriting-services.md
-//
-// Do not base new services on this code.
-module.exports = class GithubDownloads extends LegacyService {
+const releaseSchema = Joi.object({
+  assets: Joi.array()
+    .items({
+      name: Joi.string().required(),
+      download_count: nonNegativeInteger,
+    })
+    .required(),
+}).required()
+
+const releaseArraySchema = Joi.alternatives().try(
+  Joi.array().items(releaseSchema),
+  Joi.array().length(0)
+)
+
+const keywords = ['github download']
+
+module.exports = class GithubDownloads extends GithubAuthService {
   static get category() {
     return 'downloads'
   }
@@ -23,7 +32,7 @@ module.exports = class GithubDownloads extends LegacyService {
   static get route() {
     return {
       base: 'github',
-      pattern: '',
+      pattern: ':kind(downloads|downloads-pre)/:user/:repo/:tag*/:assetName',
     }
   }
 
@@ -36,12 +45,12 @@ module.exports = class GithubDownloads extends LegacyService {
           user: 'atom',
           repo: 'atom',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '857k total',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          assetName: 'total',
+          downloadCount: 857000,
+        }),
         documentation,
+        keywords,
       },
       {
         title: 'GitHub Releases',
@@ -51,12 +60,13 @@ module.exports = class GithubDownloads extends LegacyService {
           repo: 'atom',
           tag: 'latest',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '27k',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          tag: 'latest',
+          assetName: 'total',
+          downloadCount: 27000,
+        }),
         documentation,
+        keywords,
       },
       {
         title: 'GitHub Pre-Releases',
@@ -66,12 +76,13 @@ module.exports = class GithubDownloads extends LegacyService {
           repo: 'atom',
           tag: 'latest',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '2k',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          tag: 'latest',
+          assetName: 'total',
+          downloadCount: 2000,
+        }),
         documentation,
+        keywords,
       },
       {
         title: 'GitHub Releases (by Release)',
@@ -81,12 +92,13 @@ module.exports = class GithubDownloads extends LegacyService {
           repo: 'atom',
           tag: 'v0.190.0',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '490k v0.190.0',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          tag: 'v0.190.0',
+          assetName: 'total',
+          downloadCount: 490000,
+        }),
         documentation,
+        keywords,
       },
       {
         title: 'GitHub Releases (by Asset)',
@@ -97,12 +109,13 @@ module.exports = class GithubDownloads extends LegacyService {
           tag: 'latest',
           path: 'atom-amd64.deb',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '3k [atom-amd64.deb]',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          tag: 'latest',
+          assetName: 'atom-amd64.deb',
+          downloadCount: 3000,
+        }),
         documentation,
+        keywords,
       },
       {
         title: 'GitHub Pre-Releases (by Asset)',
@@ -113,119 +126,96 @@ module.exports = class GithubDownloads extends LegacyService {
           tag: 'latest',
           path: 'atom-amd64.deb',
         },
-        staticPreview: {
-          label: 'downloads',
-          message: '237 [atom-amd64.deb]',
-          color: 'brightgreen',
-        },
+        staticPreview: this.render({
+          tag: 'latest',
+          assetName: 'atom-amd64.deb',
+          downloadCount: 237,
+        }),
         documentation,
+        keywords,
       },
     ]
   }
 
-  static registerLegacyRouteHandler({ camp, cache, githubApiProvider }) {
-    camp.route(
-      /^\/github\/(downloads|downloads-pre)\/([^/]+)\/([^/]+)(\/.+)?\/([^/]+)\.(svg|png|gif|jpg|json)$/,
-      cache((data, match, sendBadge, request) => {
-        const type = match[1] // downloads or downloads-pre
-        const user = match[2] // eg, qubyte/rubidium
-        const repo = match[3]
+  static get defaultBadgeData() {
+    return {
+      label: 'downloads',
+      namedLogo: 'github',
+    }
+  }
 
-        let tag = match[4] // eg, v0.190.0, latest, null if querying all releases
-        const assetName = match[5].toLowerCase() // eg. total, atom-amd64.deb, atom.x86_64.rpm
-        const format = match[6]
+  static render({ tag, assetName, downloadCount }) {
+    return {
+      label: tag ? `downloads@${tag}` : 'downloads',
+      message:
+        assetName === 'total'
+          ? metric(downloadCount)
+          : `${metric(downloadCount)} [${assetName}]`,
+      color: downloadCountColor(downloadCount),
+    }
+  }
 
-        if (tag) {
-          tag = tag.slice(1)
-        }
+  static transform({ releases, assetName }) {
+    const downloadCount = releases.reduce((accum1, { assets }) => {
+      const filteredAssets =
+        assetName === 'total'
+          ? assets
+          : assets.filter(({ name }) => name.toLowerCase() === assetName)
+      return (
+        accum1 +
+        filteredAssets.reduce(
+          (accum2, { download_count: downloadCount }) => accum2 + downloadCount,
+          0
+        )
+      )
+    }, 0)
+    return { downloadCount }
+  }
 
-        let total = true
-        if (tag) {
-          total = false
-        }
-
-        let apiUrl = `/repos/${user}/${repo}/releases`
-        if (!total) {
-          const releasePath =
-            tag === 'latest'
-              ? type === 'downloads'
-                ? 'latest'
-                : ''
-              : `tags/${tag}`
-          if (releasePath) {
-            apiUrl = `${apiUrl}/${releasePath}`
-          }
-        } else {
-          apiUrl = `${apiUrl}?per_page=500`
-        }
-
-        const badgeData = getBadgeData('downloads', data)
-        if (badgeData.template === 'social') {
-          badgeData.logo = getLogo('github', data)
-        }
-        githubApiProvider.request(request, apiUrl, {}, (err, res, buffer) => {
-          if (
-            githubCheckErrorResponse(
-              badgeData,
-              err,
-              res,
-              'repo or release not found'
-            )
-          ) {
-            sendBadge(format, badgeData)
-            return
-          }
-          try {
-            let data = JSON.parse(buffer)
-            if (type === 'downloads-pre' && tag === 'latest') {
-              data = data[0]
-            }
-            let downloads = 0
-
-            const labelWords = []
-            if (total) {
-              data.forEach(tagData => {
-                tagData.assets.forEach(asset => {
-                  if (
-                    assetName === 'total' ||
-                    assetName === asset.name.toLowerCase()
-                  ) {
-                    downloads += asset.download_count
-                  }
-                })
-              })
-
-              labelWords.push('total')
-              if (assetName !== 'total') {
-                labelWords.push(`[${assetName}]`)
-              }
-            } else {
-              data.assets.forEach(asset => {
-                if (
-                  assetName === 'total' ||
-                  assetName === asset.name.toLowerCase()
-                ) {
-                  downloads += asset.download_count
-                }
-              })
-
-              if (tag !== 'latest') {
-                labelWords.push(tag)
-              }
-              if (assetName !== 'total') {
-                labelWords.push(`[${assetName}]`)
-              }
-            }
-            labelWords.unshift(metric(downloads))
-            badgeData.text[1] = labelWords.join(' ')
-            badgeData.colorscheme = 'brightgreen'
-            sendBadge(format, badgeData)
-          } catch (e) {
-            badgeData.text[1] = 'none'
-            sendBadge(format, badgeData)
-          }
-        })
+  async handle({ kind, user, repo, tag, assetName }) {
+    let releases
+    if (tag === 'latest' && kind === 'downloads') {
+      const latestRelease = await this._requestJson({
+        schema: releaseSchema,
+        url: `/repos/${user}/${repo}/releases/latest`,
+        errorMessages: errorMessagesFor('repo not found'),
       })
-    )
+      releases = [latestRelease]
+    } else if (tag === 'latest') {
+      // Keep only the latest release.
+      const [latestReleaseIncludingPrereleases] = await this._requestJson({
+        schema: releaseArraySchema,
+        url: `/repos/${user}/${repo}/releases`,
+        options: { qs: { per_page: 1 } },
+        errorMessages: errorMessagesFor('repo not found'),
+      })
+      releases = [latestReleaseIncludingPrereleases]
+    } else if (tag) {
+      const wantedRelease = await this._requestJson({
+        schema: releaseSchema,
+        url: `/repos/${user}/${repo}/releases/tags/${tag}`,
+        errorMessages: errorMessagesFor('repo or release not found'),
+      })
+      releases = [wantedRelease]
+    } else {
+      const allReleases = await this._requestJson({
+        schema: releaseArraySchema,
+        url: `/repos/${user}/${repo}/releases`,
+        options: { qs: { per_page: 500 } },
+        errorMessages: errorMessagesFor('repo not found'),
+      })
+      releases = allReleases
+    }
+
+    if (releases.length === 0) {
+      throw new NotFound({ prettyMessage: 'no releases' })
+    }
+
+    const { downloadCount } = this.constructor.transform({
+      releases,
+      assetName,
+    })
+
+    return this.constructor.render({ tag, assetName, downloadCount })
   }
 }

--- a/services/github/github-downloads.tester.js
+++ b/services/github/github-downloads.tester.js
@@ -6,69 +6,67 @@ const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('Downloads all releases')
   .get('/downloads/photonstorm/phaser/total.json')
-  .expectBadge({
-    label: 'downloads',
-    message: Joi.string().regex(/^\w+\s+total$/),
-  })
+  .expectBadge({ label: 'downloads', message: isMetric })
+
+t.create('Downloads all releases (no releases)')
+  .get('/downloads/badges/shields/total.json')
+  .expectBadge({ label: 'downloads', message: 'no releases' })
+
+t.create('Downloads-pre all releases (no releases)')
+  .get('/downloads-pre/badges/shields/total.json')
+  .expectBadge({ label: 'downloads', message: 'no releases' })
 
 t.create('Downloads all releases (repo not found)')
   .get('/downloads/badges/helmets/total.json')
-  .expectBadge({
-    label: 'downloads',
-    message: 'repo or release not found',
-  })
+  .expectBadge({ label: 'downloads', message: 'repo not found' })
+
+t.create('Downloads-pre all releases (repo not found)')
+  .get('/downloads-pre/badges/helmets/total.json')
+  .expectBadge({ label: 'downloads', message: 'repo not found' })
 
 t.create('downloads for latest release')
   .get('/downloads/photonstorm/phaser/latest/total.json')
-  .expectBadge({ label: 'downloads', message: isMetric })
+  .expectBadge({ label: 'downloads@latest', message: isMetric })
 
 t.create('downloads-pre for latest release')
   .get('/downloads-pre/photonstorm/phaser/latest/total.json')
-  .expectBadge({ label: 'downloads', message: isMetric })
+  .expectBadge({ label: 'downloads@latest', message: isMetric })
 
 t.create('downloads for release without slash')
   .get('/downloads/atom/atom/v0.190.0/total.json')
-  .expectBadge({
-    label: 'downloads',
-    message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? v0\.190\.0$/),
-  })
+  .expectBadge({ label: 'downloads@v0.190.0', message: isMetric })
 
 t.create('downloads for specific asset without slash')
   .get('/downloads/atom/atom/v0.190.0/atom-amd64.deb.json')
   .expectBadge({
-    label: 'downloads',
-    message: Joi.string().regex(
-      /^[0-9]+[kMGTPEZY]? v0\.190\.0 \[atom-amd64\.deb\]$/
-    ),
+    label: 'downloads@v0.190.0',
+    message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? \[atom-amd64\.deb\]$/),
   })
 
 t.create('downloads for specific asset from latest release')
   .get('/downloads/atom/atom/latest/atom-amd64.deb.json')
   .expectBadge({
-    label: 'downloads',
+    label: 'downloads@latest',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? \[atom-amd64\.deb\]$/),
   })
 
 t.create('downloads-pre for specific asset from latest release')
   .get('/downloads-pre/atom/atom/latest/atom-amd64.deb.json')
   .expectBadge({
-    label: 'downloads',
+    label: 'downloads@latest',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? \[atom-amd64\.deb\]$/),
   })
 
 t.create('downloads for release with slash')
   .get('/downloads/NHellFire/dban/stable/v2.2.8/total.json')
-  .expectBadge({
-    label: 'downloads',
-    message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? stable\/v2\.2\.8$/),
-  })
+  .expectBadge({ label: 'downloads@stable/v2.2.8', message: isMetric })
 
 t.create('downloads for specific asset with slash')
   .get('/downloads/NHellFire/dban/stable/v2.2.8/dban-2.2.8_i586.iso.json')
   .expectBadge({
-    label: 'downloads',
+    label: 'downloads@stable/v2.2.8',
     message: Joi.string().regex(
-      /^[0-9]+[kMGTPEZY]? stable\/v2\.2\.8 \[dban-2\.2\.8_i586\.iso\]$/
+      /^[0-9]+[kMGTPEZY]? \[dban-2\.2\.8_i586\.iso\]$/
     ),
   })
 

--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -33,12 +33,6 @@ class PowershellGalleryPlatformSupport extends BaseXmlService {
     return 'platform-support'
   }
 
-  static get defaultBadgeData() {
-    return {
-      label: 'platform',
-    }
-  }
-
   static get route() {
     return {
       base: 'powershellgallery/p',
@@ -56,6 +50,12 @@ class PowershellGalleryPlatformSupport extends BaseXmlService {
         }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'platform',
+    }
   }
 
   static render({ platforms }) {

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -22,10 +22,6 @@ module.exports = class PubVersion extends BaseJsonService {
     }
   }
 
-  static get defaultBadgeData() {
-    return { label: 'pub' }
-  }
-
   static get examples() {
     return [
       {
@@ -43,6 +39,10 @@ module.exports = class PubVersion extends BaseJsonService {
         keywords: ['dart', 'dartlang'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'pub' }
   }
 
   async fetch({ packageName }) {

--- a/services/puppetforge/puppetforge-module-version.service.js
+++ b/services/puppetforge/puppetforge-module-version.service.js
@@ -15,10 +15,6 @@ module.exports = class PuppetforgeModuleVersion extends BasePuppetForgeModulesSe
     }
   }
 
-  static get defaultBadgeData() {
-    return { label: 'puppetforge' }
-  }
-
   static get examples() {
     return [
       {
@@ -30,6 +26,10 @@ module.exports = class PuppetforgeModuleVersion extends BasePuppetForgeModulesSe
         staticPreview: renderVersionBadge({ version: '1.3.3' }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'puppetforge' }
   }
 
   async handle({ user, moduleName }) {

--- a/services/puppetforge/puppetforge-user-module-count.service.js
+++ b/services/puppetforge/puppetforge-user-module-count.service.js
@@ -9,10 +9,6 @@ module.exports = class PuppetForgeModuleCountService extends BasePuppetForgeUser
     return 'other'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'modules' }
-  }
-
   static get route() {
     return {
       base: 'puppetforge/mc',
@@ -32,9 +28,8 @@ module.exports = class PuppetForgeModuleCountService extends BasePuppetForgeUser
     ]
   }
 
-  async handle({ user }) {
-    const data = await this.fetch({ user })
-    return this.constructor.render({ modules: data.module_count })
+  static get defaultBadgeData() {
+    return { label: 'modules' }
   }
 
   static render({ modules }) {
@@ -42,5 +37,10 @@ module.exports = class PuppetForgeModuleCountService extends BasePuppetForgeUser
       message: metric(modules),
       color: floorCountColor(modules, 5, 10, 50),
     }
+  }
+
+  async handle({ user }) {
+    const data = await this.fetch({ user })
+    return this.constructor.render({ modules: data.module_count })
   }
 }

--- a/services/puppetforge/puppetforge-user-release-count.service.js
+++ b/services/puppetforge/puppetforge-user-release-count.service.js
@@ -15,6 +15,7 @@ module.exports = class PuppetForgeReleaseCountService extends BasePuppetForgeUse
       pattern: ':user',
     }
   }
+
   static get examples() {
     return [
       {

--- a/services/puppetforge/puppetforge-user-release-count.service.js
+++ b/services/puppetforge/puppetforge-user-release-count.service.js
@@ -9,17 +9,12 @@ module.exports = class PuppetForgeReleaseCountService extends BasePuppetForgeUse
     return 'other'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'releases' }
-  }
-
   static get route() {
     return {
       base: 'puppetforge/rc',
       pattern: ':user',
     }
   }
-
   static get examples() {
     return [
       {
@@ -32,9 +27,8 @@ module.exports = class PuppetForgeReleaseCountService extends BasePuppetForgeUse
     ]
   }
 
-  async handle({ user }) {
-    const data = await this.fetch({ user })
-    return this.constructor.render({ releases: data.release_count })
+  static get defaultBadgeData() {
+    return { label: 'releases' }
   }
 
   static render({ releases }) {
@@ -42,5 +36,10 @@ module.exports = class PuppetForgeReleaseCountService extends BasePuppetForgeUse
       message: metric(releases),
       color: floorCountColor(releases, 10, 50, 100),
     }
+  }
+
+  async handle({ user }) {
+    const data = await this.fetch({ user })
+    return this.constructor.render({ releases: data.release_count })
   }
 }

--- a/services/pypi/pypi-djversions.service.js
+++ b/services/pypi/pypi-djversions.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiDjangoVersions extends PypiBase {
     return this.buildRoute('pypi/djversions')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'django versions' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiDjangoVersions extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'django versions' }
   }
 
   static render({ versions }) {

--- a/services/pypi/pypi-downloads.service.js
+++ b/services/pypi/pypi-downloads.service.js
@@ -34,33 +34,6 @@ const periodMap = {
 // this badge uses PyPI Stats instead of the PyPI API
 // so it doesn't extend PypiBase
 module.exports = class PypiDownloads extends BaseJsonService {
-  async fetch({ packageName }) {
-    return this._requestJson({
-      url: `https://pypistats.org/api/packages/${packageName.toLowerCase()}/recent`,
-      schema,
-      errorMessages: { 404: 'package not found' },
-    })
-  }
-
-  static render({ period, downloads }) {
-    return {
-      message: `${metric(downloads)}${periodMap[period].suffix}`,
-      color: downloadCount(downloads),
-    }
-  }
-
-  async handle({ period, packageName }) {
-    const json = await this.fetch({ packageName })
-    return this.constructor.render({
-      period,
-      downloads: json.data[periodMap[period].api_field],
-    })
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'downloads' }
-  }
-
   static get category() {
     return 'downloads'
   }
@@ -84,5 +57,32 @@ module.exports = class PypiDownloads extends BaseJsonService {
         keywords,
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'downloads' }
+  }
+
+  static render({ period, downloads }) {
+    return {
+      message: `${metric(downloads)}${periodMap[period].suffix}`,
+      color: downloadCount(downloads),
+    }
+  }
+
+  async fetch({ packageName }) {
+    return this._requestJson({
+      url: `https://pypistats.org/api/packages/${packageName.toLowerCase()}/recent`,
+      schema,
+      errorMessages: { 404: 'package not found' },
+    })
+  }
+
+  async handle({ period, packageName }) {
+    const json = await this.fetch({ packageName })
+    return this.constructor.render({
+      period,
+      downloads: json.data[periodMap[period].api_field],
+    })
   }
 }

--- a/services/pypi/pypi-format.service.js
+++ b/services/pypi/pypi-format.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiFormat extends PypiBase {
     return this.buildRoute('pypi/format')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'format' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiFormat extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'format' }
   }
 
   static render({ hasWheel, hasEgg }) {

--- a/services/pypi/pypi-implementation.service.js
+++ b/services/pypi/pypi-implementation.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiImplementation extends PypiBase {
     return this.buildRoute('pypi/implementation')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'implementation' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiImplementation extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'implementation' }
   }
 
   static render({ implementations }) {

--- a/services/pypi/pypi-pyversions.service.js
+++ b/services/pypi/pypi-pyversions.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiPythonVersions extends PypiBase {
     return this.buildRoute('pypi/pyversions')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'python' }
-  }
-
   static get examples() {
     return [
       {
@@ -25,6 +21,10 @@ module.exports = class PypiPythonVersions extends PypiBase {
         staticPreview: this.render({ versions: ['3.5', '3.6', '3.7'] }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'python' }
   }
 
   static render({ versions }) {

--- a/services/pypi/pypi-status.service.js
+++ b/services/pypi/pypi-status.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiStatus extends PypiBase {
     return this.buildRoute('pypi/status')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'status' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiStatus extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'status' }
   }
 
   static render({ status = '' }) {

--- a/services/pypi/pypi-version.service.js
+++ b/services/pypi/pypi-version.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiVersion extends PypiBase {
     return this.buildRoute('pypi/v')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'pypi' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiVersion extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'pypi' }
   }
 
   static render({ version }) {

--- a/services/pypi/pypi-wheel.service.js
+++ b/services/pypi/pypi-wheel.service.js
@@ -12,10 +12,6 @@ module.exports = class PypiWheel extends PypiBase {
     return this.buildRoute('pypi/wheel')
   }
 
-  static get defaultBadgeData() {
-    return { label: 'wheel' }
-  }
-
   static get examples() {
     return [
       {
@@ -26,6 +22,10 @@ module.exports = class PypiWheel extends PypiBase {
         keywords: ['python'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'wheel' }
   }
 
   static render({ hasWheel }) {

--- a/services/redmine/redmine.service.js
+++ b/services/redmine/redmine.service.js
@@ -14,17 +14,17 @@ const schema = Joi.object({
 })
 
 class BaseRedminePluginRating extends BaseXmlService {
-  async fetch({ plugin }) {
-    const url = `https://www.redmine.org/plugins/${plugin}.xml`
-    return this._requestXml({ schema, url })
-  }
-
   static get category() {
     return 'rating'
   }
 
   static render({ rating }) {
     throw new Error(`render() function not implemented for ${this.name}`)
+  }
+
+  async fetch({ plugin }) {
+    const url = `https://www.redmine.org/plugins/${plugin}.xml`
+    return this._requestXml({ schema, url })
   }
 
   async handle({ plugin }) {
@@ -42,10 +42,6 @@ class RedminePluginRating extends BaseRedminePluginRating {
     }
   }
 
-  static get defaultBadgeData() {
-    return { label: 'redmine' }
-  }
-
   static get examples() {
     return [
       {
@@ -54,6 +50,10 @@ class RedminePluginRating extends BaseRedminePluginRating {
         staticPreview: this.render({ rating: 5 }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'redmine' }
   }
 
   static render({ rating }) {

--- a/services/requires/requires.service.js
+++ b/services/requires/requires.service.js
@@ -8,47 +8,15 @@ const statusSchema = Joi.object({
 }).required()
 
 module.exports = class RequiresIo extends BaseJsonService {
+  static get category() {
+    return 'dependencies'
+  }
+
   static get route() {
     return {
       base: 'requires',
       pattern: ':service/:user/:repo/:branch*',
     }
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'requirements' }
-  }
-
-  async handle({ service, user, repo, branch }) {
-    const { status } = await this.fetch({ service, user, repo, branch })
-    return this.constructor.render({ status })
-  }
-
-  async fetch({ service, user, repo, branch }) {
-    const url = `https://requires.io/api/v1/status/${service}/${user}/${repo}`
-    return this._requestJson({
-      url,
-      schema: statusSchema,
-      options: { qs: { branch } },
-    })
-  }
-
-  static render({ status }) {
-    let message = status
-    let color = 'lightgrey'
-    if (status === 'up-to-date') {
-      message = 'up to date'
-      color = 'brightgreen'
-    } else if (status === 'outdated') {
-      color = 'yellow'
-    } else if (status === 'insecure') {
-      color = 'red'
-    }
-    return { message, color }
-  }
-
-  static get category() {
-    return 'dependencies'
   }
 
   static get examples() {
@@ -71,5 +39,37 @@ module.exports = class RequiresIo extends BaseJsonService {
         staticPreview: this.render({ status: 'up-to-date' }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'requirements' }
+  }
+
+  static render({ status }) {
+    let message = status
+    let color = 'lightgrey'
+    if (status === 'up-to-date') {
+      message = 'up to date'
+      color = 'brightgreen'
+    } else if (status === 'outdated') {
+      color = 'yellow'
+    } else if (status === 'insecure') {
+      color = 'red'
+    }
+    return { message, color }
+  }
+
+  async fetch({ service, user, repo, branch }) {
+    const url = `https://requires.io/api/v1/status/${service}/${user}/${repo}`
+    return this._requestJson({
+      url,
+      schema: statusSchema,
+      options: { qs: { branch } },
+    })
+  }
+
+  async handle({ service, user, repo, branch }) {
+    const { status } = await this.fetch({ service, user, repo, branch })
+    return this.constructor.render({ status })
   }
 }

--- a/services/sonar/sonar-base.js
+++ b/services/sonar/sonar-base.js
@@ -40,17 +40,6 @@ const legacyApiSchema = Joi.array()
   .required()
 
 module.exports = class SonarBase extends BaseJsonService {
-  transform({ json, sonarVersion }) {
-    const useLegacyApi = isLegacyVersion({ sonarVersion })
-    const rawValue = useLegacyApi
-      ? json[0].msr[0].val
-      : json.component.measures[0].value
-    const value = parseInt(rawValue)
-
-    // Most values are numeric, but not all of them.
-    return { metricValue: value || rawValue }
-  }
-
   async fetch({ sonarVersion, protocol, host, component, metricName }) {
     let qs, url
     const useLegacyApi = isLegacyVersion({ sonarVersion })
@@ -87,5 +76,16 @@ module.exports = class SonarBase extends BaseJsonService {
         404: 'component or metric not found, or legacy API not supported',
       },
     })
+  }
+
+  transform({ json, sonarVersion }) {
+    const useLegacyApi = isLegacyVersion({ sonarVersion })
+    const rawValue = useLegacyApi
+      ? json[0].msr[0].val
+      : json.component.measures[0].value
+    const value = parseInt(rawValue)
+
+    // Most values are numeric, but not all of them.
+    return { metricValue: value || rawValue }
   }
 }

--- a/services/stackexchange/stackexchange-monthlyquestions.service.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.service.js
@@ -16,8 +16,11 @@ module.exports = class StackExchangeMonthlyQuestions extends BaseJsonService {
     return 'chat'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'stackoverflow' }
+  static get route() {
+    return {
+      base: 'stackexchange',
+      pattern: ':stackexchangesite/qm/:query',
+    }
   }
 
   static get examples() {
@@ -35,11 +38,8 @@ module.exports = class StackExchangeMonthlyQuestions extends BaseJsonService {
     ]
   }
 
-  static get route() {
-    return {
-      base: 'stackexchange',
-      pattern: ':stackexchangesite/qm/:query',
-    }
+  static get defaultBadgeData() {
+    return { label: 'stackoverflow' }
   }
 
   static render(props) {

--- a/services/stackexchange/stackexchange-reputation.service.js
+++ b/services/stackexchange/stackexchange-reputation.service.js
@@ -30,10 +30,6 @@ module.exports = class StackExchangeReputation extends BaseJsonService {
     }
   }
 
-  static get defaultBadgeData() {
-    return { label: 'stackoverflow' }
-  }
-
   static get examples() {
     return [
       {
@@ -46,6 +42,10 @@ module.exports = class StackExchangeReputation extends BaseJsonService {
         keywords: ['stackexchange', 'stackoverflow'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'stackoverflow' }
   }
 
   static render({ stackexchangesite, numValue }) {

--- a/services/stackexchange/stackexchange-taginfo.service.js
+++ b/services/stackexchange/stackexchange-taginfo.service.js
@@ -22,8 +22,11 @@ module.exports = class StackExchangeQuestions extends BaseJsonService {
     return 'chat'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'stackoverflow' }
+  static get route() {
+    return {
+      base: 'stackexchange',
+      pattern: ':stackexchangesite/t/:query',
+    }
   }
 
   static get examples() {
@@ -41,11 +44,8 @@ module.exports = class StackExchangeQuestions extends BaseJsonService {
     ]
   }
 
-  static get route() {
-    return {
-      base: 'stackexchange',
-      pattern: ':stackexchangesite/t/:query',
-    }
+  static get defaultBadgeData() {
+    return { label: 'stackoverflow' }
   }
 
   static render(props) {

--- a/services/steam/steam-workshop.service.js
+++ b/services/steam/steam-workshop.service.js
@@ -121,6 +121,36 @@ const fileFoundOrNotSchema = Joi.alternatives(
 )
 
 class SteamCollectionSize extends BaseSteamAPI {
+  static get category() {
+    return 'other'
+  }
+
+  static get route() {
+    return {
+      base: 'steam/collection-files',
+      pattern: ':collectionId',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Collection Files',
+        namedParams: { collectionId: '180077636' },
+        staticPreview: this.render({ size: 32 }),
+        documentation,
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'files' }
+  }
+
+  static render({ size }) {
+    return { message: metric(size), color: 'brightgreen' }
+  }
+
   static get interf() {
     return 'ISteamRemoteStorage'
   }
@@ -131,10 +161,6 @@ class SteamCollectionSize extends BaseSteamAPI {
 
   static get version() {
     return '1'
-  }
-
-  static render({ size }) {
-    return { message: metric(size), color: 'brightgreen' }
   }
 
   async handle({ collectionId }) {
@@ -159,32 +185,6 @@ class SteamCollectionSize extends BaseSteamAPI {
       size: json.response.collectiondetails[0].children.length,
     })
   }
-
-  static get category() {
-    return 'other'
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'files' }
-  }
-
-  static get route() {
-    return {
-      base: 'steam/collection-files',
-      pattern: ':collectionId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Steam Collection Files',
-        namedParams: { collectionId: '180077636' },
-        staticPreview: this.render({ size: 32 }),
-        documentation,
-      },
-    ]
-  }
 }
 
 class SteamFileService extends BaseSteamAPI {
@@ -198,6 +198,10 @@ class SteamFileService extends BaseSteamAPI {
 
   static get version() {
     return '1'
+  }
+
+  async onRequest({ response }) {
+    throw new Error(`onRequest() wasn't implemented for ${this.name}`)
   }
 
   async handle({ fileId }) {
@@ -217,27 +221,11 @@ class SteamFileService extends BaseSteamAPI {
 
     return this.onRequest({ response: json.response.publishedfiledetails[0] })
   }
-
-  async onRequest({ response }) {
-    throw new Error(`onRequest() wasn't implemented for ${this.name}`)
-  }
 }
 
 class SteamFileSize extends SteamFileService {
-  static render({ fileSize }) {
-    return { message: prettyBytes(fileSize), color: 'brightgreen' }
-  }
-
-  async onRequest({ response }) {
-    return this.constructor.render({ fileSize: response.file_size })
-  }
-
   static get category() {
     return 'size'
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'size' }
   }
 
   static get route() {
@@ -257,20 +245,23 @@ class SteamFileSize extends SteamFileService {
       },
     ]
   }
-}
 
-class SteamFileReleaseDate extends SteamFileService {
-  static render({ releaseDate }) {
-    return { message: formatDate(releaseDate), color: ageColor(releaseDate) }
+  static get defaultBadgeData() {
+    return { label: 'size' }
+  }
+
+  static render({ fileSize }) {
+    return { message: prettyBytes(fileSize), color: 'brightgreen' }
   }
 
   async onRequest({ response }) {
-    const releaseDate = new Date(0).setUTCSeconds(response.time_created)
-    return this.constructor.render({ releaseDate })
+    return this.constructor.render({ fileSize: response.file_size })
   }
+}
 
-  static get defaultBadgeData() {
-    return { label: 'release date' }
+class SteamFileReleaseDate extends SteamFileService {
+  static get category() {
+    return 'activity'
   }
 
   static get route() {
@@ -293,24 +284,21 @@ class SteamFileReleaseDate extends SteamFileService {
     ]
   }
 
-  static get category() {
-    return 'activity'
+  static get defaultBadgeData() {
+    return { label: 'release date' }
+  }
+
+  static render({ releaseDate }) {
+    return { message: formatDate(releaseDate), color: ageColor(releaseDate) }
+  }
+
+  async onRequest({ response }) {
+    const releaseDate = new Date(0).setUTCSeconds(response.time_created)
+    return this.constructor.render({ releaseDate })
   }
 }
 
 class SteamFileSubscriptions extends SteamFileService {
-  static render({ subscriptions }) {
-    return { message: metric(subscriptions), color: 'brightgreen' }
-  }
-
-  async onRequest({ response }) {
-    return this.constructor.render({ subscriptions: response.subscriptions })
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'subscriptions' }
-  }
-
   static get category() {
     return 'rating'
   }
@@ -332,21 +320,21 @@ class SteamFileSubscriptions extends SteamFileService {
       },
     ]
   }
-}
 
-class SteamFileFavorites extends SteamFileService {
-  static render({ favorites }) {
-    return { message: metric(favorites), color: 'brightgreen' }
+  static get defaultBadgeData() {
+    return { label: 'subscriptions' }
+  }
+
+  static render({ subscriptions }) {
+    return { message: metric(subscriptions), color: 'brightgreen' }
   }
 
   async onRequest({ response }) {
-    return this.constructor.render({ favorites: response.favorited })
+    return this.constructor.render({ subscriptions: response.subscriptions })
   }
+}
 
-  static get defaultBadgeData() {
-    return { label: 'favorites' }
-  }
-
+class SteamFileFavorites extends SteamFileService {
   static get category() {
     return 'rating'
   }
@@ -368,25 +356,23 @@ class SteamFileFavorites extends SteamFileService {
       },
     ]
   }
-}
 
-class SteamFileDownloads extends SteamFileService {
-  static render({ downloads }) {
-    return { message: metric(downloads), color: downloadCount(downloads) }
+  static get defaultBadgeData() {
+    return { label: 'favorites' }
+  }
+
+  static render({ favorites }) {
+    return { message: metric(favorites), color: 'brightgreen' }
   }
 
   async onRequest({ response }) {
-    return this.constructor.render({
-      downloads: response.lifetime_subscriptions,
-    })
+    return this.constructor.render({ favorites: response.favorited })
   }
+}
 
+class SteamFileDownloads extends SteamFileService {
   static get category() {
     return 'downloads'
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'downloads' }
   }
 
   static get route() {
@@ -406,19 +392,25 @@ class SteamFileDownloads extends SteamFileService {
       },
     ]
   }
-}
 
-class SteamFileViews extends SteamFileService {
-  static render({ views }) {
-    return { message: metric(views), color: 'brightgreen' }
+  static get defaultBadgeData() {
+    return { label: 'downloads' }
+  }
+
+  static render({ downloads }) {
+    return { message: metric(downloads), color: downloadCount(downloads) }
   }
 
   async onRequest({ response }) {
-    return this.constructor.render({ views: response.views })
+    return this.constructor.render({
+      downloads: response.lifetime_subscriptions,
+    })
   }
+}
 
-  static get defaultBadgeData() {
-    return { label: 'views' }
+class SteamFileViews extends SteamFileService {
+  static get category() {
+    return 'other'
   }
 
   static get route() {
@@ -439,8 +431,16 @@ class SteamFileViews extends SteamFileService {
     ]
   }
 
-  static get category() {
-    return 'other'
+  static get defaultBadgeData() {
+    return { label: 'views' }
+  }
+
+  static render({ views }) {
+    return { message: metric(views), color: 'brightgreen' }
+  }
+
+  async onRequest({ response }) {
+    return this.constructor.render({ views: response.views })
   }
 }
 

--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -15,8 +15,8 @@ const validatorSchema = Joi.object()
   .required()
 
 module.exports = class SwaggerValidatorService extends BaseJsonService {
-  static render({ message, clr }) {
-    return { message, color: clr }
+  static get category() {
+    return 'other'
   }
 
   static get route() {
@@ -24,38 +24,6 @@ module.exports = class SwaggerValidatorService extends BaseJsonService {
       base: 'swagger/valid/2.0',
       pattern: ':scheme(http|https)?/:url*',
     }
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'swagger' }
-  }
-
-  async handle({ scheme, url }) {
-    const json = await this.fetch({ scheme, urlF: url })
-    const valMessages = json.schemaValidationMessages
-
-    if (!valMessages || valMessages.length === 0) {
-      return this.constructor.render({ message: 'valid', clr: 'brightgreen' })
-    } else {
-      return this.constructor.render({ message: 'invalid', clr: 'red' })
-    }
-  }
-
-  async fetch({ scheme, urlF }) {
-    const url = 'http://online.swagger.io/validator/debug'
-    return this._requestJson({
-      url,
-      schema: validatorSchema,
-      options: {
-        qs: {
-          url: `${scheme}://${urlF}`,
-        },
-      },
-    })
-  }
-
-  static get category() {
-    return 'other'
   }
 
   static get examples() {
@@ -71,5 +39,37 @@ module.exports = class SwaggerValidatorService extends BaseJsonService {
         },
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'swagger' }
+  }
+
+  static render({ message, clr }) {
+    return { message, color: clr }
+  }
+
+  async fetch({ scheme, urlF }) {
+    const url = 'http://online.swagger.io/validator/debug'
+    return this._requestJson({
+      url,
+      schema: validatorSchema,
+      options: {
+        qs: {
+          url: `${scheme}://${urlF}`,
+        },
+      },
+    })
+  }
+
+  async handle({ scheme, url }) {
+    const json = await this.fetch({ scheme, urlF: url })
+    const valMessages = json.schemaValidationMessages
+
+    if (!valMessages || valMessages.length === 0) {
+      return this.constructor.render({ message: 'valid', clr: 'brightgreen' })
+    } else {
+      return this.constructor.render({ message: 'invalid', clr: 'red' })
+    }
   }
 }

--- a/services/symfony/symfony-insight-base.js
+++ b/services/symfony/symfony-insight-base.js
@@ -47,14 +47,14 @@ const gradeColors = {
 }
 
 class SymfonyInsightBase extends BaseXmlService {
+  static get category() {
+    return 'analysis'
+  }
+
   static get defaultBadgeData() {
     return {
       label: 'symfony insight',
     }
-  }
-
-  static get category() {
-    return 'analysis'
   }
 
   async fetch({ projectUuid }) {

--- a/services/symfony/symfony-insight-grade.service.js
+++ b/services/symfony/symfony-insight-grade.service.js
@@ -7,24 +7,6 @@ const {
 } = require('./symfony-insight-base')
 
 module.exports = class SymfonyInsightGrade extends SymfonyInsightBase {
-  static render({ status, grade }) {
-    const label = 'grade'
-    if (status !== 'finished' && status !== '') {
-      return {
-        label,
-        message: 'pending',
-        color: 'lightgrey',
-      }
-    }
-
-    const message = grade === 'none' ? 'no medal' : grade
-    return {
-      label,
-      message,
-      color: gradeColors[grade],
-    }
-  }
-
   static get route() {
     return {
       base: 'symfony/i/grade',
@@ -46,6 +28,24 @@ module.exports = class SymfonyInsightGrade extends SymfonyInsightBase {
         keywords,
       },
     ]
+  }
+
+  static render({ status, grade }) {
+    const label = 'grade'
+    if (status !== 'finished' && status !== '') {
+      return {
+        label,
+        message: 'pending',
+        color: 'lightgrey',
+      }
+    }
+
+    const message = grade === 'none' ? 'no medal' : grade
+    return {
+      label,
+      message,
+      color: gradeColors[grade],
+    }
   }
 
   async handle({ projectUuid }) {

--- a/services/symfony/symfony-insight-stars.service.js
+++ b/services/symfony/symfony-insight-stars.service.js
@@ -16,23 +16,6 @@ const gradeStars = {
 }
 
 module.exports = class SymfonyInsightStars extends SymfonyInsightBase {
-  static render({ status, grade }) {
-    const label = 'stars'
-    if (status !== 'finished' && status !== '') {
-      return {
-        label,
-        message: 'pending',
-        color: 'lightgrey',
-      }
-    }
-    const numStars = gradeStars[grade]
-    return {
-      label,
-      message: starRating(numStars, 4),
-      color: gradeColors[grade],
-    }
-  }
-
   static get route() {
     return {
       base: 'symfony/i/stars',
@@ -54,6 +37,23 @@ module.exports = class SymfonyInsightStars extends SymfonyInsightBase {
         keywords,
       },
     ]
+  }
+
+  static render({ status, grade }) {
+    const label = 'stars'
+    if (status !== 'finished' && status !== '') {
+      return {
+        label,
+        message: 'pending',
+        color: 'lightgrey',
+      }
+    }
+    const numStars = gradeStars[grade]
+    return {
+      label,
+      message: starRating(numStars, 4),
+      color: gradeColors[grade],
+    }
   }
 
   async handle({ projectUuid }) {

--- a/services/symfony/symfony-insight-violations.service.js
+++ b/services/symfony/symfony-insight-violations.service.js
@@ -3,6 +3,29 @@
 const { SymfonyInsightBase, keywords } = require('./symfony-insight-base')
 
 module.exports = class SymfonyInsightViolations extends SymfonyInsightBase {
+  static get route() {
+    return {
+      base: 'symfony/i/violations',
+      pattern: ':projectUuid',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'SymfonyInsight Violations',
+        namedParams: {
+          projectUuid: '45afb680-d4e6-4e66-93ea-bcfa79eb8a87',
+        },
+        staticPreview: this.render({
+          numViolations: 0,
+          status: 'finished',
+        }),
+        keywords,
+      },
+    ]
+  }
+
   static render({
     status,
     numViolations,
@@ -52,29 +75,6 @@ module.exports = class SymfonyInsightViolations extends SymfonyInsightBase {
       message: violationSummary.join(', '),
       color,
     }
-  }
-
-  static get route() {
-    return {
-      base: 'symfony/i/violations',
-      pattern: ':projectUuid',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'SymfonyInsight Violations',
-        namedParams: {
-          projectUuid: '45afb680-d4e6-4e66-93ea-bcfa79eb8a87',
-        },
-        staticPreview: this.render({
-          numViolations: 0,
-          status: 'finished',
-        }),
-        keywords,
-      },
-    ]
   }
 
   async handle({ projectUuid }) {

--- a/services/teamcity/teamcity-build.service.js
+++ b/services/teamcity/teamcity-build.service.js
@@ -15,31 +15,6 @@ const buildStatusSchema = Joi.object({
 }).required()
 
 module.exports = class TeamCityBuild extends TeamCityBase {
-  static render({ status, statusText, useVerbose }) {
-    if (status === 'SUCCESS') {
-      return {
-        message: 'passing',
-        color: 'brightgreen',
-      }
-    } else if (statusText && useVerbose) {
-      return {
-        message: statusText.toLowerCase(),
-        color: 'red',
-      }
-    } else {
-      return {
-        message: status.toLowerCase(),
-        color: 'red',
-      }
-    }
-  }
-
-  static get defaultBadgeData() {
-    return {
-      label: 'build',
-    }
-  }
-
   static get category() {
     return 'build'
   }
@@ -92,6 +67,31 @@ module.exports = class TeamCityBuild extends TeamCityBase {
         keywords: ['test', 'test results'],
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'build',
+    }
+  }
+
+  static render({ status, statusText, useVerbose }) {
+    if (status === 'SUCCESS') {
+      return {
+        message: 'passing',
+        color: 'brightgreen',
+      }
+    } else if (statusText && useVerbose) {
+      return {
+        message: statusText.toLowerCase(),
+        color: 'red',
+      }
+    } else {
+      return {
+        message: status.toLowerCase(),
+        color: 'red',
+      }
+    }
   }
 
   async handle({ protocol, hostAndPath, verbosity, buildId }) {

--- a/services/teamcity/teamcity-coverage.service.js
+++ b/services/teamcity/teamcity-coverage.service.js
@@ -17,19 +17,6 @@ const buildStatisticsSchema = Joi.object({
 }).required()
 
 module.exports = class TeamCityCoverage extends TeamCityBase {
-  static render({ coverage }) {
-    return {
-      message: `${coverage.toFixed(0)}%`,
-      color: coveragePercentage(coverage),
-    }
-  }
-
-  static get defaultBadgeData() {
-    return {
-      label: 'coverage',
-    }
-  }
-
   static get category() {
     return 'coverage'
   }
@@ -69,21 +56,17 @@ module.exports = class TeamCityCoverage extends TeamCityBase {
     ]
   }
 
-  async handle({ protocol, hostAndPath, buildId }) {
-    // JetBrains Docs: https://confluence.jetbrains.com/display/TCD18/REST+API#RESTAPI-Statistics
-    const buildLocator = `buildType:(id:${buildId})`
-    const apiPath = `app/rest/builds/${encodeURIComponent(
-      buildLocator
-    )}/statistics`
-    const data = await this.fetch({
-      protocol,
-      hostAndPath,
-      apiPath,
-      schema: buildStatisticsSchema,
-    })
+  static get defaultBadgeData() {
+    return {
+      label: 'coverage',
+    }
+  }
 
-    const { coverage } = this.transform({ data })
-    return this.constructor.render({ coverage })
+  static render({ coverage }) {
+    return {
+      message: `${coverage.toFixed(0)}%`,
+      color: coveragePercentage(coverage),
+    }
   }
 
   transform({ data }) {
@@ -103,5 +86,22 @@ module.exports = class TeamCityCoverage extends TeamCityBase {
     }
 
     throw new InvalidResponse({ prettyMessage: 'no coverage data available' })
+  }
+
+  async handle({ protocol, hostAndPath, buildId }) {
+    // JetBrains Docs: https://confluence.jetbrains.com/display/TCD18/REST+API#RESTAPI-Statistics
+    const buildLocator = `buildType:(id:${buildId})`
+    const apiPath = `app/rest/builds/${encodeURIComponent(
+      buildLocator
+    )}/statistics`
+    const data = await this.fetch({
+      protocol,
+      hostAndPath,
+      apiPath,
+      schema: buildStatisticsSchema,
+    })
+
+    const { coverage } = this.transform({ data })
+    return this.constructor.render({ coverage })
   }
 }

--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -94,14 +94,6 @@ class TwitterFollow extends BaseJsonService {
     }
   }
 
-  async fetch({ user }) {
-    return this._requestJson({
-      schema,
-      url: `http://cdn.syndication.twimg.com/widgets/followbutton/info.json`,
-      options: { qs: { screen_names: user } },
-    })
-  }
-
   static render({ user, followers }) {
     return {
       label: `follow @${user}`,
@@ -112,6 +104,14 @@ class TwitterFollow extends BaseJsonService {
         `https://twitter.com/${user}/followers`,
       ],
     }
+  }
+
+  async fetch({ user }) {
+    return this._requestJson({
+      schema,
+      url: `http://cdn.syndication.twimg.com/widgets/followbutton/info.json`,
+      options: { qs: { screen_names: user } },
+    })
   }
 
   async handle({ user }) {

--- a/services/uptimerobot/uptimerobot-ratio.service.js
+++ b/services/uptimerobot/uptimerobot-ratio.service.js
@@ -6,12 +6,6 @@ const UptimeRobotBase = require('./uptimerobot-base')
 const ratioColor = colorScale([10, 30, 50, 70])
 
 module.exports = class UptimeRobotRatio extends UptimeRobotBase {
-  static get defaultBadgeData() {
-    return {
-      label: 'uptime',
-    }
-  }
-
   static get route() {
     return {
       base: 'uptimerobot/ratio',
@@ -38,6 +32,12 @@ module.exports = class UptimeRobotRatio extends UptimeRobotBase {
         staticPreview: this.render({ ratio: 100 }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'uptime',
+    }
   }
 
   static render({ ratio }) {

--- a/services/uptimerobot/uptimerobot-status.service.js
+++ b/services/uptimerobot/uptimerobot-status.service.js
@@ -3,12 +3,6 @@
 const UptimeRobotBase = require('./uptimerobot-base')
 
 module.exports = class UptimeRobotStatus extends UptimeRobotBase {
-  static get defaultBadgeData() {
-    return {
-      label: 'status',
-    }
-  }
-
   static get route() {
     return {
       base: 'uptimerobot/status',
@@ -26,6 +20,12 @@ module.exports = class UptimeRobotStatus extends UptimeRobotBase {
         staticPreview: this.render({ status: 2 }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'status',
+    }
   }
 
   static render({ status }) {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.service.js
@@ -26,19 +26,6 @@ module.exports = class VisualStudioMarketplaceAzureDevOpsInstalls extends Visual
     }
   }
 
-  static get defaultBadgeData() {
-    return {
-      label: 'installs',
-    }
-  }
-
-  static render({ count }) {
-    return {
-      message: metric(count),
-      color: downloadCount(count),
-    }
-  }
-
   static get examples() {
     return [
       {
@@ -52,6 +39,19 @@ module.exports = class VisualStudioMarketplaceAzureDevOpsInstalls extends Visual
         documentation,
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'installs',
+    }
+  }
+
+  static render({ count }) {
+    return {
+      message: metric(count),
+      color: downloadCount(count),
+    }
   }
 
   async handle({ measure, extensionId }) {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-downloads.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-downloads.service.js
@@ -26,16 +26,6 @@ module.exports = class VisualStudioMarketplaceDownloads extends VisualStudioMark
     }
   }
 
-  static render({ measure, count }) {
-    const label = measure === 'd' ? 'downloads' : 'installs'
-
-    return {
-      label,
-      message: metric(count),
-      color: downloadCount(count),
-    }
-  }
-
   static get examples() {
     return [
       {
@@ -55,6 +45,16 @@ module.exports = class VisualStudioMarketplaceDownloads extends VisualStudioMark
         documentation,
       },
     ]
+  }
+
+  static render({ measure, count }) {
+    const label = measure === 'd' ? 'downloads' : 'installs'
+
+    return {
+      label,
+      message: metric(count),
+      color: downloadCount(count),
+    }
   }
 
   async handle({ measure, extensionId }) {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-rating.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-rating.service.js
@@ -17,23 +17,6 @@ module.exports = class VisualStudioMarketplaceRating extends VisualStudioMarketp
     }
   }
 
-  static get defaultBadgeData() {
-    return {
-      label: 'rating',
-    }
-  }
-
-  static render({ format, averageRating, ratingCount }) {
-    const message =
-      format === 'r'
-        ? `${averageRating.toFixed(1)}/5 (${ratingCount})`
-        : starRating(averageRating)
-    return {
-      message,
-      color: floorCount(averageRating, 2, 3, 4),
-    }
-  }
-
   static get examples() {
     return [
       {
@@ -58,6 +41,23 @@ module.exports = class VisualStudioMarketplaceRating extends VisualStudioMarketp
         keywords: this.keywords,
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'rating',
+    }
+  }
+
+  static render({ format, averageRating, ratingCount }) {
+    const message =
+      format === 'r'
+        ? `${averageRating.toFixed(1)}/5 (${ratingCount})`
+        : starRating(averageRating)
+    return {
+      message,
+      color: floorCount(averageRating, 2, 3, 4),
+    }
   }
 
   async handle({ format, extensionId }) {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-version.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-version.service.js
@@ -15,16 +15,6 @@ module.exports = class VisualStudioMarketplaceVersion extends VisualStudioMarket
     }
   }
 
-  static get defaultBadgeData() {
-    return {
-      label: 'version',
-    }
-  }
-
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
   static get examples() {
     return [
       {
@@ -35,6 +25,16 @@ module.exports = class VisualStudioMarketplaceVersion extends VisualStudioMarket
         keywords: this.keywords,
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'version',
+    }
+  }
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
   }
 
   transform({ json }) {

--- a/services/waffle/waffle-label.service.js
+++ b/services/waffle/waffle-label.service.js
@@ -23,33 +23,15 @@ module.exports = class WaffleLabel extends BaseJsonService {
     return 'issue-tracking'
   }
 
-  static get route() {
-    return {
-      base: 'waffle/label',
-      pattern: ':user/:repo/:label',
-    }
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'waffle' }
-  }
-
   static get isDeprecated() {
     const now = new Date()
     return now.getTime() >= new Date('2019-05-16')
   }
 
-  static render({ label, color, count }) {
-    if (count === 'absent') {
-      return { message: count }
-    }
-    if (count === 0 || !color) {
-      color = '78bdf2'
-    }
+  static get route() {
     return {
-      label,
-      message: metric(count),
-      color,
+      base: 'waffle/label',
+      pattern: ':user/:repo/:label',
     }
   }
 
@@ -69,6 +51,24 @@ module.exports = class WaffleLabel extends BaseJsonService {
         }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'waffle' }
+  }
+
+  static render({ label, color, count }) {
+    if (count === 'absent') {
+      return { message: count }
+    }
+    if (count === 0 || !color) {
+      color = '78bdf2'
+    }
+    return {
+      label,
+      message: metric(count),
+      color,
+    }
   }
 
   async fetch({ user, repo }) {

--- a/services/wercker/wercker.service.js
+++ b/services/wercker/wercker.service.js
@@ -15,53 +15,6 @@ const werckerSchema = Joi.array()
   .required()
 
 module.exports = class Wercker extends BaseJsonService {
-  static getBaseUrl({ projectId, applicationName }) {
-    if (applicationName) {
-      return `https://app.wercker.com/api/v3/applications/${applicationName}/builds`
-    } else {
-      return `https://app.wercker.com/api/v3/runs?applicationId=${projectId}`
-    }
-  }
-
-  async fetch({ baseUrl, branch }) {
-    return this._requestJson({
-      schema: werckerSchema,
-      url: baseUrl,
-      options: {
-        qs: {
-          branch,
-          limit: 1,
-        },
-      },
-      errorMessages: {
-        401: 'private application not supported',
-        404: 'application not found',
-      },
-    })
-  }
-
-  static render({ result }) {
-    return renderBuildStatusBadge({ status: result })
-  }
-
-  async handle({ projectId, applicationName, branch }) {
-    const json = await this.fetch({
-      baseUrl: this.constructor.getBaseUrl({
-        projectId,
-        applicationName,
-      }),
-      branch,
-    })
-    if (json.length === 0) {
-      return this.constructor.render({
-        result: 'not built',
-      })
-    }
-    const { result } = json[0]
-    return this.constructor.render({ result })
-  }
-
-  // Metadata
   static get category() {
     return 'build'
   }
@@ -112,5 +65,51 @@ module.exports = class Wercker extends BaseJsonService {
         staticPreview: this.render({ result: 'passed' }),
       },
     ]
+  }
+
+  static render({ result }) {
+    return renderBuildStatusBadge({ status: result })
+  }
+
+  static getBaseUrl({ projectId, applicationName }) {
+    if (applicationName) {
+      return `https://app.wercker.com/api/v3/applications/${applicationName}/builds`
+    } else {
+      return `https://app.wercker.com/api/v3/runs?applicationId=${projectId}`
+    }
+  }
+
+  async fetch({ baseUrl, branch }) {
+    return this._requestJson({
+      schema: werckerSchema,
+      url: baseUrl,
+      options: {
+        qs: {
+          branch,
+          limit: 1,
+        },
+      },
+      errorMessages: {
+        401: 'private application not supported',
+        404: 'application not found',
+      },
+    })
+  }
+
+  async handle({ projectId, applicationName, branch }) {
+    const json = await this.fetch({
+      baseUrl: this.constructor.getBaseUrl({
+        projectId,
+        applicationName,
+      }),
+      branch,
+    })
+    if (json.length === 0) {
+      return this.constructor.render({
+        result: 'not built',
+      })
+    }
+    const { result } = json[0]
+    return this.constructor.render({ result })
   }
 }

--- a/services/wheelmap/wheelmap.service.js
+++ b/services/wheelmap/wheelmap.service.js
@@ -11,6 +11,43 @@ const wheelmapSchema = Joi.object({
 }).required()
 
 module.exports = class Wheelmap extends BaseJsonService {
+  static get category() {
+    return 'other'
+  }
+
+  static get route() {
+    return {
+      base: 'wheelmap/a',
+      pattern: ':nodeId(-?[0-9]+)',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Wheelmap',
+        namedParams: { nodeId: '26699541' },
+        staticPreview: this.render({ accessibility: 'yes' }),
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'accessibility' }
+  }
+
+  static render({ accessibility }) {
+    let color
+    if (accessibility === 'yes') {
+      color = 'brightgreen'
+    } else if (accessibility === 'limited') {
+      color = 'yellow'
+    } else if (accessibility === 'no') {
+      color = 'red'
+    }
+    return { message: accessibility, color }
+  }
+
   async fetch({ nodeId }) {
     let options
     if (serverSecrets.wheelmap_token) {
@@ -32,46 +69,9 @@ module.exports = class Wheelmap extends BaseJsonService {
     })
   }
 
-  static render({ accessibility }) {
-    let color
-    if (accessibility === 'yes') {
-      color = 'brightgreen'
-    } else if (accessibility === 'limited') {
-      color = 'yellow'
-    } else if (accessibility === 'no') {
-      color = 'red'
-    }
-    return { message: accessibility, color }
-  }
-
   async handle({ nodeId }) {
     const json = await this.fetch({ nodeId })
     const accessibility = json.node.wheelchair
     return this.constructor.render({ accessibility })
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'accessibility' }
-  }
-
-  static get category() {
-    return 'other'
-  }
-
-  static get route() {
-    return {
-      base: 'wheelmap/a',
-      pattern: ':nodeId(-?[0-9]+)',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Wheelmap',
-        namedParams: { nodeId: '26699541' },
-        staticPreview: this.render({ accessibility: 'yes' }),
-      },
-    ]
   }
 }

--- a/services/wordpress/wordpress-downloads.service.js
+++ b/services/wordpress/wordpress-downloads.service.js
@@ -29,27 +29,8 @@ function DownloadsForExtensionType(extensionType) {
       return `Wordpress${capt}Downloads`
     }
 
-    static render({ downloads }) {
-      return {
-        message: metric(downloads),
-        color: downloadCount(downloads),
-      }
-    }
-
-    async handle({ slug }) {
-      const { downloaded: downloads } = await this.fetch({
-        extensionType,
-        slug,
-      })
-      return this.constructor.render({ downloads })
-    }
-
     static get category() {
       return 'downloads'
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'downloads' }
     }
 
     static get route() {
@@ -68,6 +49,25 @@ function DownloadsForExtensionType(extensionType) {
         },
       ]
     }
+
+    static get defaultBadgeData() {
+      return { label: 'downloads' }
+    }
+
+    static render({ downloads }) {
+      return {
+        message: metric(downloads),
+        color: downloadCount(downloads),
+      }
+    }
+
+    async handle({ slug }) {
+      const { downloaded: downloads } = await this.fetch({
+        extensionType,
+        slug,
+      })
+      return this.constructor.render({ downloads })
+    }
   }
 }
 
@@ -81,25 +81,6 @@ function InstallsForExtensionType(extensionType) {
 
     static get category() {
       return 'downloads'
-    }
-
-    static render({ installCount }) {
-      return {
-        message: metric(installCount),
-        color: downloadCount(installCount),
-      }
-    }
-
-    async handle({ slug }) {
-      const { active_installs: installCount } = await this.fetch({
-        extensionType,
-        slug,
-      })
-      return this.constructor.render({ installCount })
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'active installs' }
     }
 
     static get route() {
@@ -117,6 +98,25 @@ function InstallsForExtensionType(extensionType) {
           staticPreview: this.render({ installCount: 300000 }),
         },
       ]
+    }
+
+    static get defaultBadgeData() {
+      return { label: 'active installs' }
+    }
+
+    static render({ installCount }) {
+      return {
+        message: metric(installCount),
+        color: downloadCount(installCount),
+      }
+    }
+
+    async handle({ slug }) {
+      const { active_installs: installCount } = await this.fetch({
+        extensionType,
+        slug,
+      })
+      return this.constructor.render({ installCount })
     }
   }
 }
@@ -158,10 +158,6 @@ function DownloadsForInterval(interval) {
       return 'downloads'
     }
 
-    static get defaultBadgeData() {
-      return { label: 'downloads' }
-    }
-
     static get route() {
       return {
         base,
@@ -177,6 +173,10 @@ function DownloadsForInterval(interval) {
           staticPreview: this.render({ downloads: 30000 }),
         },
       ]
+    }
+
+    static get defaultBadgeData() {
+      return { label: 'downloads' }
     }
 
     static render({ downloads }) {

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -52,10 +52,6 @@ class WordpressPluginTestedVersion extends BaseWordpress {
     return 'platform-support'
   }
 
-  static get defaultBadgeData() {
-    return { label: 'wordpress' }
-  }
-
   static get route() {
     return {
       base: `wordpress/plugin/tested`,
@@ -73,6 +69,10 @@ class WordpressPluginTestedVersion extends BaseWordpress {
         }),
       },
     ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'wordpress' }
   }
 
   static renderStaticPreview({ testedVersion }) {


### PR DESCRIPTION
I find having these in a consistent order makes the servicees much faster to read.

This is the order I’ve generally been using:

1. Category
2. Route
3. Examples
4. Rendering
5. Other helpers (`fetch()`, `transform()`)
6. `handle()`

How does this order look to people?

If we decide to keep this order, there are many more services which will need updating.