### PR TITLE
Refactor the [nuget myget] service

### DIFF
--- a/services/nuget/nuget-v3-service-family.js
+++ b/services/nuget/nuget-v3-service-family.js
@@ -76,7 +76,7 @@ async function fetch(
   serviceInstance,
   { baseUrl, packageName, includePrereleases = false }
 ) {
-  const json = await serviceInstance._requestJson({
+  return await serviceInstance._requestJson({
     schema,
     url: await searchServiceUrl(baseUrl, 'SearchQueryService'),
     options: {
@@ -89,12 +89,6 @@ async function fetch(
       },
     },
   })
-
-  if (json.data.length === 1) {
-    return json.data[0]
-  } else {
-    throw new NotFound({ prettyMessage: 'package not found' })
-  }
 }
 
 /*
@@ -139,6 +133,21 @@ function createServiceFamily({
       return renderVersionBadge(props)
     }
 
+    /*
+     * Extract version information from the raw package info.
+     */
+    transform({ json, includePrereleases }) {
+      if (json.data.length === 1 && json.data[0].versions.length > 0) {
+        const packageInfo = json.data[0]
+        const versions = packageInfo.versions.map(item =>
+          stripBuildMetadata(item.version)
+        )
+        return selectVersion(versions, includePrereleases)
+      } else {
+        throw new NotFound({ prettyMessage: 'package not found' })
+      }
+    }
+
     async handle({ tenant, feed, which, packageName }) {
       const includePrereleases = which === 'vpre'
       const baseUrl = apiUrl({
@@ -149,9 +158,8 @@ function createServiceFamily({
         withFeed,
         feed,
       })
-      let { versions } = await fetch(this, { baseUrl, packageName })
-      versions = versions.map(item => stripBuildMetadata(item.version))
-      const version = selectVersion(versions, includePrereleases)
+      const json = await fetch(this, { baseUrl, packageName })
+      const version = this.transform({ json, includePrereleases })
       return this.constructor.render({ version, feed })
     }
   }
@@ -170,6 +178,20 @@ function createServiceFamily({
       return renderDownloadBadge(props)
     }
 
+    /*
+     * Extract download count from the raw package.
+     */
+    transform({ json }) {
+      if (json.data.length === 1) {
+        const packageInfo = json.data[0]
+        // Official NuGet server uses "totalDownloads" whereas MyGet uses
+        // "totaldownloads" (lowercase D). Ugh.
+        return packageInfo.totalDownloads || packageInfo.totaldownloads || 0
+      } else {
+        throw new NotFound({ prettyMessage: 'package not found' })
+      }
+    }
+
     async handle({ tenant, feed, which, packageName }) {
       const baseUrl = apiUrl({
         withTenant,
@@ -179,13 +201,8 @@ function createServiceFamily({
         withFeed,
         feed,
       })
-      const packageInfo = await fetch(this, { baseUrl, packageName })
-
-      // Official NuGet server uses "totalDownloads" whereas MyGet uses
-      // "totaldownloads" (lowercase D). Ugh.
-      const downloads =
-        packageInfo.totalDownloads || packageInfo.totaldownloads || 0
-
+      const json = await fetch(this, { baseUrl, packageName })
+      const downloads = this.transform({ json })
       return this.constructor.render({ downloads })
     }
   }

--- a/services/nuget/nuget-v3-service-family.js
+++ b/services/nuget/nuget-v3-service-family.js
@@ -76,7 +76,7 @@ async function fetch(
   serviceInstance,
   { baseUrl, packageName, includePrereleases = false }
 ) {
-  return await serviceInstance._requestJson({
+  return serviceInstance._requestJson({
     schema,
     url: await searchServiceUrl(baseUrl, 'SearchQueryService'),
     options: {

--- a/services/nuget/nuget-v3-service-family.js
+++ b/services/nuget/nuget-v3-service-family.js
@@ -138,8 +138,8 @@ function createServiceFamily({
      */
     transform({ json, includePrereleases }) {
       if (json.data.length === 1 && json.data[0].versions.length > 0) {
-        const packageInfo = json.data[0]
-        const versions = packageInfo.versions.map(item =>
+        const { versions: packageVersions } = json.data[0]
+        const versions = packageVersions.map(item =>
           stripBuildMetadata(item.version)
         )
         return selectVersion(versions, includePrereleases)

--- a/services/nuget/nuget-v3-service-family.spec.js
+++ b/services/nuget/nuget-v3-service-family.spec.js
@@ -1,0 +1,102 @@
+'use strict'
+
+const { test, given } = require('sazerac')
+const { createServiceFamily } = require('./nuget-v3-service-family')
+
+const { NugetVersionService, NugetDownloadService } = createServiceFamily({
+  defaultLabel: 'nuget',
+  serviceBaseUrl: 'nuget',
+  apiBaseUrl: 'test',
+})
+
+function versionJson(versions) {
+  return {
+    data: [
+      {
+        versions: versions.map(v => ({
+          version: v,
+        })),
+      },
+    ],
+  }
+}
+
+function downloadsJson(payload) {
+  return {
+    data: [payload],
+  }
+}
+
+function noDataJson() {
+  return {
+    data: [],
+  }
+}
+
+function tooMuchDataJson() {
+  return {
+    data: [{}, {}],
+  }
+}
+
+describe('Nuget Version service', function () {
+  test(NugetVersionService.prototype.transform, () => {
+    given({ json: versionJson(['1.0.0']), includePrereleases: false }).expect(
+      '1.0.0'
+    )
+    given({
+      json: versionJson(['1.0.0', '1.0.1']),
+      includePrereleases: false,
+    }).expect('1.0.1')
+    given({
+      json: versionJson(['1.0.0', '1.0.1-beta1']),
+      includePrereleases: false,
+    }).expect('1.0.0')
+    given({
+      json: versionJson(['1.0.0', '1.0.1-beta1']),
+      includePrereleases: true,
+    }).expect('1.0.1-beta1')
+
+    given({
+      json: versionJson(['1.0.0+1', '1.0.1-beta1+1']),
+      includePrereleases: false,
+    }).expect('1.0.0')
+    given({
+      json: versionJson(['1.0.0+1', '1.0.1-beta1+1']),
+      includePrereleases: true,
+    }).expect('1.0.1-beta1')
+
+    given({ json: versionJson([]), includePrereleases: false }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: versionJson([]), includePrereleases: true }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: noDataJson(), includePrereleases: false }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: noDataJson(), includePrereleases: true }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: tooMuchDataJson(), includePrereleases: false }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: tooMuchDataJson(), includePrereleases: true }).expectError(
+      'Not Found: package not found'
+    )
+  })
+})
+
+describe('Nuget Download service', function () {
+  test(NugetDownloadService.prototype.transform, () => {
+    given({ json: downloadsJson({ totalDownloads: 10 }) }).expect(10)
+    given({ json: downloadsJson({ totaldownloads: 11 }) }).expect(11)
+    given({ json: downloadsJson({ other: 11 }) }).expect(0)
+    given({ json: downloadsJson({}) }).expect(0)
+
+    given({ json: noDataJson() }).expectError('Not Found: package not found')
+    given({ json: tooMuchDataJson() }).expectError(
+      'Not Found: package not found'
+    )
+  })
+})

--- a/services/nuget/nuget-v3-service-family.spec.js
+++ b/services/nuget/nuget-v3-service-family.spec.js
@@ -27,17 +27,8 @@ function downloadsJson(payload) {
   }
 }
 
-function noDataJson() {
-  return {
-    data: [],
-  }
-}
-
-function tooMuchDataJson() {
-  return {
-    data: [{}, {}],
-  }
-}
+const noDataJson = { data: [] }
+const tooMuchDataJson = { data: [{}, {}] }
 
 describe('Nuget Version service', function () {
   test(NugetVersionService.prototype.transform, () => {
@@ -72,16 +63,16 @@ describe('Nuget Version service', function () {
     given({ json: versionJson([]), includePrereleases: true }).expectError(
       'Not Found: package not found'
     )
-    given({ json: noDataJson(), includePrereleases: false }).expectError(
+    given({ json: noDataJson, includePrereleases: false }).expectError(
       'Not Found: package not found'
     )
-    given({ json: noDataJson(), includePrereleases: true }).expectError(
+    given({ json: noDataJson, includePrereleases: true }).expectError(
       'Not Found: package not found'
     )
-    given({ json: tooMuchDataJson(), includePrereleases: false }).expectError(
+    given({ json: tooMuchDataJson, includePrereleases: false }).expectError(
       'Not Found: package not found'
     )
-    given({ json: tooMuchDataJson(), includePrereleases: true }).expectError(
+    given({ json: tooMuchDataJson, includePrereleases: true }).expectError(
       'Not Found: package not found'
     )
   })
@@ -94,9 +85,7 @@ describe('Nuget Download service', function () {
     given({ json: downloadsJson({ other: 11 }) }).expect(0)
     given({ json: downloadsJson({}) }).expect(0)
 
-    given({ json: noDataJson() }).expectError('Not Found: package not found')
-    given({ json: tooMuchDataJson() }).expectError(
-      'Not Found: package not found'
-    )
+    given({ json: noDataJson }).expectError('Not Found: package not found')
+    given({ json: tooMuchDataJson }).expectError('Not Found: package not found')
   })
 })


### PR DESCRIPTION
Hi :wave:!

In this PR I refactored (and tested) the `nuget-v3-service-family`, mainly:
1. Simplified the `fetch` function,
2. Introduced the `transform` functions in each of the base implementations,
3. Tested both.

We talked about the changes with @calebcartwright in my previous PR.

There is also the possibility to unit-test the `buildRoute` and `apiUrl` functions, but I'm not quite sure whether it is worth it. We would need to expose them from the module, but the service tests validate it sufficiently. If you think otherwise then let me know and I will add these.

We could also do the same for `v2` but the `transform` method would be really a one-liner (as we get the necessary data directly from the API) and I don't think it is worth it.