### PR TITLE
[Wordpress] Plugin Issues Badge

### DIFF
--- a/services/wordpress/wordpress-base.js
+++ b/services/wordpress/wordpress-base.js
@@ -25,6 +25,8 @@ const pluginSchema = Joi.object()
     active_installs: nonNegativeInteger,
     requires: stringOrFalse.required(),
     tested: Joi.string().required(),
+    support_threads: nonNegativeInteger,
+    support_threads_resolved: nonNegativeInteger,
   })
   .required()
 
@@ -61,6 +63,8 @@ module.exports = class BaseWordpress extends BaseJsonService {
               tags: 0,
               screenshot_url: 0,
               downloaded: 1,
+              support_threads: 1,
+              support_threads_resolved: 1,
             },
           },
         },

--- a/services/wordpress/wordpress-issues.service.js
+++ b/services/wordpress/wordpress-issues.service.js
@@ -1,0 +1,239 @@
+'use strict'
+
+const BaseWordpress = require('./wordpress-base')
+
+class WordpressPluginIssues extends BaseWordpress {
+  static category = 'issue-tracking'
+
+  static route = {
+    base: `wordpress/plugin/issues`,
+    pattern: ':variant(raw|percentage|outof)/:status(open|closed)/:slug',
+  }
+
+  static examples = [
+    {
+      title: 'WordPress Plugin Issues',
+      pattern: 'raw/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'raw',
+        issues: '365',
+        closed_issues: '200',
+      }),
+    },
+    {
+      title: 'WordPress Plugin Issues (Percentage)',
+      pattern: 'percentage/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'percentage',
+        issues: '365',
+        closed_issues: '200',
+      }),
+    },
+    {
+      title: 'WordPress Plugin Issues (OutOf)',
+      pattern: 'outof/:status(open|closed)/:slug',
+      namedParams: { status: 'open', slug: 'akismet' },
+      staticPreview: this.render({
+        status: 'open',
+        variant: 'outof',
+        issues: 365,
+        closed_issues: 200,
+      }),
+    },
+  ]
+
+  static calcOpen(issues, closed_issues) {
+    return issues - closed_issues
+  }
+
+  static colorCalc(closed_percentage) {
+    if (closed_percentage < 50) {
+      return 'red'
+    } else if (closed_percentage < 90) {
+      return 'yellow'
+    } else {
+      return 'brightgreen'
+    }
+  }
+
+  static rawCalc(issues, closed_issues, status) {
+    if (status === 'open') {
+      return this.calcOpen(issues, closed_issues)
+    } else {
+      return closed_issues
+    }
+  }
+
+  static percentageCalc(issues, closed_issues, status) {
+    const percentClosed = Math.round((closed_issues / issues) * 100)
+    if (status === 'open') {
+      return 100 - percentClosed
+    } else {
+      return percentClosed
+    }
+  }
+
+  static outOfCalc(issues, closed_issues, status) {
+    if (status === 'open') {
+      const open_issues = this.calcOpen(issues, closed_issues)
+      return `${open_issues}/${issues}`
+    } else {
+      return `${closed_issues}/${issues}`
+    }
+  }
+
+  static render({ status, variant, issues, closed_issues }) {
+    const { label, value, color } = this.transform({
+      status,
+      variant,
+      issues,
+      closed_issues,
+    })
+
+    return {
+      label,
+      message: value,
+      color,
+    }
+  }
+
+  static transform({ status, variant, issues, closed_issues }) {
+    const closed_percentage = this.percentageCalc(
+      issues,
+      closed_issues,
+      'closed'
+    )
+
+    let label
+    if (status === 'open') {
+      label = 'open issues'
+    } else if (status === 'closed') {
+      label = 'closed issues'
+    }
+
+    let value
+    if (variant === 'raw') {
+      value = this.rawCalc(issues, closed_issues, status)
+    } else if (variant === 'percentage') {
+      value = `${this.percentageCalc(issues, closed_issues, status)}%`
+    } else if (variant === 'outof') {
+      value = this.outOfCalc(issues, closed_issues, status)
+    }
+
+    const color = this.colorCalc(closed_percentage)
+
+    return {
+      label,
+      value,
+      color,
+    }
+  }
+
+  async handle({ variant, status, slug }) {
+    const json = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+    const issues = json.support_threads
+    const closed_issues = json.support_threads_resolved
+
+    return this.constructor.render({
+      status,
+      variant,
+      issues,
+      closed_issues,
+    })
+  }
+}
+
+class WordpressPluginIssuesOpenClose extends BaseWordpress {
+  static category = 'issue-tracking'
+
+  static route = {
+    base: `wordpress/plugin/issues/opcl`,
+    pattern: ':slug',
+  }
+
+  static examples = [
+    {
+      title: 'WordPress Plugin issues (open/closed)',
+      namedParams: { slug: 'akismet' },
+      staticPreview: this.render({
+        issues: 300,
+        closed_issues: 259,
+      }),
+    },
+  ]
+
+  static calcOpen(issues, closed_issues) {
+    return issues - closed_issues
+  }
+
+  static colorCalc(closed_percentage) {
+    if (closed_percentage < 50) {
+      return 'red'
+    } else if (closed_percentage < 90) {
+      return 'yellow'
+    } else {
+      return 'brightgreen'
+    }
+  }
+
+  static percentageCalc(issues, closed_issues, status) {
+    const percentClosed = Math.round((closed_issues / issues) * 100)
+    if (status === 'open') {
+      return 100 - percentClosed
+    } else {
+      return percentClosed
+    }
+  }
+
+  static valueColor(issues, closed_issues) {
+    const closed_percentage = this.percentageCalc(
+      issues,
+      closed_issues,
+      'closed'
+    )
+
+    const color = this.colorCalc(closed_percentage)
+    const open_issues = this.calcOpen(issues, closed_issues)
+    const value = `${open_issues}/${closed_issues}`
+
+    return {
+      value,
+      color,
+    }
+  }
+
+  static render({ issues, closed_issues }) {
+    const { value, color } = this.valueColor(issues, closed_issues)
+    return {
+      label: 'open/closed',
+      message: value,
+      color,
+    }
+  }
+
+  async handle({ slug }) {
+    const { support_threads, support_threads_resolved } = await this.fetch({
+      extensionType: 'plugin',
+      slug,
+    })
+    const issues = support_threads
+    const closed_issues = support_threads_resolved
+
+    return this.constructor.render({
+      issues,
+      closed_issues,
+    })
+  }
+}
+
+module.exports = {
+  WordpressPluginIssues,
+  WordpressPluginIssuesOpenClose,
+}

--- a/services/wordpress/wordpress-issues.tester.js
+++ b/services/wordpress/wordpress-issues.tester.js
@@ -1,11 +1,14 @@
 'use strict'
 
+const Joi = require('joi')
 const { ServiceTester } = require('../tester')
 const {
   isMetric,
   isIntegerPercentage,
   isMetricOverMetric,
 } = require('../test-validators')
+
+const isOpenClosedIssue = Joi.string().regex(/^[0-9]+ open, [0-9]+ closed$/)
 
 const t = new ServiceTester({
   id: 'wordpress',
@@ -55,9 +58,16 @@ t.create('Plugin Issues - Closed Out Of')
     message: isMetricOverMetric,
   })
 
-t.create('Plugin Issues - Open/Closed')
-  .get('/plugin/issues/opcl/jetpack.json')
+t.create('Plugin Issues - Open/Closed (Short)')
+  .get('/plugin/issues/opcl-min/jetpack.json')
   .expectBadge({
     label: 'open/closed',
     message: isMetricOverMetric,
+  })
+
+t.create('Plugin Issues - Open/Close (Long)')
+  .get('/plugin/issues/opcl-long/jetpack.json')
+  .expectBadge({
+    label: 'issues',
+    message: isOpenClosedIssue,
   })

--- a/services/wordpress/wordpress-issues.tester.js
+++ b/services/wordpress/wordpress-issues.tester.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const {
+  isMetric,
+  isIntegerPercentage,
+  isMetricOverMetric,
+} = require('../test-validators')
+
+const t = new ServiceTester({
+  id: 'wordpress',
+  title: 'WordPress Plugin Issues',
+})
+module.exports = t
+
+t.create('Plugin Issues - Open Raw')
+  .get('/plugin/issues/raw/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isMetric,
+  })
+
+t.create('Plugin Issues - Closed Raw')
+  .get('/plugin/issues/raw/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isMetric,
+  })
+
+t.create('Plugin Issues - Open Percentage')
+  .get('/plugin/issues/percentage/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isIntegerPercentage,
+  })
+
+t.create('Plugin Issues - Closed Percentage')
+  .get('/plugin/issues/percentage/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isIntegerPercentage,
+  })
+
+t.create('Plugin Issues - Open Out Of')
+  .get('/plugin/issues/outof/open/jetpack.json')
+  .expectBadge({
+    label: 'open issues',
+    message: isMetricOverMetric,
+  })
+
+t.create('Plugin Issues - Closed Out Of')
+  .get('/plugin/issues/outof/closed/jetpack.json')
+  .expectBadge({
+    label: 'closed issues',
+    message: isMetricOverMetric,
+  })
+
+t.create('Plugin Issues - Open/Closed')
+  .get('/plugin/issues/opcl/jetpack.json')
+  .expectBadge({
+    label: 'open/closed',
+    message: isMetricOverMetric,
+  })

--- a/services/wordpress/wordpress-platform.tester.js
+++ b/services/wordpress/wordpress-platform.tester.js
@@ -35,6 +35,8 @@ const mockedQuerySelector = {
       tags: '0',
       screenshot_url: '0',
       downloaded: 1,
+      support_threads: 1,
+      support_threads_resolved: 1,
     },
   },
 }
@@ -57,6 +59,8 @@ t.create('Plugin Tested WP Version - current')
         active_installs: 100,
         requires: '4.9',
         tested: '4.9.8',
+        support_threads: 100,
+        support_threads_resolved: 90,
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)
@@ -81,6 +85,8 @@ t.create('Plugin Tested WP Version - old')
         active_installs: 100,
         requires: '4.9',
         tested: '4.9.6',
+        support_threads: 100,
+        support_threads_resolved: 90,
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)
@@ -105,6 +111,8 @@ t.create('Plugin Tested WP Version - non-exsistant or unsupported')
         active_installs: 100,
         requires: '4.0',
         tested: '4.0.0',
+        support_threads: 100,
+        support_threads_resolved: 90,
       })
       .get('/core/version-check/1.7/')
       .reply(200, mockedCoreResponseData)


### PR DESCRIPTION
Related to #5493, this PR adds the Plugin Issues badge's. These include several styles, so may need to strip some out to be more inline with other services; I kinda just made everything I think someone may want in a badge. This includes:
- Raw (Open & Closed)
- Percentage (Open & Closed)
- Out of (Open & Closed, eg: |open issues| 20/100 |)
- Open/Closed comparison (Short or long format eg: |open/closed| 20/80| or |issues| 20 open, 80 closed | )


