### PR TITLE
Add running tests for specific badges of a service

### DIFF
--- a/core/base-service/loader.js
+++ b/core/base-service/loader.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const path = require('path')
-const glob = require('glob')
-const countBy = require('lodash.countby')
 const categories = require('../../services/categories')
 const BaseService = require('./base')
 const { assertValidServiceDefinitionExport } = require('./service-definitions')
+const countBy = require('lodash.countby')
+const glob = require('glob')
 
 const serviceDir = path.join(__dirname, '..', '..', 'services')
 
@@ -104,9 +104,11 @@ function collectDefinitions() {
 }
 
 function loadTesters() {
-  return glob
-    .sync(path.join(serviceDir, '**', '*.tester.js'))
-    .map(path => require(path))
+  return glob.sync(path.join(serviceDir, '**', '*.tester.js')).map(path => {
+    const tester = require(path)
+    tester.absolutePath = path
+    return tester
+  })
 }
 
 module.exports = {

--- a/core/service-test-runner/runner.js
+++ b/core/service-test-runner/runner.js
@@ -3,6 +3,7 @@
  * @module
  */
 
+const path = require('path')
 const { loadTesters } = require('../base-service/loader')
 
 /**
@@ -61,6 +62,51 @@ class Runner {
     // Throw at the end, to provide a better error message.
     if (missingServices.length > 0) {
       throw Error(`Unknown services: ${missingServices.join(', ')}`)
+    }
+  }
+
+  /**
+   * Limit the test run to the specified badges of a service.
+   *
+   * @param {string} service The service to run
+   * @param {string[]} badges An array of badge ids to run
+   */
+  onlyBadges(service, badges) {
+    service = service.toLowerCase()
+
+    const testers = this._testersForService(service)
+    if (testers.length === 0) {
+      throw Error(`Unknown service: ${service}`)
+    }
+
+    const normalizedBadges = new Set(
+      badges.map(badge => {
+        badge = badge.toLowerCase()
+        if (service !== badge) {
+          badge = `${service}-${badge}`
+        }
+        return badge
+      })
+    )
+
+    testers.forEach(tester => {
+      const file = path.basename(tester.absolutePath)
+      const badgeName = file.substr(0, file.indexOf('.'))
+      if (normalizedBadges.delete(badgeName)) {
+        tester.only()
+      }
+    })
+
+    // Throw at the end, to provide a better error message.
+    if (normalizedBadges.size > 0) {
+      // Removes the service name prefix prepended earlier.
+      const originalBadges = Array.from(normalizedBadges).map(v =>
+        v === service ? v : v.substr(service.length + 1)
+      )
+
+      throw Error(
+        `Unknown badges of service ${service}: ${originalBadges.join(', ')}`
+      )
     }
   }
 


### PR DESCRIPTION
Implemented because creating a badge for a service that already has a lot of badges can be cumbersome if you have to run *all* tests just to run the tests of your badge.

Usage: `$ npm run test:services -- --only=[service] --badges=[badge[, badges ...]]`

Specify a service and any amount of badges whose tests should be executed.