### PR TITLE
Remove badgerbadgerbadger from related projects and add poser

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,10 +206,10 @@ Alumni:
 
 ## Related projects
 
-- [badgerbadgerbadger gem][gem]
+- [poser PHP library][poser]
 - [pybadges python library][pybadges]
 
-[gem]: https://github.com/badges/badgerbadgerbadger
+[poser]: https://github.com/badges/poser
 [pybadges]: https://github.com/google/pybadges
 
 ## License


### PR DESCRIPTION
Whilst [badgerbadgerbadger](https://github.com/badges/badgerbadgerbadger) technically still works, it hasn't been updated for many years and generates badges that we have since deprecated (see https://github.com/badges/badgerbadgerbadger/issues/88 for example).

I suggest we stop advertising it in the README and replace it with [poser](https://github.com/badges/poser). Any ideas of other related projects are welcome!