### PR TITLE
An option to retry a failed service; test on [dynamicxml]

### DIFF
--- a/core/service-test-runner/cli.js
+++ b/core/service-test-runner/cli.js
@@ -15,6 +15,11 @@
 // Run tests on a given instance:
 //   SKIP_INTERCEPTED=TRUE TESTED_SERVER_URL=https://test.shields.io npm run test:services --
 //
+// Run tests with given number of retries and backoff:
+//   RETRY_COUNT=3 RETRY_BACKOFF=100 npm run test:services --
+// Retry option documentation:
+// https://github.com/IcedFrisby/IcedFrisby/blob/master/API.md#retrycount-backoff
+//
 // Service tests are run in CI in two cases: scheduled builds and pull
 // requests. The scheduled builds run _all_ the service tests, whereas the
 // pull requests run service tests designated in the PR title. In this way,
@@ -59,6 +64,9 @@ const Runner = require('./runner')
 
 require('../unhandled-rejection.spec')
 
+const retry = {}
+retry.count = process.env.RETRY_COUNT || 0
+retry.backoff = process.env.RETRY_BACKOFF || 0
 let baseUrl, server
 if (process.env.TESTED_SERVER_URL) {
   baseUrl = process.env.TESTED_SERVER_URL
@@ -77,7 +85,7 @@ if (process.env.TESTED_SERVER_URL) {
 }
 
 const skipIntercepted = envFlag(process.env.SKIP_INTERCEPTED, false)
-const runner = new Runner({ baseUrl, skipIntercepted })
+const runner = new Runner({ baseUrl, skipIntercepted, retry })
 runner.prepare()
 
 // The server's request cache causes side effects between tests.

--- a/core/service-test-runner/cli.js
+++ b/core/service-test-runner/cli.js
@@ -65,8 +65,8 @@ const Runner = require('./runner')
 require('../unhandled-rejection.spec')
 
 const retry = {}
-retry.count = process.env.RETRY_COUNT || 0
-retry.backoff = process.env.RETRY_BACKOFF || 0
+retry.count = parseInt(process.env.RETRY_COUNT) || 0
+retry.backoff = parseInt(process.env.RETRY_BACKOFF) || 0
 let baseUrl, server
 if (process.env.TESTED_SERVER_URL) {
   baseUrl = process.env.TESTED_SERVER_URL

--- a/core/service-test-runner/cli.js
+++ b/core/service-test-runner/cli.js
@@ -15,7 +15,7 @@
 // Run tests on a given instance:
 //   SKIP_INTERCEPTED=TRUE TESTED_SERVER_URL=https://test.shields.io npm run test:services --
 //
-// Run tests with given number of retries and backoff:
+// Run tests with given number of retries and backoff (in milliseconds):
 //   RETRY_COUNT=3 RETRY_BACKOFF=100 npm run test:services --
 // Retry option documentation:
 // https://github.com/IcedFrisby/IcedFrisby/blob/master/API.md#retrycount-backoff

--- a/core/service-test-runner/runner.js
+++ b/core/service-test-runner/runner.js
@@ -9,9 +9,10 @@ const { loadTesters } = require('../base-service/loader')
  * Load a collection of ServiceTester objects and register them with Mocha.
  */
 class Runner {
-  constructor({ baseUrl, skipIntercepted }) {
+  constructor({ baseUrl, skipIntercepted, retry }) {
     this.baseUrl = baseUrl
     this.skipIntercepted = skipIntercepted
+    this.retry = retry
   }
 
   /**
@@ -67,8 +68,8 @@ class Runner {
    * Register the tests with Mocha.
    */
   toss() {
-    const { testers, baseUrl, skipIntercepted } = this
-    testers.forEach(tester => tester.toss({ baseUrl, skipIntercepted }))
+    const { testers, baseUrl, skipIntercepted, retry } = this
+    testers.forEach(tester => tester.toss({ baseUrl, skipIntercepted, retry }))
   }
 }
 module.exports = Runner

--- a/core/service-test-runner/service-tester.js
+++ b/core/service-test-runner/service-tester.js
@@ -115,6 +115,9 @@ class ServiceTester {
    * @param {object} attrs Refer to individual attrs
    * @param {string} attrs.baseUrl base URL for test server
    * @param {boolean} attrs.skipIntercepted skip tests which intercept requests
+   * @param {object} attrs.retry retry configuration
+   * @param {number} attrs.retry.count number of times to retry test
+   * @param {number} attrs.retry.backoff number of milliseconds to add to the wait between each retry
    */
   toss({ baseUrl, skipIntercepted, retry }) {
     const { specs, pathPrefix } = this

--- a/core/service-test-runner/service-tester.js
+++ b/core/service-test-runner/service-tester.js
@@ -116,7 +116,7 @@ class ServiceTester {
    * @param {string} attrs.baseUrl base URL for test server
    * @param {boolean} attrs.skipIntercepted skip tests which intercept requests
    */
-  toss({ baseUrl, skipIntercepted }) {
+  toss({ baseUrl, skipIntercepted, retry }) {
     const { specs, pathPrefix } = this
     const testerBaseUrl = `${baseUrl}${pathPrefix}`
 
@@ -129,6 +129,7 @@ class ServiceTester {
         }`
         if (!skipIntercepted || !spec.intercepted) {
           spec.baseUri(testerBaseUrl)
+          spec.retry(retry.count, retry.backoff)
           spec.toss()
         }
       })


### PR DESCRIPTION
This PR adds an option to retry all failed service tests. It uses IcedFrisby's [retry()](https://github.com/IcedFrisby/IcedFrisby/blob/master/API.md#retrycount-backoff) function. 
Usage:
```bash
RETRY_COUNT=3 RETRY_BACKOFF=0 npm run test:services -- --only=dynamicxml
```
Retried tests are marked with `R` in logs. An example:
```
    [live] XML from url | invalid url
RR      ✓ 
	[ GET .json?url=https://github.com/badges/shields/raw/master/notafile.xml&query=//version ] (413ms)
```
Default values:
- count: 0
- backoff: 0

I've tested it manually by setting different values of a timeout for specific service tests. 
I would like to use the functionality from this PR for https://github.com/badges/shields/issues/2688.  