### PR TITLE
[npmversion] require key 'latest' to exist

### DIFF
--- a/services/npm/npm-version.service.js
+++ b/services/npm/npm-version.service.js
@@ -9,6 +9,7 @@ const keywords = ['node']
 
 // Joi.string should be a semver.
 const schema = Joi.object()
+  .keys({ latest: Joi.string().required() })
   .pattern(/./, Joi.string())
   .required()
 

--- a/services/npm/npm-version.tester.js
+++ b/services/npm/npm-version.tester.js
@@ -49,3 +49,16 @@ t.create(
 t.create('invalid package name')
   .get('/frodo-is-not-a-package.json')
   .expectBadge({ label: 'npm', message: 'package not found' })
+
+t.create("Response doesn't include a 'latest' key")
+  .intercept(nock =>
+    nock('https://registry.npmjs.org')
+      .get('/-/package/npm/dist-tags')
+      .reply(200, { next: 'v4.5.6' })
+  )
+  .get('/npm.json')
+  .expectBadge({
+    label: 'npm',
+    message: 'invalid response data',
+    color: 'lightgrey',
+  })


### PR DESCRIPTION
Closes #3794

I think the reason we're seeing this is because (for some reason) sometimes we get a response back from NPM with no `latest` key. This modifies the schema to require the `latest` key to be present in order to accept the response.