### PR TITLE
Fix typos

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -149,7 +149,7 @@ rules:
   # allow Joi as an undefined type
   jsdoc/no-undefined-types: ['error', { definedTypes: ['Joi'] }]
 
-  # all the other reccomended rules as errors (not warnings)
+  # all the other recommended rules as errors (not warnings)
   jsdoc/check-alignment: 'error'
   jsdoc/check-param-names: 'error'
   jsdoc/check-tag-names: 'error'

--- a/entrypoint.spec.js
+++ b/entrypoint.spec.js
@@ -7,7 +7,7 @@ const got = require('./core/got-test-client')
 let server
 before(function () {
   this.timeout('5s')
-  // remove args comming from mocha
+  // remove args coming from mocha
   // https://github.com/badges/shields/issues/3365
   process.argv = []
   server = require('./server')

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -189,7 +189,7 @@ t.create('query with node function')
     color: 'blue',
   })
 
-t.create('query with type convertion to string')
+t.create('query with type conversion to string')
   .get(
     `.json?${queryString.stringify({
       url: exampleUrl,
@@ -203,7 +203,7 @@ t.create('query with type convertion to string')
     color: 'blue',
   })
 
-t.create('query with type convertion to number')
+t.create('query with type conversion to number')
   .get(
     `.json?${queryString.stringify({
       url: exampleUrl,

--- a/services/nuget/nuget-v3-service-family.js
+++ b/services/nuget/nuget-v3-service-family.js
@@ -100,7 +100,7 @@ const schema = Joi.object({
 /*
  * Strip Build MetaData
  * Nuget versions may include an optional "build metadata" clause,
- * seperated from the version by a + character.
+ * separated from the version by a + character.
  */
 function stripBuildMetadata(version) {
   return version.split('+')[0]


### PR DESCRIPTION
Hi,

This PR will fix : 

- 1 typo in `.eslintrc.yml`
- 1 typo in `entrypoint.spec.js`
- 2 typos in `services/dynamic/dynamic-xml.tester.js`
- 1 typo in `services/nuget/nuget-v3-service-family.js`



Best! :robot: