### PR TITLE
Fix code review guidelines link in Contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Feel free to reach out to one of the [maintainers][]
 if you need help getting started.
 
 [service badge pr tag]: https://github.com/badges/shields/pulls?q=is%3Apr+is%3Aopen+label%3Aservice-badge
-[code review guidelines]: http://amyciavolino.com/assets/MindfulCommunicationInCodeReviews.pdf
+[code review guidelines]: https://kickstarter.engineering/a-guide-to-mindful-communication-in-code-reviews-48aab5282e5e
 [issues]: https://github.com/badges/shields/issues
 [chat room]: https://discordapp.com/invite/HjJCwm5
 [maintainers]: https://github.com/badges/shields#project-leaders


### PR DESCRIPTION
I just noticed this but looks like the original link (http://amyciavolino.com/assets/MindfulCommunicationInCodeReviews.pdf) in our Contributing guide for code review guidelines no longer works and redirects here: https://amy.tech/. That site then has a link to what I assume is the original doc here: https://kickstarter.engineering/a-guide-to-mindful-communication-in-code-reviews-48aab5282e5e

Updating the link accordingly in our Contributing doc