### PR TITLE
Add Crates.io recent downloads badge (fixes #4186), run [Crates]

### DIFF
--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -9,6 +9,7 @@ const keywords = ['Rust']
 const crateSchema = Joi.object({
   crate: Joi.object({
     downloads: nonNegativeInteger,
+    recent_downloads: nonNegativeInteger,
     max_version: Joi.string().required(),
   }).required(),
   versions: Joi.array()

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -2,6 +2,7 @@
 
 const { downloadCount: downloadCountColor } = require('../color-formatters')
 const { metric } = require('../text-formatters')
+const { InvalidParameter, NotFound } = require('../../core/base-service/errors')
 const { BaseCratesService, keywords } = require('./crates-base')
 
 module.exports = class CratesDownloads extends BaseCratesService {
@@ -97,7 +98,9 @@ module.exports = class CratesDownloads extends BaseCratesService {
       /* crates.io doesn't currently expose
          recent download counts for individual
          versions */
-      return { message: 'no data' }
+      throw new InvalidParameter({
+        prettyMessage: 'recent downloads not supported for specific versions',
+      })
     }
 
     const json = await this.fetch({ crate, version })
@@ -108,7 +111,7 @@ module.exports = class CratesDownloads extends BaseCratesService {
          or
          https://crates.io/api/v1/crates/libc/0.1.76
          returns a 200 OK with an errors object */
-      return { message: json.errors[0].detail }
+      throw new NotFound({ prettyMessage: json.errors[0].detail })
     }
 
     const downloads = this.transform({ variant, json })

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -12,7 +12,7 @@ module.exports = class CratesDownloads extends BaseCratesService {
   static get route() {
     return {
       base: 'crates',
-      pattern: ':variant(d|dv)/:crate/:version?',
+      pattern: ':variant(d|dv|dr)/:crate/:version?',
     }
   }
 
@@ -20,34 +20,56 @@ module.exports = class CratesDownloads extends BaseCratesService {
     return [
       {
         title: 'Crates.io',
-        pattern: ':variant(d|dv)/:crate',
-        namedParams: { variant: 'd', crate: 'rustc-serialize' },
-        staticPreview: this.render({ downloads: 5000000 }),
+        pattern: 'd/:crate',
+        namedParams: {
+          crate: 'rustc-serialize',
+        },
+        staticPreview: this.render({ variant: 'd', downloads: 5000000 }),
         keywords,
       },
       {
-        title: 'Crates.io',
-        pattern: ':variant(d|dv)/:crate/:version',
+        title: 'Crates.io (latest)',
+        pattern: 'dv/:crate',
         namedParams: {
-          variant: 'd',
+          crate: 'rustc-serialize',
+        },
+        staticPreview: this.render({ variant: 'dv', downloads: 2000000 }),
+        keywords,
+      },
+      {
+        title: 'Crates.io (version)',
+        pattern: 'dv/:crate/:version',
+        namedParams: {
           crate: 'rustc-serialize',
           version: '0.3.24',
         },
-        staticPreview: this.render({ downloads: 2000000, version: '0.3.24' }),
+        staticPreview: this.render({
+          variant: 'dv',
+          downloads: 2000000,
+          version: '0.3.24',
+        }),
+        keywords,
+      },
+      {
+        title: 'Crates.io (recent)',
+        pattern: 'dr/:crate',
+        namedParams: {
+          crate: 'rustc-serialize',
+        },
+        staticPreview: this.render({ variant: 'dr', downloads: 2000000 }),
         keywords,
       },
     ]
   }
 
   static _getLabel(version, variant) {
-    if (version) {
-      return `downloads@${version}`
-    } else {
-      if (variant === 'dv') {
-        return 'downloads@latest'
-      } else {
-        return 'downloads'
-      }
+    switch (variant) {
+      case 'dv':
+        return version ? `downloads@${version}` : 'downloads@latest'
+      case 'dr':
+        return 'recent downloads'
+      default:
+        return version ? `downloads@${version}` : 'downloads'
     }
   }
 
@@ -59,7 +81,25 @@ module.exports = class CratesDownloads extends BaseCratesService {
     }
   }
 
+  _extractDownloads({ variant, json }) {
+    switch (variant) {
+      case 'dv':
+        return json.crate ? json.versions[0].downloads : json.version.downloads
+      case 'dr':
+        return json.crate.recent_downloads
+      default:
+        return json.crate ? json.crate.downloads : json.version.downloads
+    }
+  }
+
   async handle({ variant, crate, version }) {
+    if (variant === 'dr' && version) {
+      /* crates.io doesn't currently expose
+         recent download counts for individual
+         versions */
+      return { message: 'no data' }
+    }
+
     const json = await this.fetch({ crate, version })
 
     if (json.errors) {
@@ -71,14 +111,8 @@ module.exports = class CratesDownloads extends BaseCratesService {
       return { message: json.errors[0].detail }
     }
 
-    let downloads
-    if (variant === 'dv') {
-      downloads = json.version
-        ? json.version.downloads
-        : json.versions[0].downloads
-    } else {
-      downloads = json.crate ? json.crate.downloads : json.version.downloads
-    }
+    const downloads = this._extractDownloads({ variant, json })
+
     return this.constructor.render({ variant, downloads, version })
   }
 }

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -2,8 +2,8 @@
 
 const { downloadCount: downloadCountColor } = require('../color-formatters')
 const { metric } = require('../text-formatters')
-const { InvalidParameter, NotFound } = require('../../core/base-service/errors')
 const { BaseCratesService, keywords } = require('./crates-base')
+const { InvalidParameter, NotFound } = require('..')
 
 module.exports = class CratesDownloads extends BaseCratesService {
   static get category() {

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -81,7 +81,7 @@ module.exports = class CratesDownloads extends BaseCratesService {
     }
   }
 
-  _extractDownloads({ variant, json }) {
+  transform({ variant, json }) {
     switch (variant) {
       case 'dv':
         return json.crate ? json.versions[0].downloads : json.version.downloads
@@ -111,7 +111,7 @@ module.exports = class CratesDownloads extends BaseCratesService {
       return { message: json.errors[0].detail }
     }
 
-    const downloads = this._extractDownloads({ variant, json })
+    const downloads = this.transform({ variant, json })
 
     return this.constructor.render({ variant, downloads, version })
   }

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -41,11 +41,11 @@ t.create('recent downloads')
     message: isMetric,
   })
 
-t.create('recent downloads (missing data)')
+t.create('recent downloads (with version)')
   .get('/dr/libc/0.2.31.json')
   .expectBadge({
     label: 'crates.io',
-    message: 'no data',
+    message: 'recent downloads not supported for specific versions',
   })
 
 t.create('downloads (invalid version)')

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -34,6 +34,20 @@ t.create('downloads for version (with version)')
     message: isMetric,
   })
 
+t.create('recent downloads')
+  .get('/dr/libc.json')
+  .expectBadge({
+    label: 'recent downloads',
+    message: isMetric,
+  })
+
+t.create('recent downloads (missing data)')
+  .get('/dr/libc/0.2.31.json')
+  .expectBadge({
+    label: 'crates.io',
+    message: 'no data',
+  })
+
 t.create('downloads (invalid version)')
   .get('/d/libc/7.json')
   .expectBadge({ label: 'crates.io', message: 'invalid semver: 7' })


### PR DESCRIPTION
Summary of the changes:

* Added a 'recent downloads' badge for Crates.io.
  * I exposed it at `/crates/dr/:crate` (r for recent), as this seemed consistent with the existing routes in that namespace.
  * The data for recent downloads is only available for the crate as a whole, not individual versions, so I made the service bail out early with an error if you try to do that, to avoid unneccecary calls to Crates.io.
* Cleaned up some of the existing code.
* Updated the examples.
    * I left `/d/:crate/:version` out of the examples, because it does the same thing as `/dt/:crate/:version` and the latter makes more sense to me. The URL still works, though.
    * The URLs in the examples now include the relevant variants instead of `:variant` - this seems to play nicer with the modal editor.

Hopefully this is okay, first time contributing :)

![image](https://user-images.githubusercontent.com/784533/67038828-18420600-f118-11e9-84e8-9f8b01b00ac8.png)
