### PR TITLE
Refactor forgotten `static get` in services; affects [appveyor aur azuredevops jenkins jsdelivr keybase lgtm liberapay opencollective snyk sonar teamcity tokei twitter visualstudiomarketplace]

### DIFF
--- a/services/appveyor/appveyor-tests.service.js
+++ b/services/appveyor/appveyor-tests.service.js
@@ -100,10 +100,8 @@ module.exports = class AppVeyorTests extends AppVeyorBase {
     },
   ]
 
-  static get defaultBadgeData() {
-    return {
-      label: 'tests',
-    }
+  static defaultBadgeData = {
+    label: 'tests',
   }
 
   static render({

--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -168,30 +168,22 @@ class AurMaintainer extends BaseAurService {
 }
 
 class AurLastModified extends BaseAurService {
-  static get category() {
-    return 'activity'
+  static category = 'activity'
+
+  static route = {
+    base: 'aur/last-modified',
+    pattern: ':packageName',
   }
 
-  static get route() {
-    return {
-      base: 'aur/last-modified',
-      pattern: ':packageName',
-    }
-  }
+  static examples = [
+    {
+      title: 'AUR last modified',
+      namedParams: { packageName: 'google-chrome' },
+      staticPreview: this.render({ date: new Date().getTime() }),
+    },
+  ]
 
-  static get examples() {
-    return [
-      {
-        title: 'AUR last modified',
-        namedParams: { packageName: 'google-chrome' },
-        staticPreview: this.render({ date: new Date().getTime() }),
-      },
-    ]
-  }
-
-  static get defaultBadgeData() {
-    return { label: 'last modified' }
-  }
+  static defaultBadgeData = { label: 'last modified' }
 
   static render({ date }) {
     const color = ageColor(date)

--- a/services/azure-devops/azure-devops-base.js
+++ b/services/azure-devops/azure-devops-base.js
@@ -15,12 +15,10 @@ const latestBuildSchema = Joi.object({
 }).required()
 
 module.exports = class AzureDevOpsBase extends BaseJsonService {
-  static get auth() {
-    return {
-      passKey: 'azure_devops_token',
-      authorizedOrigins: ['https://dev.azure.com'],
-      defaultToEmptyStringForUser: true,
-    }
+  static auth = {
+    passKey: 'azure_devops_token',
+    authorizedOrigins: ['https://dev.azure.com'],
+    defaultToEmptyStringForUser: true,
   }
 
   async fetch({ url, options, schema, errorMessages }) {

--- a/services/jenkins/jenkins-base.js
+++ b/services/jenkins/jenkins-base.js
@@ -3,12 +3,10 @@
 const { BaseJsonService } = require('..')
 
 module.exports = class JenkinsBase extends BaseJsonService {
-  static get auth() {
-    return {
-      userKey: 'jenkins_user',
-      passKey: 'jenkins_pass',
-      serviceKey: 'jenkins',
-    }
+  static auth = {
+    userKey: 'jenkins_user',
+    passKey: 'jenkins_pass',
+    serviceKey: 'jenkins',
   }
 
   async fetch({

--- a/services/jenkins/jenkins-coverage.service.js
+++ b/services/jenkins/jenkins-coverage.service.js
@@ -82,38 +82,30 @@ const documentation = `
 `
 
 module.exports = class JenkinsCoverage extends JenkinsBase {
-  static get category() {
-    return 'coverage'
+  static category = 'coverage'
+
+  static route = {
+    base: 'jenkins/coverage',
+    pattern: ':format(jacoco|cobertura|api)',
+    queryParamSchema,
   }
 
-  static get route() {
-    return {
-      base: 'jenkins/coverage',
-      pattern: ':format(jacoco|cobertura|api)',
-      queryParamSchema,
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Jenkins Coverage',
-        namedParams: {
-          format: 'cobertura',
-        },
-        queryParams: {
-          jobUrl: 'https://jenkins.sqlalchemy.org/job/alembic_coverage',
-        },
-        keywords: ['jacoco', 'cobertura', 'llvm-cov', 'istanbul'],
-        staticPreview: this.render({ coverage: 95 }),
-        documentation,
+  static examples = [
+    {
+      title: 'Jenkins Coverage',
+      namedParams: {
+        format: 'cobertura',
       },
-    ]
-  }
+      queryParams: {
+        jobUrl: 'https://jenkins.sqlalchemy.org/job/alembic_coverage',
+      },
+      keywords: ['jacoco', 'cobertura', 'llvm-cov', 'istanbul'],
+      staticPreview: this.render({ coverage: 95 }),
+      documentation,
+    },
+  ]
 
-  static get defaultBadgeData() {
-    return { label: 'coverage' }
-  }
+  static defaultBadgeData = { label: 'coverage' }
 
   static render({ coverage }) {
     return {

--- a/services/jsdelivr/jsdelivr-base.js
+++ b/services/jsdelivr/jsdelivr-base.js
@@ -17,14 +17,10 @@ const periodMap = {
 }
 
 class BaseJsDelivrService extends BaseJsonService {
-  static get category() {
-    return 'downloads'
-  }
+  static category = 'downloads'
 
-  static get defaultBadgeData() {
-    return {
-      label: 'jsdelivr',
-    }
+  static defaultBadgeData = {
+    label: 'jsdelivr',
   }
 
   static render({ period, hits }) {

--- a/services/keybase/keybase-profile.js
+++ b/services/keybase/keybase-profile.js
@@ -8,9 +8,7 @@ module.exports = class KeybaseProfile extends BaseJsonService {
     throw new Error(`apiVersion() is not implemented for ${this.name}`)
   }
 
-  static get category() {
-    return 'social'
-  }
+  static category = 'social'
 
   async fetch({ schema, options }) {
     const apiVersion = this.constructor.apiVersion

--- a/services/lgtm/lgtm-base.js
+++ b/services/lgtm/lgtm-base.js
@@ -23,17 +23,11 @@ const hostMappings = {
 }
 
 module.exports = class LgtmBaseService extends BaseJsonService {
-  static get category() {
-    return 'analysis'
-  }
+  static category = 'analysis'
 
-  static get defaultBadgeData() {
-    return { label: 'lgtm' }
-  }
+  static defaultBadgeData = { label: 'lgtm' }
 
-  static get pattern() {
-    return `:host(${Object.keys(hostMappings).join('|')})/:user/:repo`
-  }
+  static pattern = `:host(${Object.keys(hostMappings).join('|')})/:user/:repo`
 
   async fetch({ host, user, repo }) {
     const mappedHost = hostMappings[host]

--- a/services/liberapay/liberapay-base.js
+++ b/services/liberapay/liberapay-base.js
@@ -43,15 +43,11 @@ function renderCurrencyBadge({ label, amount, currency }) {
 }
 
 class LiberapayBase extends BaseJsonService {
-  static get category() {
-    return 'funding'
-  }
+  static category = 'funding'
 
-  static get defaultBadgeData() {
-    return {
-      label: 'liberapay',
-      namedLogo: 'liberapay',
-    }
+  static defaultBadgeData = {
+    label: 'liberapay',
+    namedLogo: 'liberapay',
   }
 
   async fetch({ entity }) {

--- a/services/opencollective/opencollective-base.js
+++ b/services/opencollective/opencollective-base.js
@@ -22,9 +22,7 @@ function buildMembersArraySchema({ userType, tierRequired }) {
 }
 
 module.exports = class OpencollectiveBase extends BaseJsonService {
-  static get category() {
-    return 'funding'
-  }
+  static category = 'funding'
 
   static buildRoute(base, withTierId) {
     return {

--- a/services/snyk/snyk-vulnerability-base.js
+++ b/services/snyk/snyk-vulnerability-base.js
@@ -10,14 +10,10 @@ const schema = Joi.object({
 }).required()
 
 module.exports = class SnykVulnerabilityBase extends BaseSvgScrapingService {
-  static get category() {
-    return 'analysis'
-  }
+  static category = 'analysis'
 
-  static get defaultBadgeData() {
-    return {
-      label: 'vulnerabilities',
-    }
+  static defaultBadgeData = {
+    label: 'vulnerabilities',
   }
 
   static render({ vulnerabilities }) {

--- a/services/sonar/sonar-base.js
+++ b/services/sonar/sonar-base.js
@@ -52,9 +52,7 @@ const legacySchema = Joi.array()
   .required()
 
 module.exports = class SonarBase extends BaseJsonService {
-  static get auth() {
-    return { userKey: 'sonarqube_token', serviceKey: 'sonar' }
-  }
+  static auth = { userKey: 'sonarqube_token', serviceKey: 'sonar' }
 
   async fetch({ sonarVersion, server, component, metricName }) {
     const useLegacyApi = isLegacyVersion({ sonarVersion })

--- a/services/teamcity/teamcity-base.js
+++ b/services/teamcity/teamcity-base.js
@@ -3,12 +3,10 @@
 const { BaseJsonService } = require('..')
 
 module.exports = class TeamCityBase extends BaseJsonService {
-  static get auth() {
-    return {
-      userKey: 'teamcity_user',
-      passKey: 'teamcity_pass',
-      serviceKey: 'teamcity',
-    }
+  static auth = {
+    userKey: 'teamcity_user',
+    passKey: 'teamcity_pass',
+    serviceKey: 'teamcity',
   }
 
   async fetch({ url, schema, qs = {}, errorMessages = {} }) {

--- a/services/tokei/tokei.service.js
+++ b/services/tokei/tokei.service.js
@@ -31,21 +31,19 @@ module.exports = class Tokei extends BaseJsonService {
 
   static route = { base: 'tokei/lines', pattern: ':provider/:user/:repo' }
 
-  static get examples() {
-    return [
-      {
-        title: 'Lines of code',
-        namedParams: {
-          provider: 'github',
-          user: 'badges',
-          repo: 'shields',
-        },
-        staticPreview: this.render({ lines: 119500 }),
-        keywords: ['loc', 'tokei'],
-        documentation,
+  static examples = [
+    {
+      title: 'Lines of code',
+      namedParams: {
+        provider: 'github',
+        user: 'badges',
+        repo: 'shields',
       },
-    ]
-  }
+      staticPreview: this.render({ lines: 119500 }),
+      keywords: ['loc', 'tokei'],
+      documentation,
+    },
+  ]
 
   static defaultBadgeData = {
     label: 'total lines',

--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -56,40 +56,32 @@ class TwitterUrl extends BaseService {
 const schema = Joi.any()
 
 class TwitterFollow extends BaseJsonService {
-  static get category() {
-    return 'social'
+  static category = 'social'
+
+  static route = {
+    base: 'twitter/follow',
+    pattern: ':user',
   }
 
-  static get route() {
-    return {
-      base: 'twitter/follow',
-      pattern: ':user',
-    }
-  }
-
-  static get examples() {
-    return [
-      {
-        title: 'Twitter Follow',
-        namedParams: {
-          user: 'espadrine',
-        },
-        queryParams: { label: 'Follow' },
-        // hard code the static preview
-        // because link[] is not allowed in examples
-        staticPreview: {
-          label: 'Follow',
-          message: '393',
-          style: 'social',
-        },
+  static examples = [
+    {
+      title: 'Twitter Follow',
+      namedParams: {
+        user: 'espadrine',
       },
-    ]
-  }
+      queryParams: { label: 'Follow' },
+      // hard code the static preview
+      // because link[] is not allowed in examples
+      staticPreview: {
+        label: 'Follow',
+        message: '393',
+        style: 'social',
+      },
+    },
+  ]
 
-  static get defaultBadgeData() {
-    return {
-      namedLogo: 'twitter',
-    }
+  static defaultBadgeData = {
+    namedLogo: 'twitter',
   }
 
   static render({ user, followers }) {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-base.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-base.js
@@ -46,22 +46,18 @@ const statisticSchema = Joi.object().keys({
 })
 
 module.exports = class VisualStudioMarketplaceBase extends BaseJsonService {
-  static get keywords() {
-    return [
-      'vscode',
-      'tfs',
-      'vsts',
-      'visual-studio-marketplace',
-      'vs-marketplace',
-      'vscode-marketplace',
-    ]
-  }
+  static keywords = [
+    'vscode',
+    'tfs',
+    'vsts',
+    'visual-studio-marketplace',
+    'vs-marketplace',
+    'vscode-marketplace',
+  ]
 
-  static get defaultBadgeData() {
-    return {
-      label: 'vs marketplace',
-      color: 'blue',
-    }
+  static defaultBadgeData = {
+    label: 'vs marketplace',
+    color: 'blue',
   }
 
   async fetch({ extensionId }) {


### PR DESCRIPTION
End of refactoring every possible `static get` for #5555 

I did exclude refactor in `badge-maker` and `services/discord` as requested, it turned out that only services where affected in the whole code base.

@calebcartwright you might want to check this merge (and maybe ~close~ #5555 if you merge this one)