### PR TITLE
Fix calculation of start date for [GitHubHacktoberfest] badge

### DIFF
--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -207,8 +207,10 @@ module.exports = class GithubHacktoberfestCombinedStatus extends GithubAuthV4Ser
   }
 
   static getCalendarPosition(year) {
-    const daysToStart =
-      moment(`${year}-10-01 12:00:00 Z`).diff(moment(), 'days') + 1
+    const daysToStart = moment(`${year}-10-01 00:00:00 Z`).diff(
+      moment(),
+      'days'
+    )
     const isBefore = daysToStart > 0
     return { daysToStart, isBefore }
   }


### PR DESCRIPTION
I was a little reckless with the copy/paste when updating our Hacktoberfest badge to work with the current year (it was previously hardcoded for 2019) and that resulted in a small bug in how the determination of the start date was made (refs #5637).

This PR corrects that by using October 1st (UTC) precisely