### PR TITLE
Do not log errors in influx tests

### DIFF
--- a/core/server/influx-metrics.spec.js
+++ b/core/server/influx-metrics.spec.js
@@ -122,7 +122,7 @@ describe('Influx metrics', function() {
 
   describe('sendMetrics', function() {
     beforeEach(function() {
-      sinon.spy(log, 'error')
+      sinon.stub(log, 'error')
     })
     afterEach(function() {
       log.error.restore()


### PR DESCRIPTION
@calebcartwright [noticed](https://github.com/badges/shields/issues/4930#issue-604428004) errors regarding metrics logged by the daily tests. It was introduced in https://github.com/badges/shields/pull/4874 and we can easily get rid of them. 
Before:
```
NODE_CONFIG_ENV=test node_modules/.bin/mocha core/server/influx-metrics.spec.js


  Influx metrics
    "metrics" function
      ✓ should use an environment variable value as an instance label
      ✓ should use a hostname as an instance label
      ✓ should use a random string as an instance label
      ✓ should use a hostname alias as an instance label
    startPushingMetrics
      ✓ should send metrics
    sendMetrics
0422180208 Error: Cannot push metrics. Cause: NetConnectNotAllowedError: Nock: Disallowed net connect for "shields-metrics.io:80/metrics"
    at InfluxMetrics.sendMetrics (/Users/m/workspaces/github/shields/core/server/influx-metrics.js:35:9)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
      ✓ should log errors
0422180208 Error: Cannot push metrics. http://shields-metrics.io/metrics responded with status code 400
    at InfluxMetrics.sendMetrics (/Users/m/workspaces/github/shields/core/server/influx-metrics.js:40:9)
    at processTicksAndRejections (internal/process/task_queues.js:94:5)
    at async Context.<anonymous> (/Users/m/workspaces/github/shields/core/server/influx-metrics.spec.js:163:7)
      ✓ should log error responses


  7 passing (46ms)
```

After:
```
NODE_CONFIG_ENV=test node_modules/.bin/mocha core/server/influx-metrics.spec.js


  Influx metrics
    "metrics" function
      ✓ should use an environment variable value as an instance label
      ✓ should use a hostname as an instance label
      ✓ should use a random string as an instance label
      ✓ should use a hostname alias as an instance label
    startPushingMetrics
      ✓ should send metrics
    sendMetrics
      ✓ should log errors
      ✓ should log error responses


  7 passing (39ms)
```