### PR TITLE
Docker: Don't installl Cypress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ COPY package.json package-lock.json /usr/src/app/
 # Without the gh-badges package.json and CLI script in place, `npm ci` will fail.
 COPY gh-badges /usr/src/app/gh-badges/
 
-# We need dev deps to build the front end.
-RUN NODE_ENV=development npm ci
+# We need dev deps to build the front end. We don't need Cypress, though.
+RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci
 
 COPY . /usr/src/app
 RUN npm run build


### PR DESCRIPTION
Noticed this in the Docker Hub build log:

https://cloud.docker.com/u/shieldsio/repository/registry-1.docker.io/shieldsio/shields/builds/de14f15e-0f10-4842-9ad2-42b8558bc2ff

Ref #3558