### PR TITLE
Add [Treeware] badge

### DIFF
--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -25,7 +25,7 @@ module.exports = class TreewareTrees extends BaseJsonService {
   static get examples() {
     return [
       {
-        title: 'Treeware',
+        title: 'Treeware (Trees)',
         namedParams: { owner: 'stoplightio', packageName: 'spectral' },
         staticPreview: this.render({ count: 250 }),
       },

--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const crypto = require('crypto')
+const Joi = require('@hapi/joi')
+const { metric } = require('../text-formatters')
+const { floorCount } = require('../color-formatters')
+const { BaseJsonService } = require('..')
+
+const apiSchema = Joi.object({
+  total: Joi.number().required(),
+}).required()
+
+module.exports = class TreewareTrees extends BaseJsonService {
+  static get category() {
+    return 'other'
+  }
+
+  static get route() {
+    return {
+      base: 'treeware/trees',
+      pattern: ':owner/:packageName',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Treeware',
+        namedParams: { owner: 'jamesmills', packageName: 'laravel-timezone' },
+        staticPreview: this.render({ count: 50 }),
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'trees' }
+  }
+
+  static render({ count }) {
+    return { message: metric(count), color: floorCount(count, 10, 50, 100) }
+  }
+
+  async fetch({ reference }) {
+    const url = `https://public.offset.earth/users/treeware/trees?ref=${reference}`
+    return this._requestJson({
+      url,
+      schema: apiSchema,
+      errorMessages: {
+        404: 'repository not found',
+      },
+    })
+  }
+
+  async handle({ owner, packageName }) {
+    const reference = crypto
+      .createHash('md5')
+      .update(`${owner}/${packageName}`)
+      .digest('hex')
+    const { total } = await this.fetch({ reference })
+
+    return this.constructor.render({ count: total })
+  }
+}

--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -41,12 +41,12 @@ module.exports = class TreewareTrees extends BaseJsonService {
   }
 
   async fetch({ reference }) {
-    const url = `https://public.offset.earth/users/treeware/trees?ref=${reference}`
+    const url = `https://public.offset.earth/users/treeware/trees`
     return this._requestJson({
       url,
       schema: apiSchema,
-      errorMessages: {
-        404: 'repository not found',
+      options: {
+        qs: { ref: reference },
       },
     })
   }

--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -26,8 +26,8 @@ module.exports = class TreewareTrees extends BaseJsonService {
     return [
       {
         title: 'Treeware',
-        namedParams: { owner: 'jamesmills', packageName: 'laravel-timezone' },
-        staticPreview: this.render({ count: 50 }),
+        namedParams: { owner: 'stoplightio', packageName: 'spectral' },
+        staticPreview: this.render({ count: 250 }),
       },
     ]
   }

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -20,8 +20,9 @@ t.create('request for existing package (mock)')
   .expectBadge({
     label: 'trees',
     message: '50',
+    color: 'green',
   })
 
 t.create('invalid package')
   .get('/non-existent-user/non-existent-package.json')
-  .expectBadge({ label: 'trees', message: '0' })
+  .expectBadge({ label: 'trees', message: '0', color: 'red' })

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const t = (module.exports = require('../tester').createServiceTester())
+const { isMetric } = require('../test-validators')
+
+t.create('request for existing package')
+  .timeout(10000)
+  .get('/jamesmills/laravel-timezone.json')
+  .expectBadge({
+    label: 'trees',
+    message: isMetric,
+  })
+
+t.create('request for existing profile (mock)')
+  .get('/jamesmills/laravel-timezone.json')
+  .intercept(nock =>
+    nock('https://public.offset.earth')
+      .get('/users/treeware/trees?ref=363b1ef94302eebf42e884856a52b7e4')
+      .reply(200, { total: 50 })
+  )
+  .expectBadge({
+    label: 'trees',
+    message: isMetric,
+  })
+
+t.create('invalid profile (mock)')
+  .get('/non-existent-user/non-existent-package.json')
+  .intercept(nock =>
+    nock('https://public.offset.earth')
+      .get('/users/treeware/trees?ref=54a1ec3dccd0c2702084adcf72b4f02b')
+      .reply(200, { total: 0 })
+  )
+  .expectBadge({ label: 'trees', message: '0' })

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -4,7 +4,6 @@ const t = (module.exports = require('../tester').createServiceTester())
 const { isMetric } = require('../test-validators')
 
 t.create('request for existing package')
-  .timeout(10000)
   .get('/stoplightio/spectral.json')
   .expectBadge({
     label: 'trees',

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -10,7 +10,7 @@ t.create('request for existing package')
     message: isMetric,
   })
 
-t.create('request for existing profile (mock)')
+t.create('request for existing package (mock)')
   .get('/stoplightio/spectral.json')
   .intercept(nock =>
     nock('https://public.offset.earth')
@@ -19,14 +19,9 @@ t.create('request for existing profile (mock)')
   )
   .expectBadge({
     label: 'trees',
-    message: isMetric,
+    message: '50',
   })
 
-t.create('invalid profile (mock)')
+t.create('invalid package')
   .get('/non-existent-user/non-existent-package.json')
-  .intercept(nock =>
-    nock('https://public.offset.earth')
-      .get('/users/treeware/trees?ref=54a1ec3dccd0c2702084adcf72b4f02b')
-      .reply(200, { total: 0 })
-  )
   .expectBadge({ label: 'trees', message: '0' })

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -5,17 +5,17 @@ const { isMetric } = require('../test-validators')
 
 t.create('request for existing package')
   .timeout(10000)
-  .get('/jamesmills/laravel-timezone.json')
+  .get('/stoplightio/spectral.json')
   .expectBadge({
     label: 'trees',
     message: isMetric,
   })
 
 t.create('request for existing profile (mock)')
-  .get('/jamesmills/laravel-timezone.json')
+  .get('/stoplightio/spectral.json')
   .intercept(nock =>
     nock('https://public.offset.earth')
-      .get('/users/treeware/trees?ref=363b1ef94302eebf42e884856a52b7e4')
+      .get('/users/treeware/trees?ref=65c6e3e942e7464b4591e0c8b70d11d5')
       .reply(200, { total: 50 })
   )
   .expectBadge({


### PR DESCRIPTION
This is related to https://github.com/badges/shields/issues/4728, it adds a badge for the [Treeware](https://treeware.earth) project.

The badge this adds contains tests, and displays the trees that have been planted by a package (based on a referer hash).