### PR TITLE
tell dependabot not to offer incompatible upgrades

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -29,6 +29,28 @@ update_configs:
       - match:
           dependency_name: 'snap-shot-it'
           update_type: 'semver:minor'
+    ignored_updates:
+      - match:
+          dependency_name: cross-env
+          version_requirement: '>=7.0.0'
+      - match:
+          dependency_name: decamelize
+          version_requirement: '>=4.0.0'
+      - match:
+          dependency_name: got
+          version_requirement: '>=10.0.0'
+      - match:
+          dependency_name: '@hapi/joi'
+          version_requirement: '>=17.0.0'
+      - match:
+          dependency_name: husky
+          version_requirement: '>=4.0.0'
+      - match:
+          dependency_name: lint-staged
+          version_requirement: '>=10.0.0'
+      - match:
+          dependency_name: eslint-plugin-jsdoc
+          version_requirement: '>=21.0.0'
 
   # gh-badges package dependencies
   - package_manager: 'javascript'

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -51,6 +51,9 @@ update_configs:
       - match:
           dependency_name: eslint-plugin-jsdoc
           version_requirement: '>=21.0.0'
+      - match:
+          dependency_name: start-server-and-test
+          version_requirement: '>=10.0.8'
 
   # gh-badges package dependencies
   - package_manager: 'javascript'


### PR DESCRIPTION
I'm starting to lose track of which dependencies we want to avoid merging.

Until we can sort out our production environment, lets add them all to [ignored_updates](https://dependabot.com/docs/config-file/#ignored_updates). This will stop dependabot from opening PRs to upgrade to these dependency versions. As we find more, we can add additional entires.

Once we get that upgrade done, we can remove them all and get back to these upgrades.