### PR TITLE
Missing spaces added do the usage section

### DIFF
--- a/frontend/components/usage.tsx
+++ b/frontend/components/usage.tsx
@@ -414,16 +414,16 @@ export default function Usage({ baseUrl }: { baseUrl: string }) {
       </QueryParamTable>
 
       <p>
-        We support <code>.svg</code> and <code>.json</code>. The default is
+        We support <code>.svg</code> and <code>.json</code>. The default is{' '}
         <code>.svg</code>, which can be omitted from the URL.
       </p>
 
       <p>
-        While we highly recommend using SVG, we also support <code>.png</code>
+        While we highly recommend using SVG, we also support <code>.png</code>{' '}
         for use cases where SVG will not work. These requests should be made to
         our raster server <code>https://raster.shields.io</code>. For example,
-        the raster equivalent of
-        <code>https://img.shields.io/v/npm/express</code> is
+        the raster equivalent of{' '}
+        <code>https://img.shields.io/v/npm/express</code> is{' '}
         <code>https://raster.shields.io/v/npm/express</code>. For backward
         compatibility, the badge server will redirect <code>.png</code> badges
         to the raster server.


### PR DESCRIPTION
Before:
![Screenshot_2019-10-03 Shields io Quality metadata badges for open source projects_](https://user-images.githubusercontent.com/1526000/66160315-2c6f0900-e62a-11e9-82e1-00a7e3f1a28d.png)

After:
![Screenshot_2019-10-03 Shields io Quality metadata badges for open source projects(2)](https://user-images.githubusercontent.com/1526000/66160331-342ead80-e62a-11e9-95de-bd64d73048cb.png)

Changes were made using Visual Studio Code + Prettier plugin. 
I've changed manually:
```jsx
        We support <code>.svg</code> and <code>.json</code>. The default is
        <code>.svg</code>, which can be omitted from the URL.
```
to
```jsx
        We support <code>.svg</code> and <code>.json</code>. The default is <code>.svg</code>, which can be omitted from the URL.
```
At this stage problem was fixed. Then I formated code with the "Format Document" action and the code was changed to:
```jsx
        We support <code>.svg</code> and <code>.json</code>. The default is{' '}
        <code>.svg</code>, which can be omitted from the URL.
```