### PR TITLE
remove git add from lint-staged action

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,8 +122,7 @@
       "prettier --write"
     ],
     "**/*.@(md|json|yml)": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "nodemonConfig": {


### PR DESCRIPTION
`git add` is no longer needed. We overlooked this one in https://github.com/badges/shields/pull/5022