### PR TITLE
[dynamicxml] wrap xpath errors

### DIFF
--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -41,9 +41,15 @@ module.exports = class DynamicXml extends BaseService {
 
     const parsed = new DOMParser().parseFromString(buffer)
 
-    const values = xpath
-      .select(pathExpression, parsed)
-      .map((node, i) => (pathIsAttr ? node.value : node.firstChild.data))
+    let values
+    try {
+      values = xpath.select(pathExpression, parsed)
+    } catch (e) {
+      throw new InvalidResponse({ prettyMessage: e.message })
+    }
+    values = values.map((node, i) =>
+      pathIsAttr ? node.value : node.firstChild.data
+    )
 
     if (!values.length) {
       throw new InvalidResponse({ prettyMessage: 'no result' })

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -4,7 +4,7 @@ const { DOMParser } = require('xmldom')
 const xpath = require('xpath')
 const { renderDynamicBadge, errorMessages } = require('../dynamic-common')
 const { createRoute } = require('./dynamic-helpers')
-const { BaseService, InvalidResponse } = require('..')
+const { BaseService, InvalidResponse, InvalidParameter } = require('..')
 
 // This service extends BaseService because it uses a different XML parser
 // than BaseXmlService which can be used with xpath.
@@ -45,7 +45,7 @@ module.exports = class DynamicXml extends BaseService {
     try {
       values = xpath.select(pathExpression, parsed)
     } catch (e) {
-      throw new InvalidResponse({ prettyMessage: e.message })
+      throw new InvalidParameter({ prettyMessage: e.message })
     }
     values = values.map((node, i) =>
       pathIsAttr ? node.value : node.firstChild.data

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -123,6 +123,34 @@ t.create('query doesnt exist (attribute)')
     color: 'lightgrey',
   })
 
+t.create('Cannot resolve QName')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//a:si',
+    })}`
+  )
+  .intercept(withExampleXml)
+  .expectBadge({
+    label: 'custom badge',
+    message: 'Cannot resolve QName a',
+    color: 'lightgrey',
+  })
+
+t.create('XPath parse error')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//a[contains(@href, "foo"]',
+    })}`
+  )
+  .intercept(withExampleXml)
+  .expectBadge({
+    label: 'custom badge',
+    message: 'XPath parse error',
+    color: 'lightgrey',
+  })
+
 t.create('XML from url | invalid url')
   .get(
     '.json?url=https://github.com/badges/shields/raw/master/notafile.xml&query=//version'

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -134,7 +134,7 @@ t.create('Cannot resolve QName')
   .expectBadge({
     label: 'custom badge',
     message: 'Cannot resolve QName a',
-    color: 'lightgrey',
+    color: 'red',
   })
 
 t.create('XPath parse error')
@@ -148,7 +148,7 @@ t.create('XPath parse error')
   .expectBadge({
     label: 'custom badge',
     message: 'XPath parse error',
-    color: 'lightgrey',
+    color: 'red',
   })
 
 t.create('XML from url | invalid url')


### PR DESCRIPTION
Closes #3796

Usually we don't directly bounce the exception message back to the user like this, but I reckon if you're trying to construct an xpath query, this is probably the most useful output and better than a runtime error.