### PR TITLE
Configure max-age header for frontend

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -149,6 +149,9 @@ const publicConfigSchema = Joi.object({
   rateLimit: Joi.boolean().required(),
   handleInternalErrors: Joi.boolean().required(),
   fetchLimit: Joi.string().regex(/^[0-9]+(b|kb|mb|gb|tb)$/i),
+  documentRoot: Joi.string().default(
+    path.resolve(__dirname, '..', '..', 'public')
+  ),
 }).required()
 
 const privateConfigSchema = Joi.object({
@@ -429,7 +432,7 @@ class Server {
     log(`Server is starting up: ${this.baseUrl}`)
 
     const camp = (this.camp = Camp.create({
-      documentRoot: path.resolve(__dirname, '..', '..', 'public'),
+      documentRoot: this.config.public.documentRoot,
       port,
       hostname,
       secure,

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -45,6 +45,16 @@ describe('The server', function () {
         .and.to.include('apple')
     })
 
+    it('should serve front-end with default maxAge', async function () {
+      const { headers } = await got(`${baseUrl}/`)
+      expect(headers['cache-control']).to.equal('max-age=300, s-maxage=300')
+    })
+
+    it('should serve badges with custom maxAge', async function () {
+      const { headers } = await got(`${baseUrl}npm/l/express`)
+      expect(headers['cache-control']).to.equal('max-age=3600, s-maxage=3600')
+    })
+
     it('should redirect colorscheme PNG badges as configured', async function () {
       const { statusCode, headers } = await got(
         `${baseUrl}:fruit-apple-green.png`,

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const { expect } = require('chai')
 const isSvg = require('is-svg')
 const config = require('config')
@@ -13,7 +14,11 @@ describe('The server', function () {
     before('Start the server', async function () {
       // Fixes https://github.com/badges/shields/issues/2611
       this.timeout(10000)
-      server = await createTestServer()
+      server = await createTestServer({
+        public: {
+          documentRoot: path.resolve(__dirname, 'test-public'),
+        },
+      })
       baseUrl = server.baseUrl
       await server.start()
     })

--- a/core/server/test-public/index.html
+++ b/core/server/test-public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>shields.io</title>
+  </head>
+  <body>
+    concise, consistent, legible
+  </body>
+</html>


### PR DESCRIPTION
Refs #5014

Turned out this did not require a PR to camp, but it took a long time to figure out this small diff :smile: 
What this actually does is apply `frontendMaxAge` to everything, but then for every other request we then overwrite it with subsequent calls to `setHeader()`. I think this is fine though.

I've decided to just serve the front-end with a 5 minute expiry. Its not massively sophisticated, but at the moment we deploy the front-end on GH pages. GH pages just serves everything with a non-configurable 5 min expiry and I don't recall ever seeing any major front-end/back-end out-of-sync bugs (and if there are, they get fixed in 5 mins). Our current deploy strategy means we deploy front-end and back-end a bit out of sync anyway, so.. opening gambit: lets just do that and see what happens :shrug: I guess the concern is not so much front-end/back-end out-of-sync bugs, but maybe taking on the extra traffic/load of serving the front-end with a relatively short max-age might be a performance hit. We have absolutely no idea how much traffic the frontend does, so I guess we just have to try it and see..

The other questions this throws up for me are:

* Assuming this is the missing piece of the jigsaw for #5014 what are the next steps to actually move to serving everything from heroku?
* Once we do this, is there actually any value to `localhost:3000` and `localhost:8080` being different in dev? i.e: Should `npm start` become `npm run build && npm run start:server` instead of `concurrently --names server,frontend "npm run start:server" "cross-env GATSBY_BASE_URL=http://localhost:8080 gatsby develop --port 3000"` ?