### PR TITLE
Update service tests for [Scrutinizer Microbadger jsDelivr]

### DIFF
--- a/services/jsdelivr/jsdelivr-hits-github.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-github.tester.js
@@ -28,7 +28,7 @@ t.create('jquery/jquery hits/month')
   })
 
 t.create('jquery/jquery hits/year')
-  .timeout(10000)
+  .timeout(25000)
   .get('/hy/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',

--- a/services/jsdelivr/jsdelivr-hits-npm.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.tester.js
@@ -28,7 +28,7 @@ t.create('jquery hits/month')
   })
 
 t.create('jquery hits/year')
-  .timeout(10000)
+  .timeout(25000)
   .get('/hy/ky.json')
   .expectBadge({
     label: 'jsdelivr',

--- a/services/microbadger/microbadger-layers.tester.js
+++ b/services/microbadger/microbadger-layers.tester.js
@@ -8,7 +8,7 @@ t.create('layers without a specified tag')
   .timeout(150000)
   .expectBadge({
     label: 'layers',
-    message: nonNegativeInteger
+    message: nonNegativeInteger,
   })
 
 t.create('layers with a specified tag')

--- a/services/microbadger/microbadger-layers.tester.js
+++ b/services/microbadger/microbadger-layers.tester.js
@@ -1,24 +1,22 @@
 'use strict'
 
-const Joi = require('@hapi/joi')
+const { nonNegativeInteger } = require('../validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('layers without a specified tag')
   .get('/_/alpine.json')
+  .timeout(150000)
   .expectBadge({
     label: 'layers',
-    message: Joi.number()
-      .integer()
-      .positive(),
+    message: nonNegativeInteger
   })
 
 t.create('layers with a specified tag')
   .get('/_/alpine/2.7.json')
+  .timeout(150000)
   .expectBadge({
     label: 'layers',
-    message: Joi.number()
-      .integer()
-      .positive(),
+    message: nonNegativeInteger,
   })
 
 t.create('specified tag when repository has only one')

--- a/services/microbadger/microbadger-size.tester.js
+++ b/services/microbadger/microbadger-size.tester.js
@@ -5,6 +5,7 @@ const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('image size without a specified tag')
   .get('/fedora/apache.json')
+  .timeout(150000)
   .expectBadge({
     label: 'image size',
     message: isFileSize,
@@ -12,6 +13,7 @@ t.create('image size without a specified tag')
 
 t.create('image size with a specified tag')
   .get('/fedora/apache/latest.json')
+  .timeout(150000)
   .expectBadge({
     label: 'image size',
     message: isFileSize,

--- a/services/scrutinizer/scrutinizer-base.js
+++ b/services/scrutinizer/scrutinizer-base.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { BaseJsonService, NotFound } = require('..')
+const { BaseJsonService, NotFound, InvalidResponse } = require('..')
 
 module.exports = class ScrutinizerBase extends BaseJsonService {
   // https://scrutinizer-ci.com/docs/api/#repository-details
@@ -30,13 +30,17 @@ module.exports = class ScrutinizerBase extends BaseJsonService {
   }
 
   transformBranchInfoMetricValue({ json, branch, metric }) {
+    const branchInfo = this.transformBranchInfo({ json, wantedBranch: branch })
+    if (!branchInfo.index) {
+      throw new InvalidResponse({ prettyMessage: 'metrics missing for branch' })
+    }
     const {
       index: {
         _embedded: {
           project: { metric_values: metricValues },
         },
       },
-    } = this.transformBranchInfo({ json, wantedBranch: branch })
+    } = branchInfo
 
     return { value: metricValues[metric] }
   }

--- a/services/scrutinizer/scrutinizer-coverage.service.js
+++ b/services/scrutinizer/scrutinizer-coverage.service.js
@@ -19,7 +19,7 @@ const schema = Joi.object({
               }).required(),
             }).required(),
           }).required(),
-        }).required(),
+        }),
       })
     )
     .required(),

--- a/services/scrutinizer/scrutinizer-coverage.spec.js
+++ b/services/scrutinizer/scrutinizer-coverage.spec.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai')
 const { test, given } = require('sazerac')
 const [ScrutinizerCoverage] = require('./scrutinizer-coverage.service')
-const { NotFound } = require('..')
+const { InvalidResponse, NotFound } = require('..')
 
 describe('ScrutinizerCoverage', function() {
   test(ScrutinizerCoverage.render, () => {
@@ -49,6 +49,25 @@ describe('ScrutinizerCoverage', function() {
         expect(e).to.be.an.instanceof(NotFound)
         expect(e.prettyMessage).to.equal('coverage not found')
       }
+    })
+    it('throws InvalidResponse error when branch is missing statistics', function() {
+      expect(() =>
+        ScrutinizerCoverage.prototype.transform({
+          branch: 'gh-pages',
+          json: {
+            applications: {
+              master: { index: {} },
+              'gh-pages': {
+                build_status: {
+                  status: 'unknown',
+                },
+              },
+            },
+          },
+        })
+      )
+        .to.throw(InvalidResponse)
+        .with.property('prettyMessage', 'metrics missing for branch')
     })
   })
 })

--- a/services/scrutinizer/scrutinizer-quality.service.js
+++ b/services/scrutinizer/scrutinizer-quality.service.js
@@ -18,7 +18,7 @@ const schema = Joi.object({
               }).required(),
             }).required(),
           }).required(),
-        }).required(),
+        }),
       })
     )
     .required(),


### PR DESCRIPTION
Resolves #4144 

Fixes the schema used for Scrutinzer Coverage and Quality badges to handle the API response (which can include branches missing statistics) and increases the timeouts on a couple service tests for Microbadger and jsDelivr that regularly timeout during the daily test runs