### PR TITLE
Remove code duplication in CircleCI configuration; test on [jetbrains]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,7 @@ jobs:
             - node_modules
           key: v2-dependencies-{{ checksum "package-lock.json" }}
 
-  main:
-    docker:
-      - image: circleci/node:8
-
+  main_steps: &main_steps
     steps:
       - checkout
 
@@ -81,10 +78,19 @@ jobs:
           when: always
           command: npm run prettier:check
 
+  main:
+    docker:
+      - image: circleci/node:8
+
+    <<: *main_steps
+
   main@node-latest:
     docker:
       - image: circleci/node:latest
 
+    <<: *main_steps
+
+  integration_steps: &integration_steps
     steps:
       - checkout
 
@@ -99,99 +105,29 @@ jobs:
           command: npm ci
 
       - run:
-          name: Linter
-          when: always
-          command: npm run lint
-
-      - run:
-          name: Core tests
+          name: Integration tests
           when: always
           environment:
             mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/core/results.xml
-          command: npm run test:core
-
-      - run:
-          name: Entrypoint tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/entrypoint/results.xml
-          command: npm run test:entrypoint
-
-      - run:
-          name: Tests for gh-badges package
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/gh-badges/results.xml
-          command: npm run test:package
+            MOCHA_FILE: junit/integration/results.xml
+          command: npm run test:integration
 
       - store_test_results:
           path: junit
-
-      - run:
-          name: 'Prettier check (quick fix: `npm run prettier`)'
-          when: always
-          command: npm run prettier:check
 
   integration:
     docker:
       - image: circleci/node:8
       - image: redis
 
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - run:
-          name: Integration tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/integration/results.xml
-          command: npm run test:integration
-
-      - store_test_results:
-          path: junit
+    <<: *integration_steps
 
   integration@node-latest:
     docker:
       - image: circleci/node:latest
       - image: redis
 
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - run:
-          name: Integration tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/integration/results.xml
-          command: npm run test:integration
-
-      - store_test_results:
-          path: junit
+    <<: *integration_steps
 
   danger:
     docker:
@@ -252,9 +188,7 @@ jobs:
           when: always
           command: npm run build
 
-  services:
-    docker:
-      - image: circleci/node:8
+  services_steps: &services_steps
     steps:
       - checkout
 
@@ -281,36 +215,18 @@ jobs:
 
       - store_test_results:
           path: junit
+
+  services:
+    docker:
+      - image: circleci/node:8
+
+    <<: *services_steps
 
   services@node-latest:
     docker:
       - image: circleci/node:latest
-    steps:
-      - checkout
 
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - run:
-          name: Identify services tagged in the PR title
-          command: npm run test:services:pr:prepare
-
-      - run:
-          name: Run tests for tagged services
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/services/results.xml
-          command: npm run test:services:pr:run
-
-      - store_test_results:
-          path: junit
+    <<: *services_steps
 
   e2e:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,114 @@
 version: 2
 
+main_steps: &main_steps
+  steps:
+    - checkout
+
+    - restore_cache:
+        keys:
+          - v2-dependencies-{{ checksum "package-lock.json" }}
+          # https://github.com/badges/shields/issues/1937
+          - v2-dependencies-
+
+    - run:
+        name: Install dependencies
+        command: npm ci
+
+    - save_cache:
+        paths:
+          - node_modules
+        key: v2-dependencies-{{ checksum "package-lock.json" }}
+
+    - run:
+        name: Linter
+        when: always
+        command: npm run lint
+
+    - run:
+        name: Core tests
+        when: always
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/core/results.xml
+        command: npm run test:core
+
+    - run:
+        name: Entrypoint tests
+        when: always
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/entrypoint/results.xml
+        command: npm run test:entrypoint
+
+    - run:
+        name: Tests for gh-badges package
+        when: always
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/gh-badges/results.xml
+        command: npm run test:package
+
+    - store_test_results:
+        path: junit
+
+    - run:
+        name: 'Prettier check (quick fix: `npm run prettier`)'
+        when: always
+        command: npm run prettier:check
+
+integration_steps: &integration_steps
+  steps:
+    - checkout
+
+    - restore_cache:
+        keys:
+          - v2-dependencies-{{ checksum "package-lock.json" }}
+          # https://github.com/badges/shields/issues/1937
+          - v2-dependencies-
+
+    - run:
+        name: Install dependencies
+        command: npm ci
+
+    - run:
+        name: Integration tests
+        when: always
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/integration/results.xml
+        command: npm run test:integration
+
+    - store_test_results:
+        path: junit
+
+services_steps: &services_steps
+  steps:
+    - checkout
+
+    - restore_cache:
+        keys:
+          - v2-dependencies-{{ checksum "package-lock.json" }}
+          # https://github.com/badges/shields/issues/1937
+          - v2-dependencies-
+
+    - run:
+        name: Install dependencies
+        command: npm ci
+
+    - run:
+        name: Identify services tagged in the PR title
+        command: npm run test:services:pr:prepare
+
+    - run:
+        name: Run tests for tagged services
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/services/results.xml
+        command: npm run test:services:pr:run
+
+    - store_test_results:
+        path: junit
+
 jobs:
   npm-install:
     docker:
@@ -22,62 +131,6 @@ jobs:
             - node_modules
           key: v2-dependencies-{{ checksum "package-lock.json" }}
 
-  main_steps: &main_steps
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "package-lock.json" }}
-
-      - run:
-          name: Linter
-          when: always
-          command: npm run lint
-
-      - run:
-          name: Core tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/core/results.xml
-          command: npm run test:core
-
-      - run:
-          name: Entrypoint tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/entrypoint/results.xml
-          command: npm run test:entrypoint
-
-      - run:
-          name: Tests for gh-badges package
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/gh-badges/results.xml
-          command: npm run test:package
-
-      - store_test_results:
-          path: junit
-
-      - run:
-          name: 'Prettier check (quick fix: `npm run prettier`)'
-          when: always
-          command: npm run prettier:check
-
   main:
     docker:
       - image: circleci/node:8
@@ -89,31 +142,6 @@ jobs:
       - image: circleci/node:latest
 
     <<: *main_steps
-
-  integration_steps: &integration_steps
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - run:
-          name: Integration tests
-          when: always
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/integration/results.xml
-          command: npm run test:integration
-
-      - store_test_results:
-          path: junit
 
   integration:
     docker:
@@ -187,34 +215,6 @@ jobs:
           name: Frontend build completes successfully
           when: always
           command: npm run build
-
-  services_steps: &services_steps
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "package-lock.json" }}
-            # https://github.com/badges/shields/issues/1937
-            - v2-dependencies-
-
-      - run:
-          name: Install dependencies
-          command: npm ci
-
-      - run:
-          name: Identify services tagged in the PR title
-          command: npm run test:services:pr:prepare
-
-      - run:
-          name: Run tests for tagged services
-          environment:
-            mocha_reporter: mocha-junit-reporter
-            MOCHA_FILE: junit/services/results.xml
-          command: npm run test:services:pr:run
-
-      - store_test_results:
-          path: junit
 
   services:
     docker:


### PR DESCRIPTION
In https://github.com/badges/shields/pull/3390/files#diff-1d37e48f9ceff6d8030570cd36286a61 I added entrypoint tests to two jobs (node8/node-latest). It's time to remove this code duplication. I'm using the https://circleci.com/docs/2.0/writing-yaml/#merging-maps syntax. More info about this approach: https://circleci.com/blog/circleci-hacks-reuse-yaml-in-your-circleci-config-with-yaml/. CircleCI 2.1 has an alternative solution (https://circleci.com/docs/2.0/reusing-config/), but I think solution from this PR also OK. 