### PR TITLE
[MavenMetadata] should use version as string (#4188), also run [MavenCentral]

### DIFF
--- a/services/maven-central/maven-central.tester.js
+++ b/services/maven-central/maven-central.tester.js
@@ -50,4 +50,4 @@ t.create('version ending with zero')
       `
       )
   )
-  .expectBadge({ label: 'maven-central', message: /^v1\.30$/ })
+  .expectBadge({ label: 'maven-central', message: 'v1.30' })

--- a/services/maven-metadata/maven-metadata.service.js
+++ b/services/maven-metadata/maven-metadata.service.js
@@ -14,9 +14,7 @@ const schema = Joi.object({
     versioning: Joi.object({
       versions: Joi.object({
         version: Joi.array()
-          .items(
-            Joi.alternatives(Joi.string().required(), Joi.number().required())
-          )
+          .items(Joi.string().required())
           .single()
           .required(),
       }).required(),
@@ -56,7 +54,11 @@ module.exports = class MavenMetadata extends BaseXmlService {
   }
 
   async fetch({ metadataUrl }) {
-    return this._requestXml({ schema, url: metadataUrl })
+    return this._requestXml({
+      schema,
+      url: metadataUrl,
+      parserOptions: { parseNodeValue: false },
+    })
   }
 
   async handle(_namedParams, { metadataUrl }) {

--- a/services/maven-metadata/maven-metadata.tester.js
+++ b/services/maven-metadata/maven-metadata.tester.js
@@ -12,6 +12,33 @@ t.create('valid maven-metadata.xml uri')
     message: isVPlusDottedVersionAtLeastOne,
   })
 
+t.create('version ending with zero')
+  .get(
+    '/v.json?metadataUrl=http://central.maven.org/maven2/mocked-group-id/mocked-artifact-id/maven-metadata.xml'
+  )
+  .intercept(nock =>
+    nock('http://central.maven.org/maven2')
+      .get('/mocked-group-id/mocked-artifact-id/maven-metadata.xml')
+      .reply(
+        200,
+        `
+      <metadata>
+        <groupId>mocked-group-id</groupId>
+        <artifactId>mocked-artifact-id</artifactId>
+        <versioning>
+          <latest>1.30</latest>
+          <release>1.30</release>
+          <versions>
+            <version>1.30</version>
+          </versions>
+          <lastUpdated>20190902002617</lastUpdated>
+        </versioning>
+      </metadata>
+      `
+      )
+  )
+  .expectBadge({ label: 'maven', message: 'v1.30' })
+
 t.create('invalid maven-metadata.xml uri')
   .get(
     '/v.json?metadataUrl=http://central.maven.org/maven2/com/google/code/gson/gson/foobar.xml'


### PR DESCRIPTION
This PR proposes a fix to #4188, where version numbers from `maven-metadata.xml` get trimmed erroneously in the `maven-metadata` service.

The fix is directly adapted from #3935 (done to `maven-central` by @reda-alaoui).
