### PR TITLE
deps: pin `start-server-and-test` to 1.10.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28051,15 +28051,15 @@
       "integrity": "sha512-NQOxSeB8gOI5WjSaxjBgog2QFw55FV8TkS6Y07BiB3VJ8xNTvUYm0wl0s8ObgQ5NhdpnNfigMIKjgPESzgr4tg=="
     },
     "start-server-and-test": {
-      "version": "1.10.8",
-      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.10.8.tgz",
-      "integrity": "sha512-5I190MiIHBqmArTnxk9dfHlwO8I35B1hFhuAgv2L/UMDArRCtIXL/QftgNtgfuIz5NQN3yrN0kCsY+zYkX+dUg==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.10.7.tgz",
+      "integrity": "sha512-JEMVYJJSlGPb6w/XlEa0CVOWfAXFvzwKdXhePAJoTlzhSa7AUVntoWFxEh0GGMTMxpgxI7HCejDTdOSkc4aviw==",
       "dev": true,
       "requires": {
         "bluebird": "3.7.1",
         "check-more-types": "2.24.0",
         "debug": "4.1.1",
-        "execa": "4.0.0",
+        "execa": "2.1.0",
         "lazy-ass": "1.6.0",
         "ps-tree": "1.2.0",
         "wait-on": "4.0.0"
@@ -28092,18 +28092,18 @@
           }
         },
         "execa": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
-          "integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
             "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
             "is-stream": "^2.0.0",
             "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
+            "npm-run-path": "^3.0.0",
             "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
           }
@@ -28136,9 +28136,9 @@
           "dev": true
         },
         "npm-run-path": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
           "dev": true,
           "requires": {
             "path-key": "^3.0.0"
@@ -28152,6 +28152,12 @@
           "requires": {
             "mimic-fn": "^2.1.0"
           }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
         },
         "path-key": {
           "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "sinon": "^8.1.1",
     "sinon-chai": "^3.4.0",
     "snap-shot-it": "^7.9.1",
-    "start-server-and-test": "^1.10.8",
+    "start-server-and-test": "1.10.7",
     "styled-components": "^5.0.0",
     "tmp": "0.1.0",
     "ts-mocha": "^6.0.0",


### PR DESCRIPTION
Apparently v1.10.8 of `start-server-and-test` requires Node 10.x+ due to transitive dependencies

https://github.com/badges/shields/pull/4600#issuecomment-581162776