### PR TITLE
Add [Mastodon] service

### DIFF
--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -3,11 +3,11 @@
 const Joi = require('joi')
 const { BaseJsonService, NotFound } = require('..')
 const { metric } = require('../text-formatters')
-const { optionalUrl } = require('../validators')
+const { optionalUrl, nonNegativeInteger } = require('../validators')
 
 const schema = Joi.object({
   username: Joi.string().required(),
-  followers_count: Joi.number().required(),
+  followers_count: nonNegativeInteger,
 })
 
 const queryParamSchema = Joi.object({

--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const Joi = require('joi')
+const { BaseJsonService, NotFound } = require('..')
+const { metric } = require('../text-formatters')
+const { optionalUrl } = require('../validators')
+
+const schema = Joi.object({
+  username: Joi.string().required(),
+  followers_count: Joi.number().required(),
+})
+
+const queryParamSchema = Joi.object({
+  domain: optionalUrl,
+}).required()
+
+module.exports = class MastodonFollow extends BaseJsonService {
+  static get category() {
+    return 'social'
+  }
+
+  static get route() {
+    return {
+      base: 'mastodon/follow',
+      pattern: ':id',
+      queryParamSchema,
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Mastodon Follow',
+        namedParams: {
+          id: '26471',
+        },
+        queryParams: { domain: 'https://mastodon.social' },
+        staticPreview: {
+          label: 'Follow',
+          message: '862',
+          style: 'social',
+        },
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      namedLogo: 'mastodon',
+    }
+  }
+
+  static render({ username, followers, domain }) {
+    return {
+      label: `follow @${username}`,
+      message: metric(followers),
+      style: 'social',
+      link: [
+        `${domain}/users/${username}/remote_follow`,
+        `${domain}/users/${username}/followers`,
+      ],
+    }
+  }
+
+  async fetch({ id, domain }) {
+    return this._requestJson({
+      schema,
+      url: `${domain}/api/v1/accounts/${id}/`,
+    })
+  }
+
+  async handle({ id }, { domain = 'https://mastodon.social' }) {
+    if (isNaN(id))
+      throw new NotFound({ prettyMessage: 'invalid user id format' })
+    const data = await this.fetch({ id, domain })
+    return this.constructor.render({
+      username: data.username,
+      followers: data.followers_count,
+      domain,
+    })
+  }
+}

--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -14,6 +14,12 @@ const queryParamSchema = Joi.object({
   domain: optionalUrl,
 }).required()
 
+const documentation = `
+<p>To find your user id, you can use <a link target="_blank" href="https://prouser123.me/misc/mastodon-userid-lookup.html">this tool</a>.</p><br>
+<p>Alternatively you can make a request to <code><br>https://your.mastodon.server/.well-known/webfinger?resource=acct:{user}@{domain}</br></code></p>
+<p>Failing that, you can also visit your profile page, where your user ID will be in the header in a tag like this: <code>&lt;link href='https://your.mastodon.server/api/salmon/{your-user-id}' rel='salmon'></code></p>
+`
+
 module.exports = class MastodonFollow extends BaseJsonService {
   static get category() {
     return 'social'
@@ -40,6 +46,7 @@ module.exports = class MastodonFollow extends BaseJsonService {
           message: '862',
           style: 'social',
         },
+        documentation,
       },
     ]
   }

--- a/services/mastodon/mastodon-follow.tester.js
+++ b/services/mastodon/mastodon-follow.tester.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { isMetric } = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('Followers - default domain')
+  .get('/26471.json')
+  .expectBadge({
+    label: 'follow @wilkie',
+    message: isMetric,
+    link: [
+      'https://mastodon.social/users/wilkie/remote_follow',
+      'https://mastodon.social/users/wilkie/followers',
+    ],
+  })
+
+t.create('Followers - default domain - invalid user ID format (not a number)')
+  .get('/a.json')
+  .expectBadge({
+    label: 'social',
+    message: 'invalid user id format',
+  })
+
+t.create('Followers - default domain - invalid user ID (id not in use)')
+  .get('/0.json')
+  .expectBadge({
+    label: 'social',
+    message: 'not found',
+  })
+
+t.create('Followers - alternate domain')
+  .get('/2214.json?domain=https%3A%2F%2Fmastodon.xyz')
+  .expectBadge({
+    label: 'follow @PhotonQyv',
+    message: isMetric,
+    link: [
+      'https://mastodon.xyz/users/PhotonQyv/remote_follow',
+      'https://mastodon.xyz/users/PhotonQyv/followers',
+    ],
+  })


### PR DESCRIPTION
Closes #3458.

The API requires a user ID to get an account instead of their username.
I found the ID in a `<link>` tag in the header of a user's profile page.

Example: `<link href="{domain}/api/salmon/2214" rel="salmon">` (2214 is the user ID)

We should either add this to the documentation for the badge or find another solution to get the user ID.

Also posted on discord.