### PR TITLE
fix [jsdelivr] service tests

### DIFF
--- a/services/jsdelivr/jsdelivr-hits-github.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-github.tester.js
@@ -1,14 +1,23 @@
 'use strict'
 
-const { isMetricOverTimePeriod } = require('../test-validators')
+const Joi = require('@hapi/joi')
+const {
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod,
+} = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
+
+const isDownloadsOverTimePeriod = Joi.alternatives().try(
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod
+)
 
 t.create('jquery/jquery hits/day')
   .timeout(10000)
   .get('/hd/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
-    message: isMetricOverTimePeriod,
+    message: isDownloadsOverTimePeriod,
   })
 
 t.create('jquery/jquery hits/week')
@@ -16,7 +25,7 @@ t.create('jquery/jquery hits/week')
   .get('/hw/jquery/jquery.json')
   .expectBadge({
     label: 'jsdelivr',
-    message: isMetricOverTimePeriod,
+    message: isDownloadsOverTimePeriod,
   })
 
 t.create('jquery/jquery hits/month')

--- a/services/jsdelivr/jsdelivr-hits-npm.tester.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.tester.js
@@ -1,16 +1,25 @@
 'use strict'
 
-const { isMetricOverTimePeriod } = require('../test-validators')
+const Joi = require('@hapi/joi')
+const {
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod,
+} = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
+
+const isDownloadsOverTimePeriod = Joi.alternatives().try(
+  isMetricOverTimePeriod,
+  isZeroOverTimePeriod
+)
 
 t.create('jquery hits/day').timeout(10000).get('/hd/ky.json').expectBadge({
   label: 'jsdelivr',
-  message: isMetricOverTimePeriod,
+  message: isDownloadsOverTimePeriod,
 })
 
 t.create('jquery hits/week').timeout(10000).get('/hw/ky.json').expectBadge({
   label: 'jsdelivr',
-  message: isMetricOverTimePeriod,
+  message: isDownloadsOverTimePeriod,
 })
 
 t.create('jquery hits/month').timeout(10000).get('/hm/ky.json').expectBadge({


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/badges/daily-tests/495/workflows/4dcc5a2d-179a-40da-8956-0ffb7c3540fe/jobs/1393

Another batch of failing tests due to 0/week 

Leveraging a similar approach as #5583 for this one vs the approach in #5618 as I've found the jsdelivr service to be trickier to find good test targets