### PR TITLE
Allow nulls for boolean fields on Libraries.io APIs

### DIFF
--- a/services/librariesio/librariesio-dependencies.service.js
+++ b/services/librariesio/librariesio-dependencies.service.js
@@ -11,8 +11,12 @@ const schema = Joi.object({
   dependencies: Joi.array()
     .items(
       Joi.object({
-        deprecated: Joi.boolean().required(),
-        outdated: Joi.boolean().required(),
+        deprecated: Joi.boolean()
+          .allow(null)
+          .required(),
+        outdated: Joi.boolean()
+          .allow(null)
+          .required(),
       })
     )
     .default([]),


### PR DESCRIPTION
Fix the issue #3529 