### PR TITLE
Move JSON rendering from badge-maker to server [*****]

### DIFF
--- a/badge-maker/lib/color.spec.js
+++ b/badge-maker/lib/color.spec.js
@@ -18,15 +18,50 @@ test(isHexColor, () => {
 })
 
 test(normalizeColor, () => {
+  // Shields named color.
   given('red').expect('red')
+  given('green').expect('green')
   given('blue').expect('blue')
-  given('4c1').expect('#4c1')
-  given('f00f00').expect('#f00f00')
-  given('ABC123').expect('#abc123')
-  given('#ABC123').expect('#abc123')
+  given('yellow').expect('yellow')
+
+  // valid hex
+  forCases([given('#4c1'), given('#4C1'), given('4C1'), given('4c1')]).expect(
+    '#4c1'
+  )
+  forCases([
+    given('#abc123'),
+    given('#ABC123'),
+    given('abc123'),
+    given('ABC123'),
+  ]).expect('#abc123')
+
+  // valid rgb(a)
+  given('rgb(0,128,255)').expect('rgb(0,128,255)')
+  given('rgba(0,128,255,0)').expect('rgba(0,128,255,0)')
+  // valid hsl(a)
+  given('hsl(100, 56%, 10%)').expect('hsl(100, 56%, 10%)')
+  given('hsla(25,20%,0%,0.1)').expect('hsla(25,20%,0%,0.1)')
+
+  // CSS named color.
   given('papayawhip').expect('papayawhip')
   given('purple').expect('purple')
+
   forCases([
+    // invalid hex
+    given('#123red'), // contains letter above F
+    given('#red'), // contains letter above F
+    // invalid rgb(a)
+    given('rgb(220,128,255,0.5)'), // has alpha
+    given('rgba(0,0,255)'), // no alpha
+    // invalid hsl(a)
+    given('hsl(360,50%,50%,0.5)'), // has alpha
+    given('hsla(0,50%,101%)'), // no alpha
+    // neither a css named color nor colorscheme
+    given('notacolor'),
+    given('bluish'),
+    given('almostred'),
+    given('brightmaroon'),
+    given('cactus'),
     given(''),
     given('not-a-color'),
     given(undefined),
@@ -36,6 +71,9 @@ test(normalizeColor, () => {
     given({}),
     given(() => {}),
   ]).expect(undefined)
+
+  // Semantic color alias
+  given('success').expect('brightgreen')
   given('lightgray').expect('lightgrey')
   given('informational').expect('blue')
 })

--- a/badge-maker/lib/index.js
+++ b/badge-maker/lib/index.js
@@ -63,8 +63,8 @@ function _clean(format) {
     }
   })
 
-  // String coercion and whitespace removal.
-  cleaned.label = `${cleaned.label}`.trim() || ''
+  // Whitespace removal.
+  cleaned.label = `${cleaned.label}`.trim()
   cleaned.message = `${cleaned.message}`.trim()
 
   cleaned.color = normalizeColor(cleaned.color)

--- a/badge-maker/lib/index.spec.js
+++ b/badge-maker/lib/index.spec.js
@@ -25,6 +25,13 @@ describe('makeBadge function', function() {
         style: 'flat',
       })
     ).to.satisfy(isSvg)
+    expect(
+      makeBadge({
+        label: 'build',
+        message: 'passed',
+        labelColor: undefined,
+      })
+    ).to.satisfy(isSvg)
   })
 
   it('should throw a ValidationError with invalid inputs', function() {

--- a/badge-maker/lib/index.spec.js
+++ b/badge-maker/lib/index.spec.js
@@ -34,6 +34,22 @@ describe('makeBadge function', function() {
     ).to.satisfy(isSvg)
   })
 
+  // This test needs to move up a level.
+  it('should replace undefined svg template with "flat"', function() {
+    const jsonBadgeWithUnknownStyle = makeBadge({
+      label: 'name',
+      message: 'Bob',
+    })
+    const jsonBadgeWithDefaultStyle = makeBadge({
+      label: 'name',
+      message: 'Bob',
+      style: 'flat',
+    })
+    expect(jsonBadgeWithUnknownStyle)
+      .to.equal(jsonBadgeWithDefaultStyle)
+      .and.to.satisfy(isSvg)
+  })
+
   it('should throw a ValidationError with invalid inputs', function() {
     ;[null, undefined, 7, 'foo', 4.25].forEach(x => {
       console.log(x)

--- a/badge-maker/lib/make-badge.js
+++ b/badge-maker/lib/make-badge.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const camelcase = require('camelcase')
-const { normalizeColor, toSvgColor } = require('./color')
+const { toSvgColor } = require('./color')
 const badgeRenderers = require('./badge-renderers')
 
 /*
@@ -9,41 +9,19 @@ note: makeBadge() is fairly thinly wrapped so if we are making changes here
 it is likely this will impact on the package's public interface in index.js
 */
 module.exports = function makeBadge({
-  format,
-  template = 'flat',
-  text,
+  style,
+  label,
+  message,
   color,
   labelColor,
   logo,
   logoPosition,
   logoWidth,
-  links = ['', ''],
+  links,
 }) {
-  // String coercion and whitespace removal.
-  text = text.map(value => `${value}`.trim())
-
-  const [label, message] = text
-
-  color = normalizeColor(color)
-  labelColor = normalizeColor(labelColor)
-
-  // This ought to be the responsibility of the server, not `makeBadge`.
-  if (format === 'json') {
-    return JSON.stringify({
-      label,
-      message,
-      logoWidth,
-      color,
-      labelColor,
-      link: links,
-      name: label,
-      value: message,
-    })
-  }
-
-  const methodName = camelcase(template)
+  const methodName = camelcase(style)
   if (!(methodName in badgeRenderers)) {
-    throw new Error(`Unknown template: '${template}'`)
+    throw new Error(`Unknown style: '${style}'`)
   }
   const render = badgeRenderers[methodName]
 

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -8,12 +8,13 @@ const makeBadge = require('./make-badge')
 describe('The badge generator', function() {
   describe('SVG', function() {
     it('should produce SVG', function() {
-      const svg = makeBadge({
-        label: 'cactus',
-        message: 'grown',
-        style: 'flat',
-      })
-      expect(svg)
+      expect(
+        makeBadge({
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat',
+        })
+      )
         .to.satisfy(isSvg)
         .and.to.include('cactus')
         .and.to.include('grown')
@@ -25,22 +26,6 @@ describe('The badge generator', function() {
   })
 
   describe('Styles', function() {
-    // This test needs to move up a level.
-    it.skip('should replace undefined svg template with "flat"', function() {
-      const jsonBadgeWithUnknownStyle = makeBadge({
-        label: 'name',
-        message: 'Bob',
-      })
-      const jsonBadgeWithDefaultStyle = makeBadge({
-        label: 'name',
-        message: 'Bob',
-        style: 'flat',
-      })
-      expect(jsonBadgeWithUnknownStyle)
-        .to.equal(jsonBadgeWithDefaultStyle)
-        .and.to.satisfy(isSvg)
-    })
-
     it('should fail with unknown svg template', function() {
       expect(() =>
         makeBadge({
@@ -280,19 +265,6 @@ describe('The badge generator', function() {
   })
 
   describe('"for-the-badge" template badge generation', function() {
-    // https://github.com/badges/shields/issues/1280
-    // This needs to be moved up a level.
-    it.skip('numbers should produce a string', function() {
-      const svg = makeBadge({
-        label: 1998,
-        message: 1999,
-        style: 'for-the-badge',
-      })
-      expect(svg)
-        .to.include('1998')
-        .and.to.include('1999')
-    })
-
     it('lowercase/mixedcase string should produce uppercase string', function() {
       const svg = makeBadge({
         label: 'Label',

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -5,15 +5,10 @@ const { expect } = require('chai')
 const snapshot = require('snap-shot-it')
 const isSvg = require('is-svg')
 const makeBadge = require('./make-badge')
+const { normalizeColor } = require('./color')
 
 function testColor(color = '', colorAttr = 'color') {
-  return JSON.parse(
-    makeBadge({
-      text: ['name', 'Bob'],
-      [colorAttr]: color,
-      format: 'json',
-    })
-  ).color
+  return normalizeColor(color)
 }
 
 describe('The badge generator', function() {
@@ -77,7 +72,11 @@ describe('The badge generator', function() {
 
   describe('SVG', function() {
     it('should produce SVG', function() {
-      const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' })
+      const svg = makeBadge({
+        label: 'cactus',
+        message: 'grown',
+        style: 'flat',
+      })
       expect(svg)
         .to.satisfy(isSvg)
         .and.to.include('cactus')
@@ -85,36 +84,21 @@ describe('The badge generator', function() {
     })
 
     it('should match snapshot', function() {
-      const svg = makeBadge({ text: ['cactus', 'grown'], format: 'svg' })
-      snapshot(svg)
+      snapshot(makeBadge({ label: 'cactus', message: 'grown', style: 'flat' }))
     })
   })
 
-  describe('JSON', function() {
-    it('should produce the expected JSON', function() {
-      const json = makeBadge({
-        text: ['cactus', 'grown'],
-        format: 'json',
-        links: ['https://example.com/', 'https://other.example.com/'],
-      })
-      expect(JSON.parse(json)).to.deep.equal({
-        name: 'cactus',
-        label: 'cactus',
-        value: 'grown',
-        message: 'grown',
-        link: ['https://example.com/', 'https://other.example.com/'],
-      })
-    })
-
-    it('should replace undefined svg template with "flat"', function() {
+  describe('Styles', function() {
+    // This test needs to move up a level.
+    it.skip('should replace undefined svg template with "flat"', function() {
       const jsonBadgeWithUnknownStyle = makeBadge({
-        text: ['name', 'Bob'],
-        format: 'svg',
+        label: 'name',
+        message: 'Bob',
       })
       const jsonBadgeWithDefaultStyle = makeBadge({
-        text: ['name', 'Bob'],
-        format: 'svg',
-        template: 'flat',
+        label: 'name',
+        message: 'Bob',
+        style: 'flat',
       })
       expect(jsonBadgeWithUnknownStyle)
         .to.equal(jsonBadgeWithDefaultStyle)
@@ -125,10 +109,9 @@ describe('The badge generator', function() {
       expect(() =>
         makeBadge({
           text: ['name', 'Bob'],
-          format: 'svg',
-          template: 'unknown_style',
+          style: 'unknown_style',
         })
-      ).to.throw(Error, "Unknown template: 'unknown_style'")
+      ).to.throw(Error, "Unknown style: 'unknown_style'")
     })
   })
 
@@ -136,9 +119,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat',
           color: '#b3e',
           labelColor: '#0f0',
         })
@@ -148,9 +131,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -161,10 +144,10 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: '',
+          message: 'grown',
           color: '#b3e',
+          style: 'flat',
         })
       )
     })
@@ -172,9 +155,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: '',
+          message: 'grown',
+          style: 'flat',
           color: '#b3e',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
         })
@@ -184,9 +167,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo and labelColor', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: '',
+          message: 'grown',
+          style: 'flat',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -197,9 +180,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with links', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat',
           color: '#b3e',
           labelColor: '#0f0',
           links: ['https://shields.io/', 'https://www.google.co.uk/'],
@@ -212,9 +195,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
           labelColor: '#0f0',
         })
@@ -224,9 +207,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -237,9 +220,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: '',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
         })
       )
@@ -248,9 +231,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: '',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
         })
@@ -260,9 +243,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo and labelColor', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: '',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -273,9 +256,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with links', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'flat-square',
+          label: 'cactus',
+          message: 'grown',
+          style: 'flat-square',
           color: '#b3e',
           labelColor: '#0f0',
           links: ['https://shields.io/', 'https://www.google.co.uk/'],
@@ -288,9 +271,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: 'cactus',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
           labelColor: '#0f0',
         })
@@ -300,9 +283,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: 'cactus',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -313,9 +296,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: '',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
         })
       )
@@ -324,9 +307,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: '',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
         })
@@ -336,9 +319,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo and labelColor', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: '',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -349,9 +332,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with links', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'plastic',
+          label: 'cactus',
+          message: 'grown',
+          style: 'plastic',
           color: '#b3e',
           labelColor: '#0f0',
           links: ['https://shields.io/', 'https://www.google.co.uk/'],
@@ -362,11 +345,12 @@ describe('The badge generator', function() {
 
   describe('"for-the-badge" template badge generation', function() {
     // https://github.com/badges/shields/issues/1280
-    it('numbers should produce a string', function() {
+    // This needs to be moved up a level.
+    it.skip('numbers should produce a string', function() {
       const svg = makeBadge({
-        text: [1998, 1999],
-        format: 'svg',
-        template: 'for-the-badge',
+        label: 1998,
+        message: 1999,
+        style: 'for-the-badge',
       })
       expect(svg)
         .to.include('1998')
@@ -375,9 +359,9 @@ describe('The badge generator', function() {
 
     it('lowercase/mixedcase string should produce uppercase string', function() {
       const svg = makeBadge({
-        text: ['Label', '1 string'],
-        format: 'svg',
-        template: 'for-the-badge',
+        label: 'Label',
+        message: '1 string',
+        style: 'for-the-badge',
       })
       expect(svg)
         .to.include('LABEL')
@@ -387,9 +371,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: 'cactus',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
           labelColor: '#0f0',
         })
@@ -399,9 +383,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: 'cactus',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -412,9 +396,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: '',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
         })
       )
@@ -423,9 +407,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: '',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
         })
@@ -435,9 +419,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo and labelColor', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: '',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -448,9 +432,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with links', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'for-the-badge',
+          label: 'cactus',
+          message: 'grown',
+          style: 'for-the-badge',
           color: '#b3e',
           labelColor: '#0f0',
           links: ['https://shields.io/', 'https://www.google.co.uk/'],
@@ -462,9 +446,9 @@ describe('The badge generator', function() {
   describe('"social" template badge generation', function() {
     it('should produce capitalized string for badge key', function() {
       const svg = makeBadge({
-        text: ['some-key', 'some-value'],
-        format: 'svg',
-        template: 'social',
+        label: 'some-key',
+        message: 'some-value',
+        style: 'social',
       })
       expect(svg)
         .to.include('Some-key')
@@ -474,21 +458,21 @@ describe('The badge generator', function() {
     // https://github.com/badges/shields/issues/1606
     it('should handle empty strings used as badge keys', function() {
       const svg = makeBadge({
-        text: ['', 'some-value'],
-        format: 'json',
-        template: 'social',
+        label: '',
+        message: 'some-value',
+        style: 'social',
       })
       expect(svg)
-        .to.include('""')
+        .to.include('><')
         .and.to.include('some-value')
     })
 
     it('should match snapshots: message/label, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: 'cactus',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
           labelColor: '#0f0',
         })
@@ -498,9 +482,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: 'cactus',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -511,9 +495,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, no logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: '',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
         })
       )
@@ -522,9 +506,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: '',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
         })
@@ -534,9 +518,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message only, with logo and labelColor', function() {
       snapshot(
         makeBadge({
-          text: ['', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: '',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
           labelColor: '#0f0',
           logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
@@ -547,9 +531,9 @@ describe('The badge generator', function() {
     it('should match snapshots: message/label, with links', function() {
       snapshot(
         makeBadge({
-          text: ['cactus', 'grown'],
-          format: 'svg',
-          template: 'social',
+          label: 'cactus',
+          message: 'grown',
+          style: 'social',
           color: '#b3e',
           labelColor: '#0f0',
           links: ['https://shields.io/', 'https://www.google.co.uk/'],
@@ -560,12 +544,14 @@ describe('The badge generator', function() {
 
   describe('badges with logos should always produce the same badge', function() {
     it('badge with logo', function() {
-      const svg = makeBadge({
-        text: ['label', 'message'],
-        format: 'svg',
-        logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
-      })
-      snapshot(svg)
+      snapshot(
+        makeBadge({
+          label: 'label',
+          message: 'message',
+          style: 'flat',
+          logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
+        })
+      )
     })
   })
 })

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -1,75 +1,11 @@
 'use strict'
 
-const { test, given, forCases } = require('sazerac')
 const { expect } = require('chai')
 const snapshot = require('snap-shot-it')
 const isSvg = require('is-svg')
 const makeBadge = require('./make-badge')
-const { normalizeColor } = require('./color')
-
-function testColor(color = '', colorAttr = 'color') {
-  return normalizeColor(color)
-}
 
 describe('The badge generator', function() {
-  describe('color test', function() {
-    test(testColor, () => {
-      // valid hex
-      forCases([
-        given('#4c1'),
-        given('#4C1'),
-        given('4C1'),
-        given('4c1'),
-      ]).expect('#4c1')
-      forCases([
-        given('#abc123'),
-        given('#ABC123'),
-        given('abc123'),
-        given('ABC123'),
-      ]).expect('#abc123')
-      // valid rgb(a)
-      given('rgb(0,128,255)').expect('rgb(0,128,255)')
-      given('rgba(0,128,255,0)').expect('rgba(0,128,255,0)')
-      // valid hsl(a)
-      given('hsl(100, 56%, 10%)').expect('hsl(100, 56%, 10%)')
-      given('hsla(25,20%,0%,0.1)').expect('hsla(25,20%,0%,0.1)')
-      // CSS named color.
-      given('papayawhip').expect('papayawhip')
-      // Shields named color.
-      given('red').expect('red')
-      given('green').expect('green')
-      given('blue').expect('blue')
-      given('yellow').expect('yellow')
-      // Semantic color alias
-      given('success').expect('brightgreen')
-      given('informational').expect('blue')
-
-      forCases(
-        // invalid hex
-        given('#123red'), // contains letter above F
-        given('#red'), // contains letter above F
-        // invalid rgb(a)
-        given('rgb(220,128,255,0.5)'), // has alpha
-        given('rgba(0,0,255)'), // no alpha
-        // invalid hsl(a)
-        given('hsl(360,50%,50%,0.5)'), // has alpha
-        given('hsla(0,50%,101%)'), // no alpha
-        // neither a css named color nor colorscheme
-        given('notacolor'),
-        given('bluish'),
-        given('almostred'),
-        given('brightmaroon'),
-        given('cactus')
-      ).expect(undefined)
-    })
-  })
-
-  describe('color aliases', function() {
-    test(testColor, () => {
-      forCases([given('#4c1', 'color')]).expect('#4c1')
-    })
-  })
-
   describe('SVG', function() {
     it('should produce SVG', function() {
       const svg = makeBadge({

--- a/core/base-service/base-non-memory-caching.js
+++ b/core/base-service/base-non-memory-caching.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const makeBadge = require('../../badge-maker/lib/make-badge')
 const BaseService = require('./base')
 const { MetricHelper } = require('./metric-helper')
 const { setCacheHeaders } = require('./cache-headers')
 const { makeSend } = require('./legacy-result-sender')
+const { makeBadgeOrJson } = require('./make-badge-or-json')
 const coalesceBadge = require('./coalesce-badge')
 const { prepareRoute, namedParamsForMatch } = require('./route')
 
@@ -57,7 +57,7 @@ module.exports = class NonMemoryCachingBaseService extends BaseService {
       const format = (match.slice(-1)[0] || '.svg').replace(/^\./, '')
       badgeData.format = format
 
-      const svg = makeBadge(badgeData)
+      const badgeOrJson = makeBadgeOrJson(badgeData, format)
 
       setCacheHeaders({
         cacheHeaderConfig,
@@ -66,7 +66,7 @@ module.exports = class NonMemoryCachingBaseService extends BaseService {
         res: ask.res,
       })
 
-      makeSend(format, ask.res, end)(svg)
+      makeSend(format, ask.res, end)(badgeOrJson)
 
       metricHandle.noteResponseSent()
     })

--- a/core/base-service/base-static.js
+++ b/core/base-service/base-static.js
@@ -1,12 +1,12 @@
 'use strict'
 
-const makeBadge = require('../../badge-maker/lib/make-badge')
 const BaseService = require('./base')
 const {
   serverHasBeenUpSinceResourceCached,
   setCacheHeadersForStaticResource,
 } = require('./cache-headers')
 const { makeSend } = require('./legacy-result-sender')
+const { makeBadgeOrJson } = require('./make-badge-or-json')
 const { MetricHelper } = require('./metric-helper')
 const coalesceBadge = require('./coalesce-badge')
 const { prepareRoute, namedParamsForMatch } = require('./route')
@@ -51,8 +51,8 @@ module.exports = class BaseStaticService extends BaseService {
 
       setCacheHeadersForStaticResource(ask.res)
 
-      const svg = makeBadge(badgeData)
-      makeSend(format, ask.res, end)(svg)
+      const badgeOrJson = makeBadgeOrJson(badgeData, format)
+      makeSend(format, ask.res, end)(badgeOrJson)
 
       metricHandle.noteResponseSent()
     })

--- a/core/base-service/base-svg-scraping.spec.js
+++ b/core/base-service/base-svg-scraping.spec.js
@@ -7,7 +7,11 @@ const makeBadge = require('../../badge-maker/lib/make-badge')
 const BaseSvgScrapingService = require('./base-svg-scraping')
 
 function makeExampleSvg({ label, message }) {
-  return makeBadge({ text: ['this is the label', 'this is the result!'] })
+  return makeBadge({
+    label: 'this is the label',
+    message: 'this is the result!',
+    style: 'flat',
+  })
 }
 
 const schema = Joi.object({

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -390,9 +390,10 @@ describe('BaseService', function() {
       const expectedFormat = 'svg'
       expect(mockSendBadge).to.have.been.calledOnce
       expect(mockSendBadge).to.have.been.calledWith(expectedFormat, {
-        text: ['cat', 'Hello namedParamA: bar with queryParamA: ?'],
+        label: 'cat',
+        message: 'Hello namedParamA: bar with queryParamA: ?',
         color: 'lightgrey',
-        template: 'flat',
+        style: 'flat',
         namedLogo: undefined,
         logo: undefined,
         logoWidth: undefined,

--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -162,8 +162,8 @@ module.exports = function coalesceBadge(
   return {
     // Use `coalesce()` to support empty labels and messages, as in the
     // static badge.
-    label: coalesce(overrideLabel, serviceLabel, defaultLabel, category),
-    message: coalesce(serviceMessage, 'n/a'),
+    label: `${coalesce(overrideLabel, serviceLabel, defaultLabel, category)}`,
+    message: `${coalesce(serviceMessage, 'n/a')}`,
     color: coalesce(
       // In case of an error, disregard user's color override.
       isError ? undefined : overrideColor,

--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -160,12 +160,10 @@ module.exports = function coalesceBadge(
   }
 
   return {
-    text: [
-      // Use `coalesce()` to support empty labels and messages, as in the
-      // static badge.
-      coalesce(overrideLabel, serviceLabel, defaultLabel, category),
-      coalesce(serviceMessage, 'n/a'),
-    ],
+    // Use `coalesce()` to support empty labels and messages, as in the
+    // static badge.
+    label: coalesce(overrideLabel, serviceLabel, defaultLabel, category),
+    message: coalesce(serviceMessage, 'n/a'),
     color: coalesce(
       // In case of an error, disregard user's color override.
       isError ? undefined : overrideColor,
@@ -179,7 +177,7 @@ module.exports = function coalesceBadge(
       serviceLabelColor,
       defaultLabelColor
     ),
-    template: style,
+    style,
     namedLogo,
     logo: logoSvgBase64,
     logoWidth,

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -7,47 +7,44 @@ const coalesceBadge = require('./coalesce-badge')
 describe('coalesceBadge', function() {
   describe('Label', function() {
     it('uses the default label', function() {
-      expect(coalesceBadge({}, {}, { label: 'heyo' }).text).to.deep.equal([
-        'heyo',
-        'n/a',
-      ])
+      expect(coalesceBadge({}, {}, { label: 'heyo' })).to.include({
+        label: 'heyo',
+      })
     })
 
     // This behavior isn't great and we might want to remove it.
     it('uses the category as a default label', function() {
-      expect(
-        coalesceBadge({}, {}, {}, { category: 'cat' }).text
-      ).to.deep.equal(['cat', 'n/a'])
+      expect(coalesceBadge({}, {}, {}, { category: 'cat' })).to.include({
+        label: 'cat',
+      })
     })
 
     it('preserves an empty label', function() {
-      expect(
-        coalesceBadge({}, { label: '', message: '10k' }, {}).text
-      ).to.deep.equal(['', '10k'])
+      expect(coalesceBadge({}, { label: '', message: '10k' }, {})).to.include({
+        label: '',
+      })
     })
 
     it('overrides the label', function() {
       expect(
-        coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {}).text
-      ).to.deep.equal(['purr count', 'n/a'])
+        coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {})
+      ).to.include({ label: 'purr count' })
     })
   })
 
   describe('Message', function() {
     it('applies the service message', function() {
-      expect(coalesceBadge({}, { message: '10k' }, {}).text).to.deep.equal([
-        undefined,
-        '10k',
-      ])
+      expect(coalesceBadge({}, { message: '10k' }, {})).to.include({
+        message: '10k',
+      })
     })
 
     it('applies a numeric service message', function() {
       // While a number of badges use this, in the long run we may want
       // `render()` to always return a string.
-      expect(coalesceBadge({}, { message: 10 }, {}).text).to.deep.equal([
-        undefined,
-        10,
-      ])
+      expect(coalesceBadge({}, { message: 10 }, {})).to.include({
+        message: 10,
+      })
     })
   })
 
@@ -279,20 +276,16 @@ describe('coalesceBadge', function() {
 
   describe('Style', function() {
     it('falls back to flat with invalid style', function() {
-      expect(coalesceBadge({ style: 'pill' }, {}, {}).template).to.equal('flat')
-      expect(coalesceBadge({ style: 7 }, {}, {}).template).to.equal('flat')
-      expect(coalesceBadge({ style: undefined }, {}, {}).template).to.equal(
-        'flat'
-      )
+      expect(coalesceBadge({ style: 'pill' }, {}, {}).style).to.equal('flat')
+      expect(coalesceBadge({ style: 7 }, {}, {}).style).to.equal('flat')
+      expect(coalesceBadge({ style: undefined }, {}, {}).style).to.equal('flat')
     })
 
     it('replaces legacy popout styles', function() {
-      expect(coalesceBadge({ style: 'popout' }, {}, {}).template).to.equal(
-        'flat'
+      expect(coalesceBadge({ style: 'popout' }, {}, {}).style).to.equal('flat')
+      expect(coalesceBadge({ style: 'popout-square' }, {}, {}).style).to.equal(
+        'flat-square'
       )
-      expect(
-        coalesceBadge({ style: 'popout-square' }, {}, {}).template
-      ).to.equal('flat-square')
     })
   })
 

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -30,6 +30,13 @@ describe('coalesceBadge', function() {
         coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {})
       ).to.include({ label: 'purr count' })
     })
+
+    // https://github.com/badges/shields/issues/1280
+    it('converts a number to a string', function() {
+      expect(coalesceBadge({}, { label: 1998 }, {})).to.include({
+        label: '1998',
+      })
+    })
   })
 
   describe('Message', function() {
@@ -39,11 +46,12 @@ describe('coalesceBadge', function() {
       })
     })
 
-    it('applies a numeric service message', function() {
+    // https://github.com/badges/shields/issues/1280
+    it('converts a number to a string', function() {
       // While a number of badges use this, in the long run we may want
       // `render()` to always return a string.
       expect(coalesceBadge({}, { message: 10 }, {})).to.include({
-        message: 10,
+        message: '10',
       })
     })
   })

--- a/core/base-service/examples.js
+++ b/core/base-service/examples.js
@@ -131,12 +131,7 @@ function transformExample(inExample, index, ServiceClass) {
     documentation,
   } = validateExample(inExample, index, ServiceClass)
 
-  const {
-    text: [label, message],
-    color,
-    template: style,
-    namedLogo,
-  } = coalesceBadge(
+  const { label, message, color, style, namedLogo } = coalesceBadge(
     {},
     staticPreview,
     ServiceClass.defaultBadgeData,

--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -149,7 +149,10 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
       // A request was made not long ago.
       const tooSoon = +reqTime - cached.time < cached.interval
       if (tooSoon || cached.dataChange / cached.reqs <= freqRatioMax) {
-        const badgeOrJson = makeBadgeOrJson(cached.data.badgeData)
+        const badgeOrJson = makeBadgeOrJson(
+          cached.data.badgeData,
+          cached.data.format
+        )
         setCacheHeadersOnResponse(
           ask.res,
           cached.data.badgeData.cacheLengthSeconds
@@ -172,7 +175,10 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
       }
       if (requestCache.has(cacheIndex)) {
         const cached = requestCache.get(cacheIndex)
-        const badgeOrJson = makeBadgeOrJson(cached.data.badgeData)
+        const badgeOrJson = makeBadgeOrJson(
+          cached.data.badgeData,
+          cached.data.format
+        )
         setCacheHeadersOnResponse(
           ask.res,
           cached.data.badgeData.cacheLengthSeconds

--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -260,7 +260,7 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
         let dataHasChanged = false
         if (
           cached !== undefined &&
-          cached.data.badgeData.text[1] !== badgeData.text[1]
+          cached.data.badgeData.message !== badgeData.message
         ) {
           dataHasChanged = true
         }

--- a/core/base-service/make-badge-or-json.js
+++ b/core/base-service/make-badge-or-json.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const makeBadge = require('../../badge-maker/lib/make-badge')
+const { _clean } = require('../../badge-maker')
+
+function pick(obj, keys) {
+  const result = {}
+  keys.forEach(k => {
+    result[k] = obj[k]
+  })
+  return result
+}
+
+function makeBadgeOrJson(badgeData, format = 'svg') {
+  if (format === 'json') {
+    const { label, message, color, labelColor } = _clean(
+      pick(badgeData, ['label', 'message', 'labelColor', 'color'])
+    )
+    const { links, logoWidth } = badgeData
+    return JSON.stringify({
+      label,
+      message,
+      color,
+      labelColor,
+      link: links,
+      logoWidth,
+      name: label,
+      value: message,
+    })
+  } else {
+    return makeBadge({ style: 'flat', ...badgeData })
+  }
+}
+
+module.exports = { makeBadgeOrJson }

--- a/core/base-service/make-badge-or-json.js
+++ b/core/base-service/make-badge-or-json.js
@@ -28,7 +28,7 @@ function makeBadgeOrJson(badgeData, format = 'svg') {
       value: message,
     })
   } else {
-    return makeBadge({ style: 'flat', ...badgeData })
+    return makeBadge(badgeData)
   }
 }
 

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -308,7 +308,7 @@ class Server {
           label: '410',
           message: `${format} no longer available`,
           color: 'lightgray',
-          format: 'svg',
+          style: 'flat',
         })
       )
     })
@@ -324,7 +324,7 @@ class Server {
             label: '404',
             message: 'raster badges not available',
             color: 'lightgray',
-            format: 'svg',
+            style: 'flat',
           })
         )
       })
@@ -344,6 +344,7 @@ class Server {
             label: '404',
             message: 'badge not found',
             color: 'red',
+            style: 'flat',
           },
           format
         )

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -9,10 +9,10 @@ const { URL } = url
 const bytes = require('bytes')
 const Camp = require('@shields_io/camp')
 const originalJoi = require('@hapi/joi')
-const makeBadge = require('../../badge-maker/lib/make-badge')
 const GithubConstellation = require('../../services/github/github-constellation')
 const suggest = require('../../services/suggest')
 const { loadServiceClasses } = require('../base-service/loader')
+const { makeBadgeOrJson } = require('../base-service/make-badge-or-json')
 const { makeSend } = require('../base-service/legacy-result-sender')
 const {
   handleRequest,
@@ -304,8 +304,9 @@ class Server {
         request.res,
         end
       )(
-        makeBadge({
-          text: ['410', `${format} no longer available`],
+        makeBadgeOrJson({
+          label: '410',
+          message: `${format} no longer available`,
           color: 'lightgray',
           format: 'svg',
         })
@@ -319,8 +320,9 @@ class Server {
           request.res,
           end
         )(
-          makeBadge({
-            text: ['404', 'raster badges not available'],
+          makeBadgeOrJson({
+            label: '404',
+            message: 'raster badges not available',
             color: 'lightgray',
             format: 'svg',
           })
@@ -337,11 +339,14 @@ class Server {
         request.res,
         end
       )(
-        makeBadge({
-          text: ['404', 'badge not found'],
-          color: 'red',
-          format,
-        })
+        makeBadgeOrJson(
+          {
+            label: '404',
+            message: 'badge not found',
+            color: 'red',
+          },
+          format
+        )
       )
     })
   }


### PR DESCRIPTION
1. Move normalization from "internal" `makeBadge()` into a `_clean()` function which is privately exported by badge-maker. It's necessary that the server can access this functionality to do the JSON rendering. (Alternatively we could remove the underscore to make this part of the public API. However this may not be necessary, as I think it will only be needed for Shields.)
2. Some changes to help with #4950:
    1. Bring the "internal" badge-maker schema more in line with the badge-maker public schema.
    2. Bring the output of `coalesceBadge()` more in line with the badge-maker public schema.
    3. Since the badge-maker public interface requires strings, the package internals should assume a string. Accordingly, move numeric coercion from the the package internals to the server.

Closes #4948