### PR TITLE
Remove obsolete peer-to-peer GitHub token-sharing code

### DIFF
--- a/config/shields-io-production.yml
+++ b/config/shields-io-production.yml
@@ -18,7 +18,3 @@ public:
   redirectUrl: 'https://shields.io/'
 
   rasterUrl: 'https://raster.shields.io'
-
-private:
-  # These are not really private; they should be moved to `public`.
-  shields_ips: ['192.99.59.72', '51.254.114.150', '149.56.96.133']

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -59,10 +59,6 @@ function setRoutes({ rateLimit }, { server, metricInstance }) {
     next()
   })
 
-  server.get('/sys/network', (req, res) => {
-    res.json({ ips: config.public.shields_ips })
-  })
-
   server.ws('/sys/logs', socket => {
     const listener = (...msg) => socket.send(msg.join(' '))
     socket.on('close', () => log.removeListener(listener))

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const config = require('config').util.toObject()
 const secretIsValid = require('./secret-is-valid')
 const RateLimit = require('./rate-limit')
 const log = require('./log')

--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const secretIsValid = require('./secret-is-valid')
-const config = require('config').util.toObject()
 const RateLimit = require('./rate-limit')
 
 function setRoutes({ rateLimit }, { server, metricInstance }) {

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -168,7 +168,6 @@ const privateConfigSchema = Joi.object({
   npm_token: Joi.string(),
   redis_url: Joi.string().uri({ scheme: ['redis', 'rediss'] }),
   sentry_dsn: Joi.string(),
-  shields_ips: Joi.array().items(Joi.string().ip()),
   shields_secret: Joi.string(),
   sl_insight_userUuid: Joi.string(),
   sl_insight_apiToken: Joi.string(),

--- a/services/github/auth/acceptor.spec.js
+++ b/services/github/auth/acceptor.spec.js
@@ -8,27 +8,14 @@ const portfinder = require('portfinder')
 const queryString = require('query-string')
 const nock = require('nock')
 const got = require('../../../core/got-test-client')
-const serverSecrets = require('../../../lib/server-secrets')
 const GithubConstellation = require('../github-constellation')
 const acceptor = require('./acceptor')
 
 const fakeClientId = 'githubdabomb'
-const fakeShieldsSecret = 'letmeinplz'
 
 describe('Github token acceptor', function () {
   const oauthHelper = GithubConstellation._createOauthHelper({
     private: { gh_client_id: fakeClientId },
-  })
-  before(function () {
-    // Make sure properties exist.
-    // https://github.com/sinonjs/sinon/pull/1557
-    serverSecrets.shields_ips = undefined
-    serverSecrets.shields_secret = undefined
-    sinon.stub(serverSecrets, 'shields_ips').value([])
-    sinon.stub(serverSecrets, 'shields_secret').value(fakeShieldsSecret)
-  })
-  after(function () {
-    sinon.restore()
   })
 
   let port, baseUrl
@@ -128,21 +115,9 @@ describe('Github token acceptor', function () {
         expect(res.body).to.startWith(
           '<p>Shields.io has received your app-specific GitHub user token.'
         )
+
+        expect(onTokenAccepted).to.have.been.calledWith(fakeAccessToken)
       })
     })
-  })
-
-  it('should add a received token', async function () {
-    const fakeAccessToken = 'its-my-token'
-    const form = new FormData()
-    form.append('shieldsSecret', fakeShieldsSecret)
-    form.append('token', fakeAccessToken)
-
-    const { body } = await got.post(`${baseUrl}/github-auth/add-token`, {
-      body: form,
-    })
-
-    expect(onTokenAccepted).to.have.been.calledWith(fakeAccessToken)
-    expect(body).to.equal('Thanks!')
   })
 })

--- a/services/github/auth/is-valid-token.js
+++ b/services/github/auth/is-valid-token.js
@@ -1,8 +1,0 @@
-'use strict'
-
-// This is only used by the TokenProviders, though probably the acceptor
-// should use it too.
-
-const isValidToken = t => /^[0-9a-f]{40}$/.test(t)
-
-module.exports = isValidToken


### PR DESCRIPTION
Tokens are now shared exclusively through the Redis DB.

Ref #3393