### PR TITLE
increase timeout on unique service names test

### DIFF
--- a/services/check-services.spec.js
+++ b/services/check-services.spec.js
@@ -9,6 +9,7 @@ const {
 // `expect().not.to.throw()` makes the error output unreadable.
 
 it('Services have unique names', function() {
+  this.timeout(5000)
   checkNames()
 })
 


### PR DESCRIPTION
Refs (and _may_ resolve) #4930

It seems that when running with `nyc` coverage enabled that `checkNames` is pretty consistently exceeding mocha's default 2 second timeout which is causing failures in the daily-tests job

https://github.com/badges/shields/blob/d9c483abbebb32b3619e443f2505adfe2f47d8db/services/check-services.spec.js#L11-L13

https://app.circleci.com/pipelines/github/badges/daily-tests/196/workflows/fbf25f75-8ab5-4f77-821f-1d120d38d555/jobs/1091/steps