### PR TITLE
Open Collective funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: shields


### PR DESCRIPTION
See the [documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for more information about this new GitHub feature.

The preview looked like this when creating the file through the UI:
![shields](https://user-images.githubusercontent.com/10694593/58379793-66efd780-7fa0-11e9-9e52-92543e7a0485.png)
