### PR TITLE
 fix: allow empty but required resolution property for [Bugzilla] (#4102)

### DIFF
--- a/services/bugzilla/bugzilla.service.js
+++ b/services/bugzilla/bugzilla.service.js
@@ -13,7 +13,9 @@ const schema = Joi.object({
     .items(
       Joi.object({
         status: Joi.string().required(),
-        resolution: Joi.string().required(),
+        resolution: Joi.string()
+          .allow('')
+          .required(),
       }).required()
     )
     .min(1)

--- a/services/github/github-contributors.tester.js
+++ b/services/github/github-contributors.tester.js
@@ -4,14 +4,14 @@ const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 t.create('Contributors')
-  .get('/contributors/cdnjs/cdnjs.json')
+  .get('/contributors/badges/shields.json')
   .expectBadge({
     label: 'contributors',
     message: isMetric,
   })
 
 t.create('1 contributor')
-  .get('/contributors/paulmelnikow/local-credential-storage.json')
+  .get('/contributors/badges/shields-tests.json')
   .expectBadge({
     label: 'contributors',
     message: '1',


### PR DESCRIPTION
This was tested against a test case with the bug id 1536094 as shown in the attached.
<img width="680" alt="Screen Shot 2019-10-02 at 1 48 40 AM" src="https://user-images.githubusercontent.com/35116035/66021616-3f160080-e4b9-11e9-951c-1eefbb429653.png">

The test was not committed since the bug can be modified in future with the resolution field populated which will break the test. There is a way to query the the Bugzilla API and search by status providing a limit of 1 in order to create a robust test. But that involves changing the behavior of the service that is not much to do just for the test. So I am leaving out the unit test for this change 