### PR TITLE
support basic auth with just pass token

### DIFF
--- a/core/base-service/auth-helper.js
+++ b/core/base-service/auth-helper.js
@@ -2,7 +2,12 @@
 
 class AuthHelper {
   constructor(
-    { userKey, passKey, isRequired = false, useEmptyStringForUser = false },
+    {
+      userKey,
+      passKey,
+      isRequired = false,
+      defaultToEmptyStringForUser = false,
+    },
     privateConfig
   ) {
     if (!userKey && !passKey) {
@@ -14,7 +19,7 @@ class AuthHelper {
     if (userKey) {
       this.user = privateConfig[userKey]
     } else {
-      this.user = useEmptyStringForUser ? '' : undefined
+      this.user = defaultToEmptyStringForUser ? '' : undefined
     }
     this.pass = passKey ? privateConfig[passKey] : undefined
     this.isRequired = isRequired

--- a/core/base-service/auth-helper.js
+++ b/core/base-service/auth-helper.js
@@ -1,14 +1,21 @@
 'use strict'
 
 class AuthHelper {
-  constructor({ userKey, passKey, isRequired = false }, privateConfig) {
+  constructor(
+    { userKey, passKey, isRequired = false, useEmptyStringForUser = false },
+    privateConfig
+  ) {
     if (!userKey && !passKey) {
       throw Error('Expected userKey or passKey to be set')
     }
 
     this._userKey = userKey
     this._passKey = passKey
-    this.user = userKey ? privateConfig[userKey] : undefined
+    if (userKey) {
+      this.user = privateConfig[userKey]
+    } else {
+      this.user = useEmptyStringForUser ? '' : undefined
+    }
     this.pass = passKey ? privateConfig[passKey] : undefined
     this.isRequired = isRequired
   }

--- a/core/base-service/auth-helper.spec.js
+++ b/core/base-service/auth-helper.spec.js
@@ -92,7 +92,7 @@ describe('AuthHelper', function() {
         undefined
       )
       given(
-        { passKey: 'myci_pass', useEmptyStringForUser: true },
+        { passKey: 'myci_pass', defaultToEmptyStringForUser: true },
         { myci_pass: 'abc123' }
       ).expect({
         user: '',

--- a/core/base-service/auth-helper.spec.js
+++ b/core/base-service/auth-helper.spec.js
@@ -91,6 +91,13 @@ describe('AuthHelper', function() {
       given({ userKey: 'myci_user', passKey: 'myci_pass' }, {}).expect(
         undefined
       )
+      given(
+        { passKey: 'myci_pass', useEmptyStringForUser: true },
+        { myci_pass: 'abc123' }
+      ).expect({
+        user: '',
+        pass: 'abc123',
+      })
     })
   })
 })

--- a/services/azure-devops/azure-devops-base.js
+++ b/services/azure-devops/azure-devops-base.js
@@ -18,7 +18,7 @@ module.exports = class AzureDevOpsBase extends BaseJsonService {
   static get auth() {
     return {
       passKey: 'azure_devops_token',
-      useEmptyStringForUser: true,
+      defaultToEmptyStringForUser: true,
     }
   }
 

--- a/services/azure-devops/azure-devops-base.js
+++ b/services/azure-devops/azure-devops-base.js
@@ -16,7 +16,10 @@ const latestBuildSchema = Joi.object({
 
 module.exports = class AzureDevOpsBase extends BaseJsonService {
   static get auth() {
-    return { passKey: 'azure_devops_token' }
+    return {
+      passKey: 'azure_devops_token',
+      useEmptyStringForUser: true,
+    }
   }
 
   async fetch({ url, options, schema, errorMessages }) {


### PR DESCRIPTION
Fixes #4037 

Request does not support basic auth with `undefined` for the user, so this updates our auth mechanism to allow a service class to use an empty string for the user.

I confirmed that this resolves the authentication issues for the Azure DevOps badges referenced in #4037

https://github.com/request/request/blob/master/lib/auth.js#L131