### PR TITLE
add [homebrew] cask service

### DIFF
--- a/services/homebrew/homebrew-cask.service.js
+++ b/services/homebrew/homebrew-cask.service.js
@@ -16,7 +16,7 @@ module.exports = class HomebrewCask extends BaseJsonService {
   static get route() {
     return {
       base: 'homebrew/cask/v',
-      pattern: ':formula',
+      pattern: ':cask',
     }
   }
 
@@ -24,7 +24,7 @@ module.exports = class HomebrewCask extends BaseJsonService {
     return [
       {
         title: 'homebrew cask',
-        namedParams: { formula: 'iterm2' },
+        namedParams: { cask: 'iterm2' },
         staticPreview: renderVersionBadge({ version: 'v3.2.5' }),
       },
     ]
@@ -34,15 +34,15 @@ module.exports = class HomebrewCask extends BaseJsonService {
     return { label: 'homebrew cask' }
   }
 
-  async fetch({ formula }) {
+  async fetch({ cask }) {
     return this._requestJson({
       schema,
-      url: `https://formulae.brew.sh/api/cask/${formula}.json`,
+      url: `https://formulae.brew.sh/api/cask/${cask}.json`,
     })
   }
 
-  async handle({ formula }) {
-    const data = await this.fetch({ formula })
+  async handle({ cask }) {
+    const data = await this.fetch({ cask })
     return renderVersionBadge({ version: data.version })
   }
 }

--- a/services/homebrew/homebrew-cask.service.js
+++ b/services/homebrew/homebrew-cask.service.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const Joi = require('@hapi/joi')
+const { renderVersionBadge } = require('../version')
+const { BaseJsonService } = require('..')
+
+const schema = Joi.object({
+  version: Joi.string().required(),
+}).required()
+
+module.exports = class HomebrewCask extends BaseJsonService {
+  static get category() {
+    return 'version'
+  }
+
+  static get route() {
+    return {
+      base: 'homebrew/cask/v',
+      pattern: ':formula',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'homebrew cask',
+        namedParams: { formula: 'iterm2' },
+        staticPreview: renderVersionBadge({ version: 'v3.2.5' }),
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'homebrew cask' }
+  }
+
+  async fetch({ formula }) {
+    return this._requestJson({
+      schema,
+      url: `https://formulae.brew.sh/api/cask/${formula}.json`,
+    })
+  }
+
+  async handle({ formula }) {
+    const data = await this.fetch({ formula })
+    return renderVersionBadge({ version: data.version })
+  }
+}

--- a/services/homebrew/homebrew-cask.tester.js
+++ b/services/homebrew/homebrew-cask.tester.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const { isVPlusTripleDottedVersion } = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('homebrew cask (valid)')
+  .get('/iterm2.json')
+  .expectBadge({
+    label: 'homebrew cask',
+    message: isVPlusTripleDottedVersion,
+  })
+
+t.create('homebrew cask (valid)')
+  .get('/iterm2.json')
+  .intercept(nock =>
+    nock('https://formulae.brew.sh')
+      .get('/api/cask/iterm2.json')
+      .reply(200, { version: '3.3.6' })
+  )
+  .expectBadge({ label: 'homebrew cask', message: 'v3.3.6' })
+
+t.create('homebrew cask (not found)')
+  .get('/not-a-package.json')
+  .expectBadge({ label: 'homebrew cask', message: 'not found' })


### PR DESCRIPTION
I went for the '/' route to distinguish regular and cask formulas, much like many other services

both regular and cask services are similar in implementation, but different schemas and api routes make it quite hard to find any common code to refactor, so I decided to leave it as it

this closes #1638