### PR TITLE
Bump simple-icons from 1.19.0 to 1.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23110,9 +23110,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.19.0.tgz",
-      "integrity": "sha512-BsV3jdhckw3J5GxcPRlEeqWlQh4zzi2aWA2NZeOlK+F6Dz+yFYmtZl9lDQF9uBbw0xbBqrlt194cvOX4C5XQQg=="
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-1.19.1.tgz",
+      "integrity": "sha512-tZpdvsJ98C0lrym8eFtAbXUeMpLbpN/UKek333fGDIZ6CRhPtpMloA3HvDcGTtfOAi4KDev7yJe3H4LI9iLH8g=="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "query-string": "^6.8.3",
     "request": "~2.88.0",
     "semver": "~6.3.0",
-    "simple-icons": "1.19.0",
+    "simple-icons": "1.19.1",
     "xmldom": "~0.1.27",
     "xpath": "~0.0.27"
   },


### PR DESCRIPTION
The latest release contains a handful of icons that are widely used in the industry, namely: C, arxiv, Notion, Zoom, etc.