### PR TITLE
Stop calling variables "which"; affects [chocolatey codeclimate conda crates debug gem github mozillaobservatory nuget powershellgallery pub resharper vaadindirectory]

### DIFF
--- a/services/codeclimate/codeclimate-analysis.service.js
+++ b/services/codeclimate/codeclimate-analysis.service.js
@@ -40,7 +40,7 @@ const issueColorScale = colorScale(
   ['brightgreen', 'green', 'yellowgreen', 'yellow', 'red']
 )
 
-const whichMap = {
+const variantMap = {
   maintainability: {
     transform: data => ({
       maintainabilityLetter: data.attributes.ratings[0].letter,
@@ -96,7 +96,7 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
     return {
       base: 'codeclimate',
       pattern:
-        ':which(maintainability|maintainability-percentage|tech-debt|issues)/:user/:repo',
+        ':variant(maintainability|maintainability-percentage|tech-debt|issues)/:user/:repo',
     }
   }
 
@@ -105,14 +105,14 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
       {
         title: 'Code Climate maintainability',
         pattern:
-          ':which(maintainability|maintainability-percentage)/:user/:repo',
+          ':format(maintainability|maintainability-percentage)/:user/:repo',
         namedParams: {
-          which: 'maintainability',
+          format: 'maintainability',
           user: 'angular',
           repo: 'angular.js',
         },
         staticPreview: this.render({
-          which: 'maintainability',
+          variant: 'maintainability',
           maintainabilityLetter: 'F',
         }),
         keywords,
@@ -122,7 +122,7 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
         pattern: 'issues/:user/:repo',
         namedParams: { user: 'twbs', repo: 'bootstrap' },
         staticPreview: this.render({
-          which: 'issues',
+          variant: 'issues',
           issueCount: '89',
         }),
         keywords,
@@ -132,7 +132,7 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
         pattern: 'tech-debt/:user/:repo',
         namedParams: { user: 'jekyll', repo: 'jekyll' },
         staticPreview: this.render({
-          which: 'tech-debt',
+          variant: 'tech-debt',
           techDebtPercentage: 3.0,
         }),
         keywords,
@@ -140,8 +140,8 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
     ]
   }
 
-  static render({ which, ...props }) {
-    const { render } = whichMap[which]
+  static render({ variant, ...props }) {
+    const { render } = variantMap[variant]
 
     return render(props)
   }
@@ -165,13 +165,13 @@ module.exports = class CodeclimateAnalysis extends BaseJsonService {
     return data
   }
 
-  async handle({ which, user, repo }) {
-    const { transform } = whichMap[which]
+  async handle({ variant, user, repo }) {
+    const { transform } = variantMap[variant]
 
     const data = await this.fetch({ user, repo })
     const props = transform(data)
     return this.constructor.render({
-      which,
+      variant,
       ...props,
     })
   }

--- a/services/codeclimate/codeclimate-coverage-redirector.service.js
+++ b/services/codeclimate/codeclimate-coverage-redirector.service.js
@@ -10,7 +10,7 @@ module.exports = [
     category: 'coverage',
     route: {
       base: 'codeclimate',
-      pattern: ':which(c|coverage-percentage)/:user/:repo',
+      pattern: ':alias(c|coverage-percentage)/:user/:repo',
     },
     transformPath: ({ user, repo }) => `/codeclimate/coverage/${user}/${repo}`,
     dateAdded: new Date('2019-04-15'),

--- a/services/codeclimate/codeclimate-coverage.service.js
+++ b/services/codeclimate/codeclimate-coverage.service.js
@@ -24,7 +24,7 @@ module.exports = class CodeclimateCoverage extends BaseJsonService {
   static get route() {
     return {
       base: 'codeclimate',
-      pattern: ':which(coverage|coverage-letter)/:user/:repo',
+      pattern: ':format(coverage|coverage-letter)/:user/:repo',
     }
   }
 
@@ -32,9 +32,9 @@ module.exports = class CodeclimateCoverage extends BaseJsonService {
     return [
       {
         title: 'Code Climate coverage',
-        namedParams: { which: 'coverage', user: 'jekyll', repo: 'jekyll' },
+        namedParams: { format: 'coverage', user: 'jekyll', repo: 'jekyll' },
         staticPreview: this.render({
-          which: 'coverage',
+          format: 'coverage',
           percentage: 95.123,
           letter: 'A',
         }),
@@ -76,7 +76,7 @@ module.exports = class CodeclimateCoverage extends BaseJsonService {
     return data
   }
 
-  async handle({ which, user, repo }) {
+  async handle({ format, user, repo }) {
     const {
       attributes: {
         rating: { letter },
@@ -85,7 +85,7 @@ module.exports = class CodeclimateCoverage extends BaseJsonService {
     } = await this.fetch({ user, repo })
 
     return this.constructor.render({
-      wantLetter: which === 'coverage-letter',
+      wantLetter: format === 'coverage-letter',
       letter,
       percentage,
     })

--- a/services/conda/conda-downloads.service.js
+++ b/services/conda/conda-downloads.service.js
@@ -12,7 +12,7 @@ module.exports = class CondaDownloads extends BaseCondaService {
   static get route() {
     return {
       base: 'conda',
-      pattern: ':which(d|dn)/:channel/:pkg',
+      pattern: ':variant(d|dn)/:channel/:pkg',
     }
   }
 
@@ -22,25 +22,25 @@ module.exports = class CondaDownloads extends BaseCondaService {
         title: 'Conda',
         namedParams: { channel: 'conda-forge', package: 'python' },
         pattern: 'dn/:channel/:package',
-        staticPreview: this.render({ which: 'dn', downloads: 5000000 }),
+        staticPreview: this.render({ variant: 'dn', downloads: 5000000 }),
       },
     ]
   }
 
-  static render({ which, downloads }) {
+  static render({ variant, downloads }) {
     return {
-      label: which === 'dn' ? 'downloads' : 'conda|downloads',
+      label: variant === 'dn' ? 'downloads' : 'conda|downloads',
       message: metric(downloads),
       color: downloadCount(downloads),
     }
   }
 
-  async handle({ which, channel, pkg }) {
+  async handle({ variant, channel, pkg }) {
     const json = await this.fetch({ channel, pkg })
     const downloads = json.files.reduce(
       (total, file) => total + file.ndownloads,
       0
     )
-    return this.constructor.render({ which, downloads })
+    return this.constructor.render({ variant, downloads })
   }
 }

--- a/services/conda/conda-platform.service.js
+++ b/services/conda/conda-platform.service.js
@@ -10,7 +10,7 @@ module.exports = class CondaPlatform extends BaseCondaService {
   static get route() {
     return {
       base: 'conda',
-      pattern: ':which(p|pn)/:channel/:pkg',
+      pattern: ':variant(p|pn)/:channel/:pkg',
     }
   }
 
@@ -21,22 +21,22 @@ module.exports = class CondaPlatform extends BaseCondaService {
         namedParams: { channel: 'conda-forge', package: 'python' },
         pattern: 'pn/:channel/:package',
         staticPreview: this.render({
-          which: 'pn',
+          variant: 'pn',
           platforms: ['linux-64', 'win-32', 'osx-64', 'win-64'],
         }),
       },
     ]
   }
 
-  static render({ which, platforms }) {
+  static render({ variant, platforms }) {
     return {
-      label: which === 'pn' ? 'platform' : 'conda|platform',
+      label: variant === 'pn' ? 'platform' : 'conda|platform',
       message: platforms.join(' | '),
     }
   }
 
-  async handle({ which, channel, pkg }) {
+  async handle({ variant, channel, pkg }) {
     const json = await this.fetch({ channel, pkg })
-    return this.constructor.render({ which, platforms: json.conda_platforms })
+    return this.constructor.render({ variant, platforms: json.conda_platforms })
   }
 }

--- a/services/conda/conda-version.service.js
+++ b/services/conda/conda-version.service.js
@@ -12,7 +12,7 @@ module.exports = class CondaVersion extends BaseCondaService {
   static get route() {
     return {
       base: 'conda',
-      pattern: ':which(v|vn)/:channel/:pkg',
+      pattern: ':variant(v|vn)/:channel/:pkg',
     }
   }
 
@@ -23,7 +23,7 @@ module.exports = class CondaVersion extends BaseCondaService {
         namedParams: { channel: 'conda-forge', package: 'python' },
         pattern: 'v/:channel/:package',
         staticPreview: this.render({
-          which: 'v',
+          variant: 'v',
           channel: 'conda-forge',
           version: '3.7.1',
         }),
@@ -33,7 +33,7 @@ module.exports = class CondaVersion extends BaseCondaService {
         namedParams: { channel: 'conda-forge', package: 'python' },
         pattern: 'vn/:channel/:package',
         staticPreview: this.render({
-          which: 'vn',
+          variant: 'vn',
           channel: 'conda-forge',
           version: '3.7.1',
         }),
@@ -41,18 +41,18 @@ module.exports = class CondaVersion extends BaseCondaService {
     ]
   }
 
-  static render({ which, channel, version }) {
+  static render({ variant, channel, version }) {
     return {
-      label: which === 'vn' ? channel : `conda|${channel}`,
+      label: variant === 'vn' ? channel : `conda|${channel}`,
       message: versionText(version),
       color: versionColor(version),
     }
   }
 
-  async handle({ which, channel, pkg }) {
+  async handle({ variant, channel, pkg }) {
     const json = await this.fetch({ channel, pkg })
     return this.constructor.render({
-      which,
+      variant,
       channel,
       version: json.latest_version,
     })

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -12,7 +12,7 @@ module.exports = class CratesDownloads extends BaseCratesService {
   static get route() {
     return {
       base: 'crates',
-      pattern: ':which(d|dv)/:crate/:version?',
+      pattern: ':variant(d|dv)/:crate/:version?',
     }
   }
 
@@ -20,16 +20,16 @@ module.exports = class CratesDownloads extends BaseCratesService {
     return [
       {
         title: 'Crates.io',
-        pattern: ':which(d|dv)/:crate',
-        namedParams: { which: 'd', crate: 'rustc-serialize' },
+        pattern: ':variant(d|dv)/:crate',
+        namedParams: { variant: 'd', crate: 'rustc-serialize' },
         staticPreview: this.render({ downloads: 5000000 }),
         keywords,
       },
       {
         title: 'Crates.io',
-        pattern: ':which(d|dv)/:crate/:version',
+        pattern: ':variant(d|dv)/:crate/:version',
         namedParams: {
-          which: 'd',
+          variant: 'd',
           crate: 'rustc-serialize',
           version: '0.3.24',
         },
@@ -39,11 +39,11 @@ module.exports = class CratesDownloads extends BaseCratesService {
     ]
   }
 
-  static _getLabel(version, which) {
+  static _getLabel(version, variant) {
     if (version) {
       return `downloads@${version}`
     } else {
-      if (which === 'dv') {
+      if (variant === 'dv') {
         return 'downloads@latest'
       } else {
         return 'downloads'
@@ -51,15 +51,15 @@ module.exports = class CratesDownloads extends BaseCratesService {
     }
   }
 
-  static render({ which, downloads, version }) {
+  static render({ variant, downloads, version }) {
     return {
-      label: this._getLabel(version, which),
+      label: this._getLabel(version, variant),
       message: metric(downloads),
       color: downloadCountColor(downloads),
     }
   }
 
-  async handle({ which, crate, version }) {
+  async handle({ variant, crate, version }) {
     const json = await this.fetch({ crate, version })
 
     if (json.errors) {
@@ -72,13 +72,13 @@ module.exports = class CratesDownloads extends BaseCratesService {
     }
 
     let downloads
-    if (which === 'dv') {
+    if (variant === 'dv') {
       downloads = json.version
         ? json.version.downloads
         : json.versions[0].downloads
     } else {
       downloads = json.crate ? json.crate.downloads : json.version.downloads
     }
-    return this.constructor.render({ which, downloads, version })
+    return this.constructor.render({ variant, downloads, version })
   }
 }

--- a/services/debug/debug.service.js
+++ b/services/debug/debug.service.js
@@ -13,7 +13,7 @@ module.exports = class Debug extends NonMemoryCachingBaseService {
   static get route() {
     return {
       base: 'debug',
-      pattern: ':which(time|starttime|flip)',
+      pattern: ':variant(time|starttime|flip)',
     }
   }
 
@@ -24,8 +24,8 @@ module.exports = class Debug extends NonMemoryCachingBaseService {
     }
   }
 
-  async handle({ which }) {
-    switch (which) {
+  async handle({ variant }) {
+    switch (variant) {
       case 'time':
         return {
           label: 'time',

--- a/services/gem/gem-downloads.service.js
+++ b/services/gem/gem-downloads.service.js
@@ -34,7 +34,7 @@ module.exports = class GemDownloads extends BaseJsonService {
   static get route() {
     return {
       base: 'gem',
-      pattern: ':which(dt|dtv|dv)/:gem/:version?',
+      pattern: ':variant(dt|dtv|dv)/:gem/:version?',
     }
   }
 
@@ -48,7 +48,7 @@ module.exports = class GemDownloads extends BaseJsonService {
           version: 'stable',
         },
         staticPreview: this.render({
-          which: 'dv',
+          variant: 'dv',
           version: 'stable',
           downloads: 70000,
         }),
@@ -62,7 +62,7 @@ module.exports = class GemDownloads extends BaseJsonService {
           version: '4.1.0',
         },
         staticPreview: this.render({
-          which: 'dv',
+          variant: 'dv',
           version: '4.1.0',
           downloads: 50000,
         }),
@@ -73,7 +73,7 @@ module.exports = class GemDownloads extends BaseJsonService {
         pattern: 'dtv/:gem',
         namedParams: { gem: 'rails' },
         staticPreview: this.render({
-          which: 'dtv',
+          variant: 'dtv',
           downloads: 70000,
         }),
         keywords,
@@ -83,7 +83,7 @@ module.exports = class GemDownloads extends BaseJsonService {
         pattern: 'dt/:gem',
         namedParams: { gem: 'rails' },
         staticPreview: this.render({
-          which: 'dt',
+          variant: 'dt',
           downloads: 900000,
         }),
         keywords,
@@ -95,11 +95,11 @@ module.exports = class GemDownloads extends BaseJsonService {
     return { label: 'downloads' }
   }
 
-  static render({ which, version, downloads }) {
+  static render({ variant, version, downloads }) {
     let label
     if (version) {
       label = `downloads@${version}`
-    } else if (which === 'dtv') {
+    } else if (variant === 'dtv') {
       label = 'downloads@latest'
     }
 
@@ -152,9 +152,9 @@ module.exports = class GemDownloads extends BaseJsonService {
     return { totalDownloads, versionDownloads }
   }
 
-  async handle({ which, gem, version }) {
+  async handle({ variant, gem, version }) {
     let downloads
-    if (which === 'dv') {
+    if (variant === 'dv') {
       if (!version) {
         throw new InvalidParameter({
           prettyMessage: 'version downloads requires a version',
@@ -170,9 +170,9 @@ module.exports = class GemDownloads extends BaseJsonService {
       const {
         totalDownloads,
         versionDownloads,
-      } = await this.fetchDownloadCountForGem({ gem, which })
-      downloads = which === 'dtv' ? versionDownloads : totalDownloads
+      } = await this.fetchDownloadCountForGem({ gem, variant })
+      downloads = variant === 'dtv' ? versionDownloads : totalDownloads
     }
-    return this.constructor.render({ which, version, downloads })
+    return this.constructor.render({ variant, version, downloads })
   }
 }

--- a/services/github/github-contributors.service.js
+++ b/services/github/github-contributors.service.js
@@ -17,7 +17,7 @@ module.exports = class GithubContributors extends GithubAuthService {
   static get route() {
     return {
       base: 'github',
-      pattern: ':which(contributors|contributors-anon)/:user/:repo',
+      pattern: ':variant(contributors|contributors-anon)/:user/:repo',
     }
   }
 
@@ -26,7 +26,7 @@ module.exports = class GithubContributors extends GithubAuthService {
       {
         title: 'GitHub contributors',
         namedParams: {
-          which: 'contributors',
+          variant: 'contributors',
           user: 'cdnjs',
           repo: 'cdnjs',
         },
@@ -44,8 +44,8 @@ module.exports = class GithubContributors extends GithubAuthService {
     return renderContributorBadge({ contributorCount })
   }
 
-  async handle({ which, user, repo }) {
-    const isAnon = which === 'contributors-anon'
+  async handle({ variant, user, repo }) {
+    const isAnon = variant === 'contributors-anon'
 
     const { res, buffer } = await this._request({
       url: `/repos/${user}/${repo}/contributors`,

--- a/services/github/github-issue-detail-redirect.service.js
+++ b/services/github/github-issue-detail-redirect.service.js
@@ -2,7 +2,7 @@
 
 const { redirector } = require('..')
 
-const whichMap = {
+const variantMap = {
   s: 'state',
   u: 'author',
 }
@@ -13,11 +13,11 @@ module.exports = [
     route: {
       base: 'github',
       pattern:
-        ':issueKind(issues|pulls)/detail/:which(s|u)/:user/:repo/:number([0-9]+)',
+        ':issueKind(issues|pulls)/detail/:variant(s|u)/:user/:repo/:number([0-9]+)',
     },
-    transformPath: ({ issueKind, which, user, repo, number }) =>
+    transformPath: ({ issueKind, variant, user, repo, number }) =>
       `/github/${issueKind}/detail/${
-        whichMap[which]
+        variantMap[variant]
       }/${user}/${repo}/${number}`,
     dateAdded: new Date('2019-04-04'),
   }),

--- a/services/github/github-issue-detail.spec.js
+++ b/services/github/github-issue-detail.spec.js
@@ -11,7 +11,7 @@ const { stateColor, commentsColor } = require('./github-helpers')
 describe('GithubIssueDetail', function() {
   test(GithubIssueDetail.render, () => {
     given({
-      which: 'state',
+      property: 'state',
       value: { state: 'open' },
       number: '12',
       isPR: true,
@@ -21,7 +21,7 @@ describe('GithubIssueDetail', function() {
       color: stateColor('open'),
     })
     given({
-      which: 'state',
+      property: 'state',
       value: { state: 'closed' },
       number: '15',
       isPR: false,
@@ -31,7 +31,7 @@ describe('GithubIssueDetail', function() {
       color: stateColor('closed'),
     })
     given({
-      which: 'title',
+      property: 'title',
       value: 'refactor [FooService]',
       number: '232',
       isPR: true,
@@ -40,7 +40,7 @@ describe('GithubIssueDetail', function() {
       message: 'refactor [FooService]',
     })
     given({
-      which: 'title',
+      property: 'title',
       value: 'Packagist: invalid response data',
       number: '345',
       isPR: false,
@@ -49,14 +49,14 @@ describe('GithubIssueDetail', function() {
       message: 'Packagist: invalid response data',
     })
     given({
-      which: 'author',
+      property: 'author',
       value: 'calebcartwright',
     }).expect({
       label: 'author',
       message: 'calebcartwright',
     })
     given({
-      which: 'label',
+      property: 'label',
       value: { names: ['feature'], colors: ['a2eeef'] },
     }).expect({
       color: 'a2eeef',
@@ -64,20 +64,20 @@ describe('GithubIssueDetail', function() {
       label: 'label',
     })
     given({
-      which: 'label',
+      property: 'label',
       value: { names: ['service-badge', 'bug'], colors: ['a2eeef', 'ee0701'] },
     }).expect({
       color: undefined,
       message: 'service-badge | bug',
       label: 'label',
     })
-    given({ which: 'comments', value: 27 }).expect({
+    given({ property: 'comments', value: 27 }).expect({
       label: 'comments',
       message: metric(27),
       color: commentsColor('closed'),
     })
     given({
-      which: 'age',
+      property: 'age',
       value: '2019-04-01T20:09:31Z',
     }).expect({
       label: 'created',
@@ -85,7 +85,7 @@ describe('GithubIssueDetail', function() {
       color: age('2019-04-01T20:09:31Z'),
     })
     given({
-      which: 'last-update',
+      property: 'last-update',
       value: '2019-04-02T20:09:31Z',
     }).expect({
       label: 'updated',
@@ -96,7 +96,7 @@ describe('GithubIssueDetail', function() {
 
   test(GithubIssueDetail.prototype.transform, () => {
     given({
-      which: 'state',
+      property: 'state',
       json: { state: 'closed' },
     }).expect({
       // Since it's a PR, the "merged" value is not crucial here.
@@ -104,37 +104,37 @@ describe('GithubIssueDetail', function() {
       isPR: false,
     })
     given({
-      which: 'state',
-      kind: 'pulls',
+      property: 'state',
+      issueKind: 'pulls',
       json: { state: 'closed', merged_at: null },
     }).expect({
       value: { state: 'closed', merged: false },
       isPR: true,
     })
     given({
-      which: 'state',
-      kind: 'pulls',
+      property: 'state',
+      issueKind: 'pulls',
       json: { state: 'closed', merged_at: 'I am not null' },
     }).expect({
       value: { state: 'closed', merged: true },
       isPR: true,
     })
     given({
-      which: 'title',
+      property: 'title',
       json: { pull_request: {}, title: 'refactor [Codecov]' },
     }).expect({
       value: 'refactor [Codecov]',
       isPR: true,
     })
     given({
-      which: 'author',
+      property: 'author',
       json: { user: { login: 'dependabot' } },
     }).expect({
       value: 'dependabot',
       isPR: false,
     })
     given({
-      which: 'label',
+      property: 'label',
       json: {
         pull_request: {},
         labels: [
@@ -150,7 +150,7 @@ describe('GithubIssueDetail', function() {
       isPR: true,
     })
     given({
-      which: 'label',
+      property: 'label',
       json: { labels: [{ name: 'bug', color: 'ee0701' }] },
     }).expect({
       value: {
@@ -160,21 +160,21 @@ describe('GithubIssueDetail', function() {
       isPR: false,
     })
     given({
-      which: 'comments',
+      property: 'comments',
       json: { comments: 100 },
     }).expect({
       value: 100,
       isPR: false,
     })
     given({
-      which: 'age',
+      property: 'age',
       json: { created_at: '2019-04-01T20:09:31Z' },
     }).expect({
       value: '2019-04-01T20:09:31Z',
       isPR: false,
     })
     given({
-      which: 'last-update',
+      property: 'last-update',
       json: { updated_at: '2019-04-02T20:09:31Z' },
     }).expect({
       value: '2019-04-02T20:09:31Z',
@@ -186,7 +186,7 @@ describe('GithubIssueDetail', function() {
     it('throws InvalidResponse error when issue has no labels', function() {
       try {
         GithubIssueDetail.prototype.transform({
-          which: 'label',
+          property: 'label',
           json: { labels: [] },
         })
         expect.fail('Expected to throw')

--- a/services/github/github-issues.service.js
+++ b/services/github/github-issues.service.js
@@ -6,12 +6,12 @@ const { nonNegativeInteger } = require('../validators')
 const { GithubAuthService } = require('./github-auth-service')
 const { documentation, errorMessagesFor } = require('./github-helpers')
 
-const isWhichPR = {
+const isPRVariant = {
   'issues-pr': true,
   'issues-pr-closed': true,
 }
 
-const isWhichClosed = {
+const isClosedVariant = {
   'issues-closed': true,
   'issues-pr-closed': true,
 }
@@ -29,7 +29,7 @@ module.exports = class GithubIssues extends GithubAuthService {
     return {
       base: 'github',
       pattern:
-        ':which(issues|issues-closed|issues-pr|issues-pr-closed):raw(-raw)?/:user/:repo/:label*',
+        ':variant(issues|issues-closed|issues-pr|issues-pr-closed):raw(-raw)?/:user/:repo/:label*',
     }
   }
 
@@ -223,8 +223,8 @@ module.exports = class GithubIssues extends GithubAuthService {
     }
   }
 
-  static render({ which, numIssues, raw, label }) {
-    const state = isWhichClosed[which] ? 'closed' : 'open'
+  static render({ variant, numIssues, raw, label }) {
+    const state = isClosedVariant[variant] ? 'closed' : 'open'
 
     let labelPrefix = ''
     let messageSuffix = ''
@@ -238,7 +238,7 @@ module.exports = class GithubIssues extends GithubAuthService {
     const labelText = label
       ? `${isGhLabelMultiWord ? `"${label}"` : label} `
       : ''
-    const labelSuffix = isWhichPR[which] ? 'pull requests' : 'issues'
+    const labelSuffix = isPRVariant[variant] ? 'pull requests' : 'issues'
 
     return {
       label: `${labelPrefix}${labelText}${labelSuffix}`,
@@ -247,9 +247,9 @@ module.exports = class GithubIssues extends GithubAuthService {
     }
   }
 
-  async fetch({ which, user, repo, label }) {
-    const isPR = isWhichPR[which]
-    const isClosed = isWhichClosed[which]
+  async fetch({ variant, user, repo, label }) {
+    const isPR = isPRVariant[variant]
+    const isClosed = isClosedVariant[variant]
     const query = `repo:${user}/${repo}${isPR ? ' is:pr' : ' is:issue'}${
       isClosed ? ' is:closed' : ' is:open'
     }${label ? ` label:"${label}"` : ''}`
@@ -262,10 +262,10 @@ module.exports = class GithubIssues extends GithubAuthService {
     })
   }
 
-  async handle({ which, raw, user, repo, label }) {
-    const json = await this.fetch({ which, user, repo, label })
+  async handle({ variant, raw, user, repo, label }) {
+    const json = await this.fetch({ variant, user, repo, label })
     return this.constructor.render({
-      which,
+      variant,
       numIssues: json.total_count,
       raw,
       label,

--- a/services/github/github-pull-request-check-state.service.js
+++ b/services/github/github-pull-request-check-state.service.js
@@ -27,7 +27,7 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
   static get route() {
     return {
       base: 'github/status',
-      pattern: ':which(s|contexts)/pulls/:user/:repo/:number(\\d+)',
+      pattern: ':variant(s|contexts)/pulls/:user/:repo/:number(\\d+)',
     }
   }
 
@@ -41,7 +41,7 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
           repo: 'shields',
           number: '1110',
         },
-        staticPreview: this.render({ which: 's', state: 'pending' }),
+        staticPreview: this.render({ variant: 's', state: 'pending' }),
         keywords,
         documentation,
       },
@@ -54,7 +54,7 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
           number: '1110',
         },
         staticPreview: this.render({
-          which: 'contexts',
+          variant: 'contexts',
           state: 'pending',
           stateCounts: { passed: 5, pending: 1 },
         }),
@@ -71,9 +71,9 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
     }
   }
 
-  static render({ which, state, stateCounts }) {
+  static render({ variant, state, stateCounts }) {
     let message
-    if (which === 'contexts') {
+    if (variant === 'contexts') {
       message = Object.entries(stateCounts)
         .map(([state, count]) => `${count} ${state}`)
         .join(', ')
@@ -97,7 +97,7 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
     }
   }
 
-  async handle({ which, user, repo, number }) {
+  async handle({ variant, user, repo, number }) {
     const {
       head: { sha: ref },
     } = await fetchIssue(this, { user, repo, number })
@@ -110,6 +110,6 @@ module.exports = class GithubPullRequestCheckState extends GithubAuthService {
     })
     const { state, stateCounts } = this.constructor.transform(json)
 
-    return this.constructor.render({ which, state, stateCounts })
+    return this.constructor.render({ variant, state, stateCounts })
   }
 }

--- a/services/github/github-release-date.service.js
+++ b/services/github/github-release-date.service.js
@@ -28,7 +28,7 @@ module.exports = class GithubReleaseDate extends GithubAuthService {
   static get route() {
     return {
       base: 'github',
-      pattern: ':which(release-date|release-date-pre)/:user/:repo',
+      pattern: ':variant(release-date|release-date-pre)/:user/:repo',
     }
   }
 
@@ -71,9 +71,9 @@ module.exports = class GithubReleaseDate extends GithubAuthService {
     }
   }
 
-  async fetch({ which, user, repo }) {
+  async fetch({ variant, user, repo }) {
     const url =
-      which === 'release-date'
+      variant === 'release-date'
         ? `/repos/${user}/${repo}/releases/latest`
         : `/repos/${user}/${repo}/releases`
     return this._requestJson({
@@ -83,8 +83,8 @@ module.exports = class GithubReleaseDate extends GithubAuthService {
     })
   }
 
-  async handle({ which, user, repo }) {
-    const body = await this.fetch({ which, user, repo })
+  async handle({ variant, user, repo }) {
+    const body = await this.fetch({ variant, user, repo })
     if (Array.isArray(body)) {
       return this.constructor.render({ date: body[0].created_at })
     }

--- a/services/github/github-release.service.js
+++ b/services/github/github-release.service.js
@@ -13,7 +13,7 @@ module.exports = class GithubRelease extends GithubAuthService {
   static get route() {
     return {
       base: 'github',
-      pattern: ':which(release|release-pre)/:user/:repo',
+      pattern: ':variant(release|release-pre)/:user/:repo',
     }
   }
 
@@ -22,7 +22,7 @@ module.exports = class GithubRelease extends GithubAuthService {
       {
         title: 'GitHub release',
         namedParams: {
-          which: 'release',
+          variant: 'release',
           user: 'qubyte',
           repo: 'rubidium',
         },
@@ -46,14 +46,14 @@ module.exports = class GithubRelease extends GithubAuthService {
     }
   }
 
-  async handle({ which, user, repo }) {
+  async handle({ variant, user, repo }) {
     const {
       tag_name: version,
       prerelease: isPrerelease,
     } = await fetchLatestRelease(this, {
       user,
       repo,
-      includePre: which === 'release-pre',
+      includePre: variant === 'release-pre',
     })
     return this.constructor.render({ version, isPrerelease })
   }

--- a/services/github/github-tag.service.js
+++ b/services/github/github-tag.service.js
@@ -29,7 +29,7 @@ module.exports = class GithubTag extends GithubAuthService {
   static get route() {
     return {
       base: 'github',
-      pattern: ':which(tag|tag-pre|tag-date)/:user/:repo',
+      pattern: ':variant(tag|tag-pre|tag-date)/:user/:repo',
     }
   }
 
@@ -100,9 +100,9 @@ module.exports = class GithubTag extends GithubAuthService {
     }
   }
 
-  async handle({ which, user, repo }) {
-    const usingSemver = which !== 'tag-date'
-    const includePre = which === 'tag-pre'
+  async handle({ variant, user, repo }) {
+    const usingSemver = variant !== 'tag-date'
+    const includePre = variant === 'tag-pre'
 
     const json = await this._requestJson({
       url: `/repos/${user}/${repo}/tags`,

--- a/services/mozilla-observatory/mozilla-observatory.service.js
+++ b/services/mozilla-observatory/mozilla-observatory.service.js
@@ -58,7 +58,7 @@ module.exports = class MozillaObservatory extends BaseJsonService {
   static get route() {
     return {
       base: 'mozilla-observatory',
-      pattern: ':which(grade|grade-score)/:host',
+      pattern: ':format(grade|grade-score)/:host',
       queryParamSchema,
     }
   }
@@ -67,9 +67,9 @@ module.exports = class MozillaObservatory extends BaseJsonService {
     return [
       {
         title: 'Mozilla HTTP Observatory Grade',
-        namedParams: { which: 'grade', host: 'github.com' },
+        namedParams: { format: 'grade', host: 'github.com' },
         staticPreview: this.render({
-          which: 'grade',
+          format: 'grade',
           state: 'FINISHED',
           grade: 'A+',
           score: 115,
@@ -87,7 +87,7 @@ module.exports = class MozillaObservatory extends BaseJsonService {
     }
   }
 
-  static render({ which, state, grade, score }) {
+  static render({ format, state, grade, score }) {
     if (state !== 'FINISHED') {
       return {
         message: state.toLowerCase(),
@@ -104,7 +104,7 @@ module.exports = class MozillaObservatory extends BaseJsonService {
       f: 'red',
     }
     return {
-      message: which === 'grade' ? grade : `${grade} (${score}/100)`,
+      message: format === 'grade' ? grade : `${grade} (${score}/100)`,
       color: colorMap[letter],
     }
   }
@@ -121,8 +121,8 @@ module.exports = class MozillaObservatory extends BaseJsonService {
     })
   }
 
-  async handle({ which, host }, { publish }) {
+  async handle({ format, host }, { publish }) {
     const { state, grade, score } = await this.fetch({ host, publish })
-    return this.constructor.render({ which, state, grade, score })
+    return this.constructor.render({ format, state, grade, score })
   }
 }

--- a/services/nuget/nuget-v2-service-family.js
+++ b/services/nuget/nuget-v2-service-family.js
@@ -128,7 +128,7 @@ function createServiceFamily({
     static get route() {
       return {
         base: serviceBaseUrl,
-        pattern: ':which(v|vpre)/:packageName',
+        pattern: ':variant(v|vpre)/:packageName',
       }
     }
 
@@ -161,12 +161,12 @@ function createServiceFamily({
       return renderVersionBadge(props)
     }
 
-    async handle({ which, packageName }) {
+    async handle({ variant, packageName }) {
       const packageData = await fetch(this, {
         odataFormat,
         baseUrl: apiBaseUrl,
         packageName,
-        includePrereleases: which === 'vpre',
+        includePrereleases: variant === 'vpre',
       })
       const version = packageData.NormalizedVersion || packageData.Version
       return this.constructor.render({ version })

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -18,7 +18,7 @@ module.exports = class PubVersion extends BaseJsonService {
   static get route() {
     return {
       base: 'pub',
-      pattern: ':which(v|vpre)/:packageName',
+      pattern: ':variant(v|vpre)/:packageName',
     }
   }
 
@@ -52,9 +52,9 @@ module.exports = class PubVersion extends BaseJsonService {
     })
   }
 
-  async handle({ which, packageName }) {
+  async handle({ variant, packageName }) {
     const data = await this.fetch({ packageName })
-    const includePre = which === 'vpre'
+    const includePre = variant === 'vpre'
     const versions = data.versions
     const version = latest(versions, { pre: includePre })
     return renderVersionBadge({ version })

--- a/services/vaadin-directory/vaadin-directory-rating-count.service.js
+++ b/services/vaadin-directory/vaadin-directory-rating-count.service.js
@@ -12,7 +12,7 @@ module.exports = class VaadinDirectoryRatingCount extends BaseVaadinDirectorySer
   static get route() {
     return {
       base: 'vaadin-directory',
-      pattern: ':which(rc|rating-count)/:packageName',
+      pattern: ':alias(rc|rating-count)/:packageName',
     }
   }
 
@@ -39,7 +39,7 @@ module.exports = class VaadinDirectoryRatingCount extends BaseVaadinDirectorySer
     }
   }
 
-  async handle({ which, packageName }) {
+  async handle({ alias, packageName }) {
     const { ratingCount } = await this.fetch({ packageName })
     return this.constructor.render({ ratingCount })
   }

--- a/services/vaadin-directory/vaadin-directory-rating.service.js
+++ b/services/vaadin-directory/vaadin-directory-rating.service.js
@@ -12,7 +12,7 @@ module.exports = class VaadinDirectoryRating extends BaseVaadinDirectoryService 
   static get route() {
     return {
       base: 'vaadin-directory',
-      pattern: ':which(star|stars|rating)/:packageName',
+      pattern: ':format(star|stars|rating)/:packageName',
     }
   }
 
@@ -20,9 +20,9 @@ module.exports = class VaadinDirectoryRating extends BaseVaadinDirectoryService 
     return [
       {
         title: 'Vaadin Directory',
-        pattern: ':which(stars|rating)/:packageName',
-        namedParams: { which: 'rating', packageName: 'vaadinvaadin-grid' },
-        staticPreview: this.render({ which: 'rating', score: 4.75 }),
+        pattern: ':format(stars|rating)/:packageName',
+        namedParams: { format: 'rating', packageName: 'vaadinvaadin-grid' },
+        staticPreview: this.render({ format: 'rating', score: 4.75 }),
         keywords: ['vaadin-directory', 'rating'],
       },
     ]
@@ -32,9 +32,9 @@ module.exports = class VaadinDirectoryRating extends BaseVaadinDirectoryService 
     return { label: 'rating' }
   }
 
-  static render({ which, score }) {
+  static render({ format, score }) {
     const rating = (Math.round(score * 10) / 10).toFixed(1)
-    if (which === 'rating') {
+    if (format === 'rating') {
       return {
         label: 'rating',
         message: `${rating}/5`,
@@ -48,8 +48,8 @@ module.exports = class VaadinDirectoryRating extends BaseVaadinDirectoryService 
     }
   }
 
-  async handle({ which, packageName }) {
+  async handle({ format, packageName }) {
     const { averageRating } = await this.fetch({ packageName })
-    return this.constructor.render({ which, score: averageRating })
+    return this.constructor.render({ format, score: averageRating })
   }
 }

--- a/services/vaadin-directory/vaadin-directory-release-date.service.js
+++ b/services/vaadin-directory/vaadin-directory-release-date.service.js
@@ -12,7 +12,7 @@ module.exports = class VaadinDirectoryReleaseDate extends BaseVaadinDirectorySer
   static get route() {
     return {
       base: 'vaadin-directory',
-      pattern: ':which(rd|release-date)/:packageName',
+      pattern: ':alias(rd|release-date)/:packageName',
     }
   }
 
@@ -36,7 +36,7 @@ module.exports = class VaadinDirectoryReleaseDate extends BaseVaadinDirectorySer
     return { message: formatDate(date), color: ageColor(date) }
   }
 
-  async handle({ which, packageName }) {
+  async handle({ alias, packageName }) {
     const data = await this.fetch({ packageName })
     return this.constructor.render({
       date: data.latestAvailableRelease.publicationDate,

--- a/services/vaadin-directory/vaadin-directory-version.service.js
+++ b/services/vaadin-directory/vaadin-directory-version.service.js
@@ -11,7 +11,7 @@ module.exports = class VaadinDirectoryVersion extends BaseVaadinDirectoryService
   static get route() {
     return {
       base: 'vaadin-directory',
-      pattern: ':which(v|version)/:packageName',
+      pattern: ':alias(v|version)/:packageName',
     }
   }
 
@@ -31,7 +31,7 @@ module.exports = class VaadinDirectoryVersion extends BaseVaadinDirectoryService
     return { label: 'vaadin directory' }
   }
 
-  async handle({ which, packageName }) {
+  async handle({ alias, packageName }) {
     const data = await this.fetch({ packageName })
     const lv = data.latestAvailableRelease.name.toLowerCase()
     return renderVersionBadge({ version: lv })


### PR DESCRIPTION
Woohoo - variable name bikeshedding :bike: :house: 

There are a various cases where we support multiple slight variations of what is roughly the same badge. Sometimes there is obvious descriptive terminology we can use for this e.g: `:period(dd|dw|dm)`, but often we end up using something like:

* `:which(stars|rating)`
* `:which(dt|dtv|dv)`
* `:which(d|dv)`
* `:which(grade|grade-score)`

I understand that the reason we aren't using a great var name is because we generally fall back to it when there isn't obvious meaningful terminology to use. That said, I think this is slightly more problematic now that we directly expose the variable names we use in URL patterns to users via the builder. Now that it has shifted from an internal implementation detail to part of the public interface, it seems worthwhile putting a bit more effort into giving these parameters a better name.

Having put a bit of thought into this, I propose that where there are multiple slighty different versions of the same badge and we're going to expose that to the end user, we should use the word `variant` if there is not a more meaningful option available, but I'm also open to other better ideas if anyone has any.

I've started off this PR by changing a couple of services, but happy to go through the rest of the codebase (about another 20 services) to finish this job once we establish a word we're happy with.