### PR TITLE
[nuget myget] defer decision on which version is latest to registry

### DIFF
--- a/services/myget/myget.tester.js
+++ b/services/myget/myget.tester.js
@@ -70,7 +70,7 @@ t.create('version (valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
   })
 
-t.create('total downloads (tenant)')
+t.create('version (no stable versions)')
   .get('/dotnet.myget/dotnet-coreclr/v/Microsoft.DotNet.CoreCLR.json')
   .expectBadge({
     label: 'dotnet-coreclr',
@@ -87,7 +87,7 @@ t.create('version (yellow badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amongodb.driver.core&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amongodb.driver.core&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonWithDash)
   )
@@ -107,7 +107,7 @@ t.create('version (orange badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amongodb.driver.core&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amongodb.driver.core&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonFirstCharZero)
   )
@@ -127,7 +127,7 @@ t.create('version (blue badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amongodb.driver.core&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amongodb.driver.core&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonFirstCharNotZero)
   )

--- a/services/nuget-fixtures.js
+++ b/services/nuget-fixtures.js
@@ -13,7 +13,7 @@ const nuGetV3VersionJsonWithDash = JSON.stringify({
   data: [
     {
       totalDownloads: 0,
-      versions: [{ version: '1.2-beta' }],
+      version: '1.2-beta',
     },
   ],
 })
@@ -21,7 +21,7 @@ const nuGetV3VersionJsonFirstCharZero = JSON.stringify({
   data: [
     {
       totalDownloads: 0,
-      versions: [{ version: '0.35' }],
+      version: '0.35',
     },
   ],
 })
@@ -29,23 +29,7 @@ const nuGetV3VersionJsonFirstCharNotZero = JSON.stringify({
   data: [
     {
       totalDownloads: 0,
-      versions: [{ version: '1.2.7' }],
-    },
-  ],
-})
-
-const nuGetV3VersionJsonBuildMetadataWithDash = JSON.stringify({
-  data: [
-    {
-      totalDownloads: 0,
-      versions: [
-        {
-          version: '1.16.0+388',
-        },
-        {
-          version: '1.17.0+1b81349-429',
-        },
-      ],
+      version: '1.2.7',
     },
   ],
 })
@@ -55,5 +39,4 @@ module.exports = {
   nuGetV3VersionJsonWithDash,
   nuGetV3VersionJsonFirstCharZero,
   nuGetV3VersionJsonFirstCharNotZero,
-  nuGetV3VersionJsonBuildMetadataWithDash,
 }

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -11,7 +11,6 @@ const {
   nuGetV3VersionJsonWithDash,
   nuGetV3VersionJsonFirstCharZero,
   nuGetV3VersionJsonFirstCharNotZero,
-  nuGetV3VersionJsonBuildMetadataWithDash,
 } = require('../nuget-fixtures')
 const { invalidJSON } = require('../response-fixtures')
 
@@ -65,7 +64,7 @@ t.create('version (yellow badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonWithDash)
   )
@@ -85,7 +84,7 @@ t.create('version (orange badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonFirstCharZero)
   )
@@ -105,7 +104,7 @@ t.create('version (blue badge)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=false&semVerLevel=2'
       )
       .reply(200, nuGetV3VersionJsonFirstCharNotZero)
   )
@@ -113,25 +112,6 @@ t.create('version (blue badge)')
     label: 'nuget',
     message: 'v1.2.7',
     color: 'blue',
-  })
-
-// https://github.com/badges/shields/issues/4219
-t.create('version (build metadata with -)')
-  .get('/v/MongoFramework.json')
-  .intercept(nock =>
-    nock('https://api.nuget.org')
-      .get('/v3/index.json')
-      .reply(200, queryIndex)
-  )
-  .intercept(nock =>
-    nock('https://api-v2v3search-0.nuget.org')
-      .get('/query?q=packageid%3Amongoframework&prerelease=true&semVerLevel=2')
-      .reply(200, nuGetV3VersionJsonBuildMetadataWithDash)
-  )
-  .expectBadge({
-    label: 'nuget',
-    message: 'v1.17.0+1b81349-429',
-    color: 'yellow',
   })
 
 t.create('version (not found)')
@@ -148,7 +128,7 @@ t.create('version (unexpected second response)')
   .intercept(nock =>
     nock('https://api-v2v3search-0.nuget.org')
       .get(
-        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=true&semVerLevel=2'
+        '/query?q=packageid%3Amicrosoft.aspnetcore.mvc&prerelease=false&semVerLevel=2'
       )
       .reply(invalidJSON)
   )


### PR DESCRIPTION
Closes #4494 Discussion in #4494 + on discord

tl;dr summary:
We're trying to sort nuget versions as semver. While nuget _advises_ users to use semver2, it doesn't enforce it and there's a bunch of stuff in the ecosystem that uses other versioning schemes. The nuget registry itself has some logic to apply some ordering to versions which we can't easily reproduce and users (completely reasonably) expect shields to report the same latest version that the registry does.