### PR TITLE
bump approve bot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,6 +5,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: chris48s/approve-bot@2.0.1
+      - uses: chris48s/approve-bot@2.0.2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Gatsby changed their changelog format a bit. This should get us back to auto-closing gatsby PRs that don't do anything
https://github.com/chris48s/approve-bot/commit/d6963dd399d1424c7d8ec43fd07c0a6b84d83345
