### PR TITLE
Fix lockfile to restore Heroku deploys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2726,6 +2726,15 @@
       "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
       "dev": true
     },
+    "@types/lodash.debounce": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
+      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.groupby": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
@@ -3286,6 +3295,14 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "anafanafo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-1.0.0.tgz",
+      "integrity": "sha512-pDPbI7SFRHu0byMXHAf+v74+LCcHSxnLYkcbfiV91XRlE+NSLpFCpEQdVUy9ZxZw/LuhTrOin4r8wlR3OFrKBA==",
+      "requires": {
+        "char-width-table-consumer": "^1.0.0"
+      }
     },
     "ansi-align": {
       "version": "3.0.0",
@@ -4388,6 +4405,11 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
+    "binary-search": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+    },
     "bintrees": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
@@ -5356,6 +5378,14 @@
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         }
+      }
+    },
+    "char-width-table-consumer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/char-width-table-consumer/-/char-width-table-consumer-1.0.0.tgz",
+      "integrity": "sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ==",
+      "requires": {
+        "binary-search": "^1.3.5"
       }
     },
     "chardet": {
@@ -12389,38 +12419,6 @@
         "gm": "^1.23.0",
         "is-css-color": "^1.0.0",
         "svgo": "^1.1.1"
-      },
-      "dependencies": {
-        "@hapi/joi": {
-          "version": "15.0.3",
-          "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
-          "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
-          "requires": {
-            "@hapi/address": "2.x.x",
-            "@hapi/topo": "3.x.x"
-          }
-        },
-        "anafanafo": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-1.0.0.tgz",
-          "integrity": "sha512-pDPbI7SFRHu0byMXHAf+v74+LCcHSxnLYkcbfiV91XRlE+NSLpFCpEQdVUy9ZxZw/LuhTrOin4r8wlR3OFrKBA==",
-          "requires": {
-            "char-width-table-consumer": "^1.0.0"
-          }
-        },
-        "binary-search": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.5.tgz",
-          "integrity": "sha512-RHFP0AdU6KAB0CCZsRMU2CJTk2EpL8GLURT+4gilpjr1f/7M91FgUMnXuQLmf3OKLet34gjuNFwO7e4agdX5pw=="
-        },
-        "char-width-table-consumer": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/char-width-table-consumer/-/char-width-table-consumer-1.0.0.tgz",
-          "integrity": "sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ==",
-          "requires": {
-            "binary-search": "^1.3.5"
-          }
-        }
       }
     },
     "git-config-path": {
@@ -13976,9 +13974,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.0.tgz",
-      "integrity": "sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.13.1.tgz",
+      "integrity": "sha512-AsfcOmo+imI4pt2Jd5c6NWGYYKrmoWZIN972xeTwMqqSSbdOxWoSXHyaDDMhDbX7aGDwqN19z6i5e1J6wSJhsQ==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2726,15 +2726,6 @@
       "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
       "dev": true
     },
-    "@types/lodash.debounce": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
-      "integrity": "sha512-4WTmnnhCfDvvuLMaF3KV4Qfki93KebocUF45msxhYyjMttZDQYzHkO639ohhk8+oco2cluAFL3t5+Jn4mleylQ==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/lodash.groupby": {
       "version": "4.6.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.groupby/-/lodash.groupby-4.6.6.tgz",
@@ -13985,9 +13976,9 @@
       "dev": true
     },
     "ioredis": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.13.1.tgz",
-      "integrity": "sha512-AsfcOmo+imI4pt2Jd5c6NWGYYKrmoWZIN972xeTwMqqSSbdOxWoSXHyaDDMhDbX7aGDwqN19z6i5e1J6wSJhsQ==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.14.0.tgz",
+      "integrity": "sha512-vGzyW9QTdGMjaAPUhMj48Z31mIO5qJLzkbsE5dg+orNi7L5Ph035htmkBZNDTDdDk7kp7e9UJUr+alhRuaWp8g==",
       "requires": {
         "cluster-key-slot": "^1.1.0",
         "debug": "^4.1.1",


### PR DESCRIPTION
Same idea as #3904.

Last known working was 316749bd69b684274b2ffd952f9c0872849d82af so I reverted to that and then ran npm install.

I'm on npm@6.11.2.