### PR TITLE
Rework isCSSColor check

### DIFF
--- a/badge-maker/lib/color.js
+++ b/badge-maker/lib/color.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const isCSSColor = require('is-css-color')
 const cssColorConverter = require('css-color-converter')
 
 // When updating these, be sure also to update the list in `badge-maker/README.md`.
@@ -36,6 +35,13 @@ Object.entries(aliases).forEach(([alias, original]) => {
 const hexColorRegex = /^([\da-f]{3}){1,2}$/i
 function isHexColor(s = '') {
   return hexColorRegex.test(s)
+}
+
+function isCSSColor(color) {
+  return (
+    !Array.isArray(color) &&
+    typeof cssColorConverter(color).toRgbaArray() !== 'undefined'
+  )
 }
 
 function normalizeColor(color) {

--- a/badge-maker/lib/color.js
+++ b/badge-maker/lib/color.js
@@ -39,8 +39,8 @@ function isHexColor(s = '') {
 
 function isCSSColor(color) {
   return (
-    !Array.isArray(color) &&
-    typeof cssColorConverter(color).toRgbaArray() !== 'undefined'
+    typeof color === 'string' &&
+    typeof cssColorConverter(color.trim()).toRgbaArray() !== 'undefined'
   )
 }
 

--- a/badge-maker/lib/color.spec.js
+++ b/badge-maker/lib/color.spec.js
@@ -56,7 +56,6 @@ test(normalizeColor, () => {
     given(null),
     given(true),
     given(1),
-    given(void 0),
     given(Math),
     given([]),
     given({}),

--- a/badge-maker/lib/color.spec.js
+++ b/badge-maker/lib/color.spec.js
@@ -28,15 +28,36 @@ test(normalizeColor, () => {
   given('4c1').expect('#4c1')
   given('f00f00').expect('#f00f00')
   given('ABC123').expect('#abc123')
+  given('#ccc').expect('#ccc')
+  given('#fffe').expect('#fffe')
+  given('#fffeffff').expect('#fffeffff')
   given('#ABC123').expect('#abc123')
   given('papayawhip').expect('papayawhip')
   given('purple').expect('purple')
+  given('  blue ').expect('  blue ')
+  given('rgb(100%, 200%, 222%)').expect('rgb(100%, 200%, 222%)')
+  given('rgb(122, 200, 222)').expect('rgb(122, 200, 222)')
+  given('rgb(100%, 200, 222)').expect('rgb(100%, 200, 222)')
+  given('rgba(100, 20, 111, 1)').expect('rgba(100, 20, 111, 1)')
+  given('hsl(122, 200%, 222%)').expect('hsl(122, 200%, 222%)')
+  given('hsla(122, 200%, 222%, 1)').expect('hsla(122, 200%, 222%, 1)')
   forCases([
+    given(),
     given(''),
     given('not-a-color'),
+    given('#ABCFGH'),
+    given('rgb(122, 200, 222, 1)'),
+    given('rgb(-100, 20, 111)'),
+    given('rgba(-100, 20, 111, 1.1)'),
+    given('hsl(122, 200, 222, 1)'),
+    given('hsl(122, 200, 222)'),
+    given('hsl(122, 200, 222%)'),
     given(undefined),
     given(null),
     given(true),
+    given(1),
+    given(void 0),
+    given(Math),
     given([]),
     given({}),
     given(() => {}),

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -37,8 +37,7 @@
   "dependencies": {
     "anafanafo": "^1.0.0",
     "camelcase": "^6.0.0",
-    "css-color-converter": "^1.1.1",
-    "is-css-color": "^1.0.0"
+    "css-color-converter": "^1.1.1"
   },
   "scripts": {
     "test": "echo 'Run tests from parent dir'; false"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9172,8 +9172,7 @@
       "requires": {
         "anafanafo": "^1.0.0",
         "camelcase": "^6.0.0",
-        "css-color-converter": "^1.1.1",
-        "is-css-color": "^1.0.0"
+        "css-color-converter": "^1.1.1"
       },
       "dependencies": {
         "camelcase": {
@@ -21431,11 +21430,6 @@
         "rgb-regex": "^1.0.1",
         "rgba-regex": "^1.0.0"
       }
-    },
-    "is-css-color": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-css-color/-/is-css-color-1.0.0.tgz",
-      "integrity": "sha1-EQGYzd2xVTw5Nl4px1/btQIXC78="
     },
     "is-data-descriptor": {
       "version": "1.0.0",


### PR DESCRIPTION
This PR makes the code in _color.js_ slightly more complex, but gets rid of a dependency both in the main Shields server and the NPM package.

I ran a micro-benchmark to check that performance wasn't affected negatively (careful, you have to change to badge URL in _scripts/benchmark-performance.js_ to be a non-standard Shields colour): the new `isCSSColor` is actually ~10% faster on my machine - though as we're only talking about a few μs, I wouldn't treat this as a strong argument in favour of the PR.