### PR TITLE
improve durability of [nexus] service test

### DIFF
--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -25,7 +25,9 @@ t.create('search release version of an nonexistent artifact')
 
 t.create('search snapshot version valid snapshot artifact')
   .timeout(15000)
-  .get('/s/com.google.guava/guava.json?server=https://oss.sonatype.org')
+  .get(
+    '/s/org.fusesource.apollo/apollo-karaf-feature.json?server=https://repository.jboss.org/nexus'
+  )
   .expectBadge({
     label: 'nexus',
     message: isVersion,


### PR DESCRIPTION
Same thing here as #3910 

the `search snapshot version valid snapshot artifact` service test for nexus is a regular timeout failure. this switches the target package (and nexus instance) used for the test. Admittedly anecdotal, but in my local env the original target timedout after 15 seconds on most runs, this new target is running in < 500 ms

https://circleci.com/build-insights/gh/badges/daily-tests/master