### PR TITLE
switch [powershellgallery] platform example

### DIFF
--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -44,7 +44,7 @@ class PowershellGalleryPlatformSupport extends BaseXmlService {
     return [
       {
         title: 'PowerShell Gallery',
-        namedParams: { packageName: 'Az.Storage' },
+        namedParams: { packageName: 'DNS.1.1.1.1' },
         staticPreview: this.render({
           platforms: ['windows', 'macos', 'linux'],
         }),


### PR DESCRIPTION
The example we were previously using (Az.Storage) now renders

![](https://img.shields.io/powershellgallery/p/Az.Storage.svg)

This replaces the example with a package that gives us a valid result