### PR TITLE
Disable more default Sentry integrations

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,10 +9,22 @@ require('dotenv').config()
 // Set up Sentry reporting as early in the process as possible.
 const config = require('config').util.toObject()
 const Sentry = require('@sentry/node')
+const disabledIntegrations = ['Console', 'Http']
 Sentry.init({
   dsn: process.env.SENTRY_DSN || config.private.sentry_dsn,
-  integrations: integrations =>
-    integrations.filter(integration => integration.name !== 'Console'),
+  integrations: integrations => {
+    const filtered = integrations.filter(
+      integration => !disabledIntegrations.includes(integration.name)
+    )
+    if (filtered.length != integrations.length - disabledIntegrations.length) {
+      throw Error(
+        `An error occurred while filtering integrations. The following inetgrations were found: ${integrations.map(
+          ({ name }) => name
+        )}`
+      )
+    }
+    return filtered
+  },
 })
 
 if (+process.argv[2]) {


### PR DESCRIPTION
This one is spewing a bunch of recent http calls into each error log.

I get the benefit of these plugins though I'm curious what resources they might be using. And in this case, don't want the requests to end up e.g. in a GitHub issue.