### PR TITLE
always take worst-cases usesRemaining in token pool

### DIFF
--- a/core/token-pooling/token-pool.js
+++ b/core/token-pooling/token-pool.js
@@ -109,10 +109,8 @@ class Token {
     ) {
       this._nextReset = nextReset
       this._usesRemaining = usesRemaining
-    } else if (nextReset === this._nextReset) {
-      this._usesRemaining = Math.min(this._usesRemaining, usesRemaining)
     } else {
-      // Discard the new update; it's older than the values we have.
+      this._usesRemaining = Math.min(this._usesRemaining, usesRemaining)
     }
   }
 

--- a/services/github/github-api-provider.integration.js
+++ b/services/github/github-api-provider.integration.js
@@ -95,7 +95,7 @@ describe('Github API provider', function() {
 
       const [token] = tokens
       expect(token.usesRemaining).to.equal(usesRemaining)
-      expect(token.nextReset).to.equal(nextReset)
+      expect(token.nextReset).to.be.within(nextReset - 1, nextReset)
     })
   })
 })

--- a/services/github/github-api-provider.integration.js
+++ b/services/github/github-api-provider.integration.js
@@ -95,6 +95,14 @@ describe('Github API provider', function() {
 
       const [token] = tokens
       expect(token.usesRemaining).to.equal(usesRemaining)
+
+      /*
+      There is some kind of rounding or off-by-one error
+      which causes the GitHub API to return an inconsistent
+      timestamp value for `X-RateLimit-Reset`.
+
+      see https://github.com/badges/shields/pull/4590 for more details
+      */
       expect(token.nextReset).to.be.within(nextReset - 1, nextReset)
     })
   })


### PR DESCRIPTION
Closes #4561 :tada: 

Having spent some time on this, I discovered the reason for these intermittent failures is because the GitHub API is returning an inconsistent timestamp for `X-RateLimit-Reset`. You should be able to reproduce this behaviour using cURL and a valid GH API token e.g:


```sh
$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421718

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421718

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421717

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421717

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421718

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421717

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421717

$ curl -I "https://api.github.com/rate_limit" -H "Authorization: Bearer f00b42" | grep X-RateLimit-Reset
X-RateLimit-Reset: 1580421718
```

This was causing us to sometimes not decrement `usesRemaining` because ~half the time we assume that the value we already hold is newer than the new value. This probably wasn't causing a _huge_ issue in production because the `X-RateLimit-Reset` seems to fluctuate between 2 values (I assume there's some kind of rounding issue going on upstream) so after a few requests, we catch up and adopt the new `usesRemaining` value, but it is giving us issues under test.

This PR changes the logic to ignore the timestamp and just always take `Math.min(this._usesRemaining, usesRemaining)`, even if we think `this._usesRemaining` is newer than `usesRemaining`. This means we'll always either decrement the token or update `nextReset`. This should get the test passing consistently :crossed_fingers: 

If someone gets a chance to review this before tomorrow and no changes are needed, feel free to just merge it. It would be really useful to get this one in before dependabot opens a pile of PRs tomorrow.