### PR TITLE
Cover missing PHP version requirement in [PackagistPhpVersion]

### DIFF
--- a/services/packagist/packagist-php-version.service.js
+++ b/services/packagist/packagist-php-version.service.js
@@ -63,8 +63,13 @@ module.exports = class PackagistPhpVersion extends BasePackagistService {
       throw new NotFound({ prettyMessage: 'invalid version' })
     }
 
+    const packageVersion = allData.package.versions[version]
+    if (!packageVersion.require || !packageVersion.require.php) {
+      throw new NotFound({ prettyMessage: 'version requirement not found' })
+    }
+
     return this.constructor.render({
-      php: allData.package.versions[version].require.php,
+      php: packageVersion.require.php,
     })
   }
 }

--- a/services/packagist/packagist-php-version.tester.js
+++ b/services/packagist/packagist-php-version.tester.js
@@ -11,6 +11,14 @@ t.create('gets the package version of symfony 2.8')
   .get('/symfony/symfony/v2.8.0.json')
   .expectBadge({ label: 'php', message: isComposerVersion })
 
+t.create('package with no requirements')
+  .get('/bpampuch/pdfmake.json')
+  .expectBadge({ label: 'php', message: 'version requirement not found' })
+
+t.create('package with no php version requirement')
+  .get('/raulfraile/ladybug-theme-modern.json')
+  .expectBadge({ label: 'php', message: 'version requirement not found' })
+
 t.create('invalid package name')
   .get('/frodo/is-not-a-package.json')
   .expectBadge({ label: 'php', message: 'not found' })


### PR DESCRIPTION
Fixes #3767. Two slightly different error cases are now covered: for a given package version, no requirements at all or no PHP version requirement. 