### PR TITLE
Update discord.tester.js [Along with #5103)

### DIFF
--- a/services/discord/discord.tester.js
+++ b/services/discord/discord.tester.js
@@ -18,7 +18,7 @@ t.create('invalid server ID')
 t.create('widget disabled')
   .get('/12345.json')
   .intercept(nock =>
-    nock('https://discordapp.com/')
+    nock('https://discord.com/')
       .get('/api/guilds/12345/widget.json')
       .reply(403, {
         code: 50004,
@@ -30,7 +30,7 @@ t.create('widget disabled')
 t.create('server error')
   .get('/12345.json')
   .intercept(nock =>
-    nock('https://discordapp.com/')
+    nock('https://discord.com/')
       .get('/api/guilds/12345/widget.json')
       .reply(500, 'Something broke')
   )


### PR DESCRIPTION
Discord has migrated to discord.com from discordapp.com. https:discordapp.com/api/ will not work within the next few months. Good to fix this now!
#5103 