### PR TITLE
fix [aur] service tests

### DIFF
--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -61,8 +61,8 @@ class AurLicense extends BaseAurService {
     return [
       {
         title: 'AUR license',
-        namedParams: { packageName: 'yaourt' },
-        staticPreview: this.render({ license: 'GPL' }),
+        namedParams: { packageName: 'pac' },
+        staticPreview: this.render({ license: 'MIT' }),
       },
     ]
   }
@@ -96,8 +96,8 @@ class AurVotes extends BaseAurService {
     return [
       {
         title: 'AUR votes',
-        namedParams: { packageName: 'yaourt' },
-        staticPreview: this.render({ votes: '3029' }),
+        namedParams: { packageName: 'dropbox' },
+        staticPreview: this.render({ votes: '2280' }),
       },
     ]
   }
@@ -135,8 +135,8 @@ class AurVersion extends BaseAurService {
     return [
       {
         title: 'AUR version',
-        namedParams: { packageName: 'yaourt' },
-        staticPreview: this.render({ version: 'v1.9-1', outOfDate: null }),
+        namedParams: { packageName: 'visual-studio-code-bin' },
+        staticPreview: this.render({ version: '1.34.0-2', outOfDate: null }),
       },
     ]
   }

--- a/services/aur/aur.tester.js
+++ b/services/aur/aur.tester.js
@@ -14,7 +14,7 @@ const t = (module.exports = new ServiceTester({
 // version tests
 
 t.create('version (valid)')
-  .get('/version/yaourt.json')
+  .get('/version/dropbox.json')
   .expectBadge({
     label: 'aur',
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
@@ -36,7 +36,7 @@ t.create('version (not found)')
 // votes tests
 
 t.create('votes (valid)')
-  .get('/votes/yaourt.json')
+  .get('/votes/discord.json')
   .expectBadge({
     label: 'votes',
     message: isMetric,
@@ -49,8 +49,8 @@ t.create('votes (not found)')
 // license tests
 
 t.create('license (valid)')
-  .get('/license/yaourt.json')
-  .expectBadge({ label: 'license', message: 'GPL' })
+  .get('/license/pac.json')
+  .expectBadge({ label: 'license', message: 'MIT' })
 
 t.create('license (not found)')
   .get('/license/not-a-package.json')


### PR DESCRIPTION
Fixes #3474 

There's apparently issues with the package (`yaourt`) used in many of the service tests (and examples), so I've updated both to use some different packages to resolve