### PR TITLE
fix [GitHubHacktoberfest] service test

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ When adding or changing a service [please add tests][service-tests].
 This project has quite a backlog of suggestions! If you're new to the project,
 maybe you'd like to open a pull request to address one of them:
 
-[![Hacktoberfest](https://img.shields.io/github/hacktoberfest/2019/badges/shields)](https://github.com/badges/shields/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest)
 [![GitHub issues by-label](https://img.shields.io/github/issues/badges/shields/good%20first%20issue)](https://github.com/badges/shields/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
 You can read a [tutorial on how to add a badge][tutorial].

--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -120,7 +120,7 @@ module.exports = class GithubHacktoberfestCombinedStatus extends GithubAuthV4Ser
       // We want to show "1 day left" on the last day so we add 1.
       daysLeft = moment('2019-11-01 12:00:00 Z').diff(moment(), 'days') + 1
     }
-    if (daysLeft <= 0) {
+    if (daysLeft < 0) {
       return {
         message: `is over! (${metric(contributionCount)} ${maybePluralize(
           'PR',

--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -120,7 +120,14 @@ module.exports = class GithubHacktoberfestCombinedStatus extends GithubAuthV4Ser
       // We want to show "1 day left" on the last day so we add 1.
       daysLeft = moment('2019-11-01 12:00:00 Z').diff(moment(), 'days') + 1
     }
-
+    if (daysLeft <= 0) {
+      return {
+        message: `is over! (${metric(contributionCount)} ${maybePluralize(
+          'PR',
+          contributionCount
+        )} opened)`,
+      }
+    }
     const message =
       [
         suggestedIssueCount
@@ -140,7 +147,7 @@ module.exports = class GithubHacktoberfestCombinedStatus extends GithubAuthV4Ser
           : '',
       ]
         .filter(Boolean)
-        .join(', ') || 'is done!'
+        .join(', ') || 'is over!'
 
     return { message }
   }

--- a/services/github/github-hacktoberfest.spec.js
+++ b/services/github/github-hacktoberfest.spec.js
@@ -6,7 +6,7 @@ const GitHubHacktoberfest = require('./github-hacktoberfest.service')
 describe('GitHubHacktoberfest', function() {
   test(GitHubHacktoberfest.render, () => {
     given({
-      daysLeft: 0,
+      daysLeft: -1,
       contributionCount: 12,
     }).expect({
       message: 'is over! (12 PRs opened)',

--- a/services/github/github-hacktoberfest.spec.js
+++ b/services/github/github-hacktoberfest.spec.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { test, given } = require('sazerac')
+const GitHubHacktoberfest = require('./github-hacktoberfest.service')
+
+describe('GitHubHacktoberfest', function() {
+  test(GitHubHacktoberfest.render, () => {
+    given({
+      daysLeft: 0,
+      contributionCount: 12,
+    }).expect({
+      message: 'is over! (12 PRs opened)',
+    })
+    given({
+      daysLeft: 10,
+      contributionCount: 27,
+      suggestedIssueCount: 54,
+    }).expect({
+      message: '54 open issues, 27 PRs, 10 days left',
+    })
+  })
+})

--- a/services/github/github-hacktoberfest.tester.js
+++ b/services/github/github-hacktoberfest.tester.js
@@ -3,15 +3,27 @@
 const Joi = require('@hapi/joi')
 const t = (module.exports = require('../tester').createServiceTester())
 
-const isHactoberfestCombinedStatus = Joi.string().regex(
+const isHacktoberfestNoIssuesStatus = Joi.string().regex(
+  /^[0-9]+ PRs?(, [0-9]+ days? left)?$/
+)
+const isHacktoberfestNoPRsStatus = Joi.string().regex(
+  /^([0-9]+ open issues?)?[0-9]+ days? left$/
+)
+const isHacktoberfestCombinedStatus = Joi.string().regex(
   /^[0-9]+ open issues?(, [0-9]+ PRs?)?(, [0-9]+ days? left)?$/
+)
+const isHacktoberfestStatus = Joi.alternatives().try(
+  isHacktoberfestNoIssuesStatus,
+  isHacktoberfestNoPRsStatus,
+  isHacktoberfestCombinedStatus,
+  'is done!'
 )
 
 t.create('GitHub Hacktoberfest combined status')
   .get('/badges/shields.json')
   .expectBadge({
     label: 'hacktoberfest',
-    message: isHactoberfestCombinedStatus,
+    message: isHacktoberfestStatus,
   })
 
 t.create('GitHub Hacktoberfest combined status (suggestion label override)')
@@ -22,5 +34,5 @@ t.create('GitHub Hacktoberfest combined status (suggestion label override)')
   )
   .expectBadge({
     label: 'hacktoberfest',
-    message: isHactoberfestCombinedStatus,
+    message: isHacktoberfestStatus,
   })

--- a/services/github/github-hacktoberfest.tester.js
+++ b/services/github/github-hacktoberfest.tester.js
@@ -16,7 +16,7 @@ const isHacktoberfestStatus = Joi.alternatives().try(
   isHacktoberfestNoIssuesStatus,
   isHacktoberfestNoPRsStatus,
   isHacktoberfestCombinedStatus,
-  'is done!'
+  /^is over! \([0-9]+ PRs? opened\)$/
 )
 
 t.create('GitHub Hacktoberfest combined status')


### PR DESCRIPTION
Fixes #4298 

I also removed our Hacktoberfest badge from our readme now that we've transitioned into November. 

Related aside, while working on this I find myself wondering what this badge should look like outside October/Hacktoberfest. It looks like it will only display the `is over!` message if there are no `hacktoberfest`-labeled issues, there were no PRs opened during October, and October has ended.

Would it make sense to display `is over!` after Hacktoberfest has ended regardless? 