### PR TITLE
Align documentation to the left

### DIFF
--- a/frontend/components/markup-modal/markup-modal-content.tsx
+++ b/frontend/components/markup-modal/markup-modal-content.tsx
@@ -11,6 +11,7 @@ import Customizer from '../customizer/customizer'
 const Documentation = styled.div`
   max-width: 800px;
   margin: 35px auto 20px;
+  text-align: left;
 `
 
 export function MarkupModalContent({


### PR DESCRIPTION
A tiny code change, but a nice visual impact. Fixes #4170.