### PR TITLE
Fix wrong anchor for writing tests document

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -311,7 +311,7 @@ Save, run `npm start`, and you can see it [locally](http://127.0.0.1:3000/).
 
 If you update `examples`, you don't have to restart the server. Run `npm run defs` in another terminal window and the frontend will update.
 
-### (4.5) Write Tests <!-- Change the link below when you change the heading -->
+### (4.5) Write Tests<!-- Change the link below when you change the heading -->
 
 [write tests]: #45-write-tests
 


### PR DESCRIPTION
I found a wrong anchor during I'm trying to create a new badge.

Because of trailing whitespace, the link became `#45-write-tests-` instead `#45-write-tests`. 