### PR TITLE
Minor refactor: expose custom promisify function from legacy request handler

### DIFF
--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -63,8 +63,6 @@ function flattenQueryParams(queryParams) {
   return Array.from(union).sort()
 }
 
-// Wrapper around `cachingRequest` that returns a promise rather than needing
-// to pass a callback.
 function promisify(cachingRequest) {
   return (uri, options) =>
     new Promise((resolve, reject) => {
@@ -252,6 +250,8 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
       })
     }
 
+    // Wrapper around `cachingRequest` that returns a promise rather than needing
+    // to pass a callback.
     cachingRequest.asPromise = promisify(cachingRequest)
 
     vendorDomain.run(() => {

--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -63,6 +63,27 @@ function flattenQueryParams(queryParams) {
   return Array.from(union).sort()
 }
 
+// Wrapper around `cachingRequest` that returns a promise rather than needing
+// to pass a callback.
+function promisify(cachingRequest) {
+  return (uri, options) =>
+    new Promise((resolve, reject) => {
+      cachingRequest(uri, options, (err, res, buffer) => {
+        if (err) {
+          if (err instanceof ShieldsRuntimeError) {
+            reject(err)
+          } else {
+            // Wrap the error in an Inaccessible so it can be identified
+            // by the BaseService handler.
+            reject(new Inaccessible({ underlyingError: err }))
+          }
+        } else {
+          resolve({ res, buffer })
+        }
+      })
+    })
+}
+
 // handlerOptions can contain:
 // - handler: The service's request handler function
 // - queryParams: An array of the field names of any custom query parameters
@@ -231,24 +252,7 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
       })
     }
 
-    // Wrapper around `cachingRequest` that returns a promise rather than
-    // needing to pass a callback.
-    cachingRequest.asPromise = (uri, options) =>
-      new Promise((resolve, reject) => {
-        cachingRequest(uri, options, (err, res, buffer) => {
-          if (err) {
-            if (err instanceof ShieldsRuntimeError) {
-              reject(err)
-            } else {
-              // Wrap the error in an Inaccessible so it can be identified
-              // by the BaseService handler.
-              reject(new Inaccessible({ underlyingError: err }))
-            }
-          } else {
-            resolve({ res, buffer })
-          }
-        })
-      })
+    cachingRequest.asPromise = promisify(cachingRequest)
 
     vendorDomain.run(() => {
       const result = handlerOptions.handler(
@@ -304,6 +308,7 @@ function clearRequestCache() {
 
 module.exports = {
   handleRequest,
+  promisify,
   clearRequestCache,
   // Expose for testing.
   _requestCache: requestCache,


### PR DESCRIPTION
Cherry-picked from #3410; should simplify reworking it.