### PR TITLE
Get data for [Discord] badges via OVH server proxies

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -64,6 +64,8 @@ public:
 
   fetchLimit: 'FETCH_LIMIT'
 
+  shieldsProductionHerokuHacks: 'SHIELDS_PRODUCTION_HEROKU_HACKS'
+
 private:
   azure_devops_token: 'AZURE_DEVOPS_TOKEN'
   bintray_user: 'BINTRAY_USER'

--- a/config/default.yml
+++ b/config/default.yml
@@ -36,4 +36,6 @@ public:
 
   fetchLimit: '10MB'
 
+  shieldsProductionHerokuHacks: false
+
 private: {}

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -159,6 +159,7 @@ const publicConfigSchema = Joi.object({
   rateLimit: Joi.boolean().required(),
   handleInternalErrors: Joi.boolean().required(),
   fetchLimit: Joi.string().regex(/^[0-9]+(b|kb|mb|gb|tb)$/i),
+  shieldsProductionHerokuHacks: Joi.boolean(),
 }).required()
 
 const privateConfigSchema = Joi.object({
@@ -401,6 +402,8 @@ class Server {
           rasterUrl: config.public.rasterUrl,
           private: config.private,
           public: config.public,
+          shieldsProductionHerokuHacks:
+            config.public.shieldsProductionHerokuHacks,
         }
       )
     )

--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -69,7 +69,7 @@ module.exports = class Discord extends BaseJsonService {
 
   constructor(context, config) {
     super(context, config)
-    this._runningOnHeroku = config.shieldsProductionHerokuHacks
+    this._shieldsProductionHerokuHacks = config.shieldsProductionHerokuHacks
   }
 
   async fetch({ serverId }) {
@@ -92,7 +92,7 @@ module.exports = class Discord extends BaseJsonService {
   }
 
   async handle({ serverId }) {
-    if (this._runningOnHeroku) {
+    if (this._shieldsProductionHerokuHacks) {
       const { message, color } = await this.fetchOvhProxy({ serverId })
       return { message, color }
     }

--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -8,6 +8,11 @@ const discordSchema = Joi.object({
   presence_count: nonNegativeInteger,
 }).required()
 
+const proxySchema = Joi.object({
+  message: Joi.string().required(),
+  color: Joi.string().required(),
+}).required()
+
 const documentation = `
 <p>
   The Discord badge requires the <code>SERVER ID</code> in order access the Discord JSON API.
@@ -62,6 +67,11 @@ module.exports = class Discord extends BaseJsonService {
     }
   }
 
+  constructor(context, config) {
+    super(context, config)
+    this._runningOnHeroku = config.shieldsProductionHerokuHacks
+  }
+
   async fetch({ serverId }) {
     const url = `https://discordapp.com/api/guilds/${serverId}/widget.json`
     return this._requestJson({
@@ -74,7 +84,19 @@ module.exports = class Discord extends BaseJsonService {
     })
   }
 
+  async fetchOvhProxy({ serverId }) {
+    return this._requestJson({
+      url: `https://legacy-img.shields.io/discord/${serverId}.json`,
+      schema: proxySchema,
+    })
+  }
+
   async handle({ serverId }) {
+    if (this._runningOnHeroku) {
+      const { message, color } = await this.fetchOvhProxy({ serverId })
+      return { message, color }
+    }
+
     const data = await this.fetch({ serverId })
     return this.constructor.render({ members: data.presence_count })
   }


### PR DESCRIPTION
There's more details on the underlying issue in our Discord channels, but for a tl;dr.. 

Discord throttles calls to their API, and they'd whitelisted our 3 OVH servers previously to allow us to get the requisite data. When we routed img.shields.io traffic over to our Heroku environment we lost that whitelisting and our badge servers (on Heroku) hit the rate limits pretty quickly resulting in `invalid` for all our Discord badges.

This is a temporary fix to get the Discord badges working by having our Heroku-based badge servers use the OVH servers as a proxy to get the Discord data. 