### PR TITLE
Remove camelcase from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9210,13 +9210,6 @@
       "requires": {
         "anafanafo": "^1.0.0",
         "css-color-converter": "^1.1.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
-        }
       }
     },
     "bail": {


### PR DESCRIPTION
Follow up from #5533. Apparently _package-lock.json_ needed manual updating to fully get rid of the dependency there as well.