### PR TITLE
Fix [CodeclimateCoverage] tests

### DIFF
--- a/services/codeclimate/codeclimate-analysis.tester.js
+++ b/services/codeclimate/codeclimate-analysis.tester.js
@@ -4,6 +4,9 @@ const Joi = require('@hapi/joi')
 const { isIntegerPercentage } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
+// Examples for this service can be found through the explore page:
+// https://codeclimate.com/explore
+
 t.create('issues count')
   .get('/issues/angular/angular.json')
   .expectBadge({

--- a/services/codeclimate/codeclimate-coverage.tester.js
+++ b/services/codeclimate/codeclimate-coverage.tester.js
@@ -4,15 +4,18 @@ const Joi = require('@hapi/joi')
 const { isIntegerPercentage } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
+// Examples for this service can be found through the explore page:
+// https://codeclimate.com/explore
+
 t.create('test coverage percentage')
-  .get('/coverage/jekyll/jekyll.json')
+  .get('/coverage/codeclimate/minidoc.json')
   .expectBadge({
     label: 'coverage',
     message: isIntegerPercentage,
   })
 
 t.create('test coverage letter')
-  .get('/coverage-letter/jekyll/jekyll.json')
+  .get('/coverage-letter/codeclimate/minidoc.json')
   .expectBadge({
     label: 'coverage',
     message: Joi.equal('A', 'B', 'C', 'D', 'E', 'F'),


### PR DESCRIPTION
These service tests have been failing for a few days, there no longer seem to be any test reports for the Jekyll project. Hopefully, they won't break again anytime soon with one of Code Climate's own repositories.

I've also added a link to the [explore page](https://codeclimate.com/explore); their UI has changed and I struggled to find it.