### PR TITLE
[WordPress] API Update

### DIFF
--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -9,10 +9,10 @@ const stringOrFalse = Joi.alternatives(Joi.string(), Joi.bool())
 const themeSchema = Joi.object()
   .keys({
     version: Joi.string().required(),
-    rating: nonNegativeInteger.required(),
-    num_ratings: nonNegativeInteger.required(),
-    downloaded: nonNegativeInteger.required(),
-    active_installs: nonNegativeInteger.required(),
+    rating: nonNegativeInteger,
+    num_ratings: nonNegativeInteger,
+    downloaded: nonNegativeInteger,
+    active_installs: nonNegativeInteger,
   })
   .required()
 

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -19,10 +19,10 @@ const themeSchema = Joi.object()
 const pluginSchema = Joi.object()
   .keys({
     version: Joi.string().required(),
-    rating: nonNegativeInteger.required(),
-    num_ratings: nonNegativeInteger.required(),
-    downloaded: nonNegativeInteger.required(),
-    active_installs: nonNegativeInteger.required(),
+    rating: nonNegativeInteger,
+    num_ratings: nonNegativeInteger,
+    downloaded: nonNegativeInteger,
+    active_installs: nonNegativeInteger,
     requires: stringOrFalse.required(),
     tested: Joi.string().required(),
   })

--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -8,29 +8,29 @@ const stringOrFalse = Joi.alternatives(Joi.string(), Joi.bool())
 
 const themeSchema = Joi.object()
   .keys({
-    version: Joi.string(),
-    rating: nonNegativeInteger,
-    num_ratings: nonNegativeInteger,
-    downloaded: nonNegativeInteger,
-    active_installs: nonNegativeInteger,
+    version: Joi.string().required(),
+    rating: nonNegativeInteger.required(),
+    num_ratings: nonNegativeInteger.required(),
+    downloaded: nonNegativeInteger.required(),
+    active_installs: nonNegativeInteger.required(),
   })
   .required()
 
 const pluginSchema = Joi.object()
   .keys({
-    version: Joi.string(),
-    rating: nonNegativeInteger,
-    num_ratings: nonNegativeInteger,
-    downloaded: nonNegativeInteger,
-    active_installs: nonNegativeInteger,
-    requires: stringOrFalse,
-    tested: Joi.string(),
+    version: Joi.string().required(),
+    rating: nonNegativeInteger.required(),
+    num_ratings: nonNegativeInteger.required(),
+    downloaded: nonNegativeInteger.required(),
+    active_installs: nonNegativeInteger.required(),
+    requires: stringOrFalse.required(),
+    tested: Joi.string().required(),
   })
   .required()
 
 const notFoundSchema = Joi.object()
   .keys({
-    error: Joi.string(),
+    error: Joi.string().required(),
   })
   .required()
 

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -34,6 +34,7 @@ const mockedQuerySelector = {
       homepage: '0',
       tags: '0',
       screenshot_url: '0',
+      downloaded: 1,
     },
   },
 }
@@ -46,7 +47,7 @@ t.create('Plugin Tested WP Version - current')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.3',
@@ -70,7 +71,7 @@ t.create('Plugin Tested WP Version - old')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.2',
@@ -94,7 +95,7 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
   .get('/plugin/tested/akismet.json')
   .intercept(nock =>
     nock('https://api.wordpress.org')
-      .get('/plugins/info/1.1/')
+      .get('/plugins/info/1.2/')
       .query(mockedQuerySelector)
       .reply(200, {
         version: '1.2',


### PR DESCRIPTION
Related to #5493, the API Update has been split out into its own PR, to reduce the demand on the maintainers. This should also fix #5499 

The API change, required a couple of changes to schema and request, and related testing in platform tester. I also took this chance to split the plugin and theme schemas into their own separate entities to make adding the new badges from #5493 easier, however it doesn't introduce any of the schema required for those badges.

I have also `.required()` the schema as we should always receive those items for the current badge set, however I am open to exploring the option of not requiring them at the schema but dealing with errors in the badges instead.

I will handle converting service classes to static props as I continue to submit PR's for other aspects of #5493 