### PR TITLE
Improve Gitpod automated setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,21 @@ ports:
 tasks:
   - init: npm ci && npm run build
     command: node server 8080 0.0.0.0
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,6 @@
 ports:
   - port: 8080
+    onOpen: open-preview
 tasks:
   - init: npm ci && npm run build
     command: node server 8080 0.0.0.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,3 +22,6 @@ github:
     addBadge: false
     # add a label once the prebuild is ready to pull requests (defaults to false)
     addLabel: false
+vscode:
+  extensions:
+    - esbenp.prettier-vscode@1.7.0:EbyqFvwe32qQBptkOgfQpQ==

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ It also works with full URLs like
 Use `npm run debug:server` to start server in debug mode.
 [This recipe][nodemon debug] shows how to debug Node.js application in [VS Code][].
 
-Shields has experimental support for [Gitpod Beta][gitpod], a pre-configured development
+Shields has experimental support for [Gitpod][gitpod], a pre-configured development
 environment that runs in your browser. To use Gitpod, click the button below and
 sign in with GitHub. Gitpod also offers a browser add-on, though it is not required.
 Please report any Gitpod bugs, questions, or suggestions in issue


### PR DESCRIPTION
Hi @paulmelnikow! 👋 I hope you're well, and that you're enjoying the summer. 🌴 

I noticed the Shields repo is quite popular on Gitpod (🎉) and I wanted to circle back to ensure the experience is as good as it can be, and finish some of the work items from https://github.com/badges/shields/issues/2772.

In this Pull Request, I:

1. remove the word "Beta" from README.md, since [Gitpod launched](https://www.gitpod.io/blog/gitpod-launch/) officially in April 2019

2. add `onOpen: open-preview` to the port 8080 specification, so that the Shields web app gets automatically opened in a preview when it starts

3. set up [continuously prebuilt workspaces](https://www.gitpod.io/docs/46_prebuilds/) to speed up IDE loading times. This saves 2 minutes every time you start a new workspace, but requires someone to install the (free) [Gitpod hook](https://github.com/marketplace/gitpod-io) for the Shields repo (it's pretty straightforward, but let me know if you'd like a walkthrough)

4. install the Prettier VS Code extension for Gitpod. This should enable automatic format-on-save with Prettier, but note that there is currently [a bug](https://github.com/theia-ide/theia/issues/5928) with the Prettier extension, hence the work-in-progress status of this PR

Here is what the Gitpod setup currently looks like today (2min waiting for setup, port 8080 notification):

<img width="1552" alt="Screenshot 2019-08-18 at 11 52 21" src="https://user-images.githubusercontent.com/599268/63222996-3db1a280-c1af-11e9-920e-70ca63ab536b.png">

And here is what it looks like with my PR (0s setup time, web preview instead of notification):

<img width="1552" alt="Screenshot 2019-08-18 at 11 56 28" src="https://user-images.githubusercontent.com/599268/63223010-8b2e0f80-c1af-11e9-853e-d56cf5f80929.png">

You can try it without merging by opening my fork in Gitpod: https://gitpod.io/#https://github.com/jankeromnes/shields

Please let me know if you have any thoughts or questions. 🙂 