### PR TITLE
increase [David] service test timeouts

### DIFF
--- a/services/david/david.service.js
+++ b/services/david/david.service.js
@@ -83,12 +83,12 @@ module.exports = class David extends BaseJsonService {
       options: { qs: { path } },
       errorMessages: {
         /* note:
-        david returns a 500 response for 'not found'
+        david returns a 504 response for 'not found'
         e.g: https://david-dm.org/foo/barbaz/info.json
         not a 404 so we can't handle 'not found' cleanly
         because this might also be some other error.
         */
-        500: 'repo or path not found or david internal error',
+        504: 'repo or path not found or david internal error',
       },
     })
   }

--- a/services/david/david.tester.js
+++ b/services/david/david.tester.js
@@ -11,6 +11,7 @@ const isDependencyStatus = Joi.string().valid(
 
 t.create('david dependencies (valid)')
   .get('/expressjs/express.json')
+  .timeout(15000)
   .expectBadge({
     label: 'dependencies',
     message: isDependencyStatus,
@@ -18,6 +19,7 @@ t.create('david dependencies (valid)')
 
 t.create('david dev dependencies (valid)')
   .get('/dev/expressjs/express.json')
+  .timeout(15000)
   .expectBadge({
     label: 'dev dependencies',
     message: isDependencyStatus,
@@ -25,6 +27,7 @@ t.create('david dev dependencies (valid)')
 
 t.create('david optional dependencies (valid)')
   .get('/optional/elnounch/byebye.json')
+  .timeout(15000)
   .expectBadge({
     label: 'optional dependencies',
     message: isDependencyStatus,
@@ -32,6 +35,7 @@ t.create('david optional dependencies (valid)')
 
 t.create('david peer dependencies (valid)')
   .get('/peer/webcomponents/generator-element.json')
+  .timeout(15000)
   .expectBadge({
     label: 'peer dependencies',
     message: isDependencyStatus,
@@ -39,6 +43,7 @@ t.create('david peer dependencies (valid)')
 
 t.create('david dependencies with path (valid)')
   .get('/babel/babel.json?path=packages/babel-core')
+  .timeout(15000)
   .expectBadge({
     label: 'dependencies',
     message: isDependencyStatus,
@@ -46,10 +51,12 @@ t.create('david dependencies with path (valid)')
 
 t.create('david dependencies (none)')
   .get('/peer/expressjs/express.json') // express does not specify peer dependencies
+  .timeout(15000)
   .expectBadge({ label: 'peer dependencies', message: 'none' })
 
 t.create('david dependencies (repo not found)')
   .get('/pyvesb/emptyrepo.json')
+  .timeout(15000)
   .expectBadge({
     label: 'dependencies',
     message: 'repo or path not found or david internal error',
@@ -57,6 +64,7 @@ t.create('david dependencies (repo not found)')
 
 t.create('david dependencies (path not found')
   .get('/babel/babel.json?path=invalid/path')
+  .timeout(15000)
   .expectBadge({
     label: 'dependencies',
     message: 'repo or path not found or david internal error',


### PR DESCRIPTION
We've had persistent issues with the David tests (and badges) for a while a now, and an unfortunate side effect of this has been that our daily service test runs have been in a constant state of red/failure for a very long time now. I worry that this constantly failing status of our daily service test runs are starting to defeat the purpose of their existence, as it's human nature to start to ignore the jobs (I confess I rarely check each of the two daily runs anymore because of this).

The root cause of the David failures were upstream issues with the platform that largely seem to have been resolved by some infrastructure/runtime environment changes there, but we're still getting test timeout issues (https://app.circleci.com/pipelines/github/badges/daily-tests/659/workflows/eb63b021-d2a6-4afb-81ea-9ba7b68474e5/jobs/1557)

As such I'm proposing an extensive timeout increase for these David tests. Obviously any badge request that needs 15 seconds will largely be useless in most common badge contexts, but I think it's worth trying it in this case anyway. I'd really like to get our daily test runs back into a passing (and IMO useful) state, and I don't think that it's worth blocking that possibility on these tests given the historical nature of these badges and tests