### PR TITLE
Update to Simple Icons 1.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22446,9 +22446,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.15.0.tgz",
-      "integrity": "sha512-Dc/OfbWkhJC4Hc4oLcAb/mB9fdaRylnNZidc7YA1OqVQ7ErooahGhV3QrLYesZzMsrKQHTCLgdqTtyVCEHHIcA=="
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.16.0.tgz",
+      "integrity": "sha512-uUsVbiN+SMfCElZlHy2SOl4Wr9HbBquFrdGiROCxhCzUFoG1kUrgnxn0MabLrWgrQSlyGD535B74UN+qJV/lWw=="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "query-string": "^6.8.3",
     "request": "~2.88.0",
     "semver": "~6.3.0",
-    "simple-icons": "1.15.0",
+    "simple-icons": "1.16.0",
     "xmldom": "~0.1.27",
     "xpath": "~0.0.27"
   },


### PR DESCRIPTION
# New icons

- Nintendo 3DS (simple-icons/simple-icons#1618)
- Zulip (simple-icons/simple-icons#1618)
- CodeFactor (simple-icons/simple-icons#1620)
- Showpad (simple-icons/simple-icons#1620)
- Svelte (simple-icons/simple-icons#1620)
- Expo (simple-icons/simple-icons#1621)
- Zalando (simple-icons/simple-icons#1630)
- Azure Artifacts (simple-icons/simple-icons#1630)
- GNU Privacy Guard (simple-icons/simple-icons#1632)


# Updated icons

- VK (simple-icons/simple-icons#1618)