### PR TITLE
Fix failing [JenkinsPluginInstalls] test

### DIFF
--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -26,9 +26,9 @@ t.create('version installs | valid: numeric version')
   })
 
 t.create('version installs | valid: alphanumeric version')
-  .get('/view-job-filters/1.27-DRE1.00.json')
+  .get('/build-failure-analyzer/1.17.2-DRE3.14.json')
   .expectBadge({
-    label: 'installs@1.27-DRE1.00',
+    label: 'installs@1.17.2-DRE3.14',
     message: isMetric,
   })
 


### PR DESCRIPTION
Version 1.27-DRE1.00 of View Job Filters no longer seems to be a thing:
https://stats.jenkins.io/plugin-installation-trend/view-job-filters.stats.json

This PR switches the test to a different plugin with a similarly styled version string.