### PR TITLE
Update simple-icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32022,7 +32022,7 @@
       }
     },
     "simple-icons": {
-      "version": "2.15.0",
+      "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.15.0.tgz",
       "integrity": "sha512-P8cIVf9TF9y1Dk/gLth4WEa3cLBen4YymZuUvdlSNqjGUM4x9Zcy8oXHneVLo0AYPJcHa0b3q3+QEwKAoF+C8Q=="
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "query-string": "^6.12.1",
     "request": "~2.88.2",
     "semver": "~7.3.2",
-    "simple-icons": "2.15.0",
+    "simple-icons": "2.16.0",
     "xmldom": "~0.2.1",
     "xpath": "~0.0.27"
   },


### PR DESCRIPTION
This PR updates `simple-icons` from `2.15.0` to `2.16.0`.  
(If you feel like you would rather `dependabot` do this, feel free to not merge.)  
Here's the update notes: https://github.com/simple-icons/simple-icons/compare/2.15.0...2.16.0