### PR TITLE
Clean up Danger rule for serverSecrets

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -111,10 +111,7 @@ if (allFiles.length > 100) {
 
     // eslint-disable-next-line promise/prefer-await-to-then
     danger.git.diffForFile(file).then(({ diff }) => {
-      if (
-        (diff.includes('authHelper') || diff.includes('serverSecrets')) &&
-        !secretsDocs.modified
-      ) {
+      if (diff.includes('authHelper') && !secretsDocs.modified) {
         warn(
           [
             `:books: Remember to ensure any changes to \`config.private\` `,


### PR DESCRIPTION
"serverSecrets" is no longer used to access auth in services, so it no longer makes sense to include it in this rule.

Ref #3393