### PR TITLE
Specifying logoColor does not work with logoSvg

### DIFF
--- a/frontend/pages/endpoint.tsx
+++ b/frontend/pages/endpoint.tsx
@@ -209,7 +209,7 @@ export default function EndpointPage(): JSX.Element {
         <dt>logoColor</dt>
         <dd>
           Default: none. Same meaning as the query string. Can be overridden by
-          the query string.
+          the query string. Only works for named logos.
         </dd>
         <dt>logoWidth</dt>
         <dd>


### PR DESCRIPTION
If your endpoint specifies the `logoSvg` property you can _not_ specify the `logoColor` property. This will result in the 'invalid properties: logoColor' badge.

Related to #4749