### PR TITLE
Update test matrix and docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,6 +109,7 @@ package_steps: &package_steps
           export NVM_DIR="/opt/circleci/.nvm"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
           nvm install v12
+          nvm install v14
           nvm use v12
           npm install -g npm
           npm ci
@@ -117,14 +118,6 @@ package_steps: &package_steps
 
     # Run the package tests on each currently supported node version. See:
     # https://github.com/badges/shields/blob/master/badge-maker/README.md#node-version-support
-
-    - run:
-        <<: *run_package_tests
-        environment:
-          mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/badge-maker/v8/results.xml
-          NODE_VERSION: v8
-        name: Run package tests on Node 8
 
     - run:
         <<: *run_package_tests
@@ -142,13 +135,21 @@ package_steps: &package_steps
           NODE_VERSION: v12
         name: Run package tests on Node 12
 
+    - run:
+        <<: *run_package_tests
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/badge-maker/v14/results.xml
+          NODE_VERSION: v14
+        name: Run package tests on Node 14
+
     - store_test_results:
         path: junit
 
 jobs:
   npm-install:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
 
@@ -160,33 +161,33 @@ jobs:
 
   main:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
 
     <<: *main_steps
 
-  main@node-latest:
+  main@node-12:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:12
 
     <<: *main_steps
 
   integration:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
       - image: redis
 
     <<: *integration_steps
 
-  integration@node-latest:
+  integration@node-12:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:12
       - image: redis
 
     <<: *integration_steps
 
   danger:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
 
@@ -206,7 +207,7 @@ jobs:
 
   frontend:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     steps:
       - checkout
 
@@ -247,13 +248,13 @@ jobs:
 
   services:
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
 
     <<: *services_steps
 
-  services@node-latest:
+  services@node-12:
     docker:
-      - image: circleci/node:latest
+      - image: circleci/node:12
 
     <<: *services_steps
 
@@ -308,11 +309,11 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
-      - main@node-latest:
+      - main@node-12:
           filters:
             branches:
               ignore: gh-pages
-      - integration@node-latest:
+      - integration@node-12:
           filters:
             branches:
               ignore: gh-pages
@@ -330,7 +331,7 @@ workflows:
               ignore:
                 - master
                 - gh-pages
-      - services@node-latest:
+      - services@node-12:
           filters:
             branches:
               ignore:

--- a/badge-maker/CHANGELOG.md
+++ b/badge-maker/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- Dropped support for node < 10
 - Package name has changed to `badge-maker` and moved to https://www.npmjs.com/package/badge-maker
 - `BadgeFactory` class is removed and replaced by `makeBadge()` function.
 - Deprecated parameters have been removed. In version 2.2.0 the `colorA`, `colorB` and `colorscheme` params were deprecated. In version 3.0.0 these have been removed.

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -25,7 +25,7 @@ and learn about the [Github workflow](http://try.github.io/).
 
 #### Node, NPM
 
-Node 8 or later is required. If you don't already have them,
+Node 10 or later is required. If you don't already have them,
 install node and npm: https://nodejs.org/en/download/
 
 ### Setup a dev install

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-You will need Node 8 or later, which you can install using a
+You will need Node 10 or later, which you can install using a
 [package manager][].
 
 On Ubuntu / Debian:


### PR DESCRIPTION
Refs #4977
Refs #3404
Refs #4973

I haven't bothered to update the reference in https://github.com/badges/shields/blob/master/doc/production-hosting.md as that whole doc needs revamping. I'll deal with this as another PR

My thinking here is while we are deployed on node 10 and we want to upgrade to 12 soon, those are the two most important runtimes and that's what we should run our tests on. Once we're on to 12 in production, we can switch to tracking latest again. I think running the core/service tests against 3 runtimes bloats the matrix too much.