### PR TITLE
Expose the links feature in badge-maker

### DIFF
--- a/badge-maker/README.md
+++ b/badge-maker/README.md
@@ -67,6 +67,7 @@ The format is the following:
   message: 'passed',  // (Required) Badge message
   labelColor: '#555',  // (Optional) Label color
   color: '#4c1',  // (Optional) Message color
+  links: ['https://github.com/badges/shields'],  // (Optional) Badge links (can provide up to 2 links)
 
   // (Optional) One of: 'plastic', 'flat', 'flat-square', 'for-the-badge' or 'social'
   // Each offers a different visual design.

--- a/badge-maker/lib/index.js
+++ b/badge-maker/lib/index.js
@@ -38,7 +38,14 @@ function _validate(format) {
 }
 
 function _clean(format) {
-  const expectedKeys = ['label', 'message', 'labelColor', 'color', 'style']
+  const expectedKeys = [
+    'label',
+    'message',
+    'labelColor',
+    'color',
+    'style',
+    'links',
+  ]
 
   const cleaned = {}
   Object.keys(format).forEach(key => {
@@ -71,6 +78,7 @@ function _clean(format) {
  * @param {string} format.message (Required) Badge message (e.g: 'passing')
  * @param {string} format.labelColor (Optional) Label color
  * @param {string} format.color (Optional) Message color
+ * @param {string} format.links (Optional) Badge link(s) (e.g: ['label link', 'message link'])
  * @param {string} format.style (Optional) Visual style e.g: 'flat'
  * @returns {string} Badge in SVG format
  * @see https://github.com/badges/shields/tree/master/badge-maker/README.md


### PR DESCRIPTION
In order to utilize the 'links' feature in badge-maker, 'links' must be added to `expectedKeys`.