### PR TITLE
[GithubWorkflowStatus] add event query string parameter

### DIFF
--- a/services/github/github-workflow-status.tester.js
+++ b/services/github/github-workflow-status.tester.js
@@ -23,14 +23,21 @@ t.create('nonexistent workflow')
   })
 
 t.create('valid workflow')
-  .get('/actions/toolkit/Main%20workflow.json')
+  .get('/actions/toolkit/toolkit-unit-tests.json')
   .expectBadge({
     label: 'build',
     message: isWorkflowStatus,
   })
 
 t.create('valid workflow (branch)')
-  .get('/actions/toolkit/Main%20workflow/master.json')
+  .get('/actions/toolkit/toolkit-unit-tests/master.json')
+  .expectBadge({
+    label: 'build',
+    message: isWorkflowStatus,
+  })
+
+t.create('valid workflow (event)')
+  .get('/actions/toolkit/toolkit-unit-tests.json?event=push')
   .expectBadge({
     label: 'build',
     message: isWorkflowStatus,


### PR DESCRIPTION
This adds support for the `event` query string parameter to the GithubWorkflowStatus service.
Closes #5439 

According to the [Badge URL guidelines](https://github.com/badges/shields/blob/master/doc/badge-urls.md), parameters like `branch`, etc. should be part of the URL's path. Does this also include parameters like `event` here? The reason why I've added this as a query string is that an event can be specified without a branch. Having two optional route path parameters next to each other, namely branch and event, is a bit weird. I've checked other services for similar patterns and couldn't find anything.

Also, to make `npm run test:services -- --only=GithubWorkflowStatus` succeed, I had to fix the workflow name in the tests, as the "Main workflow" doesn't exist on the [`/actions/toolkit`](https://github.com/actions/toolkit/actions) repo (anymore?) that is being used for testing. I've changed the workflow name to "toolkit-unit-tests", one of the existing workflows, and this resolved it. See the following badge requests:

- https://github.com/actions/toolkit/workflows/Main%20workflow/badge.svg
- https://github.com/actions/toolkit/workflows/Main%20workflow/badge.svg?branch=master
- https://github.com/actions/toolkit/workflows/Main%20workflow/badge.svg?event=push
- https://github.com/actions/toolkit/workflows/Main%20workflow/badge.svg?branch=master&event=push
- https://github.com/actions/toolkit/workflows/toolkit-unit-tests/badge.svg
- https://github.com/actions/toolkit/workflows/toolkit-unit-tests/badge.svg?branch=master
- https://github.com/actions/toolkit/workflows/toolkit-unit-tests/badge.svg?event=push
- https://github.com/actions/toolkit/workflows/toolkit-unit-tests/badge.svg?branch=master&event=push

If this should be split up into two commits/PRs because of this change, please tell me. Should the examples also be changed to an existing workflow name?