### PR TITLE
Align `label` and `message` props of `coalesceBadge()` with internal `makeBadge()`

### DIFF
--- a/badge-maker/lib/index.js
+++ b/badge-maker/lib/index.js
@@ -51,10 +51,10 @@ function _clean(format) {
     }
   })
 
+  // Legacy.
+  cleaned.label = cleaned.label || ''
+
   // convert "public" format to "internal" format
-  cleaned.text = [cleaned.label || '', cleaned.message]
-  delete cleaned.label
-  delete cleaned.message
   if ('style' in cleaned) {
     cleaned.template = cleaned.style
     delete cleaned.style

--- a/badge-maker/lib/make-badge.js
+++ b/badge-maker/lib/make-badge.js
@@ -10,7 +10,8 @@ it is likely this will impact on the package's public interface in index.js
 module.exports = function makeBadge({
   format,
   template = 'flat',
-  text,
+  label,
+  message,
   color,
   labelColor,
   logo,
@@ -19,9 +20,8 @@ module.exports = function makeBadge({
   links = ['', ''],
 }) {
   // String coercion and whitespace removal.
-  text = text.map(value => `${value}`.trim())
-
-  const [label, message] = text
+  label = `${label}`.trim()
+  message = `${message}`.trim()
 
   // This ought to be the responsibility of the server, not `makeBadge`.
   if (format === 'json') {

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -14,7 +14,8 @@ function expectBadgeToMatchSnapshot(format) {
 function testColor(color = '', colorAttr = 'color') {
   return JSON.parse(
     makeBadge({
-      text: ['name', 'Bob'],
+      label: 'name',
+      message: 'Bob',
       [colorAttr]: color,
       format: 'json',
     })
@@ -80,21 +81,26 @@ describe('The badge generator', function () {
 
   describe('SVG', function () {
     it('should produce SVG', function () {
-      expect(makeBadge({ text: ['cactus', 'grown'], format: 'svg' }))
+      expect(makeBadge({ label: 'cactus', message: 'grown', format: 'svg' }))
         .to.satisfy(isSvg)
         .and.to.include('cactus')
         .and.to.include('grown')
     })
 
     it('should match snapshot', function () {
-      expectBadgeToMatchSnapshot({ text: ['cactus', 'grown'], format: 'svg' })
+      expectBadgeToMatchSnapshot({
+        label: 'cactus',
+        message: 'grown',
+        format: 'svg',
+      })
     })
   })
 
   describe('JSON', function () {
     it('should produce the expected JSON', function () {
       const json = makeBadge({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'json',
         links: ['https://example.com/', 'https://other.example.com/'],
       })
@@ -107,13 +113,15 @@ describe('The badge generator', function () {
       })
     })
 
-    it('should replace undefined svg template with "flat"', function () {
+    it('should replace undefined svg badge style with "flat"', function () {
       const jsonBadgeWithUnknownStyle = makeBadge({
-        text: ['name', 'Bob'],
+        label: 'name',
+        message: 'Bob',
         format: 'svg',
       })
       const jsonBadgeWithDefaultStyle = makeBadge({
-        text: ['name', 'Bob'],
+        label: 'name',
+        message: 'Bob',
         format: 'svg',
         template: 'flat',
       })
@@ -122,10 +130,11 @@ describe('The badge generator', function () {
         .and.to.satisfy(isSvg)
     })
 
-    it('should fail with unknown svg template', function () {
+    it('should fail with unknown svg badge style', function () {
       expect(() =>
         makeBadge({
-          text: ['name', 'Bob'],
+          label: 'name',
+          message: 'Bob',
           format: 'svg',
           template: 'unknown_style',
         })
@@ -136,7 +145,8 @@ describe('The badge generator', function () {
   describe('"flat" template badge generation', function () {
     it('should match snapshots: message/label, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -146,7 +156,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -157,7 +168,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -166,7 +178,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -176,7 +189,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo and labelColor', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -187,7 +201,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with links', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#b3e',
@@ -200,7 +215,8 @@ describe('The badge generator', function () {
   describe('"flat-square" template badge generation', function () {
     it('should match snapshots: message/label, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -210,7 +226,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -221,7 +238,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -230,7 +248,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -240,7 +259,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo and labelColor', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -251,7 +271,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with links', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat-square',
         color: '#b3e',
@@ -264,7 +285,8 @@ describe('The badge generator', function () {
   describe('"plastic" template badge generation', function () {
     it('should match snapshots: message/label, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -274,7 +296,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -285,7 +308,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -294,7 +318,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -304,7 +329,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo and labelColor', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -315,7 +341,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with links', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'plastic',
         color: '#b3e',
@@ -330,7 +357,8 @@ describe('The badge generator', function () {
     it('numbers should produce a string', function () {
       expect(
         makeBadge({
-          text: [1998, 1999],
+          label: 1998,
+          message: 1999,
           format: 'svg',
           template: 'for-the-badge',
         })
@@ -342,7 +370,8 @@ describe('The badge generator', function () {
     it('lowercase/mixedcase string should produce uppercase string', function () {
       expect(
         makeBadge({
-          text: ['Label', '1 string'],
+          label: 'Label',
+          message: '1 string',
           format: 'svg',
           template: 'for-the-badge',
         })
@@ -353,7 +382,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -363,7 +393,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -374,7 +405,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -383,7 +415,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -393,7 +426,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo and labelColor', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -404,7 +438,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with links', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#b3e',
@@ -418,7 +453,8 @@ describe('The badge generator', function () {
     it('should produce capitalized string for badge key', function () {
       expect(
         makeBadge({
-          text: ['some-key', 'some-value'],
+          label: 'some-key',
+          message: 'some-value',
           format: 'svg',
           template: 'social',
         })
@@ -431,7 +467,8 @@ describe('The badge generator', function () {
     it('should handle empty strings used as badge keys', function () {
       expect(
         makeBadge({
-          text: ['', 'some-value'],
+          label: '',
+          message: 'some-value',
           format: 'json',
           template: 'social',
         })
@@ -442,7 +479,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -452,7 +490,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -463,7 +502,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, no logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -472,7 +512,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -482,7 +523,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message only, with logo and labelColor', function () {
       expectBadgeToMatchSnapshot({
-        text: ['', 'grown'],
+        label: '',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -493,7 +535,8 @@ describe('The badge generator', function () {
 
     it('should match snapshots: message/label, with links', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'social',
         color: '#b3e',
@@ -506,7 +549,8 @@ describe('The badge generator', function () {
   describe('badges with logos should always produce the same badge', function () {
     it('badge with logo', function () {
       expectBadgeToMatchSnapshot({
-        text: ['label', 'message'],
+        label: 'label',
+        message: 'message',
         format: 'svg',
         logo: 'data:image/svg+xml;base64,PHN2ZyB4bWxu',
       })
@@ -516,7 +560,8 @@ describe('The badge generator', function () {
   describe('text colors', function () {
     it('should use black text when the label color is light', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'flat',
         color: '#000',
@@ -526,7 +571,8 @@ describe('The badge generator', function () {
 
     it('should use black text when the message color is light', function () {
       expectBadgeToMatchSnapshot({
-        text: ['cactus', 'grown'],
+        label: 'cactus',
+        message: 'grown',
         format: 'svg',
         template: 'for-the-badge',
         color: '#e2ffe1',

--- a/core/base-service/base-svg-scraping.spec.js
+++ b/core/base-service/base-svg-scraping.spec.js
@@ -6,10 +6,6 @@ const Joi = require('joi')
 const makeBadge = require('../../badge-maker/lib/make-badge')
 const BaseSvgScrapingService = require('./base-svg-scraping')
 
-function makeExampleSvg({ label, message }) {
-  return makeBadge({ text: ['this is the label', 'this is the result!'] })
-}
-
 const schema = Joi.object({
   message: Joi.string().required(),
 }).required()
@@ -29,10 +25,7 @@ class DummySvgScrapingService extends BaseSvgScrapingService {
 describe('BaseSvgScrapingService', function () {
   const exampleLabel = 'this is the label'
   const exampleMessage = 'this is the result!'
-  const exampleSvg = makeExampleSvg({
-    label: exampleLabel,
-    message: exampleMessage,
-  })
+  const exampleSvg = makeBadge({ label: exampleLabel, message: exampleMessage })
 
   describe('valueFromSvgBadge', function () {
     it('should find the correct value', function () {

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -373,7 +373,8 @@ describe('BaseService', function () {
       const expectedFormat = 'svg'
       expect(mockSendBadge).to.have.been.calledOnce
       expect(mockSendBadge).to.have.been.calledWith(expectedFormat, {
-        text: ['cat', 'Hello namedParamA: bar with queryParamA: ?'],
+        label: 'cat',
+        message: 'Hello namedParamA: bar with queryParamA: ?',
         color: 'lightgrey',
         template: 'flat',
         namedLogo: undefined,

--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -160,12 +160,10 @@ module.exports = function coalesceBadge(
   }
 
   return {
-    text: [
-      // Use `coalesce()` to support empty labels and messages, as in the
-      // static badge.
-      coalesce(overrideLabel, serviceLabel, defaultLabel, category),
-      coalesce(serviceMessage, 'n/a'),
-    ],
+    // Use `coalesce()` to support empty labels and messages, as in the static
+    // badge.
+    label: coalesce(overrideLabel, serviceLabel, defaultLabel, category),
+    message: coalesce(serviceMessage, 'n/a'),
     color: coalesce(
       // In case of an error, disregard user's color override.
       isError ? undefined : overrideColor,

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -7,63 +7,61 @@ const coalesceBadge = require('./coalesce-badge')
 describe('coalesceBadge', function () {
   describe('Label', function () {
     it('uses the default label', function () {
-      expect(coalesceBadge({}, {}, { label: 'heyo' }).text).to.deep.equal([
-        'heyo',
-        'n/a',
-      ])
+      expect(coalesceBadge({}, {}, { label: 'heyo' })).to.include({
+        label: 'heyo',
+      })
     })
 
     // This behavior isn't great and we might want to remove it.
     it('uses the category as a default label', function () {
-      expect(
-        coalesceBadge({}, {}, {}, { category: 'cat' }).text
-      ).to.deep.equal(['cat', 'n/a'])
+      expect(coalesceBadge({}, {}, {}, { category: 'cat' })).to.include({
+        label: 'cat',
+      })
     })
 
     it('preserves an empty label', function () {
-      expect(
-        coalesceBadge({}, { label: '', message: '10k' }, {}).text
-      ).to.deep.equal(['', '10k'])
+      expect(coalesceBadge({}, { label: '', message: '10k' }, {})).to.include({
+        label: '',
+      })
     })
 
     it('overrides the label', function () {
       expect(
-        coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {}).text
-      ).to.deep.equal(['purr count', 'n/a'])
+        coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {})
+      ).to.include({ label: 'purr count' })
     })
   })
 
   describe('Message', function () {
     it('applies the service message', function () {
-      expect(coalesceBadge({}, { message: '10k' }, {}).text).to.deep.equal([
-        undefined,
-        '10k',
-      ])
+      expect(coalesceBadge({}, { message: '10k' }, {})).to.include({
+        message: '10k',
+      })
     })
 
-    it('applies a numeric service message', function () {
+    // https://github.com/badges/shields/issues/1280
+    it('converts a number to a string', function () {
       // While a number of badges use this, in the long run we may want
       // `render()` to always return a string.
-      expect(coalesceBadge({}, { message: 10 }, {}).text).to.deep.equal([
-        undefined,
-        10,
-      ])
+      expect(coalesceBadge({}, { message: 10 }, {})).to.include({
+        message: 10,
+      })
     })
   })
 
   describe('Right color', function () {
     it('uses the default color', function () {
-      expect(coalesceBadge({}, {}, {}).color).to.equal('lightgrey')
+      expect(coalesceBadge({}, {}, {})).to.include({ color: 'lightgrey' })
     })
 
     it('overrides the color', function () {
       expect(
-        coalesceBadge({ color: '10ADED' }, { color: 'red' }, {}).color
-      ).to.equal('10ADED')
+        coalesceBadge({ color: '10ADED' }, { color: 'red' }, {})
+      ).to.include({ color: '10ADED' })
       // also expected for legacy name
       expect(
-        coalesceBadge({ colorB: 'B0ADED' }, { color: 'red' }, {}).color
-      ).to.equal('B0ADED')
+        coalesceBadge({ colorB: 'B0ADED' }, { color: 'red' }, {})
+      ).to.include({ color: 'B0ADED' })
     })
 
     context('In case of an error', function () {
@@ -73,21 +71,23 @@ describe('coalesceBadge', function () {
             { color: '10ADED' },
             { isError: true, color: 'lightgray' },
             {}
-          ).color
-        ).to.equal('lightgray')
+          )
+        ).to.include({ color: 'lightgray' })
         // also expected for legacy name
         expect(
           coalesceBadge(
             { colorB: 'B0ADED' },
             { isError: true, color: 'lightgray' },
             {}
-          ).color
-        ).to.equal('lightgray')
+          )
+        ).to.include({ color: 'lightgray' })
       })
     })
 
     it('applies the service color', function () {
-      expect(coalesceBadge({}, { color: 'red' }, {}).color).to.equal('red')
+      expect(coalesceBadge({}, { color: 'red' }, {})).to.include({
+        color: 'red',
+      })
     })
   })
 
@@ -97,20 +97,19 @@ describe('coalesceBadge', function () {
     })
 
     it('applies the service label color', function () {
-      expect(coalesceBadge({}, { labelColor: 'red' }, {}).labelColor).to.equal(
-        'red'
-      )
+      expect(coalesceBadge({}, { labelColor: 'red' }, {})).to.include({
+        labelColor: 'red',
+      })
     })
 
     it('overrides the label color', function () {
       expect(
         coalesceBadge({ labelColor: '42f483' }, { color: 'green' }, {})
-          .labelColor
-      ).to.equal('42f483')
+      ).to.include({ labelColor: '42f483' })
       // also expected for legacy name
       expect(
-        coalesceBadge({ colorA: 'B2f483' }, { color: 'green' }, {}).labelColor
-      ).to.equal('B2f483')
+        coalesceBadge({ colorA: 'B2f483' }, { color: 'green' }, {})
+      ).to.include({ labelColor: 'B2f483' })
     })
 
     it('converts a query-string numeric color to a string', function () {
@@ -120,8 +119,8 @@ describe('coalesceBadge', function () {
           { color: 123 },
           { color: 'green' },
           {}
-        ).color
-      ).to.equal('123')
+        )
+      ).to.include({ color: '123' })
       // also expected for legacy name
       expect(
         coalesceBadge(
@@ -129,8 +128,8 @@ describe('coalesceBadge', function () {
           { colorB: 123 },
           { color: 'green' },
           {}
-        ).color
-      ).to.equal('123')
+        )
+      ).to.include({ color: '123' })
     })
   })
 
@@ -148,9 +147,9 @@ describe('coalesceBadge', function () {
     })
 
     it('applies the named logo', function () {
-      expect(coalesceBadge({}, { namedLogo: 'npm' }, {}).namedLogo).to.equal(
-        'npm'
-      )
+      expect(coalesceBadge({}, { namedLogo: 'npm' }, {})).to.include({
+        namedLogo: 'npm',
+      })
       expect(coalesceBadge({}, { namedLogo: 'npm' }, {}).logo).to.equal(
         getShieldsIcon({ name: 'npm' })
       ).and.not.to.be.empty
@@ -219,8 +218,8 @@ describe('coalesceBadge', function () {
     it('overrides the logo with custom svg', function () {
       const logoSvg = 'data:image/svg+xml;base64,PHN2ZyB4bWxu'
       expect(
-        coalesceBadge({ logo: logoSvg }, { namedLogo: 'appveyor' }, {}).logo
-      ).to.equal(logoSvg)
+        coalesceBadge({ logo: logoSvg }, { namedLogo: 'appveyor' }, {})
+      ).to.include({ logo: logoSvg })
     })
 
     it('ignores the color when custom svg is provided', function () {
@@ -230,35 +229,36 @@ describe('coalesceBadge', function () {
           { logo: logoSvg, logoColor: 'brightgreen' },
           { namedLogo: 'appveyor' },
           {}
-        ).logo
-      ).to.equal(logoSvg)
+        )
+      ).to.include({ logo: logoSvg })
     })
   })
 
   describe('Logo width', function () {
     it('overrides the logoWidth', function () {
-      expect(coalesceBadge({ logoWidth: 20 }, {}, {}).logoWidth).to.equal(20)
+      expect(coalesceBadge({ logoWidth: 20 }, {}, {})).to.include({
+        logoWidth: 20,
+      })
     })
 
     it('applies the logo width', function () {
       expect(
-        coalesceBadge({}, { namedLogo: 'npm', logoWidth: 275 }, {}).logoWidth
-      ).to.equal(275)
+        coalesceBadge({}, { namedLogo: 'npm', logoWidth: 275 }, {})
+      ).to.include({ logoWidth: 275 })
     })
   })
 
   describe('Logo position', function () {
     it('overrides the logoPosition', function () {
-      expect(
-        coalesceBadge({ logoPosition: -10 }, {}, {}).logoPosition
-      ).to.equal(-10)
+      expect(coalesceBadge({ logoPosition: -10 }, {}, {})).to.include({
+        logoPosition: -10,
+      })
     })
 
     it('applies the logo position', function () {
       expect(
         coalesceBadge({}, { namedLogo: 'npm', logoPosition: -10 }, {})
-          .logoPosition
-      ).to.equal(-10)
+      ).to.include({ logoPosition: -10 })
     })
   })
 
@@ -279,20 +279,24 @@ describe('coalesceBadge', function () {
 
   describe('Style', function () {
     it('falls back to flat with invalid style', function () {
-      expect(coalesceBadge({ style: 'pill' }, {}, {}).template).to.equal('flat')
-      expect(coalesceBadge({ style: 7 }, {}, {}).template).to.equal('flat')
-      expect(coalesceBadge({ style: undefined }, {}, {}).template).to.equal(
-        'flat'
-      )
+      expect(coalesceBadge({ style: 'pill' }, {}, {})).to.include({
+        template: 'flat',
+      })
+      expect(coalesceBadge({ style: 7 }, {}, {})).to.include({
+        template: 'flat',
+      })
+      expect(coalesceBadge({ style: undefined }, {}, {})).to.include({
+        template: 'flat',
+      })
     })
 
     it('replaces legacy popout styles', function () {
-      expect(coalesceBadge({ style: 'popout' }, {}, {}).template).to.equal(
-        'flat'
-      )
-      expect(
-        coalesceBadge({ style: 'popout-square' }, {}, {}).template
-      ).to.equal('flat-square')
+      expect(coalesceBadge({ style: 'popout' }, {}, {})).to.include({
+        template: 'flat',
+      })
+      expect(coalesceBadge({ style: 'popout-square' }, {}, {})).to.include({
+        template: 'flat-square',
+      })
     })
   })
 
@@ -300,8 +304,7 @@ describe('coalesceBadge', function () {
     it('overrides the cache length', function () {
       expect(
         coalesceBadge({ style: 'pill' }, { cacheSeconds: 123 }, {})
-          .cacheLengthSeconds
-      ).to.equal(123)
+      ).to.include({ cacheLengthSeconds: 123 })
     })
   })
 })

--- a/core/base-service/examples.js
+++ b/core/base-service/examples.js
@@ -124,12 +124,7 @@ function transformExample(inExample, index, ServiceClass) {
     documentation,
   } = validateExample(inExample, index, ServiceClass)
 
-  const {
-    text: [label, message],
-    color,
-    template: style,
-    namedLogo,
-  } = coalesceBadge(
+  const { label, message, color, template: style, namedLogo } = coalesceBadge(
     {},
     staticPreview,
     ServiceClass.defaultBadgeData,

--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -268,7 +268,7 @@ function handleRequest(cacheHeaderConfig, handlerOptions) {
         let dataHasChanged = false
         if (
           cached !== undefined &&
-          cached.data.badgeData.text[1] !== badgeData.text[1]
+          cached.data.badgeData.message !== badgeData.message
         ) {
           dataHasChanged = true
         }

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -314,7 +314,8 @@ class Server {
         end
       )(
         makeBadge({
-          text: ['410', `${format} no longer available`],
+          label: '410',
+          message: `${format} no longer available`,
           color: 'lightgray',
           format: 'svg',
         })
@@ -329,7 +330,8 @@ class Server {
           end
         )(
           makeBadge({
-            text: ['404', 'raster badges not available'],
+            label: '404',
+            message: 'raster badges not available',
             color: 'lightgray',
             format: 'svg',
           })
@@ -347,7 +349,8 @@ class Server {
         end
       )(
         makeBadge({
-          text: ['404', 'badge not found'],
+          label: '404',
+          message: 'badge not found',
           color: 'red',
           format,
         })


### PR DESCRIPTION
There is an internal `makeBadge()` function which is called from a few places in the server and from the public `makeBadge()` function which is a light wrapper. (Eventually we want to dogfood the public API: that's the work of #4950, and this helps with it by aligning the interfaces.)

Related to that is #3370, which is about aligning the `serviceData` schema (i.e. the result of `handle()`) with the public `makeBadge()` function.

A legacy quirk of the _private_ `makeBadge()` function is accepting a `text: ['label', 'message']` array instead of separate `{ label, message }` props like the rest of the codebase. `coalesceBadge()` has to translate from `{ label, message }` to `text: ['label', message']`. This removes that bit of indirection.

It also rewrites most of the tests of `coalesceBadge()` to use `.includes()`, providing IMO a slight improvement in readability.

This is cherry-picked from #4980 but stops short of the more substantive (and maybe controversial) changes of that PR.