### PR TITLE
Refactor `static get`:  [website wercker wheelmap wordpress youtube]

### DIFF
--- a/services/website/website.service.js
+++ b/services/website/website.service.js
@@ -36,37 +36,29 @@ const urlQueryParamSchema = Joi.object({
 }).required()
 
 module.exports = class Website extends BaseService {
-  static get category() {
-    return 'monitoring'
+  static category = 'monitoring'
+
+  static route = {
+    base: '',
+    pattern: 'website',
+    queryParamSchema: queryParamSchema.concat(urlQueryParamSchema),
   }
 
-  static get route() {
-    return {
-      base: '',
-      pattern: 'website',
-      queryParamSchema: queryParamSchema.concat(urlQueryParamSchema),
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Website',
-        namedParams: {},
-        queryParams: {
-          ...exampleQueryParams,
-          ...{ url: 'https://shields.io' },
-        },
-        staticPreview: renderWebsiteStatus({ isUp: true }),
-        documentation,
+  static examples = [
+    {
+      title: 'Website',
+      namedParams: {},
+      queryParams: {
+        ...exampleQueryParams,
+        ...{ url: 'https://shields.io' },
       },
-    ]
-  }
+      staticPreview: renderWebsiteStatus({ isUp: true }),
+      documentation,
+    },
+  ]
 
-  static get defaultBadgeData() {
-    return {
-      label: 'website',
-    }
+  static defaultBadgeData = {
+    label: 'website',
   }
 
   async _request({ url, options = {} }) {

--- a/services/wercker/wercker.service.js
+++ b/services/wercker/wercker.service.js
@@ -33,59 +33,53 @@ const werckerCIDocumentation = `
 `
 
 module.exports = class Wercker extends BaseJsonService {
-  static get category() {
-    return 'build'
+  static category = 'build'
+
+  static route = {
+    base: 'wercker',
+    format:
+      '(?:(?:ci/)([a-fA-F0-9]{24})|(?:build|ci)/([^/]+/[^/]+?))(?:/(.+?))?',
+    capture: ['projectId', 'applicationName', 'branch'],
   }
 
-  static get route() {
-    return {
-      base: 'wercker',
-      format:
-        '(?:(?:ci/)([a-fA-F0-9]{24})|(?:build|ci)/([^/]+/[^/]+?))(?:/(.+?))?',
-      capture: ['projectId', 'applicationName', 'branch'],
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: `Wercker CI Run`,
-        pattern: 'ci/:applicationId',
-        namedParams: { applicationId: '559e33c8e982fc615500b357' },
-        staticPreview: this.render({ result: 'passed' }),
-        documentation: werckerCIDocumentation,
+  static examples = [
+    {
+      title: `Wercker CI Run`,
+      pattern: 'ci/:applicationId',
+      namedParams: { applicationId: '559e33c8e982fc615500b357' },
+      staticPreview: this.render({ result: 'passed' }),
+      documentation: werckerCIDocumentation,
+    },
+    {
+      title: `Wercker CI Run`,
+      pattern: 'ci/:applicationId/:branch',
+      namedParams: {
+        applicationId: '559e33c8e982fc615500b357',
+        branch: 'master',
       },
-      {
-        title: `Wercker CI Run`,
-        pattern: 'ci/:applicationId/:branch',
-        namedParams: {
-          applicationId: '559e33c8e982fc615500b357',
-          branch: 'master',
-        },
-        staticPreview: this.render({ result: 'passed' }),
-        documentation: werckerCIDocumentation,
+      staticPreview: this.render({ result: 'passed' }),
+      documentation: werckerCIDocumentation,
+    },
+    {
+      title: `Wercker Build`,
+      pattern: 'build/:userName/:applicationName',
+      namedParams: {
+        userName: 'wercker',
+        applicationName: 'go-wercker-api',
       },
-      {
-        title: `Wercker Build`,
-        pattern: 'build/:userName/:applicationName',
-        namedParams: {
-          userName: 'wercker',
-          applicationName: 'go-wercker-api',
-        },
-        staticPreview: this.render({ result: 'passed' }),
+      staticPreview: this.render({ result: 'passed' }),
+    },
+    {
+      title: `Wercker Build branch`,
+      pattern: 'build/:userName/:applicationName/:branch',
+      namedParams: {
+        userName: 'wercker',
+        applicationName: 'go-wercker-api',
+        branch: 'master',
       },
-      {
-        title: `Wercker Build branch`,
-        pattern: 'build/:userName/:applicationName/:branch',
-        namedParams: {
-          userName: 'wercker',
-          applicationName: 'go-wercker-api',
-          branch: 'master',
-        },
-        staticPreview: this.render({ result: 'passed' }),
-      },
-    ]
-  }
+      staticPreview: this.render({ result: 'passed' }),
+    },
+  ]
 
   static render({ result }) {
     return renderBuildStatusBadge({ status: result })

--- a/services/wheelmap/wheelmap.service.js
+++ b/services/wheelmap/wheelmap.service.js
@@ -10,38 +10,28 @@ const schema = Joi.object({
 }).required()
 
 module.exports = class Wheelmap extends BaseJsonService {
-  static get category() {
-    return 'other'
+  static category = 'other'
+
+  static route = {
+    base: 'wheelmap/a',
+    pattern: ':nodeId(-?[0-9]+)',
   }
 
-  static get route() {
-    return {
-      base: 'wheelmap/a',
-      pattern: ':nodeId(-?[0-9]+)',
-    }
+  static auth = {
+    passKey: 'wheelmap_token',
+    authorizedOrigins: ['https://wheelmap.org'],
+    isRequired: true,
   }
 
-  static get auth() {
-    return {
-      passKey: 'wheelmap_token',
-      authorizedOrigins: ['https://wheelmap.org'],
-      isRequired: true,
-    }
-  }
+  static examples = [
+    {
+      title: 'Wheelmap',
+      namedParams: { nodeId: '26699541' },
+      staticPreview: this.render({ accessibility: 'yes' }),
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        title: 'Wheelmap',
-        namedParams: { nodeId: '26699541' },
-        staticPreview: this.render({ accessibility: 'yes' }),
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'accessibility' }
-  }
+  static defaultBadgeData = { label: 'accessibility' }
 
   static render({ accessibility }) {
     let color

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -60,24 +60,20 @@ function WordpressRequiresVersion(extensionType) {
 class WordpressPluginTestedVersion extends BaseWordpress {
   static category = 'platform-support'
 
-  static get route() {
-    return {
-      base: `wordpress/plugin/tested`,
-      pattern: ':slug',
-    }
+  static route = {
+    base: `wordpress/plugin/tested`,
+    pattern: ':slug',
   }
 
-  static get examples() {
-    return [
-      {
-        title: 'WordPress Plugin: Tested WP Version',
-        namedParams: { slug: 'bbpress' },
-        staticPreview: this.renderStaticPreview({
-          testedVersion: '4.9.8',
-        }),
-      },
-    ]
-  }
+  static examples = [
+    {
+      title: 'WordPress Plugin: Tested WP Version',
+      namedParams: { slug: 'bbpress' },
+      staticPreview: this.renderStaticPreview({
+        testedVersion: '4.9.8',
+      }),
+    },
+  ]
 
   static defaultBadgeData = { label: 'wordpress' }
 

--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -21,20 +21,18 @@ const schema = Joi.object({
 }).required()
 
 module.exports = class YouTubeBase extends BaseJsonService {
-  static get category() {
-    return 'social'
+  static category = 'social'
+
+  static auth = {
+    passKey: 'youtube_api_key',
+    authorizedOrigins: ['https://www.googleapis.com'],
+    isRequired: true,
   }
 
-  static get auth() {
-    return {
-      passKey: 'youtube_api_key',
-      authorizedOrigins: ['https://www.googleapis.com'],
-      isRequired: true,
-    }
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'youtube', color: 'red', namedLogo: 'youtube' }
+  static defaultBadgeData = {
+    label: 'youtube',
+    color: 'red',
+    namedLogo: 'youtube',
   }
 
   static renderSingleStat({ statistics, statisticName, videoId }) {

--- a/services/youtube/youtube-comments.service.js
+++ b/services/youtube/youtube-comments.service.js
@@ -3,11 +3,9 @@
 const YouTubeBase = require('./youtube-base')
 
 module.exports = class YouTubeComments extends YouTubeBase {
-  static get route() {
-    return {
-      base: 'youtube/comments',
-      pattern: ':videoId',
-    }
+  static route = {
+    base: 'youtube/comments',
+    pattern: ':videoId',
   }
 
   static get examples() {

--- a/services/youtube/youtube-likes.service.js
+++ b/services/youtube/youtube-likes.service.js
@@ -9,12 +9,10 @@ const queryParamSchema = Joi.object({
 }).required()
 
 module.exports = class YouTubeLikes extends YouTubeBase {
-  static get route() {
-    return {
-      base: 'youtube/likes',
-      pattern: ':videoId',
-      queryParamSchema,
-    }
+  static route = {
+    base: 'youtube/likes',
+    pattern: ':videoId',
+    queryParamSchema,
   }
 
   static get examples() {

--- a/services/youtube/youtube-views.service.js
+++ b/services/youtube/youtube-views.service.js
@@ -3,11 +3,9 @@
 const YouTubeBase = require('./youtube-base')
 
 module.exports = class YouTubeViews extends YouTubeBase {
-  static get route() {
-    return {
-      base: 'youtube/views',
-      pattern: ':videoId',
-    }
+  static route = {
+    base: 'youtube/views',
+    pattern: ':videoId',
   }
 
   static get examples() {


### PR DESCRIPTION
This should end the refactor for #5555.

I did left the `static get examples() { ... }` in YouTube services as those are computed values.

Searching for `static get ` still gives some results that could be migrated to `static variable = ...`, should I address theses ?