### PR TITLE
Remove a couple of unused dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -58,6 +58,9 @@ update_configs:
           dependency_name: prom-client
           version_requirement: '>=12.0.0'
       - match:
+          dependency_name: react-error-overlay
+          version_requirement: '>=3.0.0'
+      - match:
           dependency_name: sinon
           version_requirement: '>=9.0.0'
       - match:

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -52,9 +52,6 @@ update_configs:
           dependency_name: lint-staged
           version_requirement: '>=10.0.0'
       - match:
-          dependency_name: mkdirp
-          version_requirement: '>=1.0.4'
-      - match:
           dependency_name: nock
           version_requirement: '>=12.0.0'
       - match:

--- a/package-lock.json
+++ b/package-lock.json
@@ -20181,12 +20181,6 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==",
-      "dev": true
-    },
     "mocha": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
@@ -24619,12 +24613,6 @@
           }
         }
       }
-    },
-    "react-error-overlay": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
-      "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw==",
-      "dev": true
     },
     "react-fast-compare": {
       "version": "2.0.4",
@@ -29181,12 +29169,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/wait-promise/-/wait-promise-0.4.1.tgz",
       "integrity": "sha1-Hq2PgtKRolAQwLHu+NRxEyPMTas=",
-      "dev": true
-    },
-    "walkdir": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.4.1.tgz",
-      "integrity": "sha512-3eBwRyEln6E1MSzcxcVpQIhRG8Q1jLvEqRmCZqS3dsfXEDR/AhOF4d+jHg1qvDCpYaVRZjENPQyrVxAkQqxPgQ==",
       "dev": true
     },
     "warning": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24614,6 +24614,12 @@
         }
       }
     },
+    "react-error-overlay": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",
+      "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw==",
+      "dev": true
+    },
     "react-fast-compare": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -231,6 +231,7 @@
     "prettier": "1.19.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
+    "react-error-overlay": "^3.0.0",
     "react-helmet": "^5.2.1",
     "react-modal": "^3.11.2",
     "react-pose": "^4.0.10",

--- a/package.json
+++ b/package.json
@@ -145,10 +145,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.8.4",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
     "@babel/polyfill": "^7.8.3",
-    "@babel/preset-env": "^7.8.4",
     "@babel/register": "7.8.6",
     "@mapbox/react-click-to-select": "^2.2.0",
     "@types/chai": "^4.2.9",
@@ -220,7 +217,6 @@
     "lodash.difference": "^4.5.0",
     "lodash.groupby": "^4.6.0",
     "minimist": "^1.2.0",
-    "mkdirp": "^1.0.3",
     "mocha": "^6.2.2",
     "mocha-env-reporter": "^4.0.0",
     "mocha-junit-reporter": "^1.23.3",
@@ -235,7 +231,6 @@
     "prettier": "1.19.1",
     "react": "^16.13.0",
     "react-dom": "^16.13.0",
-    "react-error-overlay": "^6.0.6",
     "react-helmet": "^5.2.1",
     "react-modal": "^3.11.2",
     "react-pose": "^4.0.10",
@@ -252,9 +247,7 @@
     "styled-components": "^5.0.1",
     "tmp": "0.1.0",
     "ts-mocha": "^6.0.0",
-    "typescript": "^3.7.5",
-    "url": "^0.11.0",
-    "walkdir": "0.4.1"
+    "typescript": "^3.7.5"
   },
   "engines": {
     "node": "^10.16.3",


### PR DESCRIPTION
Removed in https://github.com/badges/shields/pull/2906/files
- @babel/plugin-proposal-class-properties
- @babel/plugin-proposal-object-rest-spread
- @babel/preset-env

Built in:
- url

No usage detected:
- mkdirp
- ~react-error-overlay~
- walkdir