### PR TITLE
Azure DevOps Artifacts Nuget Feed Badge, run [nuget myget chocolatey resharper]

### DIFF
--- a/services/azure-devops/azure-devops-artifacts.service.js
+++ b/services/azure-devops/azure-devops-artifacts.service.js
@@ -19,7 +19,42 @@ class AzureArtifactsNugetVersionService extends BaseJsonService {
   }
 
   static get examples() {
-    return []
+    return [
+      {
+        title: 'Azure Artifacts',
+        pattern: 'v/:organization/:project/:feed/:packageName',
+        namedParams: {
+          organization: 'dotnet',
+          project: 'RX.Net',
+          feed: 'RxNet',
+          packageName: 'System.Reactive',
+        },
+        staticPreview: this.render({ version: '4.2.1' }),
+      },
+      {
+        title: 'Azure Artifacts (with prereleases)',
+        pattern: 'vpre/:organization/:project/:feed/:packageName',
+        namedParams: {
+          organization: 'dotnet',
+          project: 'RX.Net',
+          feed: 'RxNet',
+          packageName: 'System.Reactive',
+        },
+        staticPreview: this.render({ version: '4.3.0-preview.10' }),
+      },
+      {
+        title: 'Azure Artifacts (with view)',
+        pattern: 'vpre/:organization/:project/:feed/:view/:packageName',
+        namedParams: {
+          organization: 'dotnet',
+          project: 'RX.Net',
+          feed: 'RxNet',
+          view: 'prerelease',
+          packageName: 'System.Reactive',
+        },
+        staticPreview: this.render({ version: '4.3.0-preview.10' }),
+      },
+    ]
   }
 
   static get defaultBadgeData() {

--- a/services/azure-devops/azure-devops-artifacts.service.js
+++ b/services/azure-devops/azure-devops-artifacts.service.js
@@ -1,0 +1,61 @@
+'use strict'
+
+const { fetchPackage, getLatestVersion } = require('../nuget/nuget-v3-helpers')
+const { renderVersionBadge } = require('../nuget/nuget-helpers')
+const { BaseJsonService } = require('..')
+const { NotFound } = require('..')
+
+class AzureArtifactsNugetVersionService extends BaseJsonService {
+  static get category() {
+    return 'version'
+  }
+
+  static get route() {
+    return {
+      base: 'azure-devops',
+      pattern:
+        ':which(v|vpre)/:organization/:project/:feed/:view(all|local|prerelease|release)?/:packageName',
+    }
+  }
+
+  static get examples() {
+    return []
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'nuget',
+    }
+  }
+
+  static render(props) {
+    return renderVersionBadge(props)
+  }
+
+  async handle({ which, organization, project, feed, view, packageName }) {
+    function getViewName() {
+      if (!view) return ''
+
+      switch (view) {
+        case 'all':
+          return ''
+        case 'local':
+          return '%40Local'
+        case 'prerelease':
+          return '%40Prerelease'
+        case 'release':
+          return '%40Release'
+        default:
+          throw new NotFound({ prettyMessage: `invalid view name: ${view}` })
+      }
+    }
+
+    const viewName = getViewName()
+    const baseUrl = `https://pkgs.dev.azure.com/${organization}/${project}/_packaging/${feed}${viewName}/nuget/v3`
+    const { versions } = await fetchPackage(this, { baseUrl, packageName })
+    const { version } = getLatestVersion(versions, which === 'vpre')
+    return this.constructor.render({ version })
+  }
+}
+
+module.exports = { AzureArtifactsNugetVersionService }

--- a/services/nuget/nuget-v3-helpers.js
+++ b/services/nuget/nuget-v3-helpers.js
@@ -1,0 +1,105 @@
+'use strict'
+
+const { promisify } = require('util')
+const Joi = require('@hapi/joi')
+const semver = require('semver')
+const { regularUpdate } = require('../../core/legacy/regular-update')
+const { NotFound } = require('..')
+
+function randomElementFrom(items) {
+  const index = Math.floor(Math.random() * items.length)
+  return items[index]
+}
+
+/*
+ * Hit the service index endpoint and return a SearchQueryService URL, chosen
+ * at random. Cache the responses, but return a different random URL each time.
+ */
+async function searchQueryServiceUrl(baseUrl) {
+  // Should we really be caching all these NuGet feeds in memory?
+  const searchQueryServices = await promisify(regularUpdate)({
+    url: `${baseUrl}/index.json`,
+    // The endpoint changes once per year (ie, a period of n = 1 year).
+    // We minimize the users' waiting time for information.
+    // With l = latency to fetch the endpoint and x = endpoint update period
+    // both in years, the yearly number of queries for the endpoint are 1/x,
+    // and when the endpoint changes, we wait for up to x years to get the
+    // right endpoint.
+    // So the waiting time within n years is n*l/x + x years, for which a
+    // derivation yields an optimum at x = sqrt(n*l), roughly 42 minutes.
+    intervalMillis: 42 * 60 * 1000,
+    json: true,
+    scraper: json =>
+      json.resources.filter(
+        resource => resource['@type'] === 'SearchQueryService/3.0.0-beta'
+      ),
+  })
+  return randomElementFrom(searchQueryServices)['@id']
+}
+
+const schema = Joi.object({
+  data: Joi.array()
+    .items(
+      Joi.object({
+        id: Joi.string().required(),
+        versions: Joi.array()
+          .items(
+            Joi.object({
+              version: Joi.string().required(),
+            })
+          )
+          .default([]),
+        totalDownloads: Joi.number().integer(),
+        totaldownloads: Joi.number().integer(),
+      })
+    )
+    // .max(1)
+    .default([]),
+}).required()
+
+/*
+ * Get information about a single package.
+ */
+async function fetchPackage(
+  serviceInstance,
+  { baseUrl, packageName, includePrereleases = false }
+) {
+  const url = await searchQueryServiceUrl(baseUrl)
+  const json = await serviceInstance._requestJson({
+    schema,
+    url,
+    options: {
+      qs: {
+        q: `${encodeURIComponent(packageName.toLowerCase())}`,
+        // Include prerelease versions.
+        prerelease: 'true',
+        // Include packages with SemVer 2 version numbers.
+        semVerLevel: '2',
+      },
+    },
+  })
+
+  for (const d of json.data) {
+    if (
+      packageName.localeCompare(d.id, undefined, { sensitivity: 'base' }) === 0
+    ) {
+      return d
+    }
+  }
+
+  throw new NotFound({ prettyMessage: 'package not found' })
+}
+
+function getLatestVersion(versions, includePrereleases = false) {
+  if (!includePrereleases) {
+    versions = versions.filter(item => !item.version.includes('-'))
+  }
+
+  versions.sort((a, b) => semver.rcompare(a.version, b.version))
+  return versions[0]
+}
+
+module.exports = {
+  fetchPackage,
+  getLatestVersion,
+}


### PR DESCRIPTION
 @calebcartwright marked #4182 as a good first issue so I decided to give it a shot. 

With this shield, you can get the same kind of shield that you get from the existing nuget shield, but this one uses [Azure Artifacts](https://docs.microsoft.com/en-us/azure/devops/artifacts/) as a back end instead of nuget.org. The azure artifacts shield requires more information than the traditional nuget shield. 

An example shield path would be `/azure-devops/vpre/dotnet/RX.Net/RxNet/System.Interactive`. 

Azure Artifacts feeds support [multiple views](https://docs.microsoft.com/en-us/azure/devops/artifacts/concepts/views). You can specify a specific view as an optional parameter in the shield path right before the package name. For example, `/azure-devops/vpre/dotnet/RX.Net/RxNet/release/System.Interactive`

I felt that the way that the nuget shield is currently implemented is kind wonky with the `withTenant` and `withFeed` options. I didn't think that approach would scale to multiple different kinds of nuget feeds. So I factored the `fetch` logic into a separate "nuget-v3-helpers" file. This way, different nuget package feeds (nuget.org, myget, azure devops artifacts, github package registry, [sleet](https://github.com/emgarten/Sleet/), etc) could share the core nuget feed search logic while each one can have it's own custom route configuration to generate the base nuget feed URL.

I did modify the package fetch logic a bit. I was hitting an issue where the package query returned more than one package. For example, searching for Some.Package will return Some.Package and Some.Package.MoreDetails. So I modified the logic to explicitly check package name. I also added a getLatestVersion helper function that explicitly sorts by decending semver + does the prerelease filtering.

I'm creating a draft pull request because I still need to go back and update the existing nuget and myget shields to use this new approach. But I wanted feedback that I was on the right path before doing that work.

