### PR TITLE
honor build qualifiers in latest version comparisons, run [pub Debian GemDownloads GitHubRelease GitHubTag PackagistVersion]

### DIFF
--- a/services/version.js
+++ b/services/version.js
@@ -84,12 +84,12 @@ function latest(versions, { pre = false } = {}) {
   try {
     // coerce to string then lowercase otherwise alpha > RC
     version = versions.sort((a, b) =>
-      semver.rcompare(
+      semver.compareBuild(
         `${a}`.toLowerCase(),
         `${b}`.toLowerCase(),
         /* loose */ true
       )
-    )[0]
+    )[versions.length - 1]
   } catch (e) {
     version = latestDottedVersion(versions)
   }

--- a/services/version.spec.js
+++ b/services/version.spec.js
@@ -102,6 +102,9 @@ describe('Version helpers', function() {
     given(['1.0.0', '1.0.2', '1.1', '1.0', 'notaversion2', '12bcde4']).expect(
       '1.1'
     )
+
+    // build qualifiers - https://github.com/badges/shields/issues/4172
+    given(['0.3.9', '0.4.0+1', '0.4.0+9']).expect('0.4.0+9')
   })
 
   test(slice, () => {


### PR DESCRIPTION
Closes #4172 

We were previously using [semver's](https://github.com/npm/node-semver/) `rcompare` function which AFAICT does not include semver build qualifiers in the comparison. This updates our `latest`version comparison to leverage `semver`'s `compareBuild` function instead which, as you may suspect, does include the build qualifiers 😉 

https://github.com/npm/node-semver/blob/07244f913d0502d9400a88629710517ca9b7d702/semver.js#L645-L665

I've confirmed this fixes the version issue we were seeing in #4172 for `pub`, but also running the service tests for other service classes that leverage this same `latest` helper function