### PR TITLE
revert cors header injection #4171

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -323,12 +323,6 @@ class Server {
     const { apiProvider: githubApiProvider } = this.githubConstellation
     suggest.setRoutes(allowedOrigin, githubApiProvider, camp)
 
-    // https://github.com/badges/shields/issues/3273
-    camp.handle((req, res, next) => {
-      res.setHeader('Access-Control-Allow-Origin', '*')
-      next()
-    })
-
     this.registerErrorHandlers()
     this.registerRedirects()
     this.registerServices()

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -151,10 +151,4 @@ describe('The server', function() {
       .and.to.include('410')
       .and.to.include('jpg no longer available')
   })
-
-  it('should return cors header for the request', async function() {
-    const { statusCode, headers } = await got(`${baseUrl}npm/v/express.svg`)
-    expect(statusCode).to.equal(200)
-    expect(headers['access-control-allow-origin']).to.equal('*')
-  })
 })


### PR DESCRIPTION
Refs #4227 #4173 #4252

This is one of the two code changes that touched a lot of services which were part of the last deployment that preceeded the resource spikes/slow response times on the badge servers. 

Though we still don't know whether _any_ of the commits in that deployment played a role, opening this in case we want to try a deployment without this change to test/validate

cc @paulmelnikow 