### PR TITLE
deprecate [ChromeWebStoreRating] badges

### DIFF
--- a/services/chrome-web-store/chrome-web-store-rating.service.js
+++ b/services/chrome-web-store/chrome-web-store-rating.service.js
@@ -1,115 +1,33 @@
 'use strict'
 
-const { floorCount: floorCountColor } = require('../color-formatters')
-const { metric, starRating } = require('../text-formatters')
-const BaseChromeWebStoreService = require('./chrome-web-store-base')
+const { deprecatedService } = require('..')
 
-class BaseChromeWebStoreRating extends BaseChromeWebStoreService {
-  static get category() {
-    return 'rating'
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'rating' }
-  }
+const commonAttrs = {
+  category: 'rating',
+  label: 'rating',
+  dateAdded: new Date('2020-09-06'),
 }
 
-class ChromeWebStoreRating extends BaseChromeWebStoreRating {
-  static get route() {
-    return {
+module.exports = [
+  deprecatedService({
+    route: {
       base: 'chrome-web-store/rating',
       pattern: ':storeId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Chrome Web Store',
-        namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-        staticPreview: this.render({ rating: '3.67' }),
-      },
-    ]
-  }
-
-  static render({ rating }) {
-    rating = Math.round(rating * 100) / 100
-    return {
-      message: `${rating}/5`,
-      color: floorCountColor(rating, 2, 3, 4),
-    }
-  }
-
-  async handle({ storeId }) {
-    const { ratingValue } = await this.fetch({ storeId })
-    return this.constructor.render({ rating: ratingValue })
-  }
-}
-
-class ChromeWebStoreRatingCount extends BaseChromeWebStoreRating {
-  static get route() {
-    return {
+    },
+    ...commonAttrs,
+  }),
+  deprecatedService({
+    route: {
       base: 'chrome-web-store/rating-count',
       pattern: ':storeId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Chrome Web Store',
-        namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-        staticPreview: this.render({ ratingCount: 12 }),
-      },
-    ]
-  }
-
-  static render({ ratingCount }) {
-    return {
-      message: `${metric(ratingCount)} total`,
-      color: floorCountColor(ratingCount, 5, 50, 500),
-    }
-  }
-
-  async handle({ storeId }) {
-    const { ratingCount } = await this.fetch({ storeId })
-    return this.constructor.render({ ratingCount })
-  }
-}
-
-class ChromeWebStoreRatingStars extends BaseChromeWebStoreRating {
-  static get route() {
-    return {
+    },
+    ...commonAttrs,
+  }),
+  deprecatedService({
+    route: {
       base: 'chrome-web-store/stars',
       pattern: ':storeId',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Chrome Web Store',
-        namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-        staticPreview: this.render({ rating: '3.75' }),
-      },
-    ]
-  }
-
-  static render({ rating }) {
-    return {
-      message: starRating(rating),
-      color: floorCountColor(rating, 2, 3, 4),
-    }
-  }
-
-  async handle({ storeId }) {
-    const { ratingValue } = await this.fetch({ storeId })
-    return this.constructor.render({ rating: parseFloat(ratingValue) })
-  }
-}
-
-module.exports = {
-  ChromeWebStoreRating,
-  ChromeWebStoreRatingCount,
-  ChromeWebStoreRatingStars,
-}
+    },
+    ...commonAttrs,
+  }),
+]

--- a/services/chrome-web-store/chrome-web-store-rating.tester.js
+++ b/services/chrome-web-store/chrome-web-store-rating.tester.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const Joi = require('@hapi/joi')
-const { isStarRating } = require('../test-validators')
 const { ServiceTester } = require('../tester')
 
 const t = (module.exports = new ServiceTester({
@@ -11,37 +9,13 @@ const t = (module.exports = new ServiceTester({
 }))
 
 t.create('Rating')
-  .get('/rating/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
-  .expectBadge({
-    label: 'rating',
-    message: Joi.string().regex(/^\d\.?\d+?\/5$/),
-  })
-
-t.create('Rating (not found)')
   .get('/rating/invalid-name-of-addon.json')
-  .expectBadge({ label: 'rating', message: 'not found' })
+  .expectBadge({ label: 'rating', message: 'no longer available' })
 
 t.create('Rating Count')
-  .get('/rating-count/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
-  .expectBadge({
-    label: 'rating',
-    message: Joi.string().regex(/^\d+?\stotal$/),
-  })
-
-t.create('Rating Count (not found)')
   .get('/rating-count/invalid-name-of-addon.json')
-  .expectBadge({ label: 'rating', message: 'not found' })
+  .expectBadge({ label: 'rating', message: 'no longer available' })
 
 t.create('Stars')
   .get('/stars/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
-  .expectBadge({ label: 'rating', message: isStarRating })
-
-t.create('Stars (not found)')
-  .get('/stars/invalid-name-of-addon.json')
-  .expectBadge({ label: 'rating', message: 'not found' })
-
-// Keep this "inaccessible" test, since this service does not use BaseService#_request.
-t.create('Rating (inaccessible)')
-  .get('/rating/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
-  .networkOff()
-  .expectBadge({ label: 'rating', message: 'inaccessible' })
+  .expectBadge({ label: 'rating', message: 'no longer available' })


### PR DESCRIPTION
closes #5475
the next release of node-chrome-web-store-item-property will drop the `ratingCount` and `ratingValue` properties