### PR TITLE
Fix base URL for npm peer dependencies

### DIFF
--- a/services/npm/npm-dependency-version.service.js
+++ b/services/npm/npm-dependency-version.service.js
@@ -32,7 +32,7 @@ module.exports = class NpmDependencyVersion extends NpmBase {
     },
     {
       title: 'npm peer dependency version (scoped)',
-      pattern: ':scope?/:packageName/dev/:dependencyScope?/:dependency',
+      pattern: ':scope?/:packageName/peer/:dependencyScope?/:dependency',
       namedParams: {
         scope: '@swellaby',
         packageName: 'eslint-config',


### PR DESCRIPTION
Base URL used to mount the NPM **peer** dependency version badge was pointing to **dev** dependencyies instead.

![Issue snapshot](https://raw.githubusercontent.com/juliolmuller/shields/image/pull-request.jpg)