### PR TITLE
fix [ansible] quality service test

### DIFF
--- a/services/ansible/ansible-quality.tester.js
+++ b/services/ansible/ansible-quality.tester.js
@@ -7,6 +7,10 @@ t.create('quality score (valid)')
   .get('/432.json')
   .expectBadge({ label: 'quality', message: nonNegativeInteger })
 
-t.create('quality score (not found)')
+t.create('quality score (project not found)')
   .get('/0101.json')
+  .expectBadge({ label: 'quality', message: 'not found' })
+
+t.create('quality score (no score available)')
+  .get('/2504.json')
   .expectBadge({ label: 'quality', message: 'no score available' })


### PR DESCRIPTION
Fixes #5283 

Apparently there's been some upstream changes in the API which is now returning a proper 404 response code in the unknown project id scenario whereas before it was a 200 response with a body that was identical to a valid/known project that had no score. 

This updates the existing test to handle the invalid project scenario and also adds an extra test to cover the `no score available` scenario (https://galaxy.ansible.com/s2504s/datadog). This was a project that was referenced as an example ~18 months ago when the badge was first added, so it seems to be a sufficiently stable test target.