### PR TITLE
Throw explicit error on invalid [codefactorgrade] color

### DIFF
--- a/services/codefactor/codefactor-grade.service.js
+++ b/services/codefactor/codefactor-grade.service.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const Joi = require('@hapi/joi')
-const { letterGrades } = require('./codefactor-helpers')
+const { isValidGrade, gradeColor } = require('./codefactor-helpers')
 const { BaseSvgScrapingService } = require('..')
 
 const schema = Joi.object({
-  message: Joi.allow(...Object.keys(letterGrades)).required(),
+  message: isValidGrade,
 }).required()
 
 module.exports = class CodeFactorGrade extends BaseSvgScrapingService {
@@ -44,7 +44,7 @@ module.exports = class CodeFactorGrade extends BaseSvgScrapingService {
   static render({ grade }) {
     return {
       message: grade,
-      color: letterGrades[grade].color,
+      color: gradeColor(grade),
     }
   }
 

--- a/services/codefactor/codefactor-grade.tester.js
+++ b/services/codefactor/codefactor-grade.tester.js
@@ -1,22 +1,20 @@
 'use strict'
 
-const Joi = require('@hapi/joi')
 const t = (module.exports = require('../tester').createServiceTester())
-const { letterGrades } = require('./codefactor-helpers')
-const codeFactorGrade = Joi.allow(...Object.keys(letterGrades))
+const { isValidGrade } = require('./codefactor-helpers')
 
 t.create('Grade')
   .get('/github/google/guava.json')
   .expectBadge({
     label: 'code quality',
-    message: codeFactorGrade,
+    message: isValidGrade,
   })
 
 t.create('Grade (branch)')
   .get('/github/pallets/flask/master.json')
   .expectBadge({
     label: 'code quality',
-    message: codeFactorGrade,
+    message: isValidGrade,
   })
 
 t.create('Grade (nonexistent repo)')

--- a/services/codefactor/codefactor-helpers.js
+++ b/services/codefactor/codefactor-helpers.js
@@ -1,43 +1,31 @@
 'use strict'
 
+const Joi = require('@hapi/joi')
+
 // https://support.codefactor.io/i14-glossary
-const letterGrades = {
-  A: {
-    color: 'brightgreen',
-  },
-  'A-': {
-    color: 'green',
-  },
-  'B+': {
-    color: 'yellowgreen',
-  },
-  B: {
-    color: 'yellowgreen',
-  },
-  'B-': {
-    color: 'yellowgreen',
-  },
-  'C+': {
-    color: 'yellow',
-  },
-  C: {
-    color: 'yellow',
-  },
-  'C-': {
-    color: 'yellow',
-  },
-  'D+': {
-    color: 'orange',
-  },
-  D: {
-    color: 'orange',
-  },
-  'D-': {
-    color: 'orange',
-  },
-  F: {
-    color: 'red',
-  },
+const colorMap = {
+  A: 'brightgreen',
+  'A-': 'green',
+  'B+': 'yellowgreen',
+  B: 'yellowgreen',
+  'B-': 'yellowgreen',
+  'C+': 'yellow',
+  C: 'yellow',
+  'C-': 'yellow',
+  'D+': 'orange',
+  D: 'orange',
+  'D-': 'orange',
+  F: 'red',
 }
 
-module.exports = { letterGrades }
+const isValidGrade = Joi.allow(Object.keys(colorMap)).required()
+
+function gradeColor(grade) {
+  const color = colorMap[grade]
+  if (color === undefined) {
+    throw Error(`Unknown grade: ${grade}`)
+  }
+  return color
+}
+
+module.exports = { isValidGrade, gradeColor }


### PR DESCRIPTION
It’s hard to understand how #3813 is persisting. The schema should reject keys not in the object… it’s very puzzling.

This replaces the code used to get the color with a function call that throws an explicit error when the key is missing. It should at least make it clear what the key value is when this fails in the future.