### PR TITLE
Fix BadgeFactory.create() docblock

### DIFF
--- a/gh-badges/lib/index.js
+++ b/gh-badges/lib/index.js
@@ -16,9 +16,11 @@ class BadgeFactory {
    *
    * @param {object} format - Object specifying badge data
    * @param {string[]} format.text
-   * @param {string} format.colorscheme
-   * @param {string} format.colorA
-   * @param {string} format.colorB
+   * @param {string} format.labelColor - label color
+   * @param {string} format.color - message color
+   * @param {string} format.colorA - deprecated: alias for `labelColor`
+   * @param {string} format.colorscheme - deprecated: alias for `color`
+   * @param {string} format.colorB - deprecated: alias for `color`
    * @param {string} format.format
    * @param {string} format.template
    * @return {string} Badge in SVG or JSON format

--- a/gh-badges/lib/make-badge.js
+++ b/gh-badges/lib/make-badge.js
@@ -90,6 +90,10 @@ function capitalize(s) {
   return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
+/*
+note: makeBadge() is fairly thinly wrapped so if we are making changes here
+it is likely this will impact on the package's public interface in index.js
+*/
 module.exports = function makeBadge({
   format,
   template,


### PR DESCRIPTION
After pushing a new release earlier, I realised that we've [changed the spec for the format object](https://github.com/badges/shields/blob/master/gh-badges/CHANGELOG.md#deprecations) but didn't update the docblock. This PR updates the docblock, but it reminds me of a related issue which I've addressed in PR #3507