### PR TITLE
update JenkinsTests example

### DIFF
--- a/services/jenkins/jenkins-tests.service.js
+++ b/services/jenkins/jenkins-tests.service.js
@@ -54,9 +54,8 @@ module.exports = class JenkinsTests extends JenkinsBase {
         title: 'Jenkins tests',
         namedParams: {
           protocol: 'https',
-          host: 'jenkins.qa.ubuntu.com',
-          job:
-            'view/Trusty/view/Smoke%20Testing/job/trusty-touch-flo-smoke-daily',
+          host: 'jenkins.sqlalchemy.org',
+          job: 'alembic_coverage',
         },
         queryParams: {
           compact_message: null,


### PR DESCRIPTION
I noticed that the example we had for JenkinsTest was no longer valid (the QA Ubuntu Jenkins instance was apparently taken offline some time back)