### PR TITLE
Switch dependabot to yaml config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+version: 1
+update_configs:
+  # shields.io dependencies
+  - package_manager: 'javascript'
+    directory: '/'
+    update_schedule: 'weekly'
+
+  # gh-badges package dependencies
+  - package_manager: 'javascript'
+    directory: '/gh-badges'
+    update_schedule: 'weekly'


### PR DESCRIPTION
Dependabot now allows config to be declared in a config file: https://dependabot.com/docs/config-file/

Merging this will move us to managing our dependabot settings in a yaml file in the repo instead of via the admin panel. This allows users who don't have access to the admin panel to view our config and propose changes to it.

However, the main reason I propose this change is the [ignored_updates](https://dependabot.com/docs/config-file/#ignored_updates) setting. An issue with things as they stand (in my opinion) is that if I say `@dependabot ignore this major`, dependabot internally preserves state based on the commands we issue but there is no way to inspect that state i.e: if someone told dependabot to "ignore this major" 2 months ago, the only place that information is recorded is in a closed pull request from 2 months ago (e.g: https://github.com/badges/shields/pull/1868 ). Perhaps its overkill if we just want to ignore one patch, but if we want to ignore a major, this allows us to make that explicit so its easier to reason about how our dependency management tool will act or why it isn't offering us updates for a particular package.