### PR TITLE
Add [Ubuntu] package version support

### DIFF
--- a/services/ubuntu/ubuntu.service.js
+++ b/services/ubuntu/ubuntu.service.js
@@ -40,7 +40,7 @@ module.exports = class Ubuntu extends BaseJsonService {
     return { label: 'ubuntu' }
   }
 
-  async handle({ series, packageName }) {
+  async fetch({ series, packageName }) {
     const seriesParam = series
       ? {
           distro_series: `https://api.launchpad.net/1.0/ubuntu/${encodeURIComponent(
@@ -48,7 +48,7 @@ module.exports = class Ubuntu extends BaseJsonService {
           )}`,
         }
       : {}
-    const data = await this._requestJson({
+    return this._requestJson({
       schema,
       url: 'https://api.launchpad.net/1.0/ubuntu/+archive/primary',
       options: {
@@ -65,6 +65,10 @@ module.exports = class Ubuntu extends BaseJsonService {
         400: 'series not found',
       },
     })
+  }
+
+  async handle({ series, packageName }) {
+    const data = await this.fetch({ series, packageName })
     if (!data.entries.length) {
       throw new NotFound()
     }

--- a/services/ubuntu/ubuntu.service.js
+++ b/services/ubuntu/ubuntu.service.js
@@ -61,6 +61,9 @@ module.exports = class Ubuntu extends BaseJsonService {
           ...seriesParam,
         },
       },
+      errorMessages: {
+        400: 'series not found',
+      },
     })
     if (!data.entries.length) {
       throw new NotFound()

--- a/services/ubuntu/ubuntu.service.js
+++ b/services/ubuntu/ubuntu.service.js
@@ -1,0 +1,72 @@
+'use strict'
+
+const Joi = require('joi')
+const { renderVersionBadge } = require('../version')
+const { BaseJsonService, NotFound } = require('..')
+
+const schema = Joi.object({
+  entries: Joi.array()
+    .items(
+      Joi.object({
+        source_package_version: Joi.string().required(),
+      })
+    )
+    .required(),
+}).required()
+
+module.exports = class Ubuntu extends BaseJsonService {
+  static get category() {
+    return 'version'
+  }
+
+  static get route() {
+    return {
+      base: 'ubuntu/v',
+      pattern: ':series?/:packageName',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Ubuntu package',
+        namedParams: { series: 'bionic', packageName: 'ubuntu-wallpapers' },
+        staticPreview: renderVersionBadge({ version: '18.04.1-0ubuntu1' }),
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'ubuntu' }
+  }
+
+  async handle({ series, packageName }) {
+    const seriesParam = series
+      ? {
+          distro_series: `https://api.launchpad.net/1.0/ubuntu/${encodeURIComponent(
+            series
+          )}`,
+        }
+      : {}
+    const data = await this._requestJson({
+      schema,
+      url: 'https://api.launchpad.net/1.0/ubuntu/+archive/primary',
+      options: {
+        qs: {
+          'ws.op': 'getPublishedSources',
+          exact_match: 'true',
+          order_by_date: 'true',
+          status: 'Published',
+          source_name: packageName,
+          ...seriesParam,
+        },
+      },
+    })
+    if (!data.entries.length) {
+      throw new NotFound()
+    }
+    return renderVersionBadge({
+      version: data.entries[0].source_package_version,
+    })
+  }
+}

--- a/services/ubuntu/ubuntu.tester.js
+++ b/services/ubuntu/ubuntu.tester.js
@@ -34,6 +34,6 @@ t.create('Ubuntu package (not found)')
   .get('/not-a-package.json')
   .expectBadge({ label: 'ubuntu', message: 'not found' })
 
-t.create('Ubuntu package (invalid series)')
+t.create('Ubuntu package (series not found)')
   .get('/not-a-series/apt.json')
-  .expectBadge({ label: 'ubuntu', message: 'invalid' })
+  .expectBadge({ label: 'ubuntu', message: 'series not found' })

--- a/services/ubuntu/ubuntu.tester.js
+++ b/services/ubuntu/ubuntu.tester.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const {
+  isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
+} = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('Ubuntu package (default distribution, valid)')
+  .get('/apt.json')
+  .expectBadge({
+    label: 'ubuntu',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
+  })
+
+t.create('Ubuntu package (valid, mocked response)')
+  .get('/bionic/ubuntu-wallpapers.json')
+  .intercept(nock =>
+    nock('https://api.launchpad.net')
+      .get(
+        '/1.0/ubuntu/+archive/primary?ws.op=getPublishedSources&exact_match=true&order_by_date=true&status=Published&source_name=ubuntu-wallpapers&distro_series=https%3A%2F%2Fapi.launchpad.net%2F1.0%2Fubuntu%2Fbionic'
+      )
+      .reply(200, {
+        entries: [
+          {
+            source_package_name: 'ubuntu-wallpapers',
+            source_package_version: '18.04.1-0ubuntu1',
+          },
+        ],
+      })
+  )
+  .expectBadge({ label: 'ubuntu', message: 'v18.04.1-0ubuntu1' })
+
+t.create('Ubuntu package (not found)')
+  .get('/not-a-package.json')
+  .expectBadge({ label: 'ubuntu', message: 'not found' })
+
+t.create('Ubuntu package (invalid series)')
+  .get('/not-a-series/apt.json')
+  .expectBadge({ label: 'ubuntu', message: 'invalid' })


### PR DESCRIPTION
https://api.launchpad.net/1.0/

Requires #3397 first for epoch version validation support.