### PR TITLE
Fix [TeamCity] build status text schema

### DIFF
--- a/services/teamcity/teamcity-build.service.js
+++ b/services/teamcity/teamcity-build.service.js
@@ -4,15 +4,9 @@ const Joi = require('@hapi/joi')
 const { optionalUrl } = require('../validators')
 const TeamCityBase = require('./teamcity-base')
 
-// The statusText field will start with a summary, potentially including test details, followed by an optional suffix.
-// Regex was updated to account for that optional suffix to address reported bugs.
-// See https://github.com/badges/shields/issues/3244 for an example.
-const buildStatusTextRegex = /^Success|Failure|Error|Tests( failed: \d+( \(\d+ new\))?)?(,)?( passed: \d+)?(,)?( ignored: \d+)?(,)?( muted: \d+)?/
 const buildStatusSchema = Joi.object({
   status: Joi.equal('SUCCESS', 'FAILURE', 'ERROR').required(),
-  statusText: Joi.string()
-    .regex(buildStatusTextRegex)
-    .required(),
+  statusText: Joi.string().required(),
 }).required()
 
 const queryParamSchema = Joi.object({

--- a/services/teamcity/teamcity-build.tester.js
+++ b/services/teamcity/teamcity-build.tester.js
@@ -126,3 +126,20 @@ t.create('full build status with failed build')
     message: 'tests failed: 10 (2 new), passed: 99',
     color: 'red',
   })
+
+t.create('full build status with passed build chain')
+  .get('/e/bt421.json?server=https://selfhosted.teamcity.com:4000')
+  .intercept(nock =>
+    nock('https://selfhosted.teamcity.com:4000/app/rest/builds')
+      .get(`/${encodeURIComponent('buildType:(id:bt421)')}`)
+      .query({ guest: 1 })
+      .reply(200, {
+        status: 'SUCCESS',
+        statusText: 'Build chain finished (success: 9)',
+      })
+  )
+  .expectBadge({
+    label: 'build',
+    message: 'passing',
+    color: 'brightgreen',
+  })


### PR DESCRIPTION
Build status is currently used as a pass through, so remove
regex, because it causes unnecessary failures.

Fix #4486