### PR TITLE
update dependabot ignore list

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -53,7 +53,7 @@ update_configs:
           version_requirement: '>=21.0.0'
       - match:
           dependency_name: start-server-and-test
-          version_requirement: '>=10.0.8'
+          version_requirement: '>=1.10.8'
       - match:
           dependency_name: mkdirp
           version_requirement: '>=1.0.4'


### PR DESCRIPTION
Correct the version number used for `start-server-and-test` in the dependabot ignore list as the change from v1.10.7 to v1.10.8 drops support for Node 8.x

Refs https://github.com/badges/shields/pull/4619#issuecomment-583710306