### PR TITLE
Fix [Spiget] rating display issue

### DIFF
--- a/services/spiget/spiget-rating.service.js
+++ b/services/spiget/spiget-rating.service.js
@@ -58,7 +58,7 @@ module.exports = class SpigetRatings extends BaseSpigetService {
     return this.constructor.render({
       format,
       total: rating.count,
-      average: rating.average,
+      average: Math.round(rating.average * 100) / 100,
     })
   }
 }

--- a/services/spiget/spiget-rating.service.js
+++ b/services/spiget/spiget-rating.service.js
@@ -58,7 +58,7 @@ module.exports = class SpigetRatings extends BaseSpigetService {
     return this.constructor.render({
       format,
       total: rating.count,
-      average: Math.round(rating.average * 100) / 100,
+      average: rating.average.toFixed(2),
     })
   }
 }


### PR DESCRIPTION
# Issue Description
Spiget rating is too long, because we only need a few decimal places and the rests are pointless.
![bugfix](https://user-images.githubusercontent.com/31719556/102815913-2aae7400-439b-11eb-8ef8-9de2b6990eb7.PNG)

# Issue Cause
Spiget API that shields is using returned a float number, and it was rendered without sanitization.
![bugfix2](https://user-images.githubusercontent.com/31719556/102816084-69dcc500-439b-11eb-852e-a3ceefb47237.PNG)

# Issue Fix
When rendering shields, we round the rating to at most 2 decimal places.