### PR TITLE
revert version comparison updates #4173, run [pub Debian GemDownloads GitHubRelease GitHubTag PackagistVersion]

### DIFF
--- a/services/version.js
+++ b/services/version.js
@@ -84,12 +84,12 @@ function latest(versions, { pre = false } = {}) {
   try {
     // coerce to string then lowercase otherwise alpha > RC
     version = versions.sort((a, b) =>
-      semver.compareBuild(
+      semver.rcompare(
         `${a}`.toLowerCase(),
         `${b}`.toLowerCase(),
         /* loose */ true
       )
-    )[versions.length - 1]
+    )[0]
   } catch (e) {
     version = latestDottedVersion(versions)
   }

--- a/services/version.spec.js
+++ b/services/version.spec.js
@@ -102,9 +102,6 @@ describe('Version helpers', function() {
     given(['1.0.0', '1.0.2', '1.1', '1.0', 'notaversion2', '12bcde4']).expect(
       '1.1'
     )
-
-    // build qualifiers - https://github.com/badges/shields/issues/4172
-    given(['0.3.9', '0.4.0+1', '0.4.0+9']).expect('0.4.0+9')
   })
 
   test(slice, () => {


### PR DESCRIPTION
Refs #4227 #4173 #4253 

This is one of the two code changes that touched a lot of services which were part of the last deployment that preceeded the resource spikes/slow response times on the badge servers. 

Though we still don't know whether _any_ of the commits in that deployment played a role, opening this in case we want to try a deployment without this change to test/validate

cc @paulmelnikow 