### PR TITLE
Updated To [Discord's] New Domain Name

### DIFF
--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -73,7 +73,7 @@ module.exports = class Discord extends BaseJsonService {
   }
 
   async fetch({ serverId }) {
-    const url = `https://discordapp.com/api/guilds/${serverId}/widget.json`
+    const url = `https://discord.com/api/guilds/${serverId}/widget.json`
     return this._requestJson({
       url,
       schema: discordSchema,


### PR DESCRIPTION
Discord has migrated to discord.com from discordapp.com. https:discordapp.com/api/ will not work within the next few months. Good to fix this now!