### PR TITLE
Enable retries for service tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ services_steps: &services_steps
         environment:
           mocha_reporter: mocha-junit-reporter
           MOCHA_FILE: junit/services/results.xml
-        command: npm run test:services:pr:run
+        command: RETRY_COUNT=3 npm run test:services:pr:run
 
     - store_test_results:
         path: junit


### PR DESCRIPTION
Agreed in https://github.com/badges/shields/pull/4166#issuecomment-541414778, this PR enables retries in service tests on CI. Similar change in daily test: https://github.com/badges/daily-tests/pull/15
I think it solves https://github.com/badges/shields/issues/2688. 