### PR TITLE
[Spack] Package Manager: Latest Version

### DIFF
--- a/services/spack/spack.service.js
+++ b/services/spack/spack.service.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const Joi = require('@hapi/joi')
+const { renderVersionBadge } = require('..//version')
+const { BaseJsonService } = require('..')
+const schema = Joi.object({
+  latest_version: Joi.string().required(),
+}).required()
+
+module.exports = class SpackVersion extends BaseJsonService {
+  static get category() {
+    return 'version'
+  }
+
+  static get route() {
+    return {
+      base: 'spack/v',
+      pattern: ':packageName',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Spack',
+        namedParams: { packageName: 'adios2' },
+        staticPreview: this.render({ version: '2.3.1' }),
+        keywords: ['hpc'],
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'spack' }
+  }
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
+  async fetch({ packageName }) {
+    const firstLetter = packageName[0]
+    return this._requestJson({
+      schema,
+      url: `https://packages.spack.io/api/${firstLetter}/${packageName}.json`,
+      errorMessages: {
+        404: 'package not found',
+      },
+    })
+  }
+
+  async handle({ packageName }) {
+    const pkg = await this.fetch({ packageName })
+    return this.constructor.render({ version: pkg['latest_version'] })
+  }
+}

--- a/services/spack/spack.tester.js
+++ b/services/spack/spack.tester.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const { isVPlusDottedVersionAtLeastOne } = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('version (valid)')
+  .get('/adios2.json')
+  .expectBadge({
+    label: 'spack',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
+t.create('version (not found)')
+  .get('/not-a-package.json')
+  .expectBadge({ label: 'spack', message: 'package not found' })


### PR DESCRIPTION
Add support for the Spack package manager (https://spack.io and repo at https://github.com/spack/spack).
Spack is a modern multi-language, multi-version, multi-variant software package manager in high-performance computing (HPC).

~~This pull-request is a draft since we are still in the process of deploying a continuous package index.~~ The package index is up :)

- [x] https://github.com/spack/spack/pull/11652
- [x] https://github.com/spack/spack/pull/11665