### PR TITLE
Fix failing [Nexus] tests

### DIFF
--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -264,7 +264,7 @@ t.create('Nexus 3 - search snapshot version for artifact without snapshots')
 
 t.create('Nexus 3 - repository version')
   .get(
-    '/proxy-public-3rd-party-release/com.fasterxml.jackson.core/jackson-databind.json?server=https://nexus.pentaho.org&nexusVersion=3'
+    '/proxy-public-3rd-party-release/com.h2database/h2.json?server=https://nexus.pentaho.org&nexusVersion=3'
   )
   .expectBadge({
     label: 'nexus',
@@ -276,7 +276,7 @@ t.create(
 )
   .timeout(15000)
   .get(
-    '/proxy-public-3rd-party-release/com.fasterxml.jackson.core/jackson-databind.json?server=https://nexus.pentaho.org'
+    '/proxy-public-3rd-party-release/com.h2database/h2.json?server=https://nexus.pentaho.org'
   )
   .expectBadge({
     label: 'nexus',


### PR DESCRIPTION
Fixes #4903. Tests were failing because `v2.11.0.rc1` does not match `/^v\d+(\.\d+)*([-+~].*)?$/`.

I've changed the test data rather than the regex. Unless I'm missing an obvious trick, the latter would be quite hard to change without making validation significantly looser. The obvious solution, `/^v\d+(\.\d+)*([-+~.].*)?$/` (extra dot in the allowed char list) would start validating strings such as `v2.11.0€rc1`, as it would capture from the previous dot - it would be pretty much equivalent to `/^v\d+(\.\d+)*(.*)?$/`.

Versions in the `v2.11.0.rc1` format are quite rare anyway, I figured there was little value in changing the validator for such an edge-case, but I can change things if you disagree!