### PR TITLE
Support [JenkinsCoverage] through the Code Coverage API plugin

### DIFF
--- a/services/jenkins/jenkins-coverage.tester.js
+++ b/services/jenkins/jenkins-coverage.tester.js
@@ -23,3 +23,13 @@ t.create('cobertura: job not found')
 t.create('cobertura: job found')
   .get('/cobertura/https/jenkins.sqlalchemy.org/alembic_coverage.json')
   .expectBadge({ label: 'coverage', message: isIntegerPercentage })
+
+t.create('code coverage API: job not found')
+  .get('/api/https/jenkins.library.illinois.edu/job/does-not-exist.json')
+  .expectBadge({ label: 'coverage', message: 'job or coverage not found' })
+
+t.create('code coverage API: job found')
+  .get(
+    '/api/https/jenkins.library.illinois.edu/job/OpenSourceProjects/job/Speedwagon/job/master.json'
+  )
+  .expectBadge({ label: 'coverage', message: isIntegerPercentage })


### PR DESCRIPTION
Closes #3785.

The plugin is called "Code Coverage API", so we could use `code-coverage-api` in the badge's path to mirror what we do with the JaCoCo and Cobertura plugins, but that gets quite lengthy and repeats the `coverage` word already present in the base path. Therefore, I went for the short and simple `api`.