### PR TITLE
Allow [librariesio] badges referencing scoped npm package (#4025)

### DIFF
--- a/services/librariesio/librariesio-common.js
+++ b/services/librariesio/librariesio-common.js
@@ -11,10 +11,12 @@ const projectSchema = Joi.object({
   rank: anyInteger,
 }).required()
 
-async function fetchProject(serviceInstance, { platform, packageName }) {
+async function fetchProject(serviceInstance, { platform, scope, packageName }) {
   return serviceInstance._requestJson({
     schema: projectSchema,
-    url: `https://libraries.io/api/${platform}/${packageName}`,
+    url: `https://libraries.io/api/${encodeURIComponent(platform)}/${
+      scope ? encodeURIComponent(`${scope}/`) : ''
+    }${encodeURIComponent(packageName)}`,
     errorMessages: { 404: 'package not found' },
   })
 }

--- a/services/librariesio/librariesio-dependencies.service.js
+++ b/services/librariesio/librariesio-dependencies.service.js
@@ -30,7 +30,7 @@ class LibrariesIoProjectDependencies extends BaseJsonService {
   static get route() {
     return {
       base: 'librariesio/release',
-      pattern: ':platform/:packageName/:version?',
+      pattern: ':platform/:scope(@[^/]+)?/:packageName/:version?',
     }
   }
 
@@ -61,13 +61,42 @@ class LibrariesIoProjectDependencies extends BaseJsonService {
           outdatedCount: 3,
         }),
       },
+      {
+        title:
+          'Libraries.io dependency status for latest release, scoped npm package',
+        pattern: ':platform/:scope/:packageName',
+        namedParams: {
+          platform: 'npm',
+          scope: '@babel',
+          packageName: 'core',
+        },
+        staticPreview: renderDependenciesBadge({
+          deprecatedCount: 8,
+          outdatedCount: 0,
+        }),
+      },
+      {
+        title:
+          'Libraries.io dependency status for specific release, scoped npm package',
+        pattern: ':platform/:scope/:packageName/:version',
+        namedParams: {
+          platform: 'npm',
+          scope: '@babel',
+          packageName: 'core',
+          version: '7.0.0',
+        },
+        staticPreview: renderDependenciesBadge({
+          deprecatedCount: 12,
+          outdatedCount: 0,
+        }),
+      },
     ]
   }
 
-  async handle({ platform, packageName, version = 'latest' }) {
-    const url = `https://libraries.io/api/${encodeURIComponent(
-      platform
-    )}/${encodeURIComponent(packageName)}/${encodeURIComponent(
+  async handle({ platform, scope, packageName, version = 'latest' }) {
+    const url = `https://libraries.io/api/${encodeURIComponent(platform)}/${
+      scope ? encodeURIComponent(`${scope}/`) : ''
+    }${encodeURIComponent(packageName)}/${encodeURIComponent(
       version
     )}/dependencies`
     const json = await this._requestJson({

--- a/services/librariesio/librariesio-dependencies.tester.js
+++ b/services/librariesio/librariesio-dependencies.tester.js
@@ -22,6 +22,20 @@ t.create('dependencies for package with version')
     message: isDependencyState,
   })
 
+t.create('dependencies for scoped npm package')
+  .get('/release/npm/@babel/core.json')
+  .expectBadge({
+    label: 'dependencies',
+    message: isDependencyState,
+  })
+
+t.create('dependencies for scoped npm package with version')
+  .get('/release/npm/@babel/core/7.0.0-rc.0.json')
+  .expectBadge({
+    label: 'dependencies',
+    message: isDependencyState,
+  })
+
 t.create('version not found')
   .get('/release/hex/phoenix/9.9.99.json')
   .expectBadge({

--- a/services/librariesio/librariesio-dependencies.tester.js
+++ b/services/librariesio/librariesio-dependencies.tester.js
@@ -9,6 +9,7 @@ const t = (module.exports = new ServiceTester({
 }))
 
 t.create('dependencies for package (project name contains dot)')
+  .timeout(10000)
   .get('/release/nuget/Newtonsoft.Json.json')
   .expectBadge({
     label: 'dependencies',
@@ -16,6 +17,7 @@ t.create('dependencies for package (project name contains dot)')
   })
 
 t.create('dependencies for package with version')
+  .timeout(10000)
   .get('/release/hex/phoenix/1.0.3.json')
   .expectBadge({
     label: 'dependencies',
@@ -23,6 +25,7 @@ t.create('dependencies for package with version')
   })
 
 t.create('dependencies for scoped npm package')
+  .timeout(10000)
   .get('/release/npm/@babel/core.json')
   .expectBadge({
     label: 'dependencies',
@@ -30,6 +33,7 @@ t.create('dependencies for scoped npm package')
   })
 
 t.create('dependencies for scoped npm package with version')
+  .timeout(10000)
   .get('/release/npm/@babel/core/7.0.0-rc.0.json')
   .expectBadge({
     label: 'dependencies',
@@ -37,6 +41,7 @@ t.create('dependencies for scoped npm package with version')
   })
 
 t.create('version not found')
+  .timeout(10000)
   .get('/release/hex/phoenix/9.9.99.json')
   .expectBadge({
     label: 'dependencies',
@@ -44,6 +49,7 @@ t.create('version not found')
   })
 
 t.create('package not found')
+  .timeout(10000)
   .get('/release/hex/invalid/4.0.4.json')
   .expectBadge({
     label: 'dependencies',
@@ -51,6 +57,7 @@ t.create('package not found')
   })
 
 t.create('dependencies for repo')
+  .timeout(10000)
   .get('/github/pyvesb/notepad4e.json')
   .expectBadge({
     label: 'dependencies',
@@ -58,6 +65,7 @@ t.create('dependencies for repo')
   })
 
 t.create('repo not found')
+  .timeout(10000)
   .get('/github/foobar/is-not-a-repo.json')
   .expectBadge({
     label: 'dependencies',

--- a/services/librariesio/librariesio-dependent-repos.service.js
+++ b/services/librariesio/librariesio-dependent-repos.service.js
@@ -13,7 +13,7 @@ module.exports = class LibrariesIoDependentRepos extends BaseJsonService {
   static get route() {
     return {
       base: 'librariesio/dependent-repos',
-      pattern: ':platform/:packageName',
+      pattern: ':platform/:scope(@[^/]+)?/:packageName',
     }
   }
 
@@ -21,11 +21,22 @@ module.exports = class LibrariesIoDependentRepos extends BaseJsonService {
     return [
       {
         title: 'Dependent repos (via libraries.io)',
+        pattern: ':platform/:packageName',
         namedParams: {
           platform: 'npm',
           packageName: 'got',
         },
         staticPreview: this.render({ dependentReposCount: 84000 }),
+      },
+      {
+        title: 'Dependent repos (via libraries.io), scoped npm package',
+        pattern: ':platform/:scope/:packageName',
+        namedParams: {
+          platform: 'npm',
+          scope: '@babel',
+          packageName: 'core',
+        },
+        staticPreview: this.render({ dependentReposCount: 50 }),
       },
     ]
   }
@@ -43,11 +54,12 @@ module.exports = class LibrariesIoDependentRepos extends BaseJsonService {
     }
   }
 
-  async handle({ platform, packageName }) {
+  async handle({ platform, scope, packageName }) {
     const { dependent_repos_count: dependentReposCount } = await fetchProject(
       this,
       {
         platform,
+        scope,
         packageName,
       }
     )

--- a/services/librariesio/librariesio-dependent-repos.tester.js
+++ b/services/librariesio/librariesio-dependent-repos.tester.js
@@ -4,6 +4,7 @@ const { isMetric } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('dependent repo count')
+  .timeout(10000)
   .get('/npm/got.json')
   .expectBadge({
     label: 'dependent repos',
@@ -11,6 +12,7 @@ t.create('dependent repo count')
   })
 
 t.create('dependent repo count (scoped npm package)')
+  .timeout(10000)
   .get('/npm/@babel/core.json')
   .expectBadge({
     label: 'dependent repos',
@@ -18,8 +20,8 @@ t.create('dependent repo count (scoped npm package)')
   })
 
 t.create('dependent repo count (not a package)')
-  .get('/npm/foobar-is-not-package.json')
   .timeout(10000)
+  .get('/npm/foobar-is-not-package.json')
   .expectBadge({
     label: 'dependent repos',
     message: 'package not found',

--- a/services/librariesio/librariesio-dependent-repos.tester.js
+++ b/services/librariesio/librariesio-dependent-repos.tester.js
@@ -10,6 +10,13 @@ t.create('dependent repo count')
     message: isMetric,
   })
 
+t.create('dependent repo count (scoped npm package)')
+  .get('/npm/@babel/core.json')
+  .expectBadge({
+    label: 'dependent repos',
+    message: isMetric,
+  })
+
 t.create('dependent repo count (not a package)')
   .get('/npm/foobar-is-not-package.json')
   .timeout(10000)

--- a/services/librariesio/librariesio-dependents.service.js
+++ b/services/librariesio/librariesio-dependents.service.js
@@ -13,7 +13,7 @@ module.exports = class LibrariesIoDependents extends BaseJsonService {
   static get route() {
     return {
       base: 'librariesio/dependents',
-      pattern: ':platform/:packageName',
+      pattern: ':platform/:scope(@[^/]+)?/:packageName',
     }
   }
 
@@ -21,11 +21,22 @@ module.exports = class LibrariesIoDependents extends BaseJsonService {
     return [
       {
         title: 'Dependents (via libraries.io)',
+        pattern: ':platform/:packageName',
         namedParams: {
           platform: 'npm',
           packageName: 'got',
         },
         staticPreview: this.render({ dependentCount: 2000 }),
+      },
+      {
+        title: 'Dependents (via libraries.io), scoped npm package',
+        pattern: ':platform/:scope/:packageName',
+        namedParams: {
+          platform: 'npm',
+          scope: '@babel',
+          packageName: 'core',
+        },
+        staticPreview: this.render({ dependentCount: 94 }),
       },
     ]
   }
@@ -43,9 +54,10 @@ module.exports = class LibrariesIoDependents extends BaseJsonService {
     }
   }
 
-  async handle({ platform, packageName }) {
+  async handle({ platform, scope, packageName }) {
     const { dependents_count: dependentCount } = await fetchProject(this, {
       platform,
+      scope,
       packageName,
     })
     return this.constructor.render({ dependentCount })

--- a/services/librariesio/librariesio-dependents.tester.js
+++ b/services/librariesio/librariesio-dependents.tester.js
@@ -10,6 +10,13 @@ t.create('dependent count')
     message: isMetric,
   })
 
+t.create('dependent count (scoped npm package)')
+  .get('/npm/@babel/core.json')
+  .expectBadge({
+    label: 'dependents',
+    message: isMetric,
+  })
+
 t.create('dependent count (nonexistent package)')
   .get('/npm/foobar-is-not-package.json')
   .timeout(10000)

--- a/services/librariesio/librariesio-dependents.tester.js
+++ b/services/librariesio/librariesio-dependents.tester.js
@@ -4,6 +4,7 @@ const { isMetric } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('dependent count')
+  .timeout(10000)
   .get('/npm/got.json')
   .expectBadge({
     label: 'dependents',
@@ -11,6 +12,7 @@ t.create('dependent count')
   })
 
 t.create('dependent count (scoped npm package)')
+  .timeout(10000)
   .get('/npm/@babel/core.json')
   .expectBadge({
     label: 'dependents',
@@ -18,8 +20,8 @@ t.create('dependent count (scoped npm package)')
   })
 
 t.create('dependent count (nonexistent package)')
-  .get('/npm/foobar-is-not-package.json')
   .timeout(10000)
+  .get('/npm/foobar-is-not-package.json')
   .expectBadge({
     label: 'dependents',
     message: 'package not found',

--- a/services/librariesio/librariesio-sourcerank.service.js
+++ b/services/librariesio/librariesio-sourcerank.service.js
@@ -14,7 +14,7 @@ module.exports = class LibrariesIoSourcerank extends BaseJsonService {
   static get route() {
     return {
       base: 'librariesio/sourcerank',
-      pattern: ':platform/:packageName',
+      pattern: ':platform/:scope(@[^/]+)?/:packageName',
     }
   }
 
@@ -22,11 +22,22 @@ module.exports = class LibrariesIoSourcerank extends BaseJsonService {
     return [
       {
         title: 'Libraries.io SourceRank',
+        pattern: ':platform/:packageName',
         namedParams: {
           platform: 'npm',
           packageName: 'got',
         },
         staticPreview: this.render({ rank: 25 }),
+      },
+      {
+        title: 'Libraries.io SourceRank, scoped npm package',
+        pattern: ':platform/:scope/:packageName',
+        namedParams: {
+          platform: 'npm',
+          scope: '@babel',
+          packageName: 'core',
+        },
+        staticPreview: this.render({ rank: 3 }),
       },
     ]
   }
@@ -44,9 +55,10 @@ module.exports = class LibrariesIoSourcerank extends BaseJsonService {
     }
   }
 
-  async handle({ platform, packageName }) {
+  async handle({ platform, scope, packageName }) {
     const { rank } = await fetchProject(this, {
       platform,
+      scope,
       packageName,
     })
     return this.constructor.render({ rank })

--- a/services/librariesio/librariesio-sourcerank.tester.js
+++ b/services/librariesio/librariesio-sourcerank.tester.js
@@ -10,7 +10,15 @@ t.create('sourcerank')
     message: anyInteger,
   })
 
-t.create('dependent count (not a package)')
+t.create('sourcerank (scoped npm package)')
+  .get('/npm/@babel/core.json')
+  .expectBadge({
+    label: 'sourcerank',
+    message: anyInteger,
+  })
+
+t.create('sourcerank (not a package)')
+  .timeout(10000)
   .get('/npm/foobar-is-not-package.json')
   .expectBadge({
     label: 'sourcerank',

--- a/services/librariesio/librariesio-sourcerank.tester.js
+++ b/services/librariesio/librariesio-sourcerank.tester.js
@@ -4,6 +4,7 @@ const { anyInteger } = require('../validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('sourcerank')
+  .timeout(10000)
   .get('/npm/got.json')
   .expectBadge({
     label: 'sourcerank',
@@ -11,6 +12,7 @@ t.create('sourcerank')
   })
 
 t.create('sourcerank (scoped npm package)')
+  .timeout(10000)
   .get('/npm/@babel/core.json')
   .expectBadge({
     label: 'sourcerank',


### PR DESCRIPTION
This PR proposes an implementation of allowing libraries.io badges (dependents, sourcerank...) to work with scoped npm packages. It is inspired by how the current [bundlephobia service](https://github.com/badges/shields/blob/2.2.1/services/bundlephobia/bundlephobia.service.js#L23) handles it.

Once merged, it should solve #4025.

Please see if it looks good to you. Thanks!