### PR TITLE
fix lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10055,7 +10055,15 @@
       "version": "file:badge-maker",
       "requires": {
         "anafanafo": "^1.0.0",
+        "camelcase": "^6.0.0",
         "is-css-color": "^1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+        }
       }
     },
     "bail": {
@@ -32032,8 +32040,8 @@
     },
     "simple-icons": {
       "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.15.0.tgz",
-      "integrity": "sha512-P8cIVf9TF9y1Dk/gLth4WEa3cLBen4YymZuUvdlSNqjGUM4x9Zcy8oXHneVLo0AYPJcHa0b3q3+QEwKAoF+C8Q=="
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.16.0.tgz",
+      "integrity": "sha512-xz4GSnzxgSk47kvXBPZEbG3IA3/EBeGplZd4lyv2I+7Oresm/ZsC8RKvdosyvWeB+KDARkqjBvjRZr/RsUhIxA=="
     },
     "simple-swizzle": {
       "version": "0.2.2",


### PR DESCRIPTION
We missed a couple of updates to this:

* https://github.com/badges/shields/pull/5189 (I think the submitter manually edited the lockfile rather than using npm and I didn't notice)
* https://github.com/badges/shields/pull/5175 dependabot updated the `package.json` in `/badge-maker` (which doesn't have its own lockfile because its a package) but didn't update the root lockfile. This is always going to be an issue for dependabot updates in badge-maker. In fact, its probably happened before and we forgot..