### PR TITLE
Exclude more in-use GitHub IPs from rate limiting and add metrics

### DIFF
--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -19,7 +19,7 @@ function secretInvalid(req, res) {
 function setRoutes({ rateLimit }, { server, metricInstance }) {
   const ipRateLimit = new RateLimit({
     // Exclude IPs for GitHub Camo, determinted experimentally by running e.g.
-    // curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit
+    // `curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit`
     whitelist: /^(?:192\.30\.252\.\d+)|(?:140\.82\.115\.\d+)$/,
   })
   const badgeTypeRateLimit = new RateLimit({ maxHitsPerPeriod: 3000 })

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -18,9 +18,8 @@ function secretInvalid(req, res) {
 
 function setRoutes({ rateLimit }, { server, metricInstance }) {
   const ipRateLimit = new RateLimit({
-    // Exclude IPs for GitHub Camo, determinted experimentally by running
+    // Exclude IPs for GitHub Camo, determinted experimentally by running e.g.
     // curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit
-    //
     whitelist: /^(?:192\.30\.252\.\d+)|(?:140\.82\.115\.\d+)$/,
   })
   const badgeTypeRateLimit = new RateLimit({ maxHitsPerPeriod: 3000 })

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -18,7 +18,7 @@ function secretInvalid(req, res) {
 
 function setRoutes({ rateLimit }, { server, metricInstance }) {
   const ipRateLimit = new RateLimit({
-    // Exclude IPs for GitHub Camo, determinted experimentally by running e.g.
+    // Exclude IPs for GitHub Camo, determined experimentally by running e.g.
     // `curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit`
     whitelist: /^(?:192\.30\.252\.\d+)|(?:140\.82\.115\.\d+)$/,
   })

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -18,7 +18,10 @@ function secretInvalid(req, res) {
 
 function setRoutes({ rateLimit }, { server, metricInstance }) {
   const ipRateLimit = new RateLimit({
-    whitelist: /^192\.30\.252\.\d+$/, // Whitelist GitHub IPs.
+    // Exclude IPs for GitHub Camo, determinted experimentally by running
+    // curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit
+    //
+    whitelist: /^(?:192\.30\.252\.\d+)|(?:140\.82\.115\.\d+)$/,
   })
   const badgeTypeRateLimit = new RateLimit({ maxHitsPerPeriod: 3000 })
   const refererRateLimit = new RateLimit({

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -16,7 +16,7 @@ function secretInvalid(req, res) {
   return false
 }
 
-function setRoutes({ rateLimit }, server) {
+function setRoutes({ rateLimit }, { server, metricInstance }) {
   const ipRateLimit = new RateLimit({
     whitelist: /^192\.30\.252\.\d+$/, // Whitelist GitHub IPs.
   })
@@ -44,12 +44,15 @@ function setRoutes({ rateLimit }, server) {
       const referer = req.headers['referer']
 
       if (ipRateLimit.isBanned(ip, req, res)) {
+        metricInstance.noteRateLimitExceeded('ip')
         return
       }
       if (badgeTypeRateLimit.isBanned(badgeType, req, res)) {
+        metricInstance.noteRateLimitExceeded('badge_type')
         return
       }
       if (refererRateLimit.isBanned(referer, req, res)) {
+        metricInstance.noteRateLimitExceeded('referrer')
         return
       }
     }

--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -53,6 +53,12 @@ module.exports = class PrometheusMetrics {
         ],
         registers: [this.register],
       }),
+      rateLimitExceeded: new prometheus.Counter({
+        name: 'rate_limit_exceeded_total',
+        help: 'Count of rate limit exceeded by type',
+        labelNames: ['rate_limit_type'],
+        registers: [this.register],
+      }),
     }
   }
 
@@ -84,5 +90,9 @@ module.exports = class PrometheusMetrics {
 
   noteResponseTime(responseTime) {
     return this.counters.responseTime.observe(responseTime)
+  }
+
+  noteRateLimitExceeded(rateLimitType) {
+    return this.counters.rateLimitExceeded.labels(rateLimitType).inc()
   }
 }

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -288,6 +288,7 @@ class Server {
    * Start listening for requests on this.baseUrl()
    */
   async start() {
+    const { metricInstance } = this
     const {
       bind: { port, address: hostname },
       ssl: { isSecure: secure, cert, key },
@@ -306,7 +307,10 @@ class Server {
       key,
     }))
 
-    this.cleanupMonitor = sysMonitor.setRoutes({ rateLimit }, camp)
+    this.cleanupMonitor = sysMonitor.setRoutes(
+      { rateLimit },
+      { server: camp, metricInstance }
+    )
 
     const { githubConstellation, metricInstance } = this
     githubConstellation.initialize(camp)

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -288,7 +288,6 @@ class Server {
    * Start listening for requests on this.baseUrl()
    */
   async start() {
-    const { metricInstance } = this
     const {
       bind: { port, address: hostname },
       ssl: { isSecure: secure, cert, key },
@@ -307,12 +306,13 @@ class Server {
       key,
     }))
 
+    const { metricInstance } = this
     this.cleanupMonitor = sysMonitor.setRoutes(
       { rateLimit },
       { server: camp, metricInstance }
     )
 
-    const { githubConstellation, metricInstance } = this
+    const { githubConstellation } = this
     githubConstellation.initialize(camp)
     if (metricInstance) {
       metricInstance.initialize(camp)


### PR DESCRIPTION
See if GitHub outages are related to onboard rate limiting.

https://github.com/badges/shields/issues/3874#issuecomment-527904731

From https://shields-staging-pr-3950.herokuapp.com/metrics

```
# HELP rate_limit_exceeded_total Count of rate limit exceeded by type
# TYPE rate_limit_exceeded_total counter
rate_limit_exceeded_total{rate_limit_type="referrer"} 146
rate_limit_exceeded_total{rate_limit_type="ip"} 929
```