### PR TITLE
Adopt static fields in [amo] and core

### DIFF
--- a/core/base-service/base-graphql.spec.js
+++ b/core/base-service/base-graphql.spec.js
@@ -12,15 +12,8 @@ const dummySchema = Joi.object({
 }).required()
 
 class DummyGraphqlService extends BaseGraphqlService {
-  static get category() {
-    return 'cat'
-  }
-
-  static get route() {
-    return {
-      base: 'foo',
-    }
-  }
+  static category = 'cat'
+  static route = { base: 'foo' }
 
   async handle() {
     const { requiredString } = await this._requestGraphql({

--- a/core/base-service/base-json.spec.js
+++ b/core/base-service/base-json.spec.js
@@ -10,15 +10,8 @@ const dummySchema = Joi.object({
 }).required()
 
 class DummyJsonService extends BaseJsonService {
-  static get category() {
-    return 'cat'
-  }
-
-  static get route() {
-    return {
-      base: 'foo',
-    }
-  }
+  static category = 'cat'
+  static route = { base: 'foo' }
 
   async handle() {
     const { requiredString } = await this._requestJson({

--- a/core/base-service/base-svg-scraping.spec.js
+++ b/core/base-service/base-svg-scraping.spec.js
@@ -15,15 +15,8 @@ const schema = Joi.object({
 }).required()
 
 class DummySvgScrapingService extends BaseSvgScrapingService {
-  static get category() {
-    return 'cat'
-  }
-
-  static get route() {
-    return {
-      base: 'foo',
-    }
-  }
+  static category = 'cat'
+  static route = { base: 'foo' }
 
   async handle() {
     return this._requestSvg({
@@ -123,9 +116,7 @@ describe('BaseSvgScrapingService', function () {
 
     it('allows overriding the valueMatcher', async function () {
       class WithValueMatcher extends BaseSvgScrapingService {
-        static get route() {
-          return {}
-        }
+        static route = {}
 
         async handle() {
           return this._requestSvg({

--- a/core/base-service/base-xml.spec.js
+++ b/core/base-service/base-xml.spec.js
@@ -10,15 +10,8 @@ const dummySchema = Joi.object({
 }).required()
 
 class DummyXmlService extends BaseXmlService {
-  static get category() {
-    return 'cat'
-  }
-
-  static get route() {
-    return {
-      base: 'foo',
-    }
-  }
+  static category = 'cat'
+  static route = { base: 'foo' }
 
   async handle() {
     const { requiredString } = await this._requestXml({
@@ -57,9 +50,7 @@ describe('BaseXmlService', function () {
 
     it('forwards options to _sendAndCacheRequest', async function () {
       class WithCustomOptions extends BaseXmlService {
-        static get route() {
-          return {}
-        }
+        static route = {}
 
         async handle() {
           const { requiredString } = await this._requestXml({

--- a/core/base-service/base-yaml.spec.js
+++ b/core/base-service/base-yaml.spec.js
@@ -10,15 +10,8 @@ const dummySchema = Joi.object({
 }).required()
 
 class DummyYamlService extends BaseYamlService {
-  static get category() {
-    return 'cat'
-  }
-
-  static get route() {
-    return {
-      base: 'foo',
-    }
-  }
+  static category = 'cat'
+  static route = { base: 'foo' }
 
   async handle() {
     const { requiredString } = await this._requestYaml({

--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -90,9 +90,7 @@ class BaseService {
     throw new Error(`Category not set for ${this.name}`)
   }
 
-  static get isDeprecated() {
-    return false
-  }
+  static isDeprecated = false
 
   /**
    * Route to mount this service on
@@ -119,9 +117,7 @@ class BaseService {
    * @abstract
    * @type {module:core/base-service/base~Auth}
    */
-  static get auth() {
-    return undefined
-  }
+  static auth = undefined
 
   /**
    * Array of Example objects describing example URLs for this service.
@@ -139,9 +135,7 @@ class BaseService {
    * @abstract
    * @type {module:core/base-service/base~Example[]}
    */
-  static get examples() {
-    return []
-  }
+  static examples = []
 
   static get _cacheLength() {
     const cacheLengths = {
@@ -160,9 +154,7 @@ class BaseService {
    *
    * @type {module:core/base-service/base~DefaultBadgeData}
    */
-  static get defaultBadgeData() {
-    return {}
-  }
+  static defaultBadgeData = {}
 
   static render(props) {
     throw new Error(`render() function not implemented for ${this.name}`)
@@ -228,9 +220,7 @@ class BaseService {
     return checkErrorResponse(errorMessages)({ buffer, res })
   }
 
-  static get enabledMetrics() {
-    return []
-  }
+  static enabledMetrics = []
 
   static isMetricEnabled(metricName) {
     return this.enabledMetrics.includes(metricName)

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -29,32 +29,19 @@ const queryParamSchema = Joi.object({
   .required()
 
 class DummyService extends BaseService {
-  static get category() {
-    return 'other'
-  }
+  static category = 'other'
+  static route = { base: 'foo', pattern: ':namedParamA', queryParamSchema }
 
-  static get route() {
-    return {
-      base: 'foo',
-      pattern: ':namedParamA',
-      queryParamSchema,
-    }
-  }
+  static examples = [
+    {
+      pattern: ':world',
+      namedParams: { world: 'World' },
+      staticPreview: this.render({ namedParamA: 'foo', queryParamA: 'bar' }),
+      keywords: ['hello'],
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        pattern: ':world',
-        namedParams: { world: 'World' },
-        staticPreview: this.render({ namedParamA: 'foo', queryParamA: 'bar' }),
-        keywords: ['hello'],
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'cat', namedLogo: 'appveyor' }
-  }
+  static defaultBadgeData = { label: 'cat', namedLogo: 'appveyor' }
 
   static render({ namedParamA, queryParamA }) {
     return {
@@ -68,9 +55,7 @@ class DummyService extends BaseService {
 }
 
 class DummyServiceWithServiceResponseSizeMetricEnabled extends DummyService {
-  static get enabledMetrics() {
-    return [MetricNames.SERVICE_RESPONSE_SIZE]
-  }
+  static enabledMetrics = [MetricNames.SERVICE_RESPONSE_SIZE]
 }
 
 describe('BaseService', function () {
@@ -124,9 +109,7 @@ describe('BaseService', function () {
     })
 
     class WithRoute extends BaseService {
-      static get route() {
-        return {}
-      }
+      static route = {}
     }
     it('Should throw if handle() is not overridden', function () {
       return expect(WithRoute.invoke({}, {}, {})).to.be.rejectedWith(
@@ -567,12 +550,10 @@ describe('BaseService', function () {
   })
   describe('auth', function () {
     class AuthService extends DummyService {
-      static get auth() {
-        return {
-          passKey: 'myci_pass',
-          serviceKey: 'myci',
-          isRequired: true,
-        }
+      static auth = {
+        passKey: 'myci_pass',
+        serviceKey: 'myci',
+        isRequired: true,
       }
 
       async handle() {

--- a/core/base-service/deprecated-service.js
+++ b/core/base-service/deprecated-service.js
@@ -26,33 +26,17 @@ function deprecatedService(attrs) {
   )
 
   return class DeprecatedService extends BaseService {
-    static get name() {
-      return name
-        ? `Deprecated${name}`
-        : `Deprecated${camelcase(route.base.replace(/\//g, '_'), {
-            pascalCase: true,
-          })}`
-    }
+    static name = name
+      ? `Deprecated${name}`
+      : `Deprecated${camelcase(route.base.replace(/\//g, '_'), {
+          pascalCase: true,
+        })}`
 
-    static get category() {
-      return category
-    }
-
-    static get isDeprecated() {
-      return true
-    }
-
-    static get route() {
-      return route
-    }
-
-    static get examples() {
-      return examples
-    }
-
-    static get defaultBadgeData() {
-      return { label }
-    }
+    static category = category
+    static isDeprecated = true
+    static route = route
+    static examples = examples
+    static defaultBadgeData = { label }
 
     async handle() {
       throw new Deprecated({ prettyMessage: message })

--- a/core/base-service/loader-test-fixtures/valid-array.fixture.js
+++ b/core/base-service/loader-test-fixtures/valid-array.fixture.js
@@ -3,28 +3,12 @@
 const BaseJsonService = require('../base-json')
 
 class GoodServiceOne extends BaseJsonService {
-  static get category() {
-    return 'build'
-  }
-
-  static get route() {
-    return {
-      base: 'good',
-      pattern: 'one',
-    }
-  }
+  static category = 'build'
+  static route = { base: 'good', pattern: 'one' }
 }
 class GoodServiceTwo extends BaseJsonService {
-  static get category() {
-    return 'build'
-  }
-
-  static get route() {
-    return {
-      base: 'good',
-      pattern: 'two',
-    }
-  }
+  static category = 'build'
+  static route = { base: 'good', pattern: 'two' }
 }
 
 module.exports = [GoodServiceOne, GoodServiceTwo]

--- a/core/base-service/loader-test-fixtures/valid-class.fixture.js
+++ b/core/base-service/loader-test-fixtures/valid-class.fixture.js
@@ -3,16 +3,8 @@
 const BaseJsonService = require('../base-json')
 
 class GoodService extends BaseJsonService {
-  static get category() {
-    return 'build'
-  }
-
-  static get route() {
-    return {
-      base: 'it/is',
-      pattern: 'good',
-    }
-  }
+  static category = 'build'
+  static route = { base: 'it/is', pattern: 'good' }
 }
 
 module.exports = GoodService

--- a/core/base-service/loader-test-fixtures/valid-object.fixture.js
+++ b/core/base-service/loader-test-fixtures/valid-object.fixture.js
@@ -3,28 +3,12 @@
 const BaseJsonService = require('../base-json')
 
 class GoodServiceOne extends BaseJsonService {
-  static get category() {
-    return 'build'
-  }
-
-  static get route() {
-    return {
-      base: 'good',
-      pattern: 'one',
-    }
-  }
+  static category = 'build'
+  static route = { base: 'good', pattern: 'one' }
 }
 class GoodServiceTwo extends BaseJsonService {
-  static get category() {
-    return 'build'
-  }
-
-  static get route() {
-    return {
-      base: 'good',
-      pattern: 'two',
-    }
-  }
+  static category = 'build'
+  static route = { base: 'good', pattern: 'two' }
 }
 
 module.exports = { GoodServiceOne, GoodServiceTwo }

--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -41,27 +41,15 @@ module.exports = function redirector(attrs) {
   } = Joi.attempt(attrs, attrSchema, `Redirector for ${attrs.route.base}`)
 
   return class Redirector extends BaseService {
-    static get name() {
-      if (name) {
-        return name
-      } else {
-        return `${camelcase(route.base.replace(/\//g, '_'), {
-          pascalCase: true,
-        })}Redirect`
-      }
-    }
+    static name =
+      name ??
+      `${camelcase(route.base.replace(/\//g, '_'), {
+        pascalCase: true,
+      })}Redirect`
 
-    static get category() {
-      return category
-    }
-
-    static get isDeprecated() {
-      return true
-    }
-
-    static get route() {
-      return route
-    }
+    static category = category
+    static isDeprecated = true
+    static route = route
 
     static register({ camp, metricInstance }, { rasterUrl }) {
       const { regex, captureNames } = prepareRoute({

--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -42,7 +42,7 @@ module.exports = function redirector(attrs) {
 
   return class Redirector extends BaseService {
     static name =
-      name ??
+      name ||
       `${camelcase(route.base.replace(/\//g, '_'), {
         pascalCase: true,
       })}Redirect`

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -116,17 +116,10 @@ const { BaseService } = require('..')
 // (3)
 module.exports = class Example extends BaseService {
   // (4)
-  static get category() {
-    return 'build'
-  }
+  static category = 'build'
 
   // (5)
-  static get route() {
-    return {
-      base: 'example',
-      pattern: ':text',
-    }
-  }
+  static route = { base: 'example', pattern: ':text' }
 
   // (6)
   async handle({ text }) {
@@ -194,22 +187,13 @@ const schema = Joi.object({
 // (5)
 module.exports = class GemVersion extends BaseJsonService {
   // (6)
-  static get category() {
-    return 'version'
-  }
+  static category = 'version'
 
   // (7)
-  static get route() {
-    return {
-      base: 'gem/v',
-      pattern: ':gem',
-    }
-  }
+  static route = { base: 'gem/v', pattern: ':gem' }
 
   // (8)
-  static get defaultBadgeData() {
-    return { label: 'gem' }
-  }
+  static defaultBadgeData = { label: 'gem' }
 
   // (11)
   static render({ version }) {
@@ -298,23 +282,19 @@ Once we have implemented our badge, we can add it to the index so that users can
 module.exports = class GemVersion extends BaseJsonService {
   // ...
 
-  static get category() {
-    // (1)
-    return 'version'
-  }
+  // (1)
+  static category = 'version'
 
-  static get examples() {
-    // (2)
-    return [
-      {
-        // (3)
-        title: 'Gem',
-        namedParams: { gem: 'formatador' },
-        staticPreview: this.render({ version: '2.1.0' }),
-        keywords: ['ruby'],
-      },
-    ]
-  }
+  // (2)
+  static examples = [
+    {
+      // (3)
+      title: 'Gem',
+      namedParams: { gem: 'formatador' },
+      staticPreview: this.render({ version: '2.1.0' }),
+      keywords: ['ruby'],
+    },
+  ]
 }
 ```
 

--- a/doc/rewriting-services.md
+++ b/doc/rewriting-services.md
@@ -17,9 +17,7 @@ Legacy services look like:
 
 ```js
 module.exports = class ExampleService extends LegacyService {
-  static get category() {
-    return 'build'
-  }
+  static category = 'build'
 
   static registerLegacyRouteHandler({ camp, cache }) {
     camp.route(
@@ -101,12 +99,7 @@ tests are passing, though.
 const BaseJsonService = require('../base-json')
 
 class ExampleDownloads extends BaseJsonService {
-  static get route() {
-    return {
-      base: 'example/d',
-      pattern: ':param1/:param2',
-    }
-  }
+  static route = { base: 'example/d', pattern: ':param1/:param2' }
 
   static defaultBadgeData() {
     return { label: 'downloads' } // or whatever

--- a/services/amo/amo-base.js
+++ b/services/amo/amo-base.js
@@ -18,9 +18,7 @@ const schema = Joi.object({
 }).required()
 
 class BaseAmoService extends BaseJsonService {
-  static get defaultBadgeData() {
-    return { label: 'mozilla add-on' }
-  }
+  static defaultBadgeData = { label: 'mozilla add-on' }
 
   async fetch({ addonId }) {
     return this._requestJson({

--- a/services/amo/amo-downloads.service.js
+++ b/services/amo/amo-downloads.service.js
@@ -14,32 +14,20 @@ const documentation = `
 `
 
 class AmoWeeklyDownloads extends BaseAmoService {
-  static get category() {
-    return 'downloads'
-  }
+  static category = 'downloads'
+  static route = { base: 'amo/dw', pattern: ':addonId' }
 
-  static get route() {
-    return {
-      base: 'amo/dw',
-      pattern: ':addonId',
-    }
-  }
+  static examples = [
+    {
+      title: 'Mozilla Add-on',
+      namedParams: { addonId: 'dustman' },
+      staticPreview: this.render({ downloads: 120 }),
+      keywords,
+      documentation,
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        title: 'Mozilla Add-on',
-        namedParams: { addonId: 'dustman' },
-        staticPreview: this.render({ downloads: 120 }),
-        keywords,
-        documentation,
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'downloads' }
-  }
+  static defaultBadgeData = { label: 'downloads' }
 
   static render({ downloads }) {
     return {

--- a/services/amo/amo-rating.service.js
+++ b/services/amo/amo-rating.service.js
@@ -5,35 +5,25 @@ const { floorCount: floorCountColor } = require('../color-formatters')
 const { BaseAmoService, keywords } = require('./amo-base')
 
 module.exports = class AmoRating extends BaseAmoService {
-  static get category() {
-    return 'rating'
-  }
+  static category = 'rating'
+  static route = { base: 'amo', pattern: ':format(stars|rating)/:addonId' }
 
-  static get route() {
-    return {
-      base: 'amo',
-      pattern: ':format(stars|rating)/:addonId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Mozilla Add-on',
-        pattern: 'rating/:addonId',
-        namedParams: { addonId: 'dustman' },
-        staticPreview: this.render({ format: 'rating', rating: 4 }),
-        keywords,
-      },
-      {
-        title: 'Mozilla Add-on',
-        pattern: 'stars/:addonId',
-        namedParams: { addonId: 'dustman' },
-        staticPreview: this.render({ format: 'stars', rating: 4 }),
-        keywords,
-      },
-    ]
-  }
+  static examples = [
+    {
+      title: 'Mozilla Add-on',
+      pattern: 'rating/:addonId',
+      namedParams: { addonId: 'dustman' },
+      staticPreview: this.render({ format: 'rating', rating: 4 }),
+      keywords,
+    },
+    {
+      title: 'Mozilla Add-on',
+      pattern: 'stars/:addonId',
+      namedParams: { addonId: 'dustman' },
+      staticPreview: this.render({ format: 'stars', rating: 4 }),
+      keywords,
+    },
+  ]
 
   static render({ format, rating }) {
     rating = Math.round(rating)

--- a/services/amo/amo-users.service.js
+++ b/services/amo/amo-users.service.js
@@ -4,33 +4,19 @@ const { metric } = require('../text-formatters')
 const { BaseAmoService, keywords } = require('./amo-base')
 
 module.exports = class AmoUsers extends BaseAmoService {
-  static get category() {
-    return 'downloads'
-  }
+  static category = 'downloads'
+  static route = { base: 'amo/users', pattern: ':addonId' }
 
-  static get route() {
-    return {
-      base: 'amo/users',
-      pattern: ':addonId',
-    }
-  }
+  static examples = [
+    {
+      title: 'Mozilla Add-on',
+      namedParams: { addonId: 'dustman' },
+      staticPreview: this.render({ users: 750 }),
+      keywords,
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        title: 'Mozilla Add-on',
-        namedParams: { addonId: 'dustman' },
-        staticPreview: this.render({ users: 750 }),
-        keywords,
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return {
-      label: 'users',
-    }
-  }
+  static defaultBadgeData = { label: 'users' }
 
   static render({ users }) {
     return {

--- a/services/amo/amo-version.service.js
+++ b/services/amo/amo-version.service.js
@@ -4,27 +4,17 @@ const { renderVersionBadge } = require('../version')
 const { BaseAmoService, keywords } = require('./amo-base')
 
 module.exports = class AmoVersion extends BaseAmoService {
-  static get category() {
-    return 'version'
-  }
+  static category = 'version'
+  static route = { base: 'amo/v', pattern: ':addonId' }
 
-  static get route() {
-    return {
-      base: 'amo/v',
-      pattern: ':addonId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Mozilla Add-on',
-        namedParams: { addonId: 'dustman' },
-        staticPreview: renderVersionBadge({ version: '2.1.0' }),
-        keywords,
-      },
-    ]
-  }
+  static examples = [
+    {
+      title: 'Mozilla Add-on',
+      namedParams: { addonId: 'dustman' },
+      staticPreview: renderVersionBadge({ version: '2.1.0' }),
+      keywords,
+    },
+  ]
 
   async handle({ addonId }) {
     const data = await this.fetch({ addonId })


### PR DESCRIPTION
Since we've upgraded production to Node 12 (#5436) we can finally adopt static fields!

This starts the process by updating core and one of the service families.

I've left the static fields alone in the badge library since for now we're targeting Node 10+.