### PR TITLE
add a validator for 0/{{time period}}, run [GitHubCommitActivity]

### DIFF
--- a/services/github/github-commit-activity.tester.js
+++ b/services/github/github-commit-activity.tester.js
@@ -1,7 +1,16 @@
 'use strict'
 
-const { isMetricOverTimePeriod } = require('../test-validators')
+const Joi = require('@hapi/joi')
+const {
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod,
+} = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
+
+const isCommitActivity = Joi.alternatives().try(
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod
+)
 
 t.create('commit activity (1 year)').get('/y/eslint/eslint.json').expectBadge({
   label: 'commit activity',
@@ -22,7 +31,7 @@ t.create('commit activity (4 weeks)')
 
 t.create('commit activity (1 week)').get('/w/eslint/eslint.json').expectBadge({
   label: 'commit activity',
-  message: isMetricOverTimePeriod,
+  message: isCommitActivity,
 })
 
 t.create('commit activity (repo not found)')

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -76,6 +76,8 @@ const isMetricOverTimePeriod = withRegex(
   /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])\/(year|month|four weeks|week|day)$/
 )
 
+const isZeroOverTimePeriod = withRegex(/^0\/(year|month|four weeks|week|day)$/)
+
 const isIntegerPercentage = withRegex(/^[1-9][0-9]?%|^100%|^0%$/)
 const isDecimalPercentage = withRegex(/^[0-9]+\.[0-9]*%$/)
 const isPercentage = Joi.alternatives().try(
@@ -150,6 +152,7 @@ module.exports = {
   isMetricOpenIssues,
   isMetricOverMetric,
   isMetricOverTimePeriod,
+  isZeroOverTimePeriod,
   isPercentage,
   isIntegerPercentage,
   isDecimalPercentage,


### PR DESCRIPTION
I know there's some history behind why certain test validators like `isMetricOverTimePeriod` reject a value of `0` and I understand why we'd want a validator that required a positive integer. 

However, sometimes the value genuinely is 0 and historically the strategy to avoid those cases causing spurious service test failures in the past was to attempt to pick a test target that was unlikely to result in a 0. That doesn't always work though, for example from the daily test run a little earlier today: https://app.circleci.com/pipelines/github/badges/daily-tests/481/workflows/8627f386-28e0-46fb-b19c-d8c6d04b4cde/jobs/1379

I've opened this PR for consideration, which adds a _new_ validator for matching 0/timePeriod, that service tests could opt into using if needed with something `Joi.alternatives().try(isMetricOverTimePeriod, isZeroOverTimePeriod)`