### PR TITLE
[Wordpress] Added Theme Required WP Version Badge & refactor

### DIFF
--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -14,6 +14,7 @@ const themeSchema = Joi.object()
     downloaded: nonNegativeInteger,
     active_installs: nonNegativeInteger,
     requires_php: stringOrFalse.required(),
+    requires: stringOrFalse.required(),
   })
   .required()
 

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -62,9 +62,7 @@ function WordpressRequiresVersion(extensionType) {
 }
 
 class WordpressPluginTestedVersion extends BaseWordpress {
-  static get category() {
-    return 'platform-support'
-  }
+  static category = 'platform-support'
 
   static get route() {
     return {
@@ -85,9 +83,7 @@ class WordpressPluginTestedVersion extends BaseWordpress {
     ]
   }
 
-  static get defaultBadgeData() {
-    return { label: 'wordpress' }
-  }
+  static defaultBadgeData = { label: 'wordpress' }
 
   static renderStaticPreview({ testedVersion }) {
     // Since this badge has an async `render()` function, but `get examples()` has to

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -25,22 +25,18 @@ function WordpressRequiresVersion(extensionType) {
 
     static category = 'platform-support'
 
-    static get route() {
-      return {
-        base: `wordpress/${extensionType}/wp-version`,
-        pattern: ':slug',
-      }
+    static route = {
+      base: `wordpress/${extensionType}/wp-version`,
+      pattern: ':slug',
     }
 
-    static get examples() {
-      return [
-        {
-          title: `WordPress ${capt}: Required WP Version`,
-          namedParams: { slug: exampleSlug },
-          staticPreview: this.render({ wordpressVersion: '4.8' }),
-        },
-      ]
-    }
+    static examples = [
+      {
+        title: `WordPress ${capt}: Required WP Version`,
+        namedParams: { slug: exampleSlug },
+        staticPreview: this.render({ wordpressVersion: '4.8' }),
+      },
+    ]
 
     static defaultBadgeData = { label: 'wordpress' }
 
@@ -165,8 +161,8 @@ function RequiresPHPVersionForType(extensionType) {
 
 const required_php = ['plugin', 'theme'].map(RequiresPHPVersionForType)
 const requiresVersion = ['plugin', 'theme'].map(WordpressRequiresVersion)
-module.exports = {
+module.exports = [
+  ...required_php,
   ...requiresVersion,
   WordpressPluginTestedVersion,
-  ...required_php,
-}
+]

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -17,45 +17,47 @@ const extensionData = {
   },
 }
 
-class WordpressPluginRequiresVersion extends BaseWordpress {
-  static get category() {
-    return 'platform-support'
-  }
+function WordpressRequiresVersion(extensionType) {
+  const { capt, exampleSlug } = extensionData[extensionType]
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/wp-version`,
-      pattern: ':slug',
+  return class WordpressRequiresVersion extends BaseWordpress {
+    static name = `Wordpress${capt}RequiresVersion`
+
+    static category = 'platform-support'
+
+    static get route() {
+      return {
+        base: `wordpress/${extensionType}/wp-version`,
+        pattern: ':slug',
+      }
     }
-  }
 
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin: Required WP Version',
-        namedParams: { slug: 'bbpress' },
-        staticPreview: this.render({ wordpressVersion: '4.8' }),
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'wordpress' }
-  }
-
-  static render({ wordpressVersion }) {
-    return {
-      message: addv(wordpressVersion),
-      color: versionColor(wordpressVersion),
+    static get examples() {
+      return [
+        {
+          title: `WordPress ${capt}: Required WP Version`,
+          namedParams: { slug: exampleSlug },
+          staticPreview: this.render({ wordpressVersion: '4.8' }),
+        },
+      ]
     }
-  }
 
-  async handle({ slug }) {
-    const { requires: wordpressVersion } = await this.fetch({
-      extensionType: 'plugin',
-      slug,
-    })
-    return this.constructor.render({ wordpressVersion })
+    static defaultBadgeData = { label: 'wordpress' }
+
+    static render({ wordpressVersion }) {
+      return {
+        message: addv(wordpressVersion),
+        color: versionColor(wordpressVersion),
+      }
+    }
+
+    async handle({ slug }) {
+      const { requires: wordpressVersion } = await this.fetch({
+        extensionType,
+        slug,
+      })
+      return this.constructor.render({ wordpressVersion })
+    }
   }
 }
 
@@ -166,8 +168,9 @@ function RequiresPHPVersionForType(extensionType) {
 }
 
 const required_php = ['plugin', 'theme'].map(RequiresPHPVersionForType)
+const requiresVersion = ['plugin', 'theme'].map(WordpressRequiresVersion)
 module.exports = {
-  WordpressPluginRequiresVersion,
+  ...requiresVersion,
   WordpressPluginTestedVersion,
   ...required_php,
 }

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -20,6 +20,13 @@ t.create('Plugin Required WP Version')
     message: isVPlusDottedVersionAtLeastOne,
   })
 
+t.create('Theme Required WP Version')
+  .get('/theme/wp-version/twentytwenty.json')
+  .expectBadge({
+    label: 'wordpress',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
 t.create('Plugin Tested WP Version')
   .get('/plugin/tested/akismet.json')
   .expectBadge({
@@ -126,6 +133,13 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
 
 t.create('Plugin Required WP Version | Not Found')
   .get('/plugin/wp-version/100.json')
+  .expectBadge({
+    label: 'wordpress',
+    message: 'not found',
+  })
+
+t.create('Theme Required WP Version | Not Found')
+  .get('/theme/wp-version/100.json')
   .expectBadge({
     label: 'wordpress',
     message: 'not found',


### PR DESCRIPTION
Related to #5493, this PR refactors the existing class for Plugin required WP version to also cover themes. Also in this is a slight refactor of Plugin Tested Version class to convert to static props.

Sorry the #5493 split up has been pending a while, been fairly busy with work and starting uni!