### PR TITLE
When token pool is empty, surface the error to the badge consumer; test [github]

### DIFF
--- a/core/token-pooling/token-pool.js
+++ b/core/token-pooling/token-pool.js
@@ -5,6 +5,7 @@
 
 const crypto = require('crypto')
 const PriorityQueue = require('priorityqueuejs')
+const { Inaccessible } = require('../base-service/errors')
 
 /**
  * Compute a one-way hash of the input string.
@@ -265,7 +266,10 @@ class TokenPool {
       }
     }
 
-    throw Error('Token pool is exhausted')
+    throw new Inaccessible({
+      underlyingError: Error('Token pool is exhausted'),
+      prettyMessage: 'no tokens available',
+    })
   }
 
   /**

--- a/core/token-pooling/token-pool.spec.js
+++ b/core/token-pooling/token-pool.spec.js
@@ -3,12 +3,13 @@
 const { expect } = require('chai')
 const sinon = require('sinon')
 const times = require('lodash.times')
+const { Inaccessible } = require('../base-service/errors')
 const { Token, TokenPool } = require('./token-pool')
 
 function expectPoolToBeExhausted(pool) {
   expect(() => {
     pool.next()
-  }).to.throw(Error, /^Token pool is exhausted$/)
+  }).to.throw(Inaccessible, /^Inaccessible: Token pool is exhausted$/)
 }
 
 describe('The token pool', function() {


### PR DESCRIPTION
Should provide better debuggability in self-hosting cases like #4862 but also on the production server.

You could argue that this could be an ImproperlyConfigured error, though I think the issues are really #2754 and #3371.