### PR TITLE
Deprecate shields-server.com domain

### DIFF
--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -36,9 +36,9 @@ There are three public badge servers on OVH VPS’s.
 
 | Cname                       | Hostname             | Type | IP             | Location           |
 | --------------------------- | -------------------- | ---- | -------------- | ------------------ |
-| [s0.shields-server.com][s0] | vps71670.vps.ovh.ca  | VPS  | 192.99.59.72   | Quebec, Canada     |
-| [s1.shields-server.com][s1] | vps244529.ovh.net    | VPS  | 51.254.114.150 | Gravelines, France |
-| [s2.shields-server.com][s2] | vps117870.vps.ovh.ca | VPS  | 149.56.96.133  | Quebec, Canada     |
+| [s0.servers.shields.io][s0] | vps71670.vps.ovh.ca  | VPS  | 192.99.59.72   | Quebec, Canada     |
+| [s1.servers.shields.io][s1] | vps244529.ovh.net    | VPS  | 51.254.114.150 | Gravelines, France |
+| [s2.servers.shields.io][s2] | vps117870.vps.ovh.ca | VPS  | 149.56.96.133  | Quebec, Canada     |
 
 - These are single-core virtual hosts with 2 GB RAM [VPS SSD 1][].
 - The Node version (v9.4.0 at time of writing) and dependency versions on the
@@ -56,9 +56,9 @@ There are three public badge servers on OVH VPS’s.
 - The public servers _do not_ use docker. The `Dockerfile` is included for
   self-hosting (including on a Docker-capable PaaS).
 
-[s0]: https://s0.shields-server.com/index.html
-[s1]: https://s1.shields-server.com/index.html
-[s2]: https://s2.shields-server.com/index.html
+[s0]: https://s0.servers.shields.io/index.html
+[s1]: https://s1.servers.shields.io/index.html
+[s2]: https://s2.servers.shields.io/index.html
 [vps ssd 1]: https://www.ovh.com/world/vps/vps-ssd.xml
 [issue 1460]: https://github.com/badges/shields/issues/1460
 [serverscript]: https://github.com/badges/ServerScript
@@ -149,9 +149,9 @@ To set things up for deployment:
 3.  Add remotes:
 
 ```sh
-git remote add s0 root@s0.shields-server.com:/home/m/shields.git
-git remote add s1 root@s1.shields-server.com:/home/m/shields.git
-git remote add s2 root@s2.shields-server.com:/home/m/shields.git
+git remote add s0 root@s0.servers.shields.io:/home/m/shields.git
+git remote add s1 root@s1.servers.shields.io:/home/m/shields.git
+git remote add s2 root@s2.servers.shields.io:/home/m/shields.git
 ```
 
 `origin` should point to GitHub as usual.

--- a/scripts/github_token_backup.fish
+++ b/scripts/github_token_backup.fish
@@ -11,7 +11,7 @@ set shields_secret $argv[1]
 
 function do_backup
   set server $argv[1]
-  curl --insecure -u ":$shields_secret" "https://$server.shields-server.com/\$github-auth/tokens" > "$server""_tokens.json"
+  curl --insecure -u ":$shields_secret" "https://$server.servers.shields.io/\$github-auth/tokens" > "$server""_tokens.json"
 end
 
 for server in s0 s1 s2

--- a/services/github/auth/admin.js
+++ b/services/github/auth/admin.js
@@ -14,7 +14,7 @@ function setRoutes(apiProvider, server) {
   // password.
   //
   // e.g.
-  // curl --insecure -u ':very-very-secret' 'https://s0.shields-server.com/$github-auth/tokens'
+  // curl --insecure -u ':very-very-secret' 'https://s0.servers.shields.io/$github-auth/tokens'
   server.ajax.on('github-auth/tokens', (json, end, ask) => {
     if (!secretIsValid(ask.password)) {
       // An unknown entity tries to connect. Let the connection linger for a minute.


### PR DESCRIPTION
Now that these s0.server.shields.io entries are set up through the main DNS on Cloudflare, we don't need the shields-server.com domain anymore. One less thing to maintain.