### PR TITLE
remove redirectUrl from prod settings

### DIFF
--- a/config/shields-io-production.yml
+++ b/config/shields-io-production.yml
@@ -15,6 +15,4 @@ public:
   cors:
     allowedOrigin: ['http://shields.io', 'https://shields.io']
 
-  redirectUrl: 'https://shields.io/'
-
   rasterUrl: 'https://raster.shields.io'


### PR DESCRIPTION
Following on from the discussion in https://github.com/badges/shields/issues/5014#issuecomment-735231731 I have set up a page rule in CloudFlare to redirect `img.shields.io/` to `shields.io/` so this redirect is now being handled by CloudFlare before the request hits heroku.

![Screenshot at 2020-11-28 18-36-29](https://user-images.githubusercontent.com/6025893/100523481-b112d400-31a8-11eb-839c-f530fcec33b2.png)

This means we can now remove this setting without changing that behaviour.

I haven't set one up for `www.` I don't think serving the website on `www.` without redirecting is a particularly bad thing tbh, but I can add a rule for that too if anyone feels particularly strongly about it.

If someone can give me a ✔️ on this I will deploy and pick up the switchover tomorrow.
