### PR TITLE
Refactor existing metrics support into MetricHelper

### DIFF
--- a/core/base-service/base-non-memory-caching.js
+++ b/core/base-service/base-non-memory-caching.js
@@ -2,6 +2,7 @@
 
 const makeBadge = require('../../gh-badges/lib/make-badge')
 const BaseService = require('./base')
+const { MetricHelper } = require('./metric-helper')
 const { setCacheHeaders } = require('./cache-headers')
 const { makeSend } = require('./legacy-result-sender')
 const coalesceBadge = require('./coalesce-badge')
@@ -24,13 +25,14 @@ const { prepareRoute, namedParamsForMatch } = require('./route')
 // configured by the service, the user's request, and the server's default
 // cache length.
 module.exports = class NonMemoryCachingBaseService extends BaseService {
-  static register({ camp, requestCounter }, serviceConfig) {
+  static register({ camp, metricInstance }, serviceConfig) {
     const { cacheHeaders: cacheHeaderConfig } = serviceConfig
     const { _cacheLength: serviceDefaultCacheLengthSeconds } = this
     const { regex, captureNames } = prepareRoute(this.route)
 
-    const serviceRequestCounter = this._createServiceRequestCounter({
-      requestCounter,
+    const metricHelper = MetricHelper.create({
+      metricInstance,
+      ServiceClass: this,
     })
 
     camp.route(regex, async (queryParams, match, end, ask) => {
@@ -64,7 +66,7 @@ module.exports = class NonMemoryCachingBaseService extends BaseService {
 
       makeSend(format, ask.res, end)(svg)
 
-      serviceRequestCounter.inc()
+      metricHelper.noteResponseSent()
     })
   }
 }

--- a/core/base-service/base-static.js
+++ b/core/base-service/base-static.js
@@ -7,18 +7,20 @@ const {
   setCacheHeadersForStaticResource,
 } = require('./cache-headers')
 const { makeSend } = require('./legacy-result-sender')
+const { MetricHelper } = require('./metric-helper')
 const coalesceBadge = require('./coalesce-badge')
 const { prepareRoute, namedParamsForMatch } = require('./route')
 
 module.exports = class BaseStaticService extends BaseService {
-  static register({ camp, requestCounter }, serviceConfig) {
+  static register({ camp, metricInstance }, serviceConfig) {
     const {
       profiling: { makeBadge: shouldProfileMakeBadge },
     } = serviceConfig
     const { regex, captureNames } = prepareRoute(this.route)
 
-    const serviceRequestCounter = this._createServiceRequestCounter({
-      requestCounter,
+    const metricHelper = MetricHelper.create({
+      metricInstance,
+      ServiceClass: this,
     })
 
     camp.route(regex, async (queryParams, match, end, ask) => {
@@ -60,7 +62,7 @@ module.exports = class BaseStaticService extends BaseService {
 
       makeSend(format, ask.res, end)(svg)
 
-      serviceRequestCounter.inc()
+      metricHelper.noteResponseSent()
     })
   }
 }

--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -3,12 +3,12 @@
  * @module
  */
 
-const decamelize = require('decamelize')
 // See available emoji at http://emoji.muan.co/
 const emojic = require('emojic')
 const Joi = require('@hapi/joi')
 const log = require('../server/log')
 const { AuthHelper } = require('./auth-helper')
+const { MetricHelper } = require('./metric-helper')
 const { assertValidCategory } = require('./categories')
 const checkErrorResponse = require('./check-error-response')
 const coalesceBadge = require('./coalesce-badge')
@@ -391,27 +391,17 @@ class BaseService {
     return serviceData
   }
 
-  static _createServiceRequestCounter({ requestCounter }) {
-    if (requestCounter) {
-      const { category, serviceFamily, name } = this
-      const service = decamelize(name)
-      return requestCounter.labels(category, serviceFamily, service)
-    } else {
-      // When metrics are disabled, return a mock counter.
-      return { inc: () => {} }
-    }
-  }
-
   static register(
-    { camp, handleRequest, githubApiProvider, requestCounter },
+    { camp, handleRequest, githubApiProvider, metricInstance },
     serviceConfig
   ) {
     const { cacheHeaders: cacheHeaderConfig, fetchLimitBytes } = serviceConfig
     const { regex, captureNames } = prepareRoute(this.route)
     const queryParams = getQueryParamNames(this.route)
 
-    const serviceRequestCounter = this._createServiceRequestCounter({
-      requestCounter,
+    const metricHelper = MetricHelper.create({
+      metricInstance,
+      ServiceClass: this,
     })
 
     camp.route(
@@ -441,7 +431,7 @@ class BaseService {
           const format = (match.slice(-1)[0] || '.svg').replace(/^\./, '')
           sendBadge(format, badgeData)
 
-          serviceRequestCounter.inc()
+          metricHelper.noteResponseSent()
         },
         cacheLength: this._cacheLength,
         fetchLimitBytes,

--- a/core/base-service/metric-helper.js
+++ b/core/base-service/metric-helper.js
@@ -3,14 +3,13 @@
 class MetricHelper {
   constructor({ metricInstance }, { category, serviceFamily, name }) {
     if (metricInstance) {
-      this._serviceRequestCounter = metricInstance.createServiceRequestCounter({
+      this.serviceRequestCounter = metricInstance.createServiceRequestCounter({
         category,
         serviceFamily,
         name,
       })
     } else {
-      // When metrics are disabled, use a mock counter.
-      this._serviceRequestCounter = { inc: () => {} }
+      this.serviceRequestCounter = undefined
     }
   }
 
@@ -20,7 +19,10 @@ class MetricHelper {
   }
 
   noteResponseSent() {
-    this._serviceRequestCounter.inc()
+    const { serviceRequestCounter } = this
+    if (serviceRequestCounter) {
+      serviceRequestCounter.inc()
+    }
   }
 }
 

--- a/core/base-service/metric-helper.js
+++ b/core/base-service/metric-helper.js
@@ -3,7 +3,7 @@
 class MetricHelper {
   constructor({ metricInstance }, { category, serviceFamily, name }) {
     if (metricInstance) {
-      this.serviceRequestCounter = metricInstance.createServiceRequestCounter({
+      this.serviceRequestCounter = metricInstance.createNumRequestCounter({
         category,
         serviceFamily,
         name,

--- a/core/base-service/metric-helper.js
+++ b/core/base-service/metric-helper.js
@@ -1,0 +1,27 @@
+'use strict'
+
+class MetricHelper {
+  constructor({ metricInstance }, { category, serviceFamily, name }) {
+    if (metricInstance) {
+      this._serviceRequestCounter = metricInstance.createServiceRequestCounter({
+        category,
+        serviceFamily,
+        name,
+      })
+    } else {
+      // When metrics are disabled, use a mock counter.
+      this._serviceRequestCounter = { inc: () => {} }
+    }
+  }
+
+  static create({ metricInstance, ServiceClass }) {
+    const { category, serviceFamily, name } = ServiceClass
+    return new this({ metricInstance }, { category, serviceFamily, name })
+  }
+
+  noteResponseSent() {
+    this._serviceRequestCounter.inc()
+  }
+}
+
+module.exports = { MetricHelper }

--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -10,6 +10,7 @@ const {
   setCacheHeadersForStaticResource,
 } = require('./cache-headers')
 const { isValidCategory } = require('./categories')
+const { MetricHelper } = require('./metric-helper')
 const { isValidRoute, prepareRoute, namedParamsForMatch } = require('./route')
 const trace = require('./trace')
 
@@ -62,14 +63,15 @@ module.exports = function redirector(attrs) {
       return route
     }
 
-    static register({ camp, requestCounter }, { rasterUrl }) {
+    static register({ camp, metricInstance }, { rasterUrl }) {
       const { regex, captureNames } = prepareRoute({
         ...this.route,
         withPng: Boolean(rasterUrl),
       })
 
-      const serviceRequestCounter = this._createServiceRequestCounter({
-        requestCounter,
+      const metricHelper = MetricHelper.create({
+        metricInstance,
+        ServiceClass: this,
       })
 
       camp.route(regex, async (queryParams, match, end, ask) => {
@@ -121,7 +123,7 @@ module.exports = function redirector(attrs) {
 
         ask.res.end()
 
-        serviceRequestCounter.inc()
+        metricHelper.noteResponseSent()
       })
     }
   }

--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const decamelize = require('decamelize')
 const prometheus = require('prom-client')
 
 module.exports = class PrometheusMetrics {
@@ -29,5 +30,13 @@ module.exports = class PrometheusMetrics {
       clearInterval(this.interval)
       this.interval = undefined
     }
+  }
+
+  /**
+   * @returns {object} `{ inc() {} }`.
+   */
+  createServiceRequestCounter({ category, serviceFamily, name }) {
+    const service = decamelize(name)
+    return this.requestCounter.labels(category, serviceFamily, service)
   }
 }

--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -6,12 +6,14 @@ const prometheus = require('prom-client')
 module.exports = class PrometheusMetrics {
   constructor() {
     this.register = new prometheus.Registry()
-    this.requestCounter = new prometheus.Counter({
-      name: 'service_requests_total',
-      help: 'Total service requests',
-      labelNames: ['category', 'family', 'service'],
-      registers: [this.register],
-    })
+    this.counters = {
+      numRequests: new prometheus.Counter({
+        name: 'service_requests_total',
+        help: 'Total service requests',
+        labelNames: ['category', 'family', 'service'],
+        registers: [this.register],
+      }),
+    }
   }
 
   async initialize(server) {
@@ -35,8 +37,8 @@ module.exports = class PrometheusMetrics {
   /**
    * @returns {object} `{ inc() {} }`.
    */
-  createServiceRequestCounter({ category, serviceFamily, name }) {
+  createNumRequestCounter({ category, serviceFamily, name }) {
     const service = decamelize(name)
-    return this.requestCounter.labels(category, serviceFamily, service)
+    return this.counters.numRequests.labels(category, serviceFamily, service)
   }
 }

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -148,7 +148,7 @@ class Server {
       private: privateConfig,
     })
     if (publicConfig.metrics.prometheus.enabled) {
-      this.metrics = new PrometheusMetrics()
+      this.metricInstance = new PrometheusMetrics()
     }
   }
 
@@ -263,13 +263,12 @@ class Server {
    * load each service and register a Scoutcamp route for each service.
    */
   registerServices() {
-    const { config, camp } = this
+    const { config, camp, metrics: metricInstance } = this
     const { apiProvider: githubApiProvider } = this.githubConstellation
-    const { requestCounter } = this.metrics || {}
 
     loadServiceClasses().forEach(serviceClass =>
       serviceClass.register(
-        { camp, handleRequest, githubApiProvider, requestCounter },
+        { camp, handleRequest, githubApiProvider, metricInstance },
         {
           handleInternalErrors: config.public.handleInternalErrors,
           cacheHeaders: config.public.cacheHeaders,
@@ -309,10 +308,10 @@ class Server {
 
     this.cleanupMonitor = sysMonitor.setRoutes({ rateLimit }, camp)
 
-    const { githubConstellation, metrics } = this
+    const { githubConstellation, metricInstance } = this
     githubConstellation.initialize(camp)
-    if (metrics) {
-      metrics.initialize(camp)
+    if (metricInstance) {
+      metricInstance.initialize(camp)
     }
 
     const { apiProvider: githubApiProvider } = this.githubConstellation
@@ -355,8 +354,8 @@ class Server {
       this.githubConstellation = undefined
     }
 
-    if (this.metrics) {
-      this.metrics.stop()
+    if (this.metricInstance) {
+      this.metricInstance.stop()
     }
   }
 }


### PR DESCRIPTION
This completes the refactor suggested at https://github.com/badges/shields/pull/3662#issuecomment-509011229 in anticipation of adding more metrics support, such as response size of an upstream service, or response time.

Marking blocker as it's related to measuring response time for #3874.

I haven't tested this yet though we should follow "how to test it" in the top comment of https://github.com/badges/shields/pull/3662#issue-295109085.