### PR TITLE
Fix for-the-badge spacing, uppercase left, right instead of text[] variables

### DIFF
--- a/gh-badges/lib/make-badge.js
+++ b/gh-badges/lib/make-badge.js
@@ -111,7 +111,7 @@ module.exports = function makeBadge({
   // String coercion and whitespace removal.
   text = text.map(value => `${value}`.trim())
 
-  const [left, right] = text
+  let [left, right] = text
 
   color = normalizeColor(color || colorB || colorscheme)
   labelColor = normalizeColor(labelColor || colorA)
@@ -143,9 +143,10 @@ module.exports = function makeBadge({
     }
   }
   if (template === 'social') {
-    text[0] = capitalize(text[0])
+    left = capitalize(left)
   } else if (template === 'for-the-badge') {
-    text = text.map(value => value.toUpperCase())
+    left = left.toUpperCase()
+    right = right.toUpperCase()
   }
 
   let leftWidth = (anafanafo(left) / 10) | 0
@@ -170,7 +171,7 @@ module.exports = function makeBadge({
 
   const context = {
     text: [left, right],
-    escapedText: text.map(escapeXml),
+    escapedText: [left, right].map(escapeXml),
     widths: [leftWidth + 10 + logoWidth + logoPadding, rightWidth + 10],
     links: links.map(escapeXml),
     logo: escapeXml(logo),


### PR DESCRIPTION
Closes #3613 

Refer https://github.com/badges/shields/issues/3613#issuecomment-508582465 https://github.com/badges/shields/issues/3613#issuecomment-506983441
This PR addresses an issue where the measured text size was using the `left`, `right` variables, but the `text[]` variable was being uppercased.
