### PR TITLE
FIx issue where anafanafo is not installed in Heroku

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8343,14 +8343,6 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
-    "anafanafo": {
-      "version": "2.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-2.0.0-beta.1.tgz",
-      "integrity": "sha512-v3uSR69R5g/Ou7xDj320//cZKFE6QzEcr+Q9xeYoU/Kln6T8Ziy3Kap1yvdaJW4kSN0Tzvp35O5ETPr+11z+yA==",
-      "requires": {
-        "char-width-table-consumer": "^1.0.0"
-      }
-    },
     "ansi-align": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
@@ -9972,6 +9964,16 @@
       "requires": {
         "anafanafo": "2.0.0",
         "css-color-converter": "^2.0.0"
+      },
+      "dependencies": {
+        "anafanafo": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-2.0.0.tgz",
+          "integrity": "sha512-Nlfq7NC4AOkTJerWRIZcOAiMNtIDVIGWGvQ98O7Jl6Kr2Dk0dX5u4MqN778kSRTy5KRqchpLdF2RtLFEz9FVkQ==",
+          "requires": {
+            "char-width-table-consumer": "^1.0.0"
+          }
+        }
       }
     },
     "bail": {


### PR DESCRIPTION
Staging is down because `anafanafo` is not installed.

```
2020-10-19T01:02:51.968076+00:00 app[web.1]: {
2020-10-19T01:02:51.968079+00:00 app[web.1]: bind: { address: '0.0.0.0', port: '37950' },
2020-10-19T01:02:51.968079+00:00 app[web.1]: metrics: {
2020-10-19T01:02:51.968081+00:00 app[web.1]: prometheus: { enabled: 'true', endpointEnabled: false },
2020-10-19T01:02:51.968081+00:00 app[web.1]: influx: {
2020-10-19T01:02:51.968082+00:00 app[web.1]: enabled: 'true',
2020-10-19T01:02:51.968082+00:00 app[web.1]: timeoutMilliseconds: 1000,
2020-10-19T01:02:51.968082+00:00 app[web.1]: intervalSeconds: 15,
2020-10-19T01:02:51.968083+00:00 app[web.1]: url: 'https://metrics.shields.io/telegraf',
2020-10-19T01:02:51.968083+00:00 app[web.1]: instanceIdFrom: 'env-var',
2020-10-19T01:02:51.968083+00:00 app[web.1]: instanceIdEnvVarName: 'HEROKU_DYNO_ID',
2020-10-19T01:02:51.968084+00:00 app[web.1]: envLabel: 'shields-staging'
2020-10-19T01:02:51.968084+00:00 app[web.1]: }
2020-10-19T01:02:51.968084+00:00 app[web.1]: },
2020-10-19T01:02:51.968085+00:00 app[web.1]: ssl: { isSecure: false },
2020-10-19T01:02:51.968085+00:00 app[web.1]: cors: { allowedOrigin: [] },
2020-10-19T01:02:51.968085+00:00 app[web.1]: services: {
2020-10-19T01:02:51.968085+00:00 app[web.1]: github: {
2020-10-19T01:02:51.968086+00:00 app[web.1]: baseUri: 'https://api.github.com/',
2020-10-19T01:02:51.968086+00:00 app[web.1]: debug: { enabled: false, intervalSeconds: 200 }
2020-10-19T01:02:51.968086+00:00 app[web.1]: },
2020-10-19T01:02:51.968087+00:00 app[web.1]: trace: false
2020-10-19T01:02:51.968087+00:00 app[web.1]: },
2020-10-19T01:02:51.968087+00:00 app[web.1]: cacheHeaders: { defaultCacheLengthSeconds: 120 },
2020-10-19T01:02:51.968087+00:00 app[web.1]: rateLimit: true,
2020-10-19T01:02:51.968088+00:00 app[web.1]: handleInternalErrors: true,
2020-10-19T01:02:51.968088+00:00 app[web.1]: fetchLimit: '10MB',
2020-10-19T01:02:51.968088+00:00 app[web.1]: requireCloudflare: false,
2020-10-19T01:02:51.968089+00:00 app[web.1]: rasterUrl: 'https://shields-raster-staging.now.sh'
2020-10-19T01:02:51.968089+00:00 app[web.1]: }
2020-10-19T01:02:52.247415+00:00 app[web.1]: internal/modules/cjs/loader.js:834
2020-10-19T01:02:52.247433+00:00 app[web.1]: throw err;
2020-10-19T01:02:52.247434+00:00 app[web.1]: ^
2020-10-19T01:02:52.247434+00:00 app[web.1]:
2020-10-19T01:02:52.247435+00:00 app[web.1]: Error: Cannot find module 'anafanafo'
2020-10-19T01:02:52.247435+00:00 app[web.1]: Require stack:
2020-10-19T01:02:52.247435+00:00 app[web.1]: - /app/badge-maker/lib/badge-renderers.js
2020-10-19T01:02:52.247436+00:00 app[web.1]: - /app/badge-maker/lib/make-badge.js
2020-10-19T01:02:52.247436+00:00 app[web.1]: - /app/core/server/server.js
2020-10-19T01:02:52.247437+00:00 app[web.1]: - /app/server.js
2020-10-19T01:02:52.247437+00:00 app[web.1]: at Function.Module._resolveFilename (internal/modules/cjs/loader.js:831:15)
2020-10-19T01:02:52.247438+00:00 app[web.1]: at Function.Module._load (internal/modules/cjs/loader.js:687:27)
2020-10-19T01:02:52.247438+00:00 app[web.1]: at Module.require (internal/modules/cjs/loader.js:903:19)
2020-10-19T01:02:52.247439+00:00 app[web.1]: at require (internal/modules/cjs/helpers.js:74:18)
2020-10-19T01:02:52.247439+00:00 app[web.1]: at Object.<anonymous> (/app/badge-maker/lib/badge-renderers.js:3:19)
2020-10-19T01:02:52.247440+00:00 app[web.1]: at Module._compile (internal/modules/cjs/loader.js:1015:30)
2020-10-19T01:02:52.247440+00:00 app[web.1]: at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
2020-10-19T01:02:52.247440+00:00 app[web.1]: at Module.load (internal/modules/cjs/loader.js:879:32)
2020-10-19T01:02:52.247441+00:00 app[web.1]: at Function.Module._load (internal/modules/cjs/loader.js:724:14)
2020-10-19T01:02:52.247441+00:00 app[web.1]: at Module.require (internal/modules/cjs/loader.js:903:19) {
2020-10-19T01:02:52.247441+00:00 app[web.1]: code: 'MODULE_NOT_FOUND',
2020-10-19T01:02:52.247442+00:00 app[web.1]: requireStack: [
2020-10-19T01:02:52.247442+00:00 app[web.1]: '/app/badge-maker/lib/badge-renderers.js',
2020-10-19T01:02:52.247443+00:00 app[web.1]: '/app/badge-maker/lib/make-badge.js',
2020-10-19T01:02:52.247443+00:00 app[web.1]: '/app/core/server/server.js',
2020-10-19T01:02:52.247443+00:00 app[web.1]: '/app/server.js'
2020-10-19T01:02:52.247444+00:00 app[web.1]: ]
2020-10-19T01:02:52.247444+00:00 app[web.1]: }
```

----

This diff was produced by running `npm install`.

I’m not sure what caused this. Maybe it was a merge error?

**Added:** Looks like it happened in a dependabot bump: #5746.