### PR TITLE
Add CORS Header to every request

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -220,11 +220,6 @@ class Server {
         })
       )
     })
-
-    camp.handle((req, res, next) => {
-      res.setHeader('Access-Control-Allow-Origin', '*')
-      next()
-    })
   }
 
   /**
@@ -327,6 +322,11 @@ class Server {
 
     const { apiProvider: githubApiProvider } = this.githubConstellation
     suggest.setRoutes(allowedOrigin, githubApiProvider, camp)
+
+    camp.handle((req, res, next) => {
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      next()
+    })
 
     this.registerErrorHandlers()
     this.registerRedirects()

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -323,6 +323,7 @@ class Server {
     const { apiProvider: githubApiProvider } = this.githubConstellation
     suggest.setRoutes(allowedOrigin, githubApiProvider, camp)
 
+    // https://github.com/badges/shields/issues/3273
     camp.handle((req, res, next) => {
       res.setHeader('Access-Control-Allow-Origin', '*')
       next()

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -220,6 +220,11 @@ class Server {
         })
       )
     })
+
+    camp.handle((req, res, next) => {
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      next()
+    })
   }
 
   /**

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -151,4 +151,10 @@ describe('The server', function() {
       .and.to.include('410')
       .and.to.include('jpg no longer available')
   })
+
+  it('should return cors header for the request', async function() {
+    const { statusCode, headers } = await got(`${baseUrl}npm/v/express.svg`)
+    expect(statusCode).to.equal(200)
+    expect(headers['access-control-allow-origin']).to.equal('*')
+  })
 })


### PR DESCRIPTION
In Issue #3273 Prouser123 said to just `Access-Control-Allow-Origin: *` have as a header to every request.

I did exactly that. I have confirmed that this works by using an [heroku app](https://shields-cors.herokuapp.com/) and a [workshop file](https://steamcommunity.com/sharedfiles/filedetails/?id=1875923653) running the changes.

I don't know whether or not this is the correct method but it works for me.