### PR TITLE
Add the /steam/update-date badge, run [steam]

### DIFF
--- a/services/steam/steam-workshop.service.js
+++ b/services/steam/steam-workshop.service.js
@@ -63,6 +63,7 @@ const steamFileSchema = Joi.object({
           Joi.object({
             file_size: Joi.number().integer().required(),
             time_created: Joi.number().integer().required(),
+            time_updated: Joi.number().integer().required(),
             subscriptions: Joi.number().integer().required(),
             favorited: Joi.number().integer().required(),
             lifetime_subscriptions: Joi.number().integer().required(),

--- a/services/steam/steam-workshop.service.js
+++ b/services/steam/steam-workshop.service.js
@@ -276,6 +276,45 @@ class SteamFileReleaseDate extends SteamFileService {
   }
 }
 
+class SteamFileUpdateDate extends SteamFileService {
+  static get category() {
+    return 'activity'
+  }
+
+  static get route() {
+    return {
+      base: 'steam/update-date',
+      pattern: ':fileId',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'Steam Update Date',
+        namedParams: { fileId: '100' },
+        staticPreview: this.render({
+          updateDate: new Date(0).setUTCSeconds(1538288239),
+        }),
+        documentation,
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return { label: 'update date' }
+  }
+
+  static render({ updateDate }) {
+    return { message: formatDate(updateDate), color: ageColor(updateDate) }
+  }
+
+  async onRequest({ response }) {
+    const updateDate = new Date(0).setUTCSeconds(response.time_updated)
+    return this.constructor.render({ updateDate })
+  }
+}
+
 class SteamFileSubscriptions extends SteamFileService {
   static get category() {
     return 'rating'

--- a/services/steam/steam-workshop.service.js
+++ b/services/steam/steam-workshop.service.js
@@ -465,6 +465,7 @@ module.exports = {
   SteamCollectionSize,
   SteamFileSize,
   SteamFileReleaseDate,
+  SteamFileUpdateDate,
   SteamFileSubscriptions,
   SteamFileFavorites,
   SteamFileDownloads,

--- a/services/steam/steam-workshop.tester.js
+++ b/services/steam/steam-workshop.tester.js
@@ -18,6 +18,10 @@ t.create('Release Date')
   .get('/release-date/1523924535.json')
   .expectBadge({ label: 'release date', message: isFormattedDate })
 
+t.create('Update Date')
+  .get('/update-date/1523924535.json')
+  .expectBadge({ label: 'update date', message: isFormattedDate })
+
 t.create('Subscriptions')
   .get('/subscriptions/1523924535.json')
   .expectBadge({ label: 'subscriptions', message: isMetric })
@@ -45,6 +49,10 @@ t.create('File Size | File Not Found')
 t.create('Release Date | File Not Found')
   .get('/release-date/1.json')
   .expectBadge({ label: 'release date', message: 'file not found' })
+
+t.create('Update Date | File Not Found')
+  .get('/update-date/1.json')
+  .expectBadge({ label: 'update date', message: 'file not found' })
 
 t.create('Subscriptions | File Not Found')
   .get('/subscriptions/1.json')


### PR DESCRIPTION
This adds the /steam/update-date badge, to also provide a badge that shows the date of a file on steam when it was last updated.

The code is pretty much straight forward, equal to the `steam/release-date` badge, except that it reads out `time_updated` instead of `time_created`.

If there is anything you would like to have changed, please let me know! 
Thank you for this amazing project!