### PR TITLE
fix: use repos from badges organization for [GithubContributors]  (#4104)

### DIFF
--- a/services/github/github-contributors.tester.js
+++ b/services/github/github-contributors.tester.js
@@ -4,14 +4,14 @@ const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 t.create('Contributors')
-  .get('/contributors/cdnjs/cdnjs.json')
+  .get('/contributors/badges/shields.json')
   .expectBadge({
     label: 'contributors',
     message: isMetric,
   })
 
 t.create('1 contributor')
-  .get('/contributors/paulmelnikow/local-credential-storage.json')
+  .get('/contributors/badges/shields-tests.json')
   .expectBadge({
     label: 'contributors',
     message: '1',


### PR DESCRIPTION
Modified the tests for GithubContributors service to make use of repos under the badges organization.