### PR TITLE
Fix raster redirect and drop the legacy static .png route

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -5,8 +5,8 @@ public:
 
   rateLimit: false
 
-  redirectUrl: 'http://badge-server.example.com'
+  redirectUrl: 'http://frontend.example.test'
 
-  rasterUrl: 'http://raster.example.com'
+  rasterUrl: 'http://raster.example.test'
 
   handleInternalErrors: false

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -16,10 +16,7 @@ const {
   clearRequestCache,
 } = require('../base-service/legacy-request-handler')
 const { clearRegularUpdateCache } = require('../legacy/regular-update')
-const {
-  staticBadgeUrl,
-  rasterRedirectUrl,
-} = require('../badge-urls/make-badge-url')
+const { rasterRedirectUrl } = require('../badge-urls/make-badge-url')
 const log = require('./log')
 const sysMonitor = require('./monitor')
 const PrometheusMetrics = require('./prometheus-metrics')

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -259,8 +259,8 @@ module.exports = class Server {
   /**
    * Register Redirects
    *
-   * Set up a couple of redirects which have to be registered last:
-   * One for the legacy static badge route.
+   * Set up a couple of redirects:
+   * One for the raster badges.
    * Another to redirect the base URL /
    * (we use this to redirect https://img.shields.io/ to https://shields.io/ )
    */
@@ -283,31 +283,6 @@ module.exports = class Server {
         // cache time in case we've made mistakes.
         // const cacheDuration = (365 * 24 * 3600) | 0 // 1 year
         const cacheDuration = 3600 | 0 // 1 hour
-        ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
-
-        ask.res.end()
-      })
-
-      // Any badge, old version. This needs to be registered last.
-      // This route isn't working at present. Will anyone notice?
-      camp.route(/^\/([^/]+)\/(.+).png$/, (queryParams, match, end, ask) => {
-        const [, label, message] = match
-        const { color } = queryParams
-
-        const redirectUrl = staticBadgeUrl({
-          baseUrl: rasterUrl,
-          label,
-          message,
-          // Fixes https://github.com/badges/shields/issues/3260
-          color: color ? color.toString() : undefined,
-          format: 'png',
-        })
-
-        ask.res.statusCode = 301
-        ask.res.setHeader('Location', redirectUrl)
-
-        // The redirect is permanent.
-        const cacheDuration = (365 * 24 * 3600) | 0 // 1 year
         ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
 
         ask.res.end()

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -271,7 +271,25 @@ module.exports = class Server {
     } = config
 
     if (rasterUrl) {
-      // Any badge, old version.
+      // Redirect to the raster server for raster versions of modern badges.
+      camp.route(/\.png$/, (queryParams, match, end, ask) => {
+        ask.res.statusCode = 301
+        ask.res.setHeader(
+          'Location',
+          rasterRedirectUrl({ rasterUrl }, ask.req.url)
+        )
+
+        // The redirect is permanent, though let's start off with a shorter
+        // cache time in case we've made mistakes.
+        // const cacheDuration = (365 * 24 * 3600) | 0 // 1 year
+        const cacheDuration = 3600 | 0 // 1 hour
+        ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
+
+        ask.res.end()
+      })
+
+      // Any badge, old version. This needs to be registered last.
+      // This route isn't working at present. Will anyone notice?
       camp.route(/^\/([^/]+)\/(.+).png$/, (queryParams, match, end, ask) => {
         const [, label, message] = match
         const { color } = queryParams
@@ -290,23 +308,6 @@ module.exports = class Server {
 
         // The redirect is permanent.
         const cacheDuration = (365 * 24 * 3600) | 0 // 1 year
-        ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
-
-        ask.res.end()
-      })
-
-      // Redirect to the raster server for raster versions of modern badges.
-      camp.route(/\.png$/, (queryParams, match, end, ask) => {
-        ask.res.statusCode = 301
-        ask.res.setHeader(
-          'Location',
-          rasterRedirectUrl({ rasterUrl }, ask.req.url)
-        )
-
-        // The redirect is permanent, though let's start off with a shorter
-        // cache time in case we've made mistakes.
-        // const cacheDuration = (365 * 24 * 3600) | 0 // 1 year
-        const cacheDuration = 3600 | 0 // 1 hour
         ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
 
         ask.res.end()

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -41,7 +41,7 @@ describe('The server', function() {
     )
     expect(statusCode).to.equal(301)
     expect(headers.location).to.equal(
-      'http://raster.example.com/:fruit-apple-green.png'
+      'http://raster.example.test/:fruit-apple-green.png'
     )
   })
 
@@ -51,7 +51,7 @@ describe('The server', function() {
     })
     expect(statusCode).to.equal(301)
     expect(headers.location).to.equal(
-      'http://raster.example.com/npm/v/express.png'
+      'http://raster.example.test/npm/v/express.png'
     )
   })
 
@@ -125,7 +125,7 @@ describe('The server', function() {
 
     expect(statusCode).to.equal(302)
     // This value is set in `config/test.yml`
-    expect(headers.location).to.equal('http://badge-server.example.com')
+    expect(headers.location).to.equal('http://frontend.example.test')
   })
 
   it('should return the 410 badge for obsolete formats', async function() {

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -45,6 +45,29 @@ describe('The server', function() {
     )
   })
 
+  it('should redirect modern PNG badges as configured', async function() {
+    const { statusCode, headers } = await got(`${baseUrl}npm/v/express.png`, {
+      followRedirect: false,
+    })
+    expect(statusCode).to.equal(301)
+    expect(headers.location).to.equal(
+      'http://raster.example.com/npm/v/express.png'
+    )
+  })
+
+  it.skip('should redirect the legacy static badge as configured', async function() {
+    const { statusCode, headers } = await got(
+      `${baseUrl}/fruit/apple.png?color=green`,
+      {
+        followRedirect: false,
+      }
+    )
+    expect(statusCode).to.equal(301)
+    expect(headers.location).to.equal(
+      'http://raster.example.com/badge/fruit-apple-green.png'
+    )
+  })
+
   it('should preserve label case', async function() {
     const { statusCode, body } = await got(`${baseUrl}:fRuiT-apple-green.svg`)
     expect(statusCode).to.equal(200)

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -55,19 +55,6 @@ describe('The server', function() {
     )
   })
 
-  it.skip('should redirect the legacy static badge as configured', async function() {
-    const { statusCode, headers } = await got(
-      `${baseUrl}/fruit/apple.png?color=green`,
-      {
-        followRedirect: false,
-      }
-    )
-    expect(statusCode).to.equal(301)
-    expect(headers.location).to.equal(
-      'http://raster.example.com/badge/fruit-apple-green.png'
-    )
-  })
-
   it('should preserve label case', async function() {
     const { statusCode, body } = await got(`${baseUrl}:fRuiT-apple-green.svg`)
     expect(statusCode).to.equal(200)


### PR DESCRIPTION
This should fix the problem I noted at https://github.com/badges/shields/pull/3644#issuecomment-508952678 though it notes a bug, which is that the legacy static badge route `/label/message.png?color=green` does not work. That route is very, very old, and has never supported SVG, so I'm inclined to drop it, though if we want it to keep working, this redirect code is going to have to be changed in a more fundamental way. That route has always been registered last because it's difficult to distinguish from real badges.

I'm inclined to just drop the legacy static badge route since it probably isn't being used much (since it doesn't support SVG) and results in the server behaving differently with .svg and .png extensions at what is otherwise the same URL.

e.g. https://img.shields.io/foo/12345.svg shows 404 not found (not rendering, like a well behaved 404), but https://img.shields.io/badge/foo-12345-lightgray.png shows ![](https://img.shields.io/badge/foo-12345-lightgray.png).