### PR TITLE
cut a v2.2.0 release

### DIFF
--- a/gh-badges/CHANGELOG.md
+++ b/gh-badges/CHANGELOG.md
@@ -1,6 +1,48 @@
 # Changelog
 
-## 2.1.0
+## 2.2.0
+
+### Deprecations
+
+- `labelColor` and `color` are now the recommended attribute names for label color and message color.
+
+  - `colorA` (now an alias for `labelColor`),
+  - `colorB` (now an alias for `color`) and
+  - `colorscheme` (now an alias for `color`)
+
+  are now deprecated and will be removed in some future release.
+
+### New Features
+
+- Semantic color aliases. Add support for:
+  - ![success](https://img.shields.io/badge/success-success.svg)
+  - ![important](https://img.shields.io/badge/important-important.svg)
+  - ![critical](https://img.shields.io/badge/critical-critical.svg)
+  - ![informational](https://img.shields.io/badge/informational-informational.svg)
+  - ![inactive](https://img.shields.io/badge/inactive-inactive.svg)
+- Add directory field to package.json (to help tools find this package in the repo)
+
+### Bug Fixes
+
+- Prevent bad letter spacing when whitespace surrounds badge text
+
+### Dependencies
+
+- Bump anafanafo
+- Use caret instead of tilde for dependencies
+
+### Internals
+
+- Generate JSON badges without using a template
+- Refactoring
+- Testing improvements
+
+### Node support
+
+- Declare support for all currently maintained Node versions
+- Explicitly test on all supported versions
+
+## 2.1.0 - 2018-11-18
 
 gh-badges v2.1.0 implements a new text width measurer which uses a lookup table, removing the dependency
 on PDFKit. It is no longer necessary to provide a local copy of Verdana for accurate text width computation.

--- a/gh-badges/package.json
+++ b/gh-badges/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-badges",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Shields.io badge library",
   "keywords": [
     "GitHub",


### PR DESCRIPTION
As noted in #3499 we've not done a gh-badges release in a while. Although bumping anafanafo isn't a massively important change, when I went to write the changelog entry, I was actually quite surprised at how much new stuff is backed up there :open_mouth: 

I've made the assumption that we're going to merge #3498 ahead of this and included the node version support work in the changelog entry.

Once this is reviewed/merged, I'll publish to NPM and close out #3499