### PR TITLE
Color fix for [GitHubForks] badge

### DIFF
--- a/services/github/github-forks.service.js
+++ b/services/github/github-forks.service.js
@@ -58,6 +58,7 @@ module.exports = class GithubForks extends GithubAuthService {
   static render({ user, repo, forkCount }) {
     return {
       message: metric(forkCount),
+      color: '4183C4',
       link: [
         `https://github.com/${user}/${repo}/fork`,
         `https://github.com/${user}/${repo}/network`,


### PR DESCRIPTION
Small detail that was left out in #3299. The non social version of the badge is now grey rather than [the previous blue](https://github.com/badges/shields/blob/11cd0bdbc59d7d244aa61112102224aabdb7ea5b/services/github/github-forks.service.js#L80).