### PR TITLE
Update to nextgen circle images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
 
   main@node-14:
     docker:
-      - image: cimg/node:14
+      - image: cimg/node:14.11
 
     <<: *main_steps
 
@@ -183,7 +183,7 @@ jobs:
 
   integration@node-14:
     docker:
-      - image: cimg/node:14
+      - image: cimg/node:14.11
       - image: redis
 
     <<: *integration_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
 
   main@node-14:
     docker:
-      - image: cimg/node:14.10
+      - image: cimg/node:14
 
     <<: *main_steps
 
@@ -183,7 +183,7 @@ jobs:
 
   integration@node-14:
     docker:
-      - image: cimg/node:14.10
+      - image: cimg/node:14
       - image: redis
 
     <<: *integration_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
 
   main@node-14:
     docker:
-      - image: cimg/node:14.9
+      - image: cimg/node:14.10
 
     <<: *main_steps
 
@@ -183,7 +183,7 @@ jobs:
 
   integration@node-14:
     docker:
-      - image: cimg/node:14.9
+      - image: cimg/node:14.10
       - image: redis
 
     <<: *integration_steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
 
   main@node-14:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.9
 
     <<: *main_steps
 
@@ -183,7 +183,7 @@ jobs:
 
   integration@node-14:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14.9
       - image: redis
 
     <<: *integration_steps


### PR DESCRIPTION
Circle apparently now has "Legacy" and "Next-Gen" images, and we've been using the former. This switches the Node v14 jobs to a Next-Gen Node v14 image because doing so fixes the failing tests on the `{main,integration}@node-14` jobs that are blocking other PRs (refs #5508 #5509 #5511)

https://circleci.com/docs/2.0/circleci-images/#next-gen-language-images
https://circleci.com/docs/2.0/circleci-images/#legacy-language-images

Note that I did set this to use the Node v14.9.0 because the next-gen node v14.10.0 also produces the same mass test time out as the legacy v14 image (my guess is they are the same). The same test are all passing fine for me locally with `v14.10.1`, so my best guess is there's something funky with the Circle v14.10.0 build. 

I'd suggest we go ahead and merge this to avoid blocking all the other PRs, and update in the near future to track the latest/current 14 release once the Circle images are fixed.