### PR TITLE
[WordPress] API Update & new badges

### DIFF
--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -16,6 +16,22 @@ const themeSchema = Joi.object()
     requires: stringOrFalse,
     last_updated: Joi.string(),
     requires_php: stringOrFalse,
+    author: Joi.object()
+      .keys({
+        user_nicename: Joi.string(),
+        profile: Joi.string(),
+        avatar: Joi.string(),
+        display_name: Joi.string(),
+      })
+      .required(),
+  })
+  .required()
+
+const pluginContributor = Joi.object()
+  .keys({
+    profile: Joi.string(),
+    avatar: Joi.string(),
+    display_name: Joi.string(),
   })
   .required()
 
@@ -32,6 +48,9 @@ const pluginSchema = Joi.object()
     support_threads_resolved: nonNegativeInteger,
     requires_php: stringOrFalse,
     last_updated: Joi.string(),
+    author: Joi.string(),
+    author_profile: Joi.string(),
+    contributors: Joi.object().pattern(/^/, pluginContributor),
   })
   .required()
 

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -13,6 +13,8 @@ const foundSchema = Joi.object()
     active_installs: nonNegativeInteger,
     requires: Joi.string(), // Plugin Only
     tested: Joi.string(), // Plugin Only
+    support_threads: nonNegativeInteger, // Plugin Only
+    support_threads_resolved: nonNegativeInteger, // Plugin Only
   })
   .required()
 
@@ -42,6 +44,8 @@ module.exports = class BaseWordpress extends BaseJsonService {
               tags: 0,
               screenshot_url: 0,
               downloaded: 1,
+              support_threads: 1,
+              support_threads_resolved: 1,
             },
           },
         },

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -13,7 +13,7 @@ const themeSchema = Joi.object()
     num_ratings: nonNegativeInteger,
     downloaded: nonNegativeInteger,
     active_installs: nonNegativeInteger,
-    requires: Joi.string(),
+    requires: stringOrFalse,
     last_updated: Joi.string(),
     requires_php: stringOrFalse,
   })
@@ -26,7 +26,7 @@ const pluginSchema = Joi.object()
     num_ratings: nonNegativeInteger,
     downloaded: nonNegativeInteger,
     active_installs: nonNegativeInteger,
-    requires: Joi.string(),
+    requires: stringOrFalse,
     tested: Joi.string(),
     support_threads: nonNegativeInteger,
     support_threads_resolved: nonNegativeInteger,
@@ -52,8 +52,6 @@ module.exports = class BaseWordpress extends BaseJsonService {
       schemas = pluginSchemas
     } else if (extensionType === 'theme') {
       schemas = themeSchemas
-    } else {
-      throw new NotFound()
     }
     const json = await this._requestJson({
       url,

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -16,13 +16,17 @@ const foundSchema = Joi.object()
   })
   .required()
 
-const notFoundSchema = Joi.string().allow(null, false)
+const notFoundSchema = Joi.object()
+  .keys({
+    error: Joi.string(),
+  })
+  .required()
 
 const schemas = Joi.alternatives(foundSchema, notFoundSchema)
 
 module.exports = class BaseWordpress extends BaseJsonService {
   async fetch({ extensionType, slug }) {
-    const url = `https://api.wordpress.org/${extensionType}s/info/1.1/`
+    const url = `https://api.wordpress.org/${extensionType}s/info/1.2/`
     const json = await this._requestJson({
       url,
       schema: schemas,
@@ -37,6 +41,7 @@ module.exports = class BaseWordpress extends BaseJsonService {
               homepage: 0,
               tags: 0,
               screenshot_url: 0,
+              downloaded: 1,
             },
           },
         },
@@ -45,7 +50,7 @@ module.exports = class BaseWordpress extends BaseJsonService {
         },
       },
     })
-    if (!json) {
+    if ('error' in json) {
       throw new NotFound()
     }
     return json

--- a/services/wordpress/wordpress-downloads.service.js
+++ b/services/wordpress/wordpress-downloads.service.js
@@ -48,34 +48,24 @@ function DownloadsForExtensionType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressDownloads extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}Downloads`
+    static name = `Wordpress${capt}Downloads`
+
+    static category = 'downloads'
+
+    static route = {
+      base: `wordpress/${extensionType}`,
+      pattern: ':interval(dd|dw|dm|dy|dt)/:slug',
     }
 
-    static get category() {
-      return 'downloads'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Downloads`,
+        namedParams: { interval: 'dm', slug: exampleSlug },
+        staticPreview: this.render({ interval: 'dm', downloads: 200000 }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}`,
-        pattern: ':interval(dd|dw|dm|dy|dt)/:slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Downloads`,
-          namedParams: { interval: 'dm', slug: exampleSlug },
-          staticPreview: this.render({ interval: 'dm', downloads: 200000 }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'downloads' }
-    }
+    static defaultBadgeData = { label: 'downloads' }
 
     static render({ interval, downloads }) {
       const { messageSuffix } = intervalMap[interval]
@@ -129,34 +119,24 @@ function InstallsForExtensionType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressInstalls extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}Installs`
+    static name = `Wordpress${capt}Installs`
+
+    static category = 'downloads'
+
+    static route = {
+      base: `wordpress/${extensionType}/installs`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'downloads'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Active Installs`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ installCount: 300000 }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/installs`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Active Installs`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ installCount: 300000 }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'active installs' }
-    }
+    static defaultBadgeData = { label: 'active installs' }
 
     static render({ installCount }) {
       return {

--- a/services/wordpress/wordpress-issues.service.js
+++ b/services/wordpress/wordpress-issues.service.js
@@ -3,54 +3,48 @@
 const BaseWordpress = require('./wordpress-base')
 
 class WordpressPluginIssues extends BaseWordpress {
-  static get category() {
-    return 'issue-tracking'
+  static category = 'issue-tracking'
+
+  static route = {
+    base: `wordpress/plugin/issues`,
+    pattern: ':variant(raw|percentage|outof)/:status(open|closed)/:slug',
   }
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/issues`,
-      pattern: ':variant(raw|percentage|outof)/:status(open|closed)/:slug',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin Issues',
-        pattern: 'raw/:status(open|closed)/:slug',
-        namedParams: { status: 'open', slug: 'akismet' },
-        staticPreview: this.render({
-          status: 'open',
-          variant: 'raw',
-          issues: '365',
-          closed_issues: '200',
-        }),
-      },
-      {
-        title: 'WordPress Plugin Issues (Percentage)',
-        pattern: 'percentage/:status(open|closed)/:slug',
-        namedParams: { status: 'open', slug: 'akismet' },
-        staticPreview: this.render({
-          status: 'open',
-          variant: 'percentage',
-          issues: '365',
-          closed_issues: '200',
-        }),
-      },
-      {
-        title: 'WordPress Plugin Issues (OutOf)',
-        pattern: 'outof/:status(open|closed)/:slug',
-        namedParams: { status: 'open', slug: 'akismet' },
-        staticPreview: this.render({
-          status: 'open',
-          variant: 'outof',
-          issues: 365,
-          closed_issues: 200,
-        }),
-      },
-    ]
-  }
+  static examples = [
+    {
+      title: 'WordPress Plugin Issues',
+      pattern: 'raw/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'raw',
+        issues: '365',
+        closed_issues: '200',
+      }),
+    },
+    {
+      title: 'WordPress Plugin Issues (Percentage)',
+      pattern: 'percentage/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'percentage',
+        issues: '365',
+        closed_issues: '200',
+      }),
+    },
+    {
+      title: 'WordPress Plugin Issues (OutOf)',
+      pattern: 'outof/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'outof',
+        issues: 365,
+        closed_issues: 200,
+      }),
+    },
+  ]
 
   static calcOpen(issues, closed_issues) {
     return issues - closed_issues
@@ -157,29 +151,23 @@ class WordpressPluginIssues extends BaseWordpress {
 }
 
 class WordpressPluginIssuesOpenClose extends BaseWordpress {
-  static get category() {
-    return 'issue-tracking'
+  static category = 'issue-tracking'
+
+  static route = {
+    base: `wordpress/plugin/issues/opcl`,
+    pattern: ':slug',
   }
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/issues/opcl`,
-      pattern: ':slug',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin issues (open/closed)',
-        namedParams: { slug: 'akismet' },
-        staticPreview: this.render({
-          issues: 300,
-          closed_issues: 259,
-        }),
-      },
-    ]
-  }
+  static examples = [
+    {
+      title: 'WordPress Plugin issues (open/closed)',
+      namedParams: { slug: 'akismet' },
+      staticPreview: this.render({
+        issues: 300,
+        closed_issues: 259,
+      }),
+    },
+  ]
 
   static calcOpen(issues, closed_issues) {
     return issues - closed_issues

--- a/services/wordpress/wordpress-issues.service.js
+++ b/services/wordpress/wordpress-issues.service.js
@@ -2,37 +2,61 @@
 
 const BaseWordpress = require('./wordpress-base')
 
-module.exports = class WordpressPluginIssues extends BaseWordpress {
+class WordpressPluginIssues extends BaseWordpress {
   static get category() {
     return 'issue-tracking'
   }
 
   static get route() {
     return {
-      base: `wordpress/plugin/issues/`,
-      pattern: ':status(open|closed)/:variant(raw|percentage|outof)/:slug',
+      base: `wordpress/plugin/issues`,
+      pattern: ':variant(raw|percentage|outof)/:status(open|closed)/:slug',
     }
   }
 
   static get examples() {
     return [
       {
-        title: 'WordPress Plugin issues',
-        namedParams: { status: 'open', variant: 'outof', slug: 'akismet' },
-        staticPreview: {
-          label: 'closed issues',
-          message: '80/100',
-          color: 'brightgreen',
-        },
+        title: 'WordPress Plugin Issues',
+        pattern: 'raw/:status(open|closed)/:slug',
+        namedParams: { status: 'open', slug: 'akismet' },
+        staticPreview: this.render({
+          status: 'open',
+          variant: 'raw',
+          issues: '365',
+          closed_issues: '200',
+        }),
+      },
+      {
+        title: 'WordPress Plugin Issues (Percentage)',
+        pattern: 'percentage/:status(open|closed)/:slug',
+        namedParams: { status: 'open', slug: 'akismet' },
+        staticPreview: this.render({
+          status: 'open',
+          variant: 'percentage',
+          issues: '365',
+          closed_issues: '200',
+        }),
+      },
+      {
+        title: 'WordPress Plugin Issues (OutOf)',
+        pattern: 'outof/:status(open|closed)/:slug',
+        namedParams: { status: 'open', slug: 'akismet' },
+        staticPreview: this.render({
+          status: 'open',
+          variant: 'outof',
+          issues: 365,
+          closed_issues: 200,
+        }),
       },
     ]
   }
 
-  calcOpen(issues, closed_issues) {
+  static calcOpen(issues, closed_issues) {
     return issues - closed_issues
   }
 
-  colorCalc(closed_percentage) {
+  static colorCalc(closed_percentage) {
     if (closed_percentage < 50) {
       return 'red'
     } else if (closed_percentage < 90) {
@@ -42,7 +66,7 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
     }
   }
 
-  rawCalc(issues, closed_issues, status) {
+  static rawCalc(issues, closed_issues, status) {
     if (status === 'open') {
       return this.calcOpen(issues, closed_issues)
     } else {
@@ -50,7 +74,7 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
     }
   }
 
-  percentageCalc(issues, closed_issues, status) {
+  static percentageCalc(issues, closed_issues, status) {
     const percentClosed = Math.round((closed_issues / issues) * 100)
     if (status === 'open') {
       return 100 - percentClosed
@@ -59,7 +83,7 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
     }
   }
 
-  outOfCalc(issues, closed_issues, status) {
+  static outOfCalc(issues, closed_issues, status) {
     if (status === 'open') {
       const open_issues = this.calcOpen(issues, closed_issues)
       return `${open_issues}/${issues}`
@@ -68,7 +92,14 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
     }
   }
 
-  static render({ label, value, color }) {
+  static render({ status, variant, issues, closed_issues }) {
+    const { label, value, color } = this.transform({
+      status,
+      variant,
+      issues,
+      closed_issues,
+    })
+
     return {
       label,
       message: value,
@@ -76,13 +107,7 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
     }
   }
 
-  async handle({ status, variant, slug }) {
-    const json = await this.fetch({
-      extensionType: 'plugin',
-      slug,
-    })
-    const issues = json.support_threads
-    const closed_issues = json.support_threads_resolved
+  static transform({ status, variant, issues, closed_issues }) {
     const closed_percentage = this.percentageCalc(
       issues,
       closed_issues,
@@ -107,10 +132,120 @@ module.exports = class WordpressPluginIssues extends BaseWordpress {
 
     const color = this.colorCalc(closed_percentage)
 
-    return this.constructor.render({
+    return {
       label,
       value,
       color,
+    }
+  }
+
+  async handle({ variant, status, slug }) {
+    const json = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+    const issues = json.support_threads
+    const closed_issues = json.support_threads_resolved
+
+    return this.constructor.render({
+      status,
+      variant,
+      issues,
+      closed_issues,
     })
   }
+}
+
+class WordpressPluginIssuesOpenClose extends BaseWordpress {
+  static get category() {
+    return 'issue-tracking'
+  }
+
+  static get route() {
+    return {
+      base: `wordpress/plugin/issues/opcl`,
+      pattern: ':slug',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'WordPress Plugin issues (open/closed)',
+        namedParams: { slug: 'akismet' },
+        staticPreview: this.render({
+          issues: 300,
+          closed_issues: 259,
+        }),
+      },
+    ]
+  }
+
+  static calcOpen(issues, closed_issues) {
+    return issues - closed_issues
+  }
+
+  static colorCalc(closed_percentage) {
+    if (closed_percentage < 50) {
+      return 'red'
+    } else if (closed_percentage < 90) {
+      return 'yellow'
+    } else {
+      return 'brightgreen'
+    }
+  }
+
+  static percentageCalc(issues, closed_issues, status) {
+    const percentClosed = Math.round((closed_issues / issues) * 100)
+    if (status === 'open') {
+      return 100 - percentClosed
+    } else {
+      return percentClosed
+    }
+  }
+
+  static valueColor(issues, closed_issues) {
+    const closed_percentage = this.percentageCalc(
+      issues,
+      closed_issues,
+      'closed'
+    )
+
+    const color = this.colorCalc(closed_percentage)
+    const open_issues = this.calcOpen(issues, closed_issues)
+    const value = `${open_issues}/${closed_issues}`
+
+    return {
+      value,
+      color,
+    }
+  }
+
+  static render({ issues, closed_issues }) {
+    const { value, color } = this.valueColor(issues, closed_issues)
+    return {
+      label: 'open/closed',
+      message: value,
+      color,
+    }
+  }
+
+  async handle({ slug }) {
+    const { support_threads, support_threads_resolved } = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+    const issues = support_threads
+    const closed_issues = support_threads_resolved
+
+    return this.constructor.render({
+      issues,
+      closed_issues,
+    })
+  }
+}
+
+module.exports = {
+  WordpressPluginIssues,
+  WordpressPluginIssuesOpenClose,
 }

--- a/services/wordpress/wordpress-issues.service.js
+++ b/services/wordpress/wordpress-issues.service.js
@@ -1,0 +1,116 @@
+'use strict'
+
+const BaseWordpress = require('./wordpress-base')
+
+module.exports = class WordpressPluginIssues extends BaseWordpress {
+  static get category() {
+    return 'issue-tracking'
+  }
+
+  static get route() {
+    return {
+      base: `wordpress/plugin/issues/`,
+      pattern: ':status(open|closed)/:variant(raw|percentage|outof)/:slug',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: 'WordPress Plugin issues',
+        namedParams: { status: 'open', variant: 'outof', slug: 'akismet' },
+        staticPreview: {
+          label: 'closed issues',
+          message: '80/100',
+          color: 'brightgreen',
+        },
+      },
+    ]
+  }
+
+  calcOpen(issues, closed_issues) {
+    return issues - closed_issues
+  }
+
+  colorCalc(closed_percentage) {
+    if (closed_percentage < 50) {
+      return 'red'
+    } else if (closed_percentage < 90) {
+      return 'yellow'
+    } else {
+      return 'brightgreen'
+    }
+  }
+
+  rawCalc(issues, closed_issues, status) {
+    if (status === 'open') {
+      return this.calcOpen(issues, closed_issues)
+    } else {
+      return closed_issues
+    }
+  }
+
+  percentageCalc(issues, closed_issues, status) {
+    const percentClosed = Math.round((closed_issues / issues) * 100)
+    if (status === 'open') {
+      return 100 - percentClosed
+    } else {
+      return percentClosed
+    }
+  }
+
+  outOfCalc(issues, closed_issues, status) {
+    if (status === 'open') {
+      const open_issues = this.calcOpen(issues, closed_issues)
+      return `${open_issues}/${issues}`
+    } else {
+      return `${closed_issues}/${issues}`
+    }
+  }
+
+  static render({ label, value, color }) {
+    return {
+      label,
+      message: value,
+      color,
+    }
+  }
+
+  async handle({ status, variant, slug }) {
+    const json = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+    const issues = json.support_threads
+    const closed_issues = json.support_threads_resolved
+    const closed_percentage = this.percentageCalc(
+      issues,
+      closed_issues,
+      'closed'
+    )
+
+    let label
+    if (status === 'open') {
+      label = 'open issues'
+    } else if (status === 'closed') {
+      label = 'closed issues'
+    }
+
+    let value
+    if (variant === 'raw') {
+      value = this.rawCalc(issues, closed_issues, status)
+    } else if (variant === 'percentage') {
+      value = `${this.percentageCalc(issues, closed_issues, status)}%`
+    } else if (variant === 'outof') {
+      value = this.outOfCalc(issues, closed_issues, status)
+    }
+
+    const color = this.colorCalc(closed_percentage)
+
+    return this.constructor.render({
+      label,
+      value,
+      color,
+    })
+  }
+}

--- a/services/wordpress/wordpress-issues.tester.js
+++ b/services/wordpress/wordpress-issues.tester.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const {
+  isMetric,
+  isIntegerPercentage,
+  isMetricOverMetric,
+} = require('../test-validators')
+
+const t = new ServiceTester({
+  id: 'wordpress',
+  title: 'WordPress Plugin Issues',
+})
+module.exports = t
+
+t.create('Plugin Issues - Open Raw')
+  .get('/plugin/issues/raw/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isMetric,
+  })
+
+t.create('Plugin Issues - Closed Raw')
+  .get('/plugin/issues/raw/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isMetric,
+  })
+
+t.create('Plugin Issues - Open Percentage')
+  .get('/plugin/issues/percentage/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isIntegerPercentage,
+  })
+
+t.create('Plugin Issues - Closed Percentage')
+  .get('/plugin/issues/percentage/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isIntegerPercentage,
+  })
+
+t.create('Plugin Issues - Open Out Of')
+  .get('/plugin/issues/outof/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isMetricOverMetric,
+  })
+
+t.create('Plugin Issues - Closed Out Of')
+  .get('/plugin/issues/outof/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isMetricOverMetric,
+  })
+
+t.create('Plugin Issues - Open/Closed')
+  .get('/plugin/issues/opcl/jetpack.json')
+  .expectBadge({
+    label: 'open/closed',
+    message: isMetricOverMetric,
+  })

--- a/services/wordpress/wordpress-last-update.service.js
+++ b/services/wordpress/wordpress-last-update.service.js
@@ -19,34 +19,24 @@ function LastUpdateForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressLastUpdate extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}LastUpdated`
+    static name = `Wordpress${capt}LastUpdated`
+
+    static category = 'activity'
+
+    static route = {
+      base: `wordpress/${extensionType}/last-updated`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'activity'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Last Updated`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ last_updated: '2020-08-11' }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/last-updated`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Last Updated`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ last_updated: '2020-08-11' }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'last updated' }
-    }
+    static defaultBadgeData = { label: 'last updated' }
 
     static render({ last_updated }) {
       return {

--- a/services/wordpress/wordpress-last-update.service.js
+++ b/services/wordpress/wordpress-last-update.service.js
@@ -1,0 +1,90 @@
+'use strict'
+
+const { formatDate } = require('../text-formatters')
+const { age: ageColor } = require('../color-formatters')
+const BaseWordpress = require('./wordpress-base')
+
+const extensionData = {
+  plugin: {
+    capt: 'Plugin',
+    exampleSlug: 'bbpress',
+  },
+  theme: {
+    capt: 'Theme',
+    exampleSlug: 'twentyseventeen',
+  },
+}
+
+function LastUpdateForType(extensionType) {
+  const { capt, exampleSlug } = extensionData[extensionType]
+
+  return class WordpressLastUpdate extends BaseWordpress {
+    static get name() {
+      return `Wordpress${capt}LastUpdated`
+    }
+
+    static get category() {
+      return 'activity'
+    }
+
+    static get route() {
+      return {
+        base: `wordpress/${extensionType}/last-updated`,
+        pattern: ':slug',
+      }
+    }
+
+    static get examples() {
+      return [
+        {
+          title: `WordPress ${capt} Last Updated`,
+          namedParams: { slug: exampleSlug },
+          staticPreview: this.render({ last_updated: '2020-08-11' }),
+        },
+      ]
+    }
+
+    static get defaultBadgeData() {
+      return { label: 'last updated' }
+    }
+
+    static render({ last_updated }) {
+      return {
+        label: 'last updated',
+        message: formatDate(last_updated),
+        color: ageColor(last_updated),
+      }
+    }
+
+    transform(date, extensionType) {
+      let d
+      if (extensionType === 'plugin') {
+        d = date.split(' ')
+        d = d[0]
+      } else {
+        d = date
+      }
+
+      const ymd = d.split('-')
+
+      const out = ymd[0] + ymd[1] + ymd[2]
+      return out
+    }
+
+    async handle({ slug }) {
+      const { last_updated } = await this.fetch({
+        extensionType,
+        slug,
+      })
+
+      const newDate = await this.transform(last_updated, extensionType)
+
+      return this.constructor.render({
+        last_updated: newDate,
+      })
+    }
+  }
+}
+
+const lastupdate = ['plugin', 'theme'].map(LastUpdateForType)
+module.exports = [...lastupdate]

--- a/services/wordpress/wordpress-last-update.tester.js
+++ b/services/wordpress/wordpress-last-update.tester.js
@@ -1,0 +1,38 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const { isFormattedDate } = require('../test-validators')
+
+const t = new ServiceTester({
+  id: 'wordpress',
+  title: 'WordPress Last Update',
+})
+module.exports = t
+
+t.create('Plugin Last Update')
+  .get('/plugin/last-updated/akismet.json')
+  .expectBadge({
+    label: 'last updated',
+    message: isFormattedDate,
+  })
+
+t.create('Plugin (Not Found)')
+  .get('/plugin/last-updated/pleasenevermakethisplugin.json')
+  .expectBadge({
+    label: 'last updated',
+    message: 'not found',
+  })
+
+t.create('Theme Last Update')
+  .get('/theme/last-updated/twentytwenty.json')
+  .expectBadge({
+    label: 'last updated',
+    message: isFormattedDate,
+  })
+
+t.create('Theme (Not Found)')
+  .get('/theme/last-updated/pleasenevermakethistheme.json')
+  .expectBadge({
+    label: 'last updated',
+    message: 'not found',
+  })

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -21,34 +21,24 @@ function RequiresForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressRequiresVersion extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}RequiresVersion`
+    static name = `Wordpress${capt}RequiresVersion`
+
+    static category = 'platform-support'
+
+    static route = {
+      base: `wordpress/${extensionType}/wp-version`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'platform-support'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Required WP Version`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ wordpressVersion: '4.8' }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/wp-version`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Required WP Version`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ wordpressVersion: '4.8' }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'wordpress' }
-    }
+    static defaultBadgeData = { label: 'wordpress' }
 
     static render({ wordpressVersion }) {
       return {
@@ -68,32 +58,24 @@ function RequiresForType(extensionType) {
 }
 
 class WordpressPluginTestedVersion extends BaseWordpress {
-  static get category() {
-    return 'platform-support'
+  static category = 'platform-support'
+
+  static route = {
+    base: `wordpress/plugin/tested`,
+    pattern: ':slug',
   }
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/tested`,
-      pattern: ':slug',
-    }
-  }
+  static examples = [
+    {
+      title: 'WordPress Plugin Tested WP Version',
+      namedParams: { slug: 'bbpress' },
+      staticPreview: this.renderStaticPreview({
+        testedVersion: '4.9.8',
+      }),
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin Tested WP Version',
-        namedParams: { slug: 'bbpress' },
-        staticPreview: this.renderStaticPreview({
-          testedVersion: '4.9.8',
-        }),
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'wordpress' }
-  }
+  static defaultBadgeData = { label: 'wordpress' }
 
   static renderStaticPreview({ testedVersion }) {
     // Since this badge has an async `render()` function, but `get examples()` has to
@@ -127,34 +109,24 @@ function RequiresPHPVersionForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressRequiresPHPVersion extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}RequiresPHPVersion`
+    static name = `Wordpress${capt}RequiresPHPVersion`
+
+    static category = 'platform-support'
+
+    static route = {
+      base: `wordpress/${extensionType}/required-php`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'platform-support'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Required PHP Version`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ version: '5.5' }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/required-php`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Required PHP Version`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ version: '5.5' }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: 'required php' }
-    }
+    static defaultBadgeData = { label: 'required php' }
 
     static render({ version }) {
       return {

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -17,45 +17,49 @@ const extensionData = {
   },
 }
 
-class WordpressPluginRequiresVersion extends BaseWordpress {
-  static get category() {
-    return 'platform-support'
-  }
+function RequiresForType(extensionType) {
+  const { capt, exampleSlug } = extensionData[extensionType]
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/wp-version`,
-      pattern: ':slug',
+  return class WordpressRequiresVersion extends BaseWordpress {
+    static get category() {
+      return 'platform-support'
     }
-  }
 
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin: Required WP Version',
-        namedParams: { slug: 'bbpress' },
-        staticPreview: this.render({ wordpressVersion: '4.8' }),
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'wordpress' }
-  }
-
-  static render({ wordpressVersion }) {
-    return {
-      message: addv(wordpressVersion),
-      color: versionColor(wordpressVersion),
+    static get route() {
+      return {
+        base: `wordpress/${extensionType}/wp-version`,
+        pattern: ':slug',
+      }
     }
-  }
 
-  async handle({ slug }) {
-    const { requires: wordpressVersion } = await this.fetch({
-      extensionType: 'plugin',
-      slug,
-    })
-    return this.constructor.render({ wordpressVersion })
+    static get examples() {
+      return [
+        {
+          title: `WordPress ${capt} Required WP Version`,
+          namedParams: { slug: exampleSlug },
+          staticPreview: this.render({ wordpressVersion: '4.8' }),
+        },
+      ]
+    }
+
+    static get defaultBadgeData() {
+      return { label: 'wordpress' }
+    }
+
+    static render({ wordpressVersion }) {
+      return {
+        message: addv(wordpressVersion),
+        color: versionColor(wordpressVersion),
+      }
+    }
+
+    async handle({ slug }) {
+      const { requires: wordpressVersion } = await this.fetch({
+        extensionType,
+        slug,
+      })
+      return this.constructor.render({ wordpressVersion })
+    }
   }
 }
 
@@ -171,9 +175,10 @@ function RequiresPHPVersionForType(extensionType) {
   }
 }
 
+const requiresVersion = ['plugin', 'theme'].map(RequiresForType)
 const required_php = ['plugin', 'theme'].map(RequiresPHPVersionForType)
 module.exports = [
-  WordpressPluginRequiresVersion,
+  ...requiresVersion,
   WordpressPluginTestedVersion,
   ...required_php,
 ]

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -21,6 +21,10 @@ function RequiresForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressRequiresVersion extends BaseWordpress {
+    static get name() {
+      return `Wordpress${capt}RequiresVersion`
+    }
+
     static get category() {
       return 'platform-support'
     }
@@ -123,6 +127,10 @@ function RequiresPHPVersionForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressRequiresPHPVersion extends BaseWordpress {
+    static get name() {
+      return `Wordpress${capt}RequiresPHPVersion`
+    }
+
     static get category() {
       return 'platform-support'
     }

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -78,7 +78,7 @@ class WordpressPluginTestedVersion extends BaseWordpress {
   static get examples() {
     return [
       {
-        title: 'WordPress Plugin: Tested WP Version',
+        title: 'WordPress Plugin Tested WP Version',
         namedParams: { slug: 'bbpress' },
         staticPreview: this.renderStaticPreview({
           testedVersion: '4.9.8',

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -34,6 +34,7 @@ const mockedQuerySelector = {
       homepage: '0',
       tags: '0',
       screenshot_url: '0',
+      downloaded: '1',
     },
   },
 }
@@ -46,7 +47,7 @@ t.create('Plugin Tested WP Version - current')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.3',
@@ -70,7 +71,7 @@ t.create('Plugin Tested WP Version - old')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.2',
@@ -94,7 +95,7 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.2',

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -148,3 +148,31 @@ t.create('Plugin Tested WP Version | Not Found')
 t.create('Plugin Tested WP Version (Alias)')
   .get('/v/100.svg')
   .expectRedirect('/wordpress/plugin/tested/100.svg')
+
+t.create('Plugin Required PHP Version')
+  .get('/plugin/required-php/jetpack.json')
+  .expectBadge({
+    label: 'required php',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
+t.create('Plugin Required PHP Version (Not Set)')
+  .get('/plugin/required-php/akismet.json')
+  .expectBadge({
+    label: 'required php',
+    message: 'not set for this plugin',
+  })
+
+t.create('Theme Required PHP Version')
+  .get('/theme/required-php/twentytwenty.json')
+  .expectBadge({
+    label: 'required php',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
+t.create('Theme Required PHP Version (Not Set)')
+  .get('/theme/required-php/generatepress.json')
+  .expectBadge({
+    label: 'required php',
+    message: 'not set for this theme',
+  })

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -35,6 +35,10 @@ const mockedQuerySelector = {
       tags: '0',
       screenshot_url: '0',
       downloaded: '1',
+      support_threads: '1',
+      support_threads_resolved: '1',
+      requires_php: '1',
+      last_updated: '1',
     },
   },
 }
@@ -57,6 +61,10 @@ t.create('Plugin Tested WP Version - current')
         active_installs: 100,
         requires: '4.9',
         tested: '4.9.8',
+        support_threads: 365,
+        support_threads_resolved: 265,
+        requires_php: '5.5',
+        last_updated: '2020-01-01',
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)
@@ -81,6 +89,10 @@ t.create('Plugin Tested WP Version - old')
         active_installs: 100,
         requires: '4.9',
         tested: '4.9.6',
+        support_threads: 365,
+        support_threads_resolved: 265,
+        requires_php: '5.5',
+        last_updated: '2020-01-01',
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)
@@ -105,6 +117,10 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
         active_installs: 100,
         requires: '4.0',
         tested: '4.0.0',
+        support_threads: 365,
+        support_threads_resolved: 265,
+        requires_php: '5.5',
+        last_updated: '2020-01-01',
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -17,6 +17,13 @@ t.create('Plugin Required WP Version')
     message: isVPlusDottedVersionAtLeastOne,
   })
 
+t.create('Theme Required WP Version')
+  .get('/theme/wp-version/twentytwenty.json')
+  .expectBadge({
+    label: 'wordpress',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
 t.create('Plugin Tested WP Version')
   .get('/plugin/tested/akismet.json')
   .expectBadge({
@@ -133,6 +140,13 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
 
 t.create('Plugin Required WP Version | Not Found')
   .get('/plugin/wp-version/100.json')
+  .expectBadge({
+    label: 'wordpress',
+    message: 'not found',
+  })
+
+t.create('Theme Required WP Version | Not Found')
+  .get('/theme/wp-version/100.json')
   .expectBadge({
     label: 'wordpress',
     message: 'not found',

--- a/services/wordpress/wordpress-rating.service.js
+++ b/services/wordpress/wordpress-rating.service.js
@@ -16,42 +16,32 @@ const extensionData = {
 }
 
 class WordpressRatingBase extends BaseWordpress {
-  static get category() {
-    return 'rating'
-  }
+  static category = 'rating'
 
-  static get defaultBadgeData() {
-    return { label: 'rating' }
-  }
+  static defaultBadgeData = { label: 'rating' }
 }
 
 function RatingForExtensionType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressRating extends WordpressRatingBase {
-    static get name() {
-      return `Wordpress${capt}Rating`
+    static name = `Wordpress${capt}Rating`
+
+    static route = {
+      base: `wordpress/${extensionType}/rating`,
+      pattern: ':slug',
     }
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/rating`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Rating`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({
-            rating: 80,
-            numRatings: 100,
-          }),
-        },
-      ]
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Rating`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({
+          rating: 80,
+          numRatings: 100,
+        }),
+      },
+    ]
 
     static render({ rating, numRatings }) {
       const scaledAndRounded = ((rating / 100) * 5).toFixed(1)
@@ -75,30 +65,24 @@ function StarsForExtensionType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressStars extends WordpressRatingBase {
-    static get name() {
-      return `Wordpress${capt}Stars`
+    static name = `Wordpress${capt}Stars`
+
+    static route = {
+      base: `wordpress/${extensionType}`,
+      pattern: '(stars|r)/:slug',
     }
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}`,
-        pattern: '(stars|r)/:slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Rating`,
-          pattern: 'stars/:slug',
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({
-            rating: 80,
-          }),
-          documentation: 'There is an alias <code>/r/:slug.svg</code> as well.',
-        },
-      ]
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Rating`,
+        pattern: 'stars/:slug',
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({
+          rating: 80,
+        }),
+        documentation: 'There is an alias <code>/r/:slug.svg</code> as well.',
+      },
+    ]
 
     static render({ rating }) {
       const scaled = (rating / 100) * 5

--- a/services/wordpress/wordpress-social.service.js
+++ b/services/wordpress/wordpress-social.service.js
@@ -18,6 +18,10 @@ function AuthorForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressAuthor extends BaseWordpress {
+    static get name() {
+      return `Wordpress${capt}Author`
+    }
+
     static get category() {
       return 'social'
     }

--- a/services/wordpress/wordpress-social.service.js
+++ b/services/wordpress/wordpress-social.service.js
@@ -18,40 +18,30 @@ function AuthorForType(extensionType) {
   const { capt, exampleSlug } = extensionData[extensionType]
 
   return class WordpressAuthor extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}Author`
+    static name = `Wordpress${capt}Author`
+
+    static category = 'social'
+
+    static route = {
+      base: `wordpress/${extensionType}/author`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'social'
-    }
-
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/author`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Author`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: {
-            label: 'author',
-            message: 'wordpress',
-            style: 'social',
-          },
+    static examples = [
+      {
+        title: `WordPress ${capt} Author`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: {
+          label: 'author',
+          message: 'wordpress',
+          style: 'social',
         },
-      ]
-    }
+      },
+    ]
 
-    static get defaultBadgeData() {
-      return {
-        label: 'author',
-        namedLogo: 'wordpress',
-      }
+    static defaultBadgeData = {
+      label: 'author',
+      namedLogo: 'wordpress',
     }
 
     static render({ author, link }) {
@@ -94,36 +84,28 @@ function AuthorForType(extensionType) {
 }
 
 class WordpressPluginContributor extends BaseWordpress {
-  static get category() {
-    return 'social'
+  static category = 'social'
+
+  static route = {
+    base: `wordpress/plugin/contributor`,
+    pattern: ':slug/:contributor',
   }
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/contributor`,
-      pattern: ':slug/:contributor',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: `WordPress Plugin Contributor`,
-        namedParams: { slug: 'akismet', contributor: 'automattic' },
-        staticPreview: {
-          label: 'contributor',
-          message: 'wordpress',
-          style: 'social',
-        },
+  static examples = [
+    {
+      title: `WordPress Plugin Contributor`,
+      namedParams: { slug: 'akismet', contributor: 'automattic' },
+      staticPreview: {
+        label: 'contributor',
+        message: 'wordpress',
+        style: 'social',
       },
-    ]
-  }
+    },
+  ]
 
-  static get defaultBadgeData() {
-    return {
-      label: 'contributor',
-      namedLogo: 'wordpress',
-    }
+  static defaultBadgeData = {
+    label: 'contributor',
+    namedLogo: 'wordpress',
   }
 
   static render({ contributor, link }) {

--- a/services/wordpress/wordpress-social.service.js
+++ b/services/wordpress/wordpress-social.service.js
@@ -1,0 +1,154 @@
+'use strict'
+
+const { NotFound } = require('..')
+const BaseWordpress = require('./wordpress-base')
+
+const extensionData = {
+  plugin: {
+    capt: 'Plugin',
+    exampleSlug: 'bbpress',
+  },
+  theme: {
+    capt: 'Theme',
+    exampleSlug: 'twentytwenty',
+  },
+}
+
+function AuthorForType(extensionType) {
+  const { capt, exampleSlug } = extensionData[extensionType]
+
+  return class WordpressAuthor extends BaseWordpress {
+    static get category() {
+      return 'social'
+    }
+
+    static get route() {
+      return {
+        base: `wordpress/${extensionType}/author`,
+        pattern: ':slug',
+      }
+    }
+
+    static get examples() {
+      return [
+        {
+          title: `WordPress ${capt} Author`,
+          namedParams: { slug: exampleSlug },
+          staticPreview: {
+            label: 'author',
+            message: 'wordpress',
+            style: 'social',
+          },
+        },
+      ]
+    }
+
+    static get defaultBadgeData() {
+      return {
+        label: 'author',
+        namedLogo: 'wordpress',
+      }
+    }
+
+    static render({ author, link }) {
+      return {
+        label: 'author',
+        message: author,
+        namedLogo: 'wordpress',
+        link,
+      }
+    }
+
+    transform(rawAuthor) {
+      return rawAuthor.substring(
+        rawAuthor.lastIndexOf('">') + 2,
+        rawAuthor.lastIndexOf('<')
+      )
+    }
+
+    async handle({ slug }) {
+      if (extensionType === 'plugin') {
+        const { author: rawAuthor, author_profile: profile } = await this.fetch(
+          {
+            extensionType,
+            slug,
+          }
+        )
+        const author = this.transform(rawAuthor)
+        return this.constructor.render({ author, link: profile })
+      } else {
+        const { author: rawAuthor } = await this.fetch({
+          extensionType,
+          slug,
+        })
+        const author = rawAuthor.display_name
+        const profile = rawAuthor.profile
+        return this.constructor.render({ author, link: profile })
+      }
+    }
+  }
+}
+
+class WordpressPluginContributor extends BaseWordpress {
+  static get category() {
+    return 'social'
+  }
+
+  static get route() {
+    return {
+      base: `wordpress/plugin/contributor`,
+      pattern: ':slug/:contributor',
+    }
+  }
+
+  static get examples() {
+    return [
+      {
+        title: `WordPress Plugin Contributor`,
+        namedParams: { slug: 'akismet', contributor: 'automattic' },
+        staticPreview: {
+          label: 'contributor',
+          message: 'wordpress',
+          style: 'social',
+        },
+      },
+    ]
+  }
+
+  static get defaultBadgeData() {
+    return {
+      label: 'contributor',
+      namedLogo: 'wordpress',
+    }
+  }
+
+  static render({ contributor, link }) {
+    return {
+      label: 'contributor',
+      message: contributor,
+      namedLogo: 'wordpress',
+      link,
+    }
+  }
+
+  async handle({ slug, contributor }) {
+    const { contributors } = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+
+    if (contributor in contributors) {
+      const data = contributors[contributor]
+      return this.constructor.render({
+        contributor: data.display_name,
+        link: data.profile,
+      })
+    } else {
+      throw new NotFound({ prettyMessage: 'Contributor not found in plugin' })
+    }
+  }
+}
+
+const authorModules = ['plugin', 'theme'].map(AuthorForType)
+const modules = [...authorModules, WordpressPluginContributor]
+module.exports = modules

--- a/services/wordpress/wordpress-social.tester.js
+++ b/services/wordpress/wordpress-social.tester.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+
+const t = new ServiceTester({
+  id: 'wordpress',
+  title: 'WordPress Social',
+})
+module.exports = t
+
+t.create('Plugin Author')
+  .get('/plugin/author/akismet.json')
+  .expectBadge({
+    label: 'author',
+    message: 'Automattic',
+    link: ['https://profiles.wordpress.org/automattic'],
+  })
+
+t.create('Plugin Author (Not Found)')
+  .get('/plugin/author/100.json')
+  .expectBadge({
+    label: 'author',
+    message: 'not found',
+  })
+
+t.create('Plugin Contributor')
+  .get('/plugin/contributor/akismet/matt.json')
+  .expectBadge({
+    label: 'contributor',
+    message: 'Matt Mullenweg',
+    link: ['https://profiles.wordpress.org/matt'],
+  })
+
+t.create('Plugin Contributor (Not Found)')
+  .get('/plugin/contributor/akismet/notacontributor.json')
+  .expectBadge({
+    label: 'contributor',
+    message: 'Contributor not found in plugin',
+  })
+
+t.create('Theme Author')
+  .get('/theme/author/twentytwenty.json')
+  .expectBadge({
+    label: 'author',
+    message: 'WordPress.org',
+    link: ['https://profiles.wordpress.org/wordpressdotorg'],
+  })
+
+t.create('Theme Author (not found)').get('/theme/author/100.json').expectBadge({
+  label: 'author',
+  message: 'not found',
+})

--- a/services/wordpress/wordpress-version.service.js
+++ b/services/wordpress/wordpress-version.service.js
@@ -17,34 +17,24 @@ function VersionForExtensionType(extensionType) {
   }[extensionType]
 
   return class WordpressVersion extends BaseWordpress {
-    static get name() {
-      return `Wordpress${capt}Version`
+    static name = `Wordpress${capt}Version`
+
+    static category = 'version'
+
+    static route = {
+      base: `wordpress/${extensionType}/v`,
+      pattern: ':slug',
     }
 
-    static get category() {
-      return 'version'
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt} Version`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ version: 2.5 }),
+      },
+    ]
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/v`,
-        pattern: ':slug',
-      }
-    }
-
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt} Version`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ version: 2.5 }),
-        },
-      ]
-    }
-
-    static get defaultBadgeData() {
-      return { label: extensionType }
-    }
+    static defaultBadgeData = { label: extensionType }
 
     static render({ version }) {
       return {


### PR DESCRIPTION
This PR does a few things, not related to an issue as I didn't open one first.

Firstly, it updates the API version used to the latest version (1.2), and adjusts some schema, services and tests to work with the new version. It also changes how we detect an error as these are now provided in JSON, instead of as plain text.

Next it add more badges where possible. These include:
- WordPress Plugin Issues
    - Open or Closed
    - Raw Value, Percentage (eg 45% open), Out of (20 open out of 100 total) and comparison (20 open, 80 closed)
- WordPress Plugin & Theme Last Updated
- WordPress Theme Required WP Version
- WordPress Plugin & Theme Required PHP Version
- WordPress Plugin & Theme Author Social Badge
- WordPress Plugin Contributor Social Badge