### PR TITLE
Adjust new [swagger] endpoint

### DIFF
--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -50,7 +50,7 @@ module.exports = class SwaggerValidatorService extends BaseJsonService {
   }
 
   async fetch({ scheme, urlF }) {
-    const url = 'http://online.swagger.io/validator/debug'
+    const url = 'http://validator.swagger.io/validator/debug'
     return this._requestJson({
       url,
       schema: validatorSchema,

--- a/services/swagger/swagger.tester.js
+++ b/services/swagger/swagger.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const getURL = '/https/example.com/example.json.json'
-const apiURL = 'http://online.swagger.io'
+const apiURL = 'http://validator.swagger.io'
 const apiGetURL = '/validator/debug'
 const apiGetQueryParams = { url: 'https://example.com/example.json' }
 


### PR DESCRIPTION
The current used endpoint of swagger.io changed to a new one. See https://github.com/swagger-api/validator-badge. In their ReadMe they changed the URL to another subdomain. This new subdomain can also validate OAS3 Specs (as well as OAS2)