### PR TITLE
[Criterion] Add support for "no change" status

### DIFF
--- a/services/criterion/constants.js
+++ b/services/criterion/constants.js
@@ -3,5 +3,6 @@
 module.exports = Object.freeze({
   IMPROVED_STATUS: 'improved',
   REGRESSED_STATUS: 'regressed',
+  NO_CHANGE_STATUS: 'no change',
   NOT_FOUND_STATUS: 'no status found',
 })

--- a/services/criterion/criterion.service.js
+++ b/services/criterion/criterion.service.js
@@ -6,9 +6,12 @@ const {
   IMPROVED_STATUS,
   NOT_FOUND_STATUS,
   REGRESSED_STATUS,
+  NO_CHANGE_STATUS,
 } = require('./constants')
 
-const schema = Joi.string().allow(IMPROVED_STATUS, REGRESSED_STATUS).required()
+const schema = Joi.string()
+  .allow(IMPROVED_STATUS, REGRESSED_STATUS, NO_CHANGE_STATUS)
+  .required()
 
 /**
  * Criterion Badge Service

--- a/services/criterion/criterion.service.js
+++ b/services/criterion/criterion.service.js
@@ -40,7 +40,7 @@ module.exports = class Criterion extends BaseJsonService {
   static defaultBadgeData = { label: 'criterion' }
 
   static render({ status }) {
-    let statusColor = 'brightgreen'
+    let statusColor = 'lightgrey'
 
     if (status !== IMPROVED_STATUS) {
       statusColor = 'yellow'

--- a/services/criterion/criterion.service.js
+++ b/services/criterion/criterion.service.js
@@ -42,8 +42,12 @@ module.exports = class Criterion extends BaseJsonService {
   static render({ status }) {
     let statusColor = 'lightgrey'
 
-    if (status !== IMPROVED_STATUS) {
-      statusColor = 'yellow'
+    if (status === IMPROVED_STATUS) {
+      statusColor = 'brightgreen'
+    } else if (status === NO_CHANGE_STATUS) {
+      statusColor = 'green'
+    } else if (statusColor === REGRESSED_STATUS) {
+      statusColor = 'red'
     }
 
     return {

--- a/services/criterion/criterion.tester.js
+++ b/services/criterion/criterion.tester.js
@@ -5,11 +5,12 @@ const t = (module.exports = require('../tester').createServiceTester())
 const {
   IMPROVED_STATUS,
   REGRESSED_STATUS,
+  NO_CHANGE_STATUS,
   NOT_FOUND_STATUS,
 } = require('./constants')
 
 const isStatus = Joi.string()
-  .allow(IMPROVED_STATUS, NOT_FOUND_STATUS, REGRESSED_STATUS)
+  .allow(IMPROVED_STATUS, REGRESSED_STATUS, NO_CHANGE_STATUS)
   .required()
 
 t.create('Criterion (valid repo)')

--- a/services/criterion/criterion.tester.js
+++ b/services/criterion/criterion.tester.js
@@ -10,7 +10,7 @@ const {
 } = require('./constants')
 
 const isStatus = Joi.string()
-  .allow(IMPROVED_STATUS, REGRESSED_STATUS, NO_CHANGE_STATUS)
+  .allow(IMPROVED_STATUS, REGRESSED_STATUS, NOT_FOUND_STATUS, NO_CHANGE_STATUS)
   .required()
 
 t.create('Criterion (valid repo)')


### PR DESCRIPTION
While adding support for the "no change" status I noticed the criterion api updates I made last week broke your tests.  We added a "noise level threshold" to the status calculation because the runner may have something going on while a benchmark is running which makes the performance _appear_ to have regressed.  Now if a benchmark is within, for example 2% of the previous measurement, we report "no change", instead of "regressed".

Thank you for helping out with the criterion badge, you are more than welcome to assign issues related to criterion to me in the future. 