### PR TITLE
Fill GitHub token pool on startup

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -441,7 +441,7 @@ class Server {
     )
 
     const { githubConstellation } = this
-    githubConstellation.initialize(camp)
+    await githubConstellation.initialize(camp)
     if (metricInstance) {
       if (this.config.public.metrics.prometheus.endpointEnabled) {
         metricInstance.registerMetricsEndpoint(camp)


### PR DESCRIPTION
We're still seeing a few "Token pool is exhausted" errors at the moment the dynos are coming up. I'm wondering if this might help.

Ref #3771