### PR TITLE
Fix [Twitch] Client-ID header

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -114,7 +114,7 @@ class BaseService {
    * credentials to the request. For example:
    * - `{ options: { auth: this.authHelper.basicAuth } }`
    * - `{ options: { headers: this.authHelper.bearerAuthHeader } }`
-   * - `{ options: { qs: { token: this.authHelper.pass } } }`
+   * - `{ options: { qs: { token: this.authHelper._pass } } }`
    *
    * @abstract
    * @type {module:core/base-service/base~Auth}

--- a/services/twitch/twitch-base.js
+++ b/services/twitch/twitch-base.js
@@ -81,7 +81,7 @@ module.exports = class TwitchBase extends BaseJsonService {
       options: {
         ...request.options,
         headers: {
-          'Client-ID': this.authHelper.user,
+          'Client-ID': this.authHelper._user,
           Authorization: `Bearer ${await this._twitchToken()}`,
           ...(request.options && request.options.headers),
         },

--- a/services/twitch/twitch.spec.js
+++ b/services/twitch/twitch.spec.js
@@ -34,7 +34,9 @@ describe('TwitchStatus', function () {
           expires_in: 2000000,
         })
 
-      const statusNock = nock('https://api.twitch.tv')
+      const statusNock = nock('https://api.twitch.tv', {
+        reqheaders: { Authorization: `Bearer ${token}`, 'Client-ID': user },
+      })
         .get('/helix/streams')
         .reply(200, {
           data: [],


### PR DESCRIPTION
Fixes #5214.

We broke Twitch badges back in #4729. I mostly fixed things in #4781, but I missed out on bit with led to the `Client-ID` not actually being set. The impact of this mistake only became visible recently for reasons outlined in #5214.

The improved spec test should prevent any regressions in the future.