### PR TITLE
lint/format typescript files in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "build-docs": "rimraf api-docs/ && jsdoc --pedantic -c ./jsdoc.json ."
   },
   "lint-staged": {
-    "**/*.js": [
+    "**/*.@(js|ts|tsx)": [
       "eslint --fix",
       "prettier --write"
     ],


### PR DESCRIPTION
not sure how we've managed to not notice this for so long :thinking: 