### PR TITLE
Add [Netlify] (fixed #3129)

### DIFF
--- a/services/build-status.js
+++ b/services/build-status.js
@@ -21,8 +21,9 @@ const redStatuses = [
   'infrastructure_failure',
 ]
 
+const yellowStatuses = ['building']
+
 const otherStatuses = [
-  'building',
   'canceled',
   'cancelled',
   'expired',
@@ -56,6 +57,9 @@ function renderBuildStatusBadge({ label, status }) {
   if (greenStatuses.includes(status)) {
     message = 'passing'
     color = 'brightgreen'
+  } else if (yellowStatuses.includes(status)) {
+    message = 'building'
+    color = 'yellow'
   } else if (orangeStatuses.includes(status)) {
     message = status === 'partially succeeded' ? 'passing' : status
     color = 'orange'

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -58,7 +58,7 @@ module.exports = class Netlify extends BaseSvgScrapingService {
 
   static render({ status }) {
     status = statusMap[status] || status
-    let result = renderBuildStatusBadge({ status })
+    const result = renderBuildStatusBadge({ status })
     if (result.message === 'building' && !result.color) {
       result.color = 'yellow'
     }

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -34,16 +34,17 @@ module.exports = class Netlify extends BaseSvgScrapingService {
         title: 'Netlify',
         namedParams: {
           projectId: 'e6d5a4e0-dee1-4261-833e-2f47f509c68f',
-          documentation: 'To locate your project id, visit your project settings, scroll to "Status badges" under "General", and copy the ID between "/api/v1/badges/" and "/deploy-status" in the code sample'
         },
+        documentation:
+          'To locate your project id, visit your project settings, scroll to "Status badges" under "General", and copy the ID between "/api/v1/badges/" and "/deploy-status" in the code sample',
         staticPreview: renderBuildStatusBadge({ status: 'passing' }),
-      }
+      },
     ]
   }
 
   static get defaultBadgeData() {
     return {
-      label: 'netlify'
+      label: 'netlify',
     }
   }
 

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const { renderBuildStatusBadge } = require('../build-status')
+const { BaseSvgScrapingService } = require('..')
+
+const pendingStatus = 'building'
+const notBuiltStatus = 'not built'
+
+const statusMap = {
+  building: pendingStatus,
+  waiting: pendingStatus,
+  initiated: pendingStatus,
+  stopped: notBuiltStatus,
+  ignored: notBuiltStatus,
+  blocked: notBuiltStatus,
+  infrastructure_failure: 'failed',
+}
+
+module.exports = class Netlify extends BaseSvgScrapingService {
+  static get category() {
+    return 'build'
+  }
+
+  static get route() {
+    return {
+      base: 'netlify',
+      pattern: ':projectId/:branch*',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Netlify',
+        pattern: ':projectId',
+        namedParams: {
+          projectId: 'e6d5a4e0-dee1-4261-833e-2f47f509c68f',
+        },
+        staticPreview: renderBuildStatusBadge({ status: 'passing' }),
+      },
+      // {
+      //   title: 'Netlify (branch)',
+      //   pattern: ':projectId/:branch',
+      //   namedParams: {
+      //     projectId: '0bdb0440-3af5-0133-00ea-0ebda3a33bf6',
+      //     branch: 'master',
+      //   },
+      //   staticPreview: renderBuildStatusBadge({ status: 'passing' }),
+      // },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'netlify' }
+  }
+
+  static render({ status }) {
+    status = statusMap[status] || status
+    return renderBuildStatusBadge({ status })
+  }
+
+  async fetch({ projectId, branch }) {
+    const url = `https://api.netlify.com/api/v1/badges/${projectId}/deploy-status`
+    const { buffer } = await this._request({
+      url,
+    })
+    if (buffer.includes('#EAFAF9')) return { message: 'passing' }
+    if (buffer.includes('#FFF3F4')) return { message: 'failing' }
+    if (buffer.includes('#FEFAEA')) return { message: 'building' }
+    return { message: 'project not found' }
+  }
+
+  async handle({ projectId, branch }) {
+    const { message: status } = await this.fetch({ projectId, branch })
+    return this.constructor.render({ status })
+  }
+}

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -32,7 +32,6 @@ module.exports = class Netlify extends BaseSvgScrapingService {
     return [
       {
         title: 'Netlify',
-        pattern: ':projectId',
         namedParams: {
           projectId: 'e6d5a4e0-dee1-4261-833e-2f47f509c68f',
         },

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -50,7 +50,10 @@ module.exports = class Netlify extends BaseSvgScrapingService {
   }
 
   static get defaultBadgeData() {
-    return { label: 'netlify' }
+    return {
+      label: 'netlify',
+      namedLogo: 'netlify',
+    }
   }
 
   static render({ status }) {

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -34,25 +34,16 @@ module.exports = class Netlify extends BaseSvgScrapingService {
         title: 'Netlify',
         namedParams: {
           projectId: 'e6d5a4e0-dee1-4261-833e-2f47f509c68f',
+          documentation: 'To locate your project id, visit your project settings, scroll to "Status badges" under "General", and copy the ID between "/api/v1/badges/" and "/deploy-status" in the code sample'
         },
         staticPreview: renderBuildStatusBadge({ status: 'passing' }),
-      },
-      // {
-      //   title: 'Netlify (branch)',
-      //   pattern: ':projectId/:branch',
-      //   namedParams: {
-      //     projectId: '0bdb0440-3af5-0133-00ea-0ebda3a33bf6',
-      //     branch: 'master',
-      //   },
-      //   staticPreview: renderBuildStatusBadge({ status: 'passing' }),
-      // },
+      }
     ]
   }
 
   static get defaultBadgeData() {
     return {
-      label: 'netlify',
-      namedLogo: 'netlify',
+      label: 'netlify'
     }
   }
 

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -24,7 +24,7 @@ module.exports = class Netlify extends BaseSvgScrapingService {
   static get route() {
     return {
       base: 'netlify',
-      pattern: ':projectId/:branch*',
+      pattern: ':projectId',
     }
   }
 

--- a/services/netlify/netlify.service.js
+++ b/services/netlify/netlify.service.js
@@ -73,7 +73,7 @@ module.exports = class Netlify extends BaseSvgScrapingService {
     if (buffer.includes('#EAFAF9')) return { message: 'passing' }
     if (buffer.includes('#FFF3F4')) return { message: 'failing' }
     if (buffer.includes('#FEFAEA')) return { message: 'building' }
-    return { message: 'project not found' }
+    return { message: 'unknown' }
   }
 
   async handle({ projectId, branch }) {

--- a/services/netlify/netlify.spec.js
+++ b/services/netlify/netlify.spec.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { test, given } = require('sazerac')
+const Netlify = require('./netlify.service')
+
+const building = { message: 'building', label: undefined, color: undefined }
+const notBuilt = { message: 'not built', label: undefined, color: undefined }
+
+describe('Netlify', function() {
+  test(Netlify.render, () => {
+    given({ status: 'building' }).expect(building)
+    given({ status: 'stopped' }).expect(notBuilt)
+    given({ status: 'infrastructure_failure' }).expect({
+      message: 'failing',
+      color: 'red',
+      label: undefined,
+    })
+  })
+})

--- a/services/netlify/netlify.tester.js
+++ b/services/netlify/netlify.tester.js
@@ -12,4 +12,4 @@ t.create('netlify (valid, no branch)')
 
 t.create('netlify (repo not found)')
   .get('/not-a-repo.json')
-  .expectBadge({ label: 'build', message: 'project not found' })
+  .expectBadge({ label: 'netlify', message: 'project not found' })

--- a/services/netlify/netlify.tester.js
+++ b/services/netlify/netlify.tester.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const { isBuildStatus } = require('../build-status')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('netlify (valid, no branch)')
+  .get('/e6d5a4e0-dee1-4261-833e-2f47f509c68f.json')
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })
+
+t.create('netlify (repo not found)')
+  .get('/not-a-repo.json')
+  .expectBadge({ label: 'build', message: 'project not found' })

--- a/services/netlify/netlify.tester.js
+++ b/services/netlify/netlify.tester.js
@@ -12,4 +12,4 @@ t.create('netlify (valid, no branch)')
 
 t.create('netlify (repo not found)')
   .get('/not-a-repo.json')
-  .expectBadge({ label: 'netlify', message: 'project not found' })
+  .expectBadge({ label: 'netlify', message: 'not found' })

--- a/services/netlify/netlify.tester.js
+++ b/services/netlify/netlify.tester.js
@@ -6,7 +6,7 @@ const t = (module.exports = require('../tester').createServiceTester())
 t.create('netlify (valid, no branch)')
   .get('/e6d5a4e0-dee1-4261-833e-2f47f509c68f.json')
   .expectBadge({
-    label: 'build',
+    label: 'netflify',
     message: isBuildStatus,
   })
 

--- a/services/netlify/netlify.tester.js
+++ b/services/netlify/netlify.tester.js
@@ -6,7 +6,7 @@ const t = (module.exports = require('../tester').createServiceTester())
 t.create('netlify (valid, no branch)')
   .get('/e6d5a4e0-dee1-4261-833e-2f47f509c68f.json')
   .expectBadge({
-    label: 'netflify',
+    label: 'netlify',
     message: isBuildStatus,
   })
 


### PR DESCRIPTION
This PR adds a status badge for Netlify, the static CDN and fixes #3953.

I tried making a PR in #3178 from scratch by using a "closest color matcher" many months ago, but I wasn't able to complete it. This time, it uses the SVG scraping service, and works pretty well (as long as Netlify doesn't update their badge colors, after which we'll update the service).

Thanks for the community for being so patient!