### PR TITLE
Remove EditorConfig from recommend VS Code plugins

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "esbenp.prettier-vscode",
-    "EditorConfig.EditorConfig",
-    "dbaeumer.vscode-eslint"
-  ]
+  "recommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
 }


### PR DESCRIPTION
Frequently when I open Shields in VS Code it pops up a message asking if I want to install the recommended plugins. I think for Shields to recommend a plugin, we should agree it is pretty much essential for working on the project.

I have never used any form of EditorConfig. I imagine it may be useful for some users on some platforms, though for the majority of users, it is definitely not essential.

Perhaps the users who need it (Windows users?) know who they are and can take it on themselves to install the plugin if PRs cause them problems.

Certainly open to discussion if people feel otherwise!