### PR TITLE
Auto-annotate live and mock tests e.g. [nodeping]

### DIFF
--- a/core/service-test-runner/service-tester.js
+++ b/core/service-test-runner/service-tester.js
@@ -119,6 +119,9 @@ class ServiceTester {
     // eslint-disable-next-line mocha/prefer-arrow-callback
     fn(this.title, function() {
       specs.forEach(spec => {
+        spec._message = `[${spec.hasIntercept ? 'mocked' : 'live'}] ${
+          spec._message
+        }`
         if (!skipIntercepted || !spec.intercepted) {
           spec.baseUri(testerBaseUrl)
           spec.toss()

--- a/doc/service-tests.md
+++ b/doc/service-tests.md
@@ -221,7 +221,7 @@ static render({ status, result }) {
 We can also use nock to intercept API calls to return a known response body.
 
 ```js
-t.create('Build passed (mocked)')
+t.create('Build passed')
   .get('/build/wercker/go-wercker-api.json')
   .intercept(nock =>
     nock('https://app.wercker.com/api/v3/applications/')
@@ -234,7 +234,7 @@ t.create('Build passed (mocked)')
     color: 'brightgreen',
   })
 
-t.create('Build failed (mocked)')
+t.create('Build failed')
   .get('/build/wercker/go-wercker-api.json')
   .intercept(nock =>
     nock('https://app.wercker.com/api/v3/applications/')

--- a/services/archlinux/archlinux.tester.js
+++ b/services/archlinux/archlinux.tester.js
@@ -12,7 +12,7 @@ t.create('Arch Linux package (valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
   })
 
-t.create('Arch Linux package (valid, mocked response)')
+t.create('Arch Linux package (valid)')
   .get('/core/x86_64/pacman.json')
   .intercept(nock =>
     nock('https://www.archlinux.org')

--- a/services/cii-best-practices/cii-best-practices.tester.js
+++ b/services/cii-best-practices/cii-best-practices.tester.js
@@ -3,28 +3,28 @@
 const { withRegex } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('live: level known project')
+t.create('level known project')
   .get(`/level/1.json`)
   .expectBadge({
     label: 'cii',
     message: withRegex(/in progress|passing|silver|gold/),
   })
 
-t.create('live: percentage known project')
+t.create('percentage known project')
   .get(`/percentage/29.json`)
   .expectBadge({
     label: 'cii',
     message: withRegex(/([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-9][0-9]|300)%/),
   })
 
-t.create('live: summary known project')
+t.create('summary known project')
   .get(`/summary/33.json`)
   .expectBadge({
     label: 'cii',
     message: withRegex(/(in progress [0-9]|[1-9][0-9]%)|passing|silver|gold/),
   })
 
-t.create('live: unknown project')
+t.create('unknown project')
   .get(`/level/abc.json`)
   .expectBadge({ label: 'cii', message: 'project not found' })
 

--- a/services/cookbook/cookbook.tester.js
+++ b/services/cookbook/cookbook.tester.js
@@ -10,7 +10,7 @@ t.create('version')
     message: isVPlusDottedVersionAtLeastOne,
   })
 
-t.create('version (mocked)')
+t.create('version')
   .get('/chef-sugar.json')
   .intercept(nock =>
     nock('https://supermarket.getchef.com')

--- a/services/coverity/coverity-scan.tester.js
+++ b/services/coverity/coverity-scan.tester.js
@@ -3,14 +3,14 @@
 const Joi = require('@hapi/joi')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('live: known project id')
+t.create('known project id')
   .get('/3997.json')
   .expectBadge({
     label: 'coverity',
     message: Joi.string().regex(/passing|passed .* new defects|pending|failed/),
   })
 
-t.create('live: unknown project id')
+t.create('unknown project id')
   .get('/abc.json')
   // Coverity actually returns an HTTP 200 status with an HTML page when the project is not found.
   .expectBadge({ label: 'coverity', message: 'unparseable json response' })

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -55,7 +55,7 @@ t.create('version')
     message: isVPlusDottedVersionAtLeastOne,
   })
 
-t.create('version (mocked)')
+t.create('version')
   .get('/v/novel.json')
   .intercept(nock =>
     nock('http://www.ctan.org')

--- a/services/debian/debian.tester.js
+++ b/services/debian/debian.tester.js
@@ -19,7 +19,7 @@ t.create('Debian package (default distribution, valid, query unsafe chars)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
   })
 
-t.create('Debian package (valid, mocked response)')
+t.create('Debian package (valid)')
   .get('/apt/unstable.json')
   .intercept(nock =>
     nock('https://api.ftp-master.debian.org')

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -93,34 +93,34 @@ t.create('Invalid Host')
   )
   .expectBadge({ label: 'discourse', message: 'not found' })
 
-t.create('Topics (live)')
+t.create('Topics')
   .get('/https/meta.discourse.org/topics.json')
   .expectBadge({
     label: 'discourse',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? topics$/),
   })
 
-t.create('Posts (live)')
+t.create('Posts')
   .get('/https/meta.discourse.org/posts.json')
   .expectBadge({
     label: 'discourse',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? posts$/),
   })
 
-t.create('Users (live)')
+t.create('Users')
   .get('/https/meta.discourse.org/users.json')
   .expectBadge({
     label: 'discourse',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? users$/),
   })
 
-t.create('Likes (live)')
+t.create('Likes')
   .get('/https/meta.discourse.org/likes.json')
   .expectBadge({
     label: 'discourse',
     message: Joi.string().regex(/^[0-9]+[kMGTPEZY]? likes$/),
   })
 
-t.create('Status (live)')
+t.create('Status')
   .get('/https/meta.discourse.org/status.json')
   .expectBadge({ label: 'discourse', message: 'online' })

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -4,7 +4,7 @@ const { expect } = require('chai')
 const { getShieldsIcon } = require('../../lib/logos')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('Valid schema (mocked)')
+t.create('Valid schema')
   .get('.json?url=https://example.com/badge')
   .intercept(nock =>
     nock('https://example.com/')
@@ -133,7 +133,7 @@ t.create('logoWidth')
     logoWidth: 30,
   })
 
-t.create('Invalid schema (mocked)')
+t.create('Invalid schema)')
   .get('.json?url=https://example.com/badge')
   .intercept(nock =>
     nock('https://example.com/')
@@ -147,7 +147,7 @@ t.create('Invalid schema (mocked)')
     message: 'invalid properties: schemaVersion',
   })
 
-t.create('Invalid schema (mocked)')
+t.create('Invalid schema)')
   .get('.json?url=https://example.com/badge')
   .intercept(nock =>
     nock('https://example.com/')

--- a/services/homebrew/homebrew.tester.js
+++ b/services/homebrew/homebrew.tester.js
@@ -10,7 +10,7 @@ t.create('homebrew (valid)')
     message: isVPlusTripleDottedVersion,
   })
 
-t.create('homebrew (valid, mocked response)')
+t.create('homebrew (valid)')
   .get('/cake.json')
   .intercept(nock =>
     nock('https://formulae.brew.sh')

--- a/services/jetbrains/jetbrains.tester.js
+++ b/services/jetbrains/jetbrains.tester.js
@@ -18,7 +18,7 @@ t.create('downloads (user friendly plugin id)')
   .get('/plugin/d/1347-scala.json')
   .expectBadge({ label: 'downloads', message: isMetric })
 
-t.create('downloads (mocked)')
+t.create('downloads')
   .get('/plugin/d/9435.json')
   .intercept(
     nock =>
@@ -275,7 +275,7 @@ t.create('version (number as a plugin id)')
     message: isVPlusDottedVersionNClauses,
   })
 
-t.create('version (mocked)')
+t.create('version)')
   .get('/plugin/v/9435.json')
   .intercept(
     nock =>

--- a/services/myget/myget.tester.js
+++ b/services/myget/myget.tester.js
@@ -77,7 +77,7 @@ t.create('total downloads (tenant)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
   })
 
-t.create('version (mocked, yellow badge)')
+t.create('version (yellow badge)')
   .get('/myget/mongodb/v/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')
@@ -97,7 +97,7 @@ t.create('version (mocked, yellow badge)')
     color: 'yellow',
   })
 
-t.create('version (mocked, orange badge)')
+t.create('version (orange badge)')
   .get('/myget/mongodb/v/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')
@@ -117,7 +117,7 @@ t.create('version (mocked, orange badge)')
     color: 'orange',
   })
 
-t.create('version (mocked, blue badge)')
+t.create('version (blue badge)')
   .get('/myget/mongodb/v/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')
@@ -150,7 +150,7 @@ t.create('version (pre) (valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
   })
 
-t.create('version (pre) (mocked, yellow badge)')
+t.create('version (pre) (yellow badge)')
   .get('/myget/mongodb/vpre/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')
@@ -170,7 +170,7 @@ t.create('version (pre) (mocked, yellow badge)')
     color: 'yellow',
   })
 
-t.create('version (pre) (mocked, orange badge)')
+t.create('version (pre) (orange badge)')
   .get('/myget/mongodb/vpre/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')
@@ -190,7 +190,7 @@ t.create('version (pre) (mocked, orange badge)')
     color: 'orange',
   })
 
-t.create('version (pre) (mocked, blue badge)')
+t.create('version (pre) (blue badge)')
   .get('/myget/mongodb/vpre/MongoDB.Driver.Core.json')
   .intercept(nock =>
     nock('https://www.myget.org')

--- a/services/nodeping/nodeping-status.tester.js
+++ b/services/nodeping/nodeping-status.tester.js
@@ -3,14 +3,14 @@
 const Joi = require('@hapi/joi')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('NodePing status - live')
+t.create('NodePing status')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .expectBadge({
     label: 'Status',
     message: Joi.equal('up', 'down').required(),
   })
 
-t.create('NodePing status - up (mock)')
+t.create('NodePing status - up')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')
@@ -24,7 +24,7 @@ t.create('NodePing status - up (mock)')
     message: 'up',
   })
 
-t.create('NodePing status - down (mock)')
+t.create('NodePing status - down')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')

--- a/services/nodeping/nodeping-uptime.tester.js
+++ b/services/nodeping/nodeping-uptime.tester.js
@@ -3,14 +3,14 @@
 const t = (module.exports = require('../tester').createServiceTester())
 const { isPercentage } = require('../test-validators')
 
-t.create('NodePing uptime - live')
+t.create('NodePing uptime')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .expectBadge({
     label: 'Uptime',
     message: isPercentage,
   })
 
-t.create('NodePing uptime - 100% (mock)')
+t.create('NodePing uptime - 100%')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')
@@ -29,7 +29,7 @@ t.create('NodePing uptime - 100% (mock)')
     color: 'brightgreen',
   })
 
-t.create('NodePing uptime - 99.999% (mock)')
+t.create('NodePing uptime - 99.999%')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')
@@ -48,7 +48,7 @@ t.create('NodePing uptime - 99.999% (mock)')
     color: 'green',
   })
 
-t.create('NodePing uptime - 99.001% (mock)')
+t.create('NodePing uptime - 99.001%')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')
@@ -67,7 +67,7 @@ t.create('NodePing uptime - 99.001% (mock)')
     color: 'yellow',
   })
 
-t.create('NodePing uptime - 90.001% (mock)')
+t.create('NodePing uptime - 90.001%')
   .get('/jkiwn052-ntpp-4lbb-8d45-ihew6d9ucoei.json')
   .intercept(nock =>
     nock('https://nodeping.com')

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -54,7 +54,7 @@ t.create('version (valid)')
     message: isVPlusDottedVersionNClauses,
   })
 
-t.create('version (mocked, yellow badge)')
+t.create('version (yellow badge)')
   .get('/v/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')
@@ -74,7 +74,7 @@ t.create('version (mocked, yellow badge)')
     color: 'yellow',
   })
 
-t.create('version (mocked, orange badge)')
+t.create('version (orange badge)')
   .get('/v/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')
@@ -94,7 +94,7 @@ t.create('version (mocked, orange badge)')
     color: 'orange',
   })
 
-t.create('version (mocked, blue badge)')
+t.create('version (blue badge)')
   .get('/v/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')
@@ -143,7 +143,7 @@ t.create('version (pre) (valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
   })
 
-t.create('version (pre) (mocked, yellow badge)')
+t.create('version (pre) (yellow badge)')
   .get('/vpre/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')
@@ -163,7 +163,7 @@ t.create('version (pre) (mocked, yellow badge)')
     color: 'yellow',
   })
 
-t.create('version (pre) (mocked, orange badge)')
+t.create('version (pre) (orange badge)')
   .get('/vpre/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')
@@ -183,7 +183,7 @@ t.create('version (pre) (mocked, orange badge)')
     color: 'orange',
   })
 
-t.create('version (pre) (mocked, blue badge)')
+t.create('version (pre) (blue badge)')
   .get('/vpre/Microsoft.AspNetCore.Mvc.json')
   .intercept(nock =>
     nock('https://api.nuget.org')

--- a/services/snyk/snyk-vulnerability-github.tester.js
+++ b/services/snyk/snyk-vulnerability-github.tester.js
@@ -7,7 +7,7 @@ const {
   zeroVulnerabilitiesSvg,
 } = require('./snyk-test-helpers')
 
-t.create('live: valid repo')
+t.create('valid repo')
   .get('/badges/shields.json')
   .timeout(10000)
   .expectBadge({
@@ -15,7 +15,7 @@ t.create('live: valid repo')
     message: Joi.number().required(),
   })
 
-t.create('live: non existent repo')
+t.create('non existent repo')
   .get('/badges/not-real.json')
   .timeout(10000)
   .expectBadge({
@@ -23,7 +23,7 @@ t.create('live: non existent repo')
     message: 'repo or manifest not found',
   })
 
-t.create('live: valid target manifest path')
+t.create('valid target manifest path')
   .get('/badges/shields/gh-badges/package.json.json')
   .timeout(10000)
   .expectBadge({
@@ -31,7 +31,7 @@ t.create('live: valid target manifest path')
     message: Joi.number().required(),
   })
 
-t.create('live: invalid target manifest path')
+t.create('invalid target manifest path')
   .get('/badges/shields/gh-badges/requirements.txt.json')
   .timeout(10000)
   .expectBadge({

--- a/services/snyk/snyk-vulnerability-npm.tester.js
+++ b/services/snyk/snyk-vulnerability-npm.tester.js
@@ -7,7 +7,7 @@ const {
   zeroVulnerabilitiesSvg,
 } = require('./snyk-test-helpers')
 
-t.create('live: valid package latest version')
+t.create('valid package latest version')
   .get('/mocha.json')
   .timeout(10000)
   .expectBadge({
@@ -15,7 +15,7 @@ t.create('live: valid package latest version')
     message: Joi.number().required(),
   })
 
-t.create('live: valid scoped package latest version')
+t.create('valid scoped package latest version')
   .get('/@babel/core.json')
   .timeout(10000)
   .expectBadge({
@@ -23,7 +23,7 @@ t.create('live: valid scoped package latest version')
     message: Joi.number().required(),
   })
 
-t.create('live: non existent package')
+t.create('non existent package')
   .get('/mochaabcdef.json')
   .timeout(10000)
   .expectBadge({
@@ -31,7 +31,7 @@ t.create('live: non existent package')
     message: 'npm package is invalid or does not exist',
   })
 
-t.create('live: valid package specific version')
+t.create('valid package specific version')
   .get('/mocha@4.0.0.json')
   .timeout(10000)
   .expectBadge({
@@ -40,7 +40,7 @@ t.create('live: valid package specific version')
     color: 'red',
   })
 
-t.create('live: non existent package version')
+t.create('non existent package version')
   .get('/gh-badges@0.3.4.json')
   .timeout(10000)
   .expectBadge({

--- a/services/swagger/swagger.tester.js
+++ b/services/swagger/swagger.tester.js
@@ -7,7 +7,7 @@ const apiGetQueryParams = { url: 'https://example.com/example.json' }
 
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('Valid (mocked)')
+t.create('Valid')
   .get(getURL)
   .intercept(nock =>
     nock(apiURL)
@@ -21,7 +21,7 @@ t.create('Valid (mocked)')
     color: 'brightgreen',
   })
 
-t.create('Invalid (mocked)')
+t.create('Invalid')
   .get(getURL)
   .intercept(nock =>
     nock(apiURL)

--- a/services/ubuntu/ubuntu.tester.js
+++ b/services/ubuntu/ubuntu.tester.js
@@ -12,7 +12,7 @@ t.create('Ubuntu package (default distribution, valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
   })
 
-t.create('Ubuntu package (valid, mocked response)')
+t.create('Ubuntu package (valid)')
   .get('/ubuntu-wallpapers/bionic.json')
   .intercept(nock =>
     nock('https://api.launchpad.net')

--- a/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
@@ -29,28 +29,28 @@ const mockResponse = {
   ],
 }
 
-t.create('live: Azure DevOps Extension total installs')
+t.create('Azure DevOps Extension total installs')
   .get('/total/swellaby.mirror-git-repository.json')
   .expectBadge({
     label: 'installs',
     message: isMetric,
   })
 
-t.create('live: Azure DevOps Extension services installs')
+t.create('Azure DevOps Extension services installs')
   .get('/services/swellaby.mirror-git-repository.json')
   .expectBadge({
     label: 'installs',
     message: isMetric,
   })
 
-t.create('live: invalid extension id')
+t.create('invalid extension id')
   .get('/services/badges-shields.json')
   .expectBadge({
     label: 'installs',
     message: 'invalid extension id',
   })
 
-t.create('live: non existent extension')
+t.create('non existent extension')
   .get('/total/badges.shields-io-fake.json')
   .expectBadge({
     label: 'installs',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
@@ -29,28 +29,28 @@ const mockResponse = {
   ],
 }
 
-t.create('live: installs')
+t.create('installs')
   .get('/visual-studio-marketplace/i/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'installs',
     message: isMetric,
   })
 
-t.create('live: downloads')
+t.create('downloads')
   .get('/visual-studio-marketplace/d/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'downloads',
     message: isMetric,
   })
 
-t.create('live: invalid extension id')
+t.create('invalid extension id')
   .get('/visual-studio-marketplace/d/badges-shields.json')
   .expectBadge({
     label: 'vs marketplace',
     message: 'invalid extension id',
   })
 
-t.create('live: non existent extension')
+t.create('non existent extension')
   .get('/visual-studio-marketplace/d/badges.shields-io-fake.json')
   .expectBadge({
     label: 'vs marketplace',
@@ -111,14 +111,14 @@ t.create('downloads')
     color: 'yellowgreen',
   })
 
-t.create('live: installs (legacy)')
+t.create('installs (legacy)')
   .get('/vscode-marketplace/i/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'installs',
     message: isMetric,
   })
 
-t.create('live: downloads (legacy)')
+t.create('downloads (legacy)')
   .get('/vscode-marketplace/d/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'downloads',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
@@ -5,14 +5,14 @@ const { withRegex, isStarRating } = require('../test-validators')
 
 const isVscodeRating = withRegex(/[0-5]\.[0-9]{1}\/5?\s*\([0-9]*\)$/)
 
-t.create('live: rating')
+t.create('rating')
   .get('/visual-studio-marketplace/r/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'rating',
     message: isVscodeRating,
   })
 
-t.create('live: stars')
+t.create('stars')
   .get('/visual-studio-marketplace/stars/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'rating',
@@ -121,14 +121,14 @@ t.create('stars')
     color: 'brightgreen',
   })
 
-t.create('live: rating (legacy)')
+t.create('rating (legacy)')
   .get('/vscode-marketplace/r/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'rating',
     message: isVscodeRating,
   })
 
-t.create('live: stars (legacy)')
+t.create('stars (legacy)')
   .get('/vscode-marketplace/stars/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'rating',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
@@ -5,7 +5,7 @@ const { withRegex } = require('../test-validators')
 
 const isMarketplaceVersion = withRegex(/^v(\d+\.\d+\.\d+)(\.\d+)?$/)
 
-t.create('live: rating')
+t.create('rating')
   .get('/visual-studio-marketplace/v/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'version',
@@ -68,7 +68,7 @@ t.create('pre-release version')
     color: 'orange',
   })
 
-t.create('live: version (legacy)')
+t.create('version (legacy)')
   .get('/vscode-marketplace/v/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'version',

--- a/services/wercker/wercker.tester.js
+++ b/services/wercker/wercker.tester.js
@@ -19,7 +19,7 @@ t.create('Build status (private application)')
   .get('/build/wercker/blueprint.json')
   .expectBadge({ label: 'build', message: 'private application not supported' })
 
-t.create('Build passed (mocked)')
+t.create('Build passed')
   .get('/build/wercker/go-wercker-api.json')
   .intercept(nock =>
     nock('https://app.wercker.com/api/v3/applications/')
@@ -32,7 +32,7 @@ t.create('Build passed (mocked)')
     color: 'brightgreen',
   })
 
-t.create('Build failed (mocked)')
+t.create('Build failed')
   .get('/build/wercker/go-wercker-api.json')
   .intercept(nock =>
     nock('https://app.wercker.com/api/v3/applications/')

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -42,7 +42,7 @@ const mockedCoreResponseData = {
   offers: [{ version: '4.9.8' }, { version: '4.9.6' }],
 }
 
-t.create('Plugin Tested WP Version - current (mocked)')
+t.create('Plugin Tested WP Version - current')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
@@ -66,7 +66,7 @@ t.create('Plugin Tested WP Version - current (mocked)')
     color: 'brightgreen',
   })
 
-t.create('Plugin Tested WP Version - old (mocked)')
+t.create('Plugin Tested WP Version - old')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
@@ -90,7 +90,7 @@ t.create('Plugin Tested WP Version - old (mocked)')
     color: 'orange',
   })
 
-t.create('Plugin Tested WP Version - non-exsistant or unsupported (mocked)')
+t.create('Plugin Tested WP Version - non-exsistant or unsupported')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')


### PR DESCRIPTION
Close #2555

To avoid conflicts with #3652 I haven’t removed all the explicit annotations, though I’ve removed a bunch of them here.