### PR TITLE
Run package tests on multiple node versions with nvm 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ package_steps: &package_steps
         <<: *run_package_tests
         environment:
           mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/gh-badges/results.xml
+          MOCHA_FILE: junit/gh-badges/v8/results.xml
           NODE_VERSION: v8
         name: Run package tests on Node 8
 
@@ -146,7 +146,7 @@ package_steps: &package_steps
         <<: *run_package_tests
         environment:
           mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/gh-badges/results.xml
+          MOCHA_FILE: junit/gh-badges/v10/results.xml
           NODE_VERSION: v10
         name: Run package tests on Node 10
 
@@ -154,7 +154,7 @@ package_steps: &package_steps
         <<: *run_package_tests
         environment:
           mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/gh-badges/results.xml
+          MOCHA_FILE: junit/gh-badges/v11/results.xml
           NODE_VERSION: v11
         name: Run package tests on Node 11
 
@@ -162,7 +162,7 @@ package_steps: &package_steps
         <<: *run_package_tests
         environment:
           mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/gh-badges/results.xml
+          MOCHA_FILE: junit/gh-badges/v12/results.xml
           NODE_VERSION: v12
         name: Run package tests on Node 12
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,9 @@ package_steps: &package_steps
           npm install -g npm
           npm ci
 
+    # Run the package tests on each currently supported node version. See:
+    # https://github.com/badges/shields/blob/master/gh-badges/README.md#node-version-support
+
     - run:
         <<: *run_package_tests
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,14 +40,6 @@ main_steps: &main_steps
           MOCHA_FILE: junit/entrypoint/results.xml
         command: npm run test:entrypoint
 
-    - run:
-        name: Tests for gh-badges package
-        when: always
-        environment:
-          mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/gh-badges/results.xml
-        command: npm run test:package
-
     - store_test_results:
         path: junit
 
@@ -105,6 +97,74 @@ services_steps: &services_steps
           mocha_reporter: mocha-junit-reporter
           MOCHA_FILE: junit/services/results.xml
         command: npm run test:services:pr:run
+
+    - store_test_results:
+        path: junit
+
+run_package_tests: &run_package_tests
+  when: always
+  command: |
+    # https://discuss.circleci.com/t/switch-nodejs-version-on-machine-executor-solved/26675/3
+    set +e
+    export NVM_DIR="/opt/circleci/.nvm"
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    nvm install $NODE_VERSION
+    nvm use $NODE_VERSION
+    node --version
+    npm run test:package
+
+package_steps: &package_steps
+  steps:
+    - checkout
+
+    - restore_cache:
+        keys:
+          - v2-dependencies-{{ checksum "package-lock.json" }}
+          # https://github.com/badges/shields/issues/1937
+          - v2-dependencies-
+
+    - run:
+        name: Install dependencies
+        command: |
+          set +e
+          export NVM_DIR="/opt/circleci/.nvm"
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install v12
+          nvm use v12
+          npm install -g npm
+          npm ci
+
+    - run:
+        <<: *run_package_tests
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/gh-badges/results.xml
+          NODE_VERSION: v8
+        name: Run package tests on Node 8
+
+    - run:
+        <<: *run_package_tests
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/gh-badges/results.xml
+          NODE_VERSION: v10
+        name: Run package tests on Node 10
+
+    - run:
+        <<: *run_package_tests
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/gh-badges/results.xml
+          NODE_VERSION: v11
+        name: Run package tests on Node 11
+
+    - run:
+        <<: *run_package_tests
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/gh-badges/results.xml
+          NODE_VERSION: v12
+        name: Run package tests on Node 12
 
     - store_test_results:
         path: junit
@@ -216,6 +276,11 @@ jobs:
           when: always
           command: npm run build
 
+  package:
+    machine: true
+
+    <<: *package_steps
+
   services:
     docker:
       - image: circleci/node:8
@@ -282,6 +347,10 @@ workflows:
             branches:
               ignore: gh-pages
       - frontend:
+          filters:
+            branches:
+              ignore: gh-pages
+      - package:
           filters:
             branches:
               ignore: gh-pages

--- a/gh-badges/README.md
+++ b/gh-badges/README.md
@@ -34,6 +34,13 @@ const format = {
 const svg = bf.create(format)
 ```
 
+### Node version support
+
+The latest version of gh-badges supports all currently maintained Node
+versions. See the [Node Release Schedule][].
+
+[node release schedule]: https://github.com/nodejs/Release#release-schedule
+
 ## Format
 
 The format is the following:


### PR DESCRIPTION
This is an alternative approach to #3428 using NVM to run the tests on multiple node versions in a single container based on the discussion in that thread.