### PR TITLE
(attempt to) fix 'failing service test' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
+++ b/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
@@ -1,5 +1,5 @@
 ---
-name: :green_heart: Failing service test
+name: 💚 Failing service test
 about: Note failing service tests
 ---
 


### PR DESCRIPTION
Had a poke about in https://github.com/badges/shields/issues/templates/edit and I've got a hunch that the reason this isn't being correctly picked up as an issue template is because the colons in `:green_heart:` are stopping the header from being parsed correctly:

![Screenshot at 2019-05-29 15-42-49](https://user-images.githubusercontent.com/6025893/58566458-9ca6f180-8228-11e9-87b2-30b6a6306170.png)

vs

![Screenshot at 2019-05-29 15-43-00](https://user-images.githubusercontent.com/6025893/58566463-9dd81e80-8228-11e9-9825-e19a2235b144.png)

This should probably fix it :crossed_fingers: 