### PR TITLE
Update simple-icons to 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5823,16 +5823,6 @@
       "integrity": "sha512-6cDuZeKSCSJ1KvfEQ25Y8OXUjqDJZ+HgUs6dhASWbAX8fxVraTfPsSeRe2bN+4QJDsgUaXaMWBYfRomCr04GGg==",
       "dev": true
     },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -6546,8 +6536,7 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/keyv": {
       "version": "3.1.1",
@@ -9631,12 +9620,6 @@
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
       }
-    },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
     },
     "caller": {
       "version": "1.0.1",
@@ -19080,12 +19063,6 @@
           }
         }
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
     },
     "global": {
       "version": "4.4.0",
@@ -30921,9 +30898,9 @@
       "dev": true
     },
     "simple-icons": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-2.18.0.tgz",
-      "integrity": "sha512-RrABnjp1ruVwD/eEPSsXjoL5sge5+arjC0eC4tLOa2xFfR17pcrHxggrk4YV9ihjo3Ab1C8wH0ocPottUdjuEQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-3.0.1.tgz",
+      "integrity": "sha512-BabLJLIvC0abhQMsBQ4I6cKwRTgc3ck5FS7Ri1U8noIfUnVQwk5mc0a7mg9ro+6Mkt6meWN/azNrsmn2jMVDtA=="
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "query-string": "^6.13.1",
     "request": "~2.88.2",
     "semver": "~7.3.2",
-    "simple-icons": "2.18.0",
+    "simple-icons": "3.0.1",
     "xmldom": "~0.2.1",
     "xpath": "~0.0.27"
   },


### PR DESCRIPTION
This PR updates simple-icons to 3.0.1. 33 icons changed since 2.18.0.
All changes: https://github.com/simple-icons/simple-icons/compare/2.18.0...3.0.1