### PR TITLE
Add service for [GitHubLabels]

### DIFF
--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -10,7 +10,7 @@ const schema = Joi.object({
 
 module.exports = class GithubLabels extends GithubAuthV3Service {
   static get category() {
-    return 'other'
+    return 'issue-tracking'
   }
 
   static get route() {

--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -5,7 +5,9 @@ const { GithubAuthV3Service } = require('./github-auth-service')
 const { documentation, errorMessagesFor } = require('./github-helpers')
 
 const schema = Joi.object({
-  color: Joi.string().hex().required(),
+  color: Joi.string()
+    .hex()
+    .required(),
 }).required()
 
 module.exports = class GithubLabels extends GithubAuthV3Service {
@@ -52,7 +54,7 @@ module.exports = class GithubLabels extends GithubAuthV3Service {
     return this._requestJson({
       url: `/repos/${user}/${repo}/labels/${name}`,
       schema,
-      errorMessages: errorMessagesFor(`${name} (repo or label not found)`),
+      errorMessages: errorMessagesFor(`repo or label not found`),
     })
   }
 

--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const Joi = require('@hapi/joi')
+const { GithubAuthV3Service } = require('./github-auth-service')
+const { documentation, errorMessagesFor } = require('./github-helpers')
+
+const schema = Joi.object({
+  color: Joi.string(),
+}).required()
+
+module.exports = class GithubLabels extends GithubAuthV3Service {
+  static get category() {
+    return 'other'
+  }
+
+  static get route() {
+    return {
+      base: 'github/labels',
+      pattern: ':user/:repo/:name',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'GitHub labels',
+        namedParams: {
+          user: 'atom',
+          repo: 'atom',
+          name: 'help-wanted',
+        },
+        staticPreview: this.render({ name: 'help-wanted', color: '#159818' }),
+        documentation,
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: ' ',
+    }
+  }
+
+  static render({ name, color }) {
+    return {
+      message: name,
+      color,
+    }
+  }
+
+  async fetch({ user, repo, name }) {
+    return this._requestJson({
+      url: `/repos/${user}/${repo}/labels/${name}`,
+      schema,
+      errorMessages: errorMessagesFor(`${name} (repo or label not found)`),
+    })
+  }
+
+  async handle({ user, repo, name }) {
+    const { color } = await this.fetch({ user, repo, name })
+    return this.constructor.render({ name, color })
+  }
+}

--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -5,7 +5,7 @@ const { GithubAuthV3Service } = require('./github-auth-service')
 const { documentation, errorMessagesFor } = require('./github-helpers')
 
 const schema = Joi.object({
-  color: Joi.string(),
+  color: Joi.string().hex().required(),
 }).required()
 
 module.exports = class GithubLabels extends GithubAuthV3Service {

--- a/services/github/github-labels.tester.js
+++ b/services/github/github-labels.tester.js
@@ -12,6 +12,5 @@ t.create('labels')
 t.create('labels (repo or label not found)')
   .get('/badges/shields/somenonexistentlabelthatwouldneverexist.json')
   .expectBadge({
-    message:
-      'somenonexistentlabelthatwouldneverexist (repo or label not found)',
+    message: 'repo or label not found',
   })

--- a/services/github/github-labels.tester.js
+++ b/services/github/github-labels.tester.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('labels')
+  .get('/badges/shields/bug.json')
+  .expectBadge({
+    message: 'bug',
+    color: '#e11d21',
+  })
+
+t.create('labels (repo or label not found)')
+  .get('/badges/shields/somenonexistentlabelthatwouldneverexist.json')
+  .expectBadge({
+    message:
+      'somenonexistentlabelthatwouldneverexist (repo or label not found)',
+  })


### PR DESCRIPTION
Hi, I created a small service for displaying labels of GitHub repos.
This is nice for mentioning labels across GitHub, as GitHub-flavored markdown does not offer the option to reference a label. It keeps the color in sync and you will easily recognize if a label does not exist anymore.

The endpoint is `/github/labels/{user}/{repo}/{label}`.
You can e.g. reference the **documentation** label of this repo with: `/github/labels/badges/shields/documentation`, which would look similar to:
![](https://img.shields.io/badge/-documentation-green)
A nonexistent label `/github/labels/badges/shields/gibberish` would look like:
![](https://img.shields.io/badge/-gibberish%20\(repo%20or%20label%20not%20found\)-red)

Please feel free to make suggestions to my code as I am not used to writing JS or developing for node.

Thanks for offering such a cool service!