### PR TITLE
increase [jsdelivr] test timeouts

### DIFF
--- a/services/jsdelivr/jsdelivr-hits-github.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-github.tester.js
@@ -4,7 +4,7 @@ const { isMetricOverTimePeriod } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('jquery/jquery hits/day')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hd/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
@@ -12,7 +12,7 @@ t.create('jquery/jquery hits/day')
   })
 
 t.create('jquery/jquery hits/week')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hw/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
@@ -20,7 +20,7 @@ t.create('jquery/jquery hits/week')
   })
 
 t.create('jquery/jquery hits/month')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hm/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
@@ -28,7 +28,7 @@ t.create('jquery/jquery hits/month')
   })
 
 t.create('jquery/jquery hits/year')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hy/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
@@ -36,7 +36,7 @@ t.create('jquery/jquery hits/year')
   })
 
 t.create('fake package')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hd/somefakepackage/somefakepackage.json')
   .expectBadge({
     label: 'jsdelivr',

--- a/services/jsdelivr/jsdelivr-hits-npm.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.tester.js
@@ -4,39 +4,39 @@ const { isMetricOverTimePeriod } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('jquery hits/day')
-  .timeout(5000)
-  .get('/hd/jquery.json')
+  .timeout(10000)
+  .get('/hd/ky.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
 t.create('jquery hits/week')
-  .timeout(5000)
-  .get('/hw/jquery.json')
+  .timeout(10000)
+  .get('/hw/ky.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
 t.create('jquery hits/month')
-  .timeout(5000)
-  .get('/hm/jquery.json')
+  .timeout(10000)
+  .get('/hm/ky.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
 t.create('jquery hits/year')
-  .timeout(5000)
-  .get('/hy/jquery.json')
+  .timeout(10000)
+  .get('/hy/ky.json')
   .expectBadge({
     label: 'jsdelivr',
     message: isMetricOverTimePeriod,
   })
 
 t.create('fake package')
-  .timeout(5000)
+  .timeout(10000)
   .get('/hd/somefakepackage.json')
   .expectBadge({
     label: 'jsdelivr',


### PR DESCRIPTION
Refs #3478 - increasing the timeout on these tests to 10s to see if that helps resolve the recurring test timeouts. There are time windows (00:00-1:00 UTC) when the underlying API is known to have issues but hopefully this will fix the service test timeouts 🤞 