### PR TITLE
Add Twitch and Wheelmap OAuth app owners

### DIFF
--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -23,6 +23,8 @@
 | Cloudflare                    | Account owner                   | @espadrine                                                                                 |
 | Cloudflare                    | Admin access                    | @espadrine, @paulmelnikow                                                                  |
 | GitHub                        | OAuth app                       | @espadrine ([could be transferred to the badges org][oauth transfer])                      |
+| Twitch                        | OAuth app                       | @PyvesB                                                                                    |
+| Wheelmap                      | OAuth app                       | @paulmelnikow                                                                              |
 | DNS                           | Account owner                   | @olivierlacan                                                                              |
 | DNS                           | Read-only account access        | @espadrine, @paulmelnikow, @chris48s                                                       |
 | Sentry                        | Error reports                   | @espadrine, @paulmelnikow                                                                  |

--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -24,7 +24,7 @@
 | Cloudflare                    | Admin access                    | @espadrine, @paulmelnikow                                                                  |
 | GitHub                        | OAuth app                       | @espadrine ([could be transferred to the badges org][oauth transfer])                      |
 | Twitch                        | OAuth app                       | @PyvesB                                                                                    |
-| Wheelmap                      | OAuth app                       | @paulmelnikow                                                                              |
+| OpenStreetMap (for Wheelmap)  | Account owner                   | @paulmelnikow                                                                              |
 | DNS                           | Account owner                   | @olivierlacan                                                                              |
 | DNS                           | Read-only account access        | @espadrine, @paulmelnikow, @chris48s                                                       |
 | Sentry                        | Error reports                   | @espadrine, @paulmelnikow                                                                  |


### PR DESCRIPTION
Just documenting a couple of missing OAuth app owners. Let me know if there are others that need adding.