### PR TITLE
auto-detect default branch name in [bitbucketpipelines gitlab travisphpversion]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5689,6 +5689,33 @@
         "@graphql-tools/graphql-tag-pluck": "6.0.4",
         "@graphql-tools/utils": "6.0.4",
         "simple-git": "2.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "simple-git": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.5.0.tgz",
+          "integrity": "sha512-4gmtMqfIL9bsBNJDP/rDwZe3GsQL/tp85Qv5cmRc8iIDNOZJS4IX1oPfcqp9b7BGPc5bfuw4yd1i3lQacvuqDQ==",
+          "dev": true,
+          "requires": {
+            "@kwsites/exec-p": "^0.4.0",
+            "debug": "^4.0.1"
+          }
+        }
       }
     },
     "@graphql-tools/github-loader": {
@@ -6606,6 +6633,29 @@
       "resolved": "https://registry.npmjs.org/@kwsites/exec-p/-/exec-p-0.4.0.tgz",
       "integrity": "sha512-44DWNv5gDR9EwrCTVQ4ZC99yPqVS0VCWrYIBl45qNR8XQy+4lbl0IQG8kBDf6NHwj4Ib4c2z1Fq1IUJOCbkZcw==",
       "dev": true
+    },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "requires": {
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "@mapbox/react-click-to-select": {
       "version": "2.2.0",
@@ -7603,8 +7653,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/keyv": {
       "version": "3.1.1",
@@ -31742,20 +31791,18 @@
       "dev": true
     },
     "simple-git": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.5.0.tgz",
-      "integrity": "sha512-4gmtMqfIL9bsBNJDP/rDwZe3GsQL/tp85Qv5cmRc8iIDNOZJS4IX1oPfcqp9b7BGPc5bfuw4yd1i3lQacvuqDQ==",
-      "dev": true,
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.8.0.tgz",
+      "integrity": "sha512-0iXwizUaanqdjn9IpboozWN2opA7jl1JZzeQEePyFXRUGOtwVuSgkMGXLnd7Toa7jqV+uZ1VnDZlCBxxSEk1Dw==",
       "requires": {
-        "@kwsites/exec-p": "^0.4.0",
-        "debug": "^4.0.1"
+        "@kwsites/file-exists": "^1.1.1",
+        "debug": "^4.1.1"
       },
       "dependencies": {
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -31763,8 +31810,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@sentry/node": "^5.17.0",
+    "@shields_io/camp": "^18.0.0",
+    "badge-maker": "file:badge-maker",
     "bytes": "^3.1.0",
     "camelcase": "^5.3.1",
-    "@shields_io/camp": "^18.0.0",
     "chai-as-promised": "^7.1.1",
     "chalk": "^4.1.0",
     "check-node-version": "^4.0.3",
@@ -39,7 +40,6 @@
     "escape-string-regexp": "^4.0.0",
     "fast-xml-parser": "^3.17.4",
     "fsos": "^1.1.6",
-    "badge-maker": "file:badge-maker",
     "glob": "^7.1.6",
     "graphql": "^14.6.0",
     "graphql-tag": "^2.10.3",
@@ -60,6 +60,7 @@
     "query-string": "^6.13.1",
     "request": "~2.88.2",
     "semver": "~7.3.2",
+    "simple-git": "^2.8.0",
     "simple-icons": "2.17.1",
     "xmldom": "~0.2.1",
     "xpath": "~0.0.27"

--- a/services/bitbucket/bitbucket-pipelines.tester.js
+++ b/services/bitbucket/bitbucket-pipelines.tester.js
@@ -3,7 +3,7 @@
 const { isBuildStatus } = require('../build-status')
 const t = (module.exports = require('../tester').createServiceTester())
 
-function bitbucketApiResponse(status) {
+function bitbucketPipelineApiResponse(status) {
   return JSON.stringify({
     values: [
       {
@@ -46,12 +46,26 @@ t.create('branch build result (never built)')
   .get('/atlassian/adf-builder-javascript/some/new/branch.json')
   .expectBadge({ label: 'build', message: 'never built' })
 
+t.create('build result (default branch is not called master)')
+  .get('/chris48s/no-master-branch.json')
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })
+
 t.create('build result (passing)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('SUCCESSFUL'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('SUCCESSFUL'))
   )
   .expectBadge({ label: 'build', message: 'passing' })
 
@@ -59,8 +73,15 @@ t.create('build result (failing)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('FAILED'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('FAILED'))
   )
   .expectBadge({ label: 'build', message: 'failing' })
 
@@ -68,8 +89,15 @@ t.create('build result (error)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('ERROR'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('ERROR'))
   )
   .expectBadge({ label: 'build', message: 'error' })
 
@@ -77,8 +105,15 @@ t.create('build result (stopped)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('STOPPED'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('STOPPED'))
   )
   .expectBadge({ label: 'build', message: 'stopped' })
 
@@ -86,8 +121,15 @@ t.create('build result (expired)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('EXPIRED'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('EXPIRED'))
   )
   .expectBadge({ label: 'build', message: 'expired' })
 
@@ -95,7 +137,14 @@ t.create('build result (unexpected status)')
   .get('/atlassian/adf-builder-javascript.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
-      .get(/^\/2.0\/.*/)
-      .reply(200, bitbucketApiResponse('NEW_AND_UNEXPECTED'))
+      .get('/2.0/repositories/atlassian/adf-builder-javascript/')
+      .reply(200, { mainbranch: { name: 'master' } })
+  )
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(
+        /^\/2.0\/repositories\/atlassian\/adf-builder-javascript\/pipelines.*/
+      )
+      .reply(200, bitbucketPipelineApiResponse('NEW_AND_UNEXPECTED'))
   )
   .expectBadge({ label: 'build', message: 'invalid response data' })

--- a/services/git.js
+++ b/services/git.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const sg = require('simple-git')()
+const { InvalidResponse, NotFound } = require('.')
+
+async function getDefaultBranch({
+  baseUrl,
+  user,
+  repo,
+  username = '',
+  password = '',
+  simpleGit = sg,
+}) {
+  /*
+  Note on authentication: if we pass the function a valid
+  username and password, they will be used:
+  https://username:password@github.com/badges/shields.git
+  This could be useful where we've got
+  BITBUCKET_USER / BITBUCKET_PASS set, for example.
+
+  If username and password aren't specified,
+  we will intentionally pass blank credentials:
+  https://:@github.com/badges/shields.git
+  This might seem like a bad idea at first, but if we pass no credentials at all
+  `git ls-remote --symref https://github.com/badges/shields.git HEAD`
+  will work, but
+  `git ls-remote --symref https://github.com/foobar/does-not-exist.git HEAD`
+  will leave us sitting at an interactive prompt
+  `Username for 'https://github.com':`
+  waiting for input that is never going to arrive.
+
+  If we pass a set of intentionally blank credentials,
+  `git ls-remote --symref https://:@github.com/badges/shields.git HEAD`
+  still works fine for a public repo, but
+  `git ls-remote --symref https://:@github.com/foobar/does-not-exist.git HEAD`
+  will instantly fail on the assumption that the repo either doesn't exist,
+  or it does but we don't have access to it. Either way simple-git
+  will throw a `GitError: remote: HTTP Basic: Access denied`
+  which we can catch and re-throw as NotFound rather than sitting at a
+  login prompt forever.
+
+  So from outside, omitting the username and password params allows us to
+  query public repos only, failing if the repo is not found/private,
+  which is what we'd expect.
+  */
+  const url = `${baseUrl
+    .replace(/\/$/, '')
+    .replace('://', `://${username}:${password}@`)}/${user}/${repo}`
+
+  let console_text
+  try {
+    console_text = await simpleGit.listRemote(['--symref', url, 'HEAD'])
+  } catch (e) {
+    // GitError
+    throw new NotFound({ prettyMessage: 'repo not found' })
+  }
+
+  const match = console_text.match(/^ref: refs\/heads\/([^\s]+)[\s]+HEAD/)
+  if (match) {
+    return match[1]
+  }
+  throw new InvalidResponse({ prettyMessage: 'invalid response data' })
+}
+
+module.exports = { getDefaultBranch }

--- a/services/git.js
+++ b/services/git.js
@@ -1,58 +1,34 @@
 'use strict'
 
 const sg = require('simple-git')()
+sg.env('GIT_TERMINAL_PROMPT', 0)
 const { InvalidResponse, NotFound } = require('.')
 
 async function getDefaultBranch({
   baseUrl,
   user,
   repo,
-  username = '',
-  password = '',
+  username,
+  password,
   simpleGit = sg,
 }) {
-  /*
-  Note on authentication: if we pass the function a valid
-  username and password, they will be used:
-  https://username:password@github.com/badges/shields.git
-  This could be useful where we've got
-  BITBUCKET_USER / BITBUCKET_PASS set, for example.
-
-  If username and password aren't specified,
-  we will intentionally pass blank credentials:
-  https://:@github.com/badges/shields.git
-  This might seem like a bad idea at first, but if we pass no credentials at all
-  `git ls-remote --symref https://github.com/badges/shields.git HEAD`
-  will work, but
-  `git ls-remote --symref https://github.com/foobar/does-not-exist.git HEAD`
-  will leave us sitting at an interactive prompt
-  `Username for 'https://github.com':`
-  waiting for input that is never going to arrive.
-
-  If we pass a set of intentionally blank credentials,
-  `git ls-remote --symref https://:@github.com/badges/shields.git HEAD`
-  still works fine for a public repo, but
-  `git ls-remote --symref https://:@github.com/foobar/does-not-exist.git HEAD`
-  will instantly fail on the assumption that the repo either doesn't exist,
-  or it does but we don't have access to it. Either way simple-git
-  will throw a `GitError: remote: HTTP Basic: Access denied`
-  which we can catch and re-throw as NotFound rather than sitting at a
-  login prompt forever.
-
-  So from outside, omitting the username and password params allows us to
-  query public repos only, failing if the repo is not found/private,
-  which is what we'd expect.
-  */
-  const url = `${baseUrl
-    .replace(/\/$/, '')
-    .replace('://', `://${username}:${password}@`)}/${user}/${repo}`
+  const url = new URL(baseUrl)
+  url.pathname = `${user}/${repo}`
 
   let console_text
   try {
-    console_text = await simpleGit.listRemote(['--symref', url, 'HEAD'])
+    const args = ['--symref', url.toString(), 'HEAD']
+    if (username != null && password != null) {
+      const authStr = Buffer.from(`${username}:${password}`).toString('base64')
+      args.push('-c')
+      args.push(`http.extraheader="Authorization: Basic ${authStr}"`)
+    }
+    console_text = await simpleGit.listRemote(args)
   } catch (e) {
-    // GitError
-    throw new NotFound({ prettyMessage: 'repo not found' })
+    if (e.message.includes('could not read Username')) {
+      throw new NotFound({ prettyMessage: 'repo not found or private' })
+    }
+    throw new InvalidResponse({ prettyMessage: 'invalid response data' })
   }
 
   const match = console_text.match(/^ref: refs\/heads\/([^\s]+)[\s]+HEAD/)

--- a/services/git.spec.js
+++ b/services/git.spec.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const { expect } = require('chai')
+const { getDefaultBranch } = require('./git')
+const { InvalidResponse, NotFound } = require('.')
+
+function mockSimpleGitValid(text) {
+  return {
+    listRemote: async function () {
+      return text
+    },
+  }
+}
+
+function mockSimpleGitInvalid() {
+  return {
+    listRemote: async function () {
+      throw new Error()
+    },
+  }
+}
+
+describe('git helper', function () {
+  it('finds the branch name with expected response', async function () {
+    expect(
+      await getDefaultBranch({
+        baseUrl: 'https://github.com',
+        user: 'badges',
+        repo: 'shields',
+        simpleGit: mockSimpleGitValid(
+          'ref: refs/heads/trunk	HEAD\na24edacbf872f4eca987e5400432084eb8b4f635	HEAD\na475913d60b3ddc5c66641686fc765b18b04fa58	refs/heads/HEAD'
+        ),
+      })
+    ).to.equal('trunk')
+  })
+
+  it('throws InvalidResponse with unexpected response', async function () {
+    expect(
+      getDefaultBranch({
+        baseUrl: 'https://github.com',
+        user: 'badges',
+        repo: 'shields',
+        simpleGit: mockSimpleGitValid('foobar'),
+      })
+    ).to.be.rejectedWith(InvalidResponse)
+  })
+
+  it('throws NotFound if repo not found/private', async function () {
+    expect(
+      getDefaultBranch({
+        baseUrl: 'https://github.com',
+        user: 'badges',
+        repo: 'shields',
+        simpleGit: mockSimpleGitInvalid('foobar'),
+      })
+    ).to.be.rejectedWith(NotFound)
+  })
+})

--- a/services/git.spec.js
+++ b/services/git.spec.js
@@ -15,7 +15,9 @@ function mockSimpleGitValid(text) {
 function mockSimpleGitInvalid() {
   return {
     listRemote: async function () {
-      throw new Error()
+      throw new Error(
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled"
+      )
     },
   }
 }

--- a/services/gitlab/gitlab-pipeline-status.service.js
+++ b/services/gitlab/gitlab-pipeline-status.service.js
@@ -2,6 +2,7 @@
 
 const Joi = require('@hapi/joi')
 const { isBuildStatus, renderBuildStatusBadge } = require('../build-status')
+const { getDefaultBranch } = require('../git')
 const { optionalUrl } = require('../validators')
 const { BaseSvgScrapingService, NotFound } = require('..')
 
@@ -83,12 +84,14 @@ module.exports = class GitlabPipelineStatus extends BaseSvgScrapingService {
   }
 
   async handle(
-    { user, repo, branch = 'master' },
+    { user, repo, branch },
     { gitlab_url: baseUrl = 'https://gitlab.com' }
   ) {
+    const branchName =
+      branch == null ? await getDefaultBranch({ baseUrl, user, repo }) : branch
     const { message: status } = await this._requestSvg({
       schema: badgeSchema,
-      url: `${baseUrl}/${user}/${repo}/badges/${branch}/pipeline.svg`,
+      url: `${baseUrl}/${user}/${repo}/badges/${branchName}/pipeline.svg`,
       errorMessages: {
         401: 'repo not found',
         404: 'repo not found',

--- a/services/gitlab/gitlab-pipeline-status.tester.js
+++ b/services/gitlab/gitlab-pipeline-status.tester.js
@@ -35,3 +35,10 @@ t.create('Pipeline status (custom gitlab URL)')
     label: 'build',
     message: isBuildStatus,
   })
+
+t.create('Pipeline status (default branch is not called master)')
+  .get('/chris48s/no-master-branch.json')
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })

--- a/services/gitlab/gitlab-pipeline-status.tester.js
+++ b/services/gitlab/gitlab-pipeline-status.tester.js
@@ -26,7 +26,7 @@ t.create('Pipeline status (nonexistent repo)')
   .get('/this-repo/does-not-exist.json')
   .expectBadge({
     label: 'build',
-    message: 'repo not found',
+    message: 'repo not found or private',
   })
 
 t.create('Pipeline status (custom gitlab URL)')

--- a/services/travis/travis-php-version.service.js
+++ b/services/travis/travis-php-version.service.js
@@ -1,15 +1,17 @@
 'use strict'
 
 const Joi = require('@hapi/joi')
+const request = require('request')
 const {
   minorVersion,
   versionReduction,
   getPhpReleases,
 } = require('../php-version')
+const checkErrorResponse = require('../../core/base-service/check-error-response')
 const { BaseJsonService } = require('..')
 
 const optionalNumberOrString = Joi.alternatives(Joi.string(), Joi.number())
-const schema = Joi.object({
+const travisSchema = Joi.object({
   branch: Joi.object({
     config: Joi.object({
       php: Joi.array().items(optionalNumberOrString),
@@ -22,6 +24,7 @@ const schema = Joi.object({
     }).required(),
   }).required(),
 }).required()
+const githubRepoSchema = Joi.object({ default_branch: Joi.string().required() })
 
 module.exports = class TravisPhpVersion extends BaseJsonService {
   static get category() {
@@ -63,7 +66,7 @@ module.exports = class TravisPhpVersion extends BaseJsonService {
     this._githubApiProvider = context.githubApiProvider
   }
 
-  async transform({ branch: { config } }) {
+  async transform({ branch: { config } }, phpReleases) {
     let travisVersions = []
 
     // from php
@@ -88,23 +91,54 @@ module.exports = class TravisPhpVersion extends BaseJsonService {
       .filter(v => v.includes('.'))
 
     return {
-      reduction: versionReduction(
-        versions,
-        await getPhpReleases(this._githubApiProvider)
-      ),
+      reduction: versionReduction(versions, phpReleases),
       hasHhvm: travisVersions.find(v => v.startsWith('hhvm')),
     }
   }
 
-  async handle({ user, repo, branch = 'master' }) {
+  async getDefaultBranch({ user, repo }) {
+    const { res, buffer } = await this._githubApiProvider.requestAsPromise(
+      request,
+      `/repos/${user}/${repo}`
+    )
+    await checkErrorResponse({ 404: 'repo not found' })({ buffer, res })
+    const json = this._parseJson(buffer)
+    const { default_branch } = this.constructor._validate(
+      json,
+      githubRepoSchema
+    )
+    return default_branch
+  }
+
+  async handle({ user, repo, branch }) {
+    let branchName
+    let phpReleases
+
+    if (branch == null) {
+      await Promise.all([
+        this.getDefaultBranch({ user, repo }),
+        getPhpReleases(this._githubApiProvider),
+      ]).then(res => {
+        branchName = res[0]
+        phpReleases = res[1]
+      })
+    } else {
+      branchName = branch
+      phpReleases = await getPhpReleases(this._githubApiProvider)
+    }
+
     const travisConfig = await this._requestJson({
-      schema,
-      url: `https://api.travis-ci.org/repos/${user}/${repo}/branches/${branch}`,
+      schema: travisSchema,
+      url: `https://api.travis-ci.org/repos/${user}/${repo}/branches/${branchName}`,
       errorMessages: {
         404: 'repo not found',
       },
     })
-    const { reduction, hasHhvm } = await this.transform(travisConfig)
+
+    const { reduction, hasHhvm } = await this.transform(
+      travisConfig,
+      phpReleases
+    )
     return this.constructor.render({ reduction, hasHhvm })
   }
 }

--- a/services/travis/travis-php-version.tester.js
+++ b/services/travis/travis-php-version.tester.js
@@ -19,6 +19,10 @@ t.create('gets the package version of pagination-bundle')
   .get('/gpslab/pagination-bundle.json')
   .expectBadge({ label: 'php', message: isPhpVersionReduction })
 
+t.create('gets the package version (default branch is not called master)')
+  .get('/slimphp/slim.json')
+  .expectBadge({ label: 'php', message: isPhpVersionReduction })
+
 t.create('invalid package name')
   .get('/frodo/is-not-a-package.json')
   .expectBadge({ label: 'php', message: 'repo not found' })


### PR DESCRIPTION
refs #5215

In some cases, we can use the handy `HEAD` trick to query whatever the default branch is with one HTTP call. Sometimes we can't, so we have to use another method to find out the default branch using another network request. One option is we can make an API call to github/bitbucket/gitlab. The other is we can shell out to `git` and call `git ls-remote --symref https://github.com/badges/shields.git HEAD`. Inevitably there are some tradeoffs to consider. Not all of them necessarily come into play in this PR, but I'm going to list them all anyway as this is something we will have to think about more in future.

In general, it is best to make an API call if we can because:

* An HTTP API gives us nice error codes (e.g: 404 = repo not found, 403 = private repo, etc)
* An HTTP API call can be easily mocked under test with nock. The request made by `git` is harder to mock
* If we need to support private repos/self-hosting, the available credentials might influence what we can use. For example, `git` only allows HTTPS basic auth or SSH key, but if we only hold an API token for self-hosting users, we can't authenticate with either of those methods for private repos.
* A JSON response can be more reliably parsed than the text output of `git`
* This probably varies a bit, but in general it seems to be faster to use a JSON API than `git`

There is one advantage of using git directly though:

* If we use `git`, we don't need to worry about an API rate limit. This makes it more suitable if we don't have API credentials, or if we would be likely to exceed a rate limit.

So.. the upshot of that is I've chosen:

* Bitbucket pipelines: Call the BitBucket API
* Gitlab Pipelines: Shell out to git
* Travis PHP Version: Call the Github API

In slightly more detail:

### BitBucket pipelines

BitBucket's API allows us to pass a `ref_type`

> The following reference types are supported:
> * branch
> * named_branch
> * bookmark
> * tag

As far as I can tell, none of them allow us to pass `HEAD` as a ref, so this now makes two API calls - fairly straightforward implementation. Making two API calls does impact performance but both the calls are pretty quick.

### Gitlab pipelines

With GitLab we don't have an API token (or a pool of them), which is why pipelines is the only gitlab badge we support. This somewhat ties our hands. I've implemented a general helper which uses simple-git to call `ls-remote` (although gitlab pipelines is the only service which uses it). It requires git to be installed (I think the heroku buildpack does have this. We'll find out when we get this on staging). Again, there is some performance impact as we're now making two network calls but its far from our worst performing badge. If/when we implement a proper suite of gitlab badges using their API it would probably be good to review this approach.

### Travis PHP Version

Travis PHP version calls the travis-ci **.org** API, which I think means the source repo is hosted on GitHub, so I've used a call to the GitHub API here (AFAIK only travis.com supports bitbucket so this is something we would need to bear in mind if we generalised). In the abstract, adding a call to the Github API isn't the end of the world - as APIs go its pretty fast. Unfortunately, the Travis PHP Version badge already makes two API calls and this brings us up to three, which is a bit rubbish.
To offset this, I've done a bit of acrobatics to fire off two of the requests at the same time to keep the performance within reasonable bounds. I think we could probably look at caching the PHP versions in Redis instead of fetching it on every request, but this solution keeps the performance in check for now.