### PR TITLE
getSimpleIcon handles 'get' icon

### DIFF
--- a/lib/logos.spec.js
+++ b/lib/logos.spec.js
@@ -6,6 +6,7 @@ const {
   prependPrefix,
   isDataUrl,
   prepareNamedLogo,
+  getSimpleIcon,
   makeLogo,
 } = require('./logos')
 
@@ -96,6 +97,13 @@ describe('Logo helpers', function () {
       ).toString('ascii')
       expect(decodedLogo).to.contain('fill="#00AFF0"')
     })
+  })
+
+  test(getSimpleIcon, () => {
+    // https://github.com/badges/shields/issues/4016
+    given({ name: 'get' }).expect(undefined)
+    // https://github.com/badges/shields/issues/4263
+    given({ name: 'get', color: 'blue' }).expect(undefined)
   })
 
   test(makeLogo, () => {


### PR DESCRIPTION
This PR adds a test which verifies that `lib/logos.js#getSimpleIcon` properly handles `get` value. Related to https://github.com/badges/shields/issues/4263 and https://github.com/badges/shields/issues/4016. 