### PR TITLE
Fix TLS errors preventing Redis connections in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13976,9 +13976,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.0.tgz",
-      "integrity": "sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.13.1.tgz",
+      "integrity": "sha512-AsfcOmo+imI4pt2Jd5c6NWGYYKrmoWZIN972xeTwMqqSSbdOxWoSXHyaDDMhDbX7aGDwqN19z6i5e1J6wSJhsQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "glob": "^7.1.4",
     "graphql": "^14.4.2",
     "graphql-tag": "^2.10.1",
-    "ioredis": "^4.14.0",
+    "ioredis": "4.13.1",
     "joi-extension-semver": "3.0.0",
     "js-yaml": "^3.13.1",
     "jsonpath": "~1.0.2",

--- a/scripts/redis-connectivity-test.js
+++ b/scripts/redis-connectivity-test.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const config = require('config').util.toObject()
+console.log(config)
+const GithubConstellation = require('../services/github/github-constellation')
+
+const { persistence } = new GithubConstellation({
+  persistence: config.public.persistence,
+  service: config.public.services.github,
+  private: config.private,
+})
+
+async function main() {
+  const tokens = await persistence.initialize()
+  console.log(`${tokens.length} tokens loaded`)
+  await persistence.stop()
+}
+
+;(async () => {
+  try {
+    await main()
+  } catch (e) {
+    console.error(e)
+    process.exit(1)
+  }
+})()


### PR DESCRIPTION
ioredis 4.14.0 introduced an issue where custom TLS options are no longer honored. I reported it here: luin/ioredis#947

This has been preventing the server from using GitHub tokens, however I'm not sure whether or not this has been causing noticeable issues.

For now let's downgrade to the latest working version, which I've confirmed working via the script (checked in).