### PR TITLE
Remove BadgeFactory

### DIFF
--- a/gh-badges/README.md
+++ b/gh-badges/README.md
@@ -21,9 +21,7 @@ badge build passed :green .png > mybadge.png
 ### As a library
 
 ```js
-const { BadgeFactory, ValidationError } = require('gh-badges')
-
-const bf = new BadgeFactory()
+const { makeBadge, ValidationError } = require('gh-badges')
 
 const format = {
   text: ['build', 'passed'],
@@ -31,8 +29,8 @@ const format = {
   template: 'flat',
 }
 
-bf.create(format) //<svg...
-bf.create({}) // ValidationError: Field `text` is required
+makeBadge(format) // <svg...
+makeBadge({}) // ValidationError: Field `text` is required
 ```
 
 ### Node version support

--- a/gh-badges/lib/index.js
+++ b/gh-badges/lib/index.js
@@ -3,85 +3,85 @@
  * @module gh-badges
  */
 
-const makeBadge = require('./make-badge')
+const _makeBadge = require('./make-badge')
 
 class ValidationError extends Error {}
 
-/**
- * BadgeFactory
- */
-class BadgeFactory {
-  constructor(options) {
-    if (options !== undefined) {
-      console.error(
-        'BadgeFactory: Constructor options are deprecated and will be ignored'
-      )
-    }
+function _validate(format) {
+  if (!('text' in format)) {
+    throw new ValidationError('Field `text` is required')
   }
 
-  _validate(format) {
-    if (!('text' in format)) {
-      throw new ValidationError('Field `text` is required')
-    }
-
-    if (
-      !Array.isArray(format.text) ||
-      format.text.length !== 2 ||
-      typeof format.text[0] !== 'string' ||
-      typeof format.text[1] !== 'string'
-    ) {
-      throw new ValidationError('Field `text` must be an array of 2 strings')
-    }
-
-    const stringFields = ['labelColor', 'color']
-    stringFields.forEach(function(field) {
-      if (field in format && typeof format[field] !== 'string') {
-        throw new ValidationError(`Field \`${field}\` must be of type string`)
-      }
-    })
-
-    const formatValues = ['svg', 'json']
-    if ('format' in format && !formatValues.includes(format.format)) {
-      throw new ValidationError(
-        `Field \`format\` must be one of (${formatValues.toString()})`
-      )
-    }
-
-    const templateValues = [
-      'plastic',
-      'flat',
-      'flat-square',
-      'for-the-badge',
-      'popout',
-      'popout-square',
-      'social',
-    ]
-    if ('template' in format && !templateValues.includes(format.template)) {
-      throw new ValidationError(
-        `Field \`template\` must be one of (${templateValues.toString()})`
-      )
-    }
+  if (
+    !Array.isArray(format.text) ||
+    format.text.length !== 2 ||
+    typeof format.text[0] !== 'string' ||
+    typeof format.text[1] !== 'string'
+  ) {
+    throw new ValidationError('Field `text` must be an array of 2 strings')
   }
 
-  /**
-   * Create a badge
-   *
-   * @param {object} format Object specifying badge data
-   * @param {string[]} format.text Badge text in an array e.g: ['build', 'passing']
-   * @param {string} format.labelColor (Optional) Label color
-   * @param {string} format.color (Optional) Message color
-   * @param {string} format.format (Optional) Output format: 'svg' or 'json'
-   * @param {string} format.template (Optional) Visual template e.g: 'flat'
-   *    see {@link https://github.com/badges/shields/tree/master/gh-badges/templates}
-   * @returns {string} Badge in SVG or JSON format
-   * @see https://github.com/badges/shields/tree/master/gh-badges/README.md
-   */
-  create(format) {
-    this._validate(format)
-    return makeBadge(format)
+  const stringFields = ['labelColor', 'color']
+  stringFields.forEach(function(field) {
+    if (field in format && typeof format[field] !== 'string') {
+      throw new ValidationError(`Field \`${field}\` must be of type string`)
+    }
+  })
+
+  const formatValues = ['svg', 'json']
+  if ('format' in format && !formatValues.includes(format.format)) {
+    throw new ValidationError(
+      `Field \`format\` must be one of (${formatValues.toString()})`
+    )
+  }
+
+  const templateValues = [
+    'plastic',
+    'flat',
+    'flat-square',
+    'for-the-badge',
+    'popout',
+    'popout-square',
+    'social',
+  ]
+  if ('template' in format && !templateValues.includes(format.template)) {
+    throw new ValidationError(
+      `Field \`template\` must be one of (${templateValues.toString()})`
+    )
   }
 }
 
+function _clean(format) {
+  const expectedKeys = ['text', 'labelColor', 'color', 'format', 'template']
+  const cleaned = {}
+  Object.keys(format).forEach(key => {
+    if (format[key] != null && expectedKeys.includes(key)) {
+      cleaned[key] = format[key]
+    }
+  })
+  return cleaned
+}
+
+/**
+ * Create a badge
+ *
+ * @param {object} format Object specifying badge data
+ * @param {string[]} format.text Badge text in an array e.g: ['build', 'passing']
+ * @param {string} format.labelColor (Optional) Label color
+ * @param {string} format.color (Optional) Message color
+ * @param {string} format.format (Optional) Output format: 'svg' or 'json'
+ * @param {string} format.template (Optional) Visual template e.g: 'flat'
+ *    see {@link https://github.com/badges/shields/tree/master/gh-badges/templates}
+ * @returns {string} Badge in SVG or JSON format
+ * @see https://github.com/badges/shields/tree/master/gh-badges/README.md
+ */
+function makeBadge(format) {
+  const cleanedFormat = _clean(format)
+  _validate(cleanedFormat)
+  return _makeBadge(cleanedFormat)
+}
+
 module.exports = {
-  BadgeFactory,
+  makeBadge,
+  ValidationError,
 }

--- a/gh-badges/lib/index.spec.js
+++ b/gh-badges/lib/index.spec.js
@@ -2,19 +2,17 @@
 
 const { expect } = require('chai')
 const isSvg = require('is-svg')
-const { BadgeFactory, ValidationError } = require('.')
-
-const bf = new BadgeFactory()
+const { makeBadge, ValidationError } = require('.')
 
 describe('BadgeFactory class', function() {
   it('should produce badge with valid input', function() {
     expect(
-      bf.create({
+      makeBadge({
         text: ['build', 'passed'],
       })
     ).to.satisfy(isSvg)
     expect(
-      bf.create({
+      makeBadge({
         text: ['build', 'passed'],
         format: 'svg',
         colorscheme: 'green',
@@ -22,7 +20,7 @@ describe('BadgeFactory class', function() {
       })
     ).to.satisfy(isSvg)
     expect(
-      bf.create({
+      makeBadge({
         text: ['build', 'passed'],
         foo: 'bar', // extra key
       })
@@ -30,25 +28,25 @@ describe('BadgeFactory class', function() {
   })
 
   it('should throw a ValidationError with invalid inputs', function() {
-    expect(() => bf.create({})).to.throw(
+    expect(() => makeBadge({})).to.throw(
       ValidationError,
       'Field `text` is required'
     )
-    expect(() => bf.create({ text: ['build'] })).to.throw(
+    expect(() => makeBadge({ text: ['build'] })).to.throw(
       ValidationError,
       'Field `text` must be an array of 2 strings'
     )
     expect(() =>
-      bf.create({ text: ['build', 'passed', 'something else'] })
+      makeBadge({ text: ['build', 'passed', 'something else'] })
     ).to.throw(ValidationError, 'Field `text` must be an array of 2 strings')
     expect(() =>
-      bf.create({ text: ['build', 'passed'], labelColor: 7 })
+      makeBadge({ text: ['build', 'passed'], labelColor: 7 })
     ).to.throw(ValidationError, 'Field `labelColor` must be of type string')
     expect(() =>
-      bf.create({ text: ['build', 'passed'], format: 'png' })
+      makeBadge({ text: ['build', 'passed'], format: 'png' })
     ).to.throw(ValidationError, 'Field `format` must be one of (svg,json)')
     expect(() =>
-      bf.create({ text: ['build', 'passed'], template: 'something else' })
+      makeBadge({ text: ['build', 'passed'], template: 'something else' })
     ).to.throw(
       ValidationError,
       'Field `template` must be one of (plastic,flat,flat-square,for-the-badge,popout,popout-square,social)'


### PR DESCRIPTION
Another one targetting v3-dev. This PR removes the `BadgeFactory` class (which we don't need now that all the text-measuring is being done by anafanafo instead of PDFKit) and just replaces it with a single function call `makeBadge()`.

The diff changes quite a lot, but its mostly just indentation. Probably the key thing here is: is `makeBadge()` the function name we want to expose?

I haven't switched our internal stuff to use the public interface of the package here yet, as there are still things (logos, links) that we support on shields.io but aren't exposed via the documented interface of the package yet.

I think I'm probably going to hold off on the other v3 changes (expose logos, rename the package, etc) until #3637 is done, as those jobs are going to create a big merge conflict with that work.