### PR TITLE
update [DubDownload] service test to increase stability/reliability

### DIFF
--- a/services/dub/dub-download.tester.js
+++ b/services/dub/dub-download.tester.js
@@ -21,9 +21,9 @@ t.create('total downloads (valid)')
   })
 
 t.create('total downloads, specific version (valid)')
-  .get('/dt/vibe-d/0.8.4.json')
+  .get('/dt/dub/1.16.0.json')
   .expectBadge({
-    label: 'downloads@0.8.4',
+    label: 'downloads@1.16.0',
     message: isMetric,
     color: isDownloadsColor,
   })


### PR DESCRIPTION
The specific version total downloads service test is frequent timeout failure in the daily test runs. This changes the target pacakge used for the test. In my local env, with this new target the test runs in < 1 sec. vs. the original package which ran in ~10 secs.

https://circleci.com/build-insights/gh/badges/daily-tests/master 