### PR TITLE
Add some aliases for license colors; refactor; test colors for [PypiLicense]

### DIFF
--- a/services/licenses.js
+++ b/services/licenses.js
@@ -67,7 +67,6 @@ Object.keys(licenseTypes).forEach(licenseType => {
     licenseToColorMap[license] = { color, priority }
   })
 })
-const defaultLicenseColor = 'lightgrey'
 
 function licenseToColor(licenses) {
   if (!Array.isArray(licenses)) {
@@ -77,12 +76,7 @@ function licenseToColor(licenses) {
   const [{ color }] = licenses
     .map(license => licenseToColorMap[license])
     .filter(Boolean)
-    .concat([
-      {
-        color: defaultLicenseColor,
-        priority: 0,
-      },
-    ])
+    .concat([{ color: 'lightgrey', priority: 0 }])
     .sort((a, b) => b.priority - a.priority)
 
   return color

--- a/services/licenses.js
+++ b/services/licenses.js
@@ -22,6 +22,7 @@ const licenseTypes = {
       'PostgreSQL',
       'Zlib',
     ],
+    aliases: ['BSD', 'Apache 2.0'],
     color: 'green',
     priority: '2',
   },
@@ -43,12 +44,14 @@ const licenseTypes = {
       'OFL-1.1',
       'OSL-3.0',
     ],
+    aliases: ['GPL', 'LGPL', 'MPL', 'MPL 1.1', 'MPL 2.0'],
     color: 'orange',
     priority: '1',
   },
   // public domain licenses do not require 'License and copyright notice' (https://choosealicense.com/appendix/#include-copyright)
   'public-domain': {
     spdxLicenseIds: ['CC0-1.0', 'Unlicense', 'WTFPL'],
+    aliases: ['CC0'],
     color: '7cd958',
     priority: '3',
   },
@@ -56,27 +59,33 @@ const licenseTypes = {
 
 const licenseToColorMap = {}
 Object.keys(licenseTypes).forEach(licenseType => {
-  const { spdxLicenseIds, color, priority } = licenseTypes[licenseType]
+  const { spdxLicenseIds, aliases, color, priority } = licenseTypes[licenseType]
   spdxLicenseIds.forEach(license => {
+    licenseToColorMap[license] = { color, priority }
+  })
+  aliases.forEach(license => {
     licenseToColorMap[license] = { color, priority }
   })
 })
 const defaultLicenseColor = 'lightgrey'
-const licenseToColor = spdxId => {
-  if (!Array.isArray(spdxId)) {
-    return (
-      (licenseToColorMap[spdxId] && licenseToColorMap[spdxId].color) ||
-      defaultLicenseColor
-    )
+
+function licenseToColor(licenses) {
+  if (!Array.isArray(licenses)) {
+    licenses = [licenses]
   }
-  const licenseType = spdxId
-    .filter(i => licenseToColorMap[i])
-    .map(i => licenseToColorMap[i])
-    .reduce((a, b) => (a.priority > b.priority ? a : b), {
-      color: defaultLicenseColor,
-      priority: 0,
-    })
-  return licenseType.color
+
+  const [{ color }] = licenses
+    .map(license => licenseToColorMap[license])
+    .filter(Boolean)
+    .concat([
+      {
+        color: defaultLicenseColor,
+        priority: 0,
+      },
+    ])
+    .sort((a, b) => b.priority - a.priority)
+
+  return color
 }
 
 function renderLicenseBadge({ license, licenses }) {

--- a/services/licenses.spec.js
+++ b/services/licenses.spec.js
@@ -5,11 +5,10 @@ const { licenseToColor, renderLicenseBadge } = require('./licenses')
 
 describe('license helpers', function() {
   test(licenseToColor, () => {
-    given('MIT').expect('green')
-    given('MPL-2.0').expect('orange')
-    given('Unlicense').expect('7cd958')
-    given('unknown-license').expect('lightgrey')
-    given(null).expect('lightgrey')
+    forCases([given('MIT'), given('BSD')]).expect('green')
+    forCases([given('MPL-2.0'), given('MPL')]).expect('orange')
+    forCases([given('Unlicense'), given('CC0')]).expect('7cd958')
+    forCases([given('unknown-license'), given(null)]).expect('lightgrey')
 
     given(['CC0-1.0', 'MPL-2.0']).expect('7cd958')
     given(['MPL-2.0', 'CC0-1.0']).expect('7cd958')

--- a/services/pypi/pypi-license.tester.js
+++ b/services/pypi/pypi-license.tester.js
@@ -4,11 +4,11 @@ const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('license (valid, package version in request)')
   .get('/requests/2.18.4.json')
-  .expectBadge({ label: 'license', message: 'Apache 2.0' })
+  .expectBadge({ label: 'license', message: 'Apache 2.0', color: 'green' })
 
 t.create('license (valid, no package version specified)')
   .get('/requests.json')
-  .expectBadge({ label: 'license', message: 'Apache 2.0' })
+  .expectBadge({ label: 'license', message: 'Apache 2.0', color: 'green' })
 
 t.create('license (invalid)')
   .get('/not-a-package.json')
@@ -31,6 +31,7 @@ t.create('license (from trove classifier)')
   .expectBadge({
     label: 'license',
     message: 'MIT',
+    color: 'green',
   })
 
 t.create('license (as acronym from trove classifier)')
@@ -52,4 +53,5 @@ t.create('license (as acronym from trove classifier)')
   .expectBadge({
     label: 'license',
     message: 'GPL',
+    color: 'orange',
   })


### PR DESCRIPTION
This covers some of the license strings used by the PyPI badges like **BSD** which currently shows up in lightgrey.

This PR:

![](http://shields-staging-pr-3431.herokuapp.com/pypi/l/vg.svg?style=flat-square)

Production:

![](http://img.shields.io/pypi/l/vg.svg?style=flat-square)