### PR TITLE
use new plugin api for [jetbrains]

### DIFF
--- a/services/jetbrains/jetbrains-base.js
+++ b/services/jetbrains/jetbrains-base.js
@@ -1,11 +1,32 @@
 'use strict'
 
 const { BaseXmlService, NotFound } = require('..')
+const { parseJson } = require('../../core/base-service/json')
 
+/*
+JetBrains is a bit awkward. Sometimes we want to call an XML API
+and sometimes we want to call a JSON API so we need a mongrel base class.
+When the legacy IntelliJ (XML) API is retired we can simplify all this and
+switch JetbrainsDownloads, JetbrainsRating and JetbrainsVersion to just
+inherit from BaseJsonService directly.
+*/
 module.exports = class JetbrainsBase extends BaseXmlService {
+  static _isLegacyPluginId(pluginId) {
+    return !pluginId.match(/^([0-9])+/)
+  }
+
+  static _cleanPluginId(pluginId) {
+    const match = pluginId.match(/^([0-9])+/)
+    if (match) {
+      return match[0]
+    }
+    return pluginId
+  }
+
+  // xml
   static _validate(data, schema) {
     if (data['plugin-repository'] === '') {
-      // Note the 'not found' response from JetBrains Plugins Repository is:
+      // Note the 'not found' response from JetBrains IntelliJ API is:
       // status code = 200,
       // body = <?xml version="1.0" encoding="UTF-8"?><plugin-repository></plugin-repository>
       // which is parsed to object = { 'plugin-repository': '' }
@@ -14,7 +35,7 @@ module.exports = class JetbrainsBase extends BaseXmlService {
     return super._validate(data, schema)
   }
 
-  async fetchPackageData({ pluginId, schema }) {
+  async fetchIntelliJPluginData({ pluginId, schema }) {
     const parserOptions = {
       parseNodeValue: false,
       ignoreAttributes: false,
@@ -24,5 +45,28 @@ module.exports = class JetbrainsBase extends BaseXmlService {
       url: `https://plugins.jetbrains.com/plugins/list?pluginId=${pluginId}`,
       parserOptions,
     })
+  }
+
+  // json
+  _parseJson(buffer) {
+    return parseJson(buffer)
+  }
+
+  static _validateJson(data, schema) {
+    return super._validate(data, schema)
+  }
+
+  async _requestJson({ schema, url, options = {}, errorMessages = {} }) {
+    const mergedOptions = {
+      ...{ headers: { Accept: 'application/json' } },
+      ...options,
+    }
+    const { buffer } = await this._request({
+      url,
+      options: mergedOptions,
+      errorMessages,
+    })
+    const json = this._parseJson(buffer)
+    return this.constructor._validateJson(json, schema)
   }
 }

--- a/services/jetbrains/jetbrains-downloads.tester.js
+++ b/services/jetbrains/jetbrains-downloads.tester.js
@@ -17,25 +17,21 @@ t.create('downloads (user friendly plugin id)')
 
 t.create('downloads')
   .get('/9435.json')
-  .intercept(
-    nock =>
-      nock('https://plugins.jetbrains.com')
-        .get('/plugins/list?pluginId=9435')
-        .reply(
-          200,
-          `<?xml version="1.0" encoding="UTF-8"?>
-            <plugin-repository>
-              <category name="Code editing">
-                <idea-plugin downloads="2" size="13159" date="1485601807000" url=""></idea-plugin>
-              </category>
-            </plugin-repository>`
-        ),
-    {
-      'Content-Type': 'text/xml;charset=UTF-8',
-    }
+  .intercept(nock =>
+    nock('https://plugins.jetbrains.com')
+      .get('/api/plugins/9435')
+      .reply(200, { downloads: 2 })
   )
   .expectBadge({ label: 'downloads', message: '2' })
 
-t.create('unknown plugin')
+t.create('unknown plugin (string)')
   .get('/unknown-plugin.json')
+  .expectBadge({ label: 'downloads', message: 'not found' })
+
+t.create('unknown plugin (numeric)')
+  .get('/9999999999999.json')
+  .expectBadge({ label: 'downloads', message: 'not found' })
+
+t.create('unknown plugin (mixed)')
+  .get('/9999999999999-abc.json')
   .expectBadge({ label: 'downloads', message: 'not found' })

--- a/services/jetbrains/jetbrains-downloads.tester.js
+++ b/services/jetbrains/jetbrains-downloads.tester.js
@@ -15,7 +15,7 @@ t.create('downloads (user friendly plugin id)')
   .get('/1347-scala.json')
   .expectBadge({ label: 'downloads', message: isMetric })
 
-t.create('downloads')
+t.create('downloads (numeric id)')
   .get('/9435.json')
   .intercept(nock =>
     nock('https://plugins.jetbrains.com')
@@ -24,14 +24,35 @@ t.create('downloads')
   )
   .expectBadge({ label: 'downloads', message: '2' })
 
-t.create('unknown plugin (string)')
+t.create('downloads (string id)')
+  .get('/io.harply.plugin.json')
+  .intercept(
+    nock =>
+      nock('https://plugins.jetbrains.com')
+        .get('/plugins/list?pluginId=io.harply.plugin')
+        .reply(
+          200,
+          `<?xml version="1.0" encoding="UTF-8"?>
+            <plugin-repository>
+              <category name="Code editing">
+                <idea-plugin downloads="2" size="13159" date="1485601807000" url=""></idea-plugin>
+              </category>
+            </plugin-repository>`
+        ),
+    {
+      'Content-Type': 'text/xml;charset=UTF-8',
+    }
+  )
+  .expectBadge({ label: 'downloads', message: '2' })
+
+t.create('unknown plugin (string id)')
   .get('/unknown-plugin.json')
   .expectBadge({ label: 'downloads', message: 'not found' })
 
-t.create('unknown plugin (numeric)')
+t.create('unknown plugin (numeric id)')
   .get('/9999999999999.json')
   .expectBadge({ label: 'downloads', message: 'not found' })
 
-t.create('unknown plugin (mixed)')
+t.create('unknown plugin (mixed id)')
   .get('/9999999999999-abc.json')
   .expectBadge({ label: 'downloads', message: 'not found' })

--- a/services/jetbrains/jetbrains-rating.tester.js
+++ b/services/jetbrains/jetbrains-rating.tester.js
@@ -41,19 +41,19 @@ t.create('rating stars (number as a plugin id)')
   .get('/stars/11941.json')
   .expectBadge({ label: 'rating', message: isStarRating })
 
-t.create('rating stars for unknown plugin (string)')
+t.create('rating stars for unknown plugin (string id)')
   .get('/stars/unknown-plugin.json')
   .expectBadge({ label: 'rating', message: 'not found' })
 
-t.create('rating stars for unknown plugin (numeric)')
+t.create('rating stars for unknown plugin (numeric id)')
   .get('/stars/9999999999999.json')
   .expectBadge({ label: 'rating', message: 'not found' })
 
-t.create('rating stars for unknown plugin (mixed)')
+t.create('rating stars for unknown plugin (mixed id)')
   .get('/stars/9999999999999-abc.json')
   .expectBadge({ label: 'rating', message: 'not found' })
 
-t.create('rating number')
+t.create('rating number (numeric id)')
   .get('/rating/11941.json')
   .intercept(nock =>
     nock('https://plugins.jetbrains.com')
@@ -62,11 +62,61 @@ t.create('rating number')
   )
   .expectBadge({ label: 'rating', message: '4.5/5' })
 
-t.create('rating stars')
+t.create('rating number (string id)')
+  .get('/rating/com.chriscarini.jetbrains.jetbrains-auto-power-saver.json')
+  .intercept(
+    nock =>
+      nock('https://plugins.jetbrains.com')
+        .get(
+          '/plugins/list?pluginId=com.chriscarini.jetbrains.jetbrains-auto-power-saver'
+        )
+        .reply(
+          200,
+          `<?xml version="1.0" encoding="UTF-8"?>
+            <plugin-repository>
+              <category name="User Interface">
+                <idea-plugin downloads="1714" size="208537" date="1586449109000" updatedDate="1586449109000" url="">
+                  <rating>4.4848</rating>
+                </idea-plugin>
+              </category>
+            </plugin-repository>`
+        ),
+    {
+      'Content-Type': 'text/xml;charset=UTF-8',
+    }
+  )
+  .expectBadge({ label: 'rating', message: '4.5/5' })
+
+t.create('rating stars (numeric id)')
   .get('/stars/11941.json')
   .intercept(nock =>
     nock('https://plugins.jetbrains.com')
       .get('/api/plugins/11941/rating')
       .reply(200, { meanRating: 4.4848 })
+  )
+  .expectBadge({ label: 'rating', message: '★★★★½' })
+
+t.create('rating stars (string id)')
+  .get('/stars/com.chriscarini.jetbrains.jetbrains-auto-power-saver.json')
+  .intercept(
+    nock =>
+      nock('https://plugins.jetbrains.com')
+        .get(
+          '/plugins/list?pluginId=com.chriscarini.jetbrains.jetbrains-auto-power-saver'
+        )
+        .reply(
+          200,
+          `<?xml version="1.0" encoding="UTF-8"?>
+            <plugin-repository>
+              <category name="User Interface">
+                <idea-plugin downloads="1714" size="208537" date="1586449109000" updatedDate="1586449109000" url="">
+                  <rating>4.4848</rating>
+                </idea-plugin>
+              </category>
+            </plugin-repository>`
+        ),
+    {
+      'Content-Type': 'text/xml;charset=UTF-8',
+    }
   )
   .expectBadge({ label: 'rating', message: '★★★★½' })

--- a/services/jetbrains/jetbrains-rating.tester.js
+++ b/services/jetbrains/jetbrains-rating.tester.js
@@ -17,8 +17,16 @@ t.create('rating number (number as a plugin id)')
   .get('/rating/11941.json')
   .expectBadge({ label: 'rating', message: isRating })
 
-t.create('rating number for unknown plugin')
+t.create('rating number for unknown plugin (string)')
   .get('/rating/unknown-plugin.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('rating stars for unknown plugin (numeric)')
+  .get('/stars/9999999999999.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('rating stars for unknown plugin (mixed)')
+  .get('/stars/9999999999999-abc.json')
   .expectBadge({ label: 'rating', message: 'not found' })
 
 t.create('rating stars (user friendly plugin id)')
@@ -33,52 +41,32 @@ t.create('rating stars (number as a plugin id)')
   .get('/stars/11941.json')
   .expectBadge({ label: 'rating', message: isStarRating })
 
-t.create('rating stars for unknown plugin')
+t.create('rating stars for unknown plugin (string)')
   .get('/stars/unknown-plugin.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('rating stars for unknown plugin (numeric)')
+  .get('/stars/9999999999999.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('rating stars for unknown plugin (mixed)')
+  .get('/stars/9999999999999-abc.json')
   .expectBadge({ label: 'rating', message: 'not found' })
 
 t.create('rating number')
   .get('/rating/11941.json')
-  .intercept(
-    nock =>
-      nock('https://plugins.jetbrains.com')
-        .get('/plugins/list?pluginId=11941')
-        .reply(
-          200,
-          `<?xml version="1.0" encoding="UTF-8"?>
-            <plugin-repository>
-              <category name="User Interface">
-                <idea-plugin downloads="1714" size="208537" date="1586449109000" updatedDate="1586449109000" url="">
-                  <rating>4.5</rating>
-                </idea-plugin>
-              </category>
-            </plugin-repository>`
-        ),
-    {
-      'Content-Type': 'text/xml;charset=UTF-8',
-    }
+  .intercept(nock =>
+    nock('https://plugins.jetbrains.com')
+      .get('/api/plugins/11941/rating')
+      .reply(200, { meanRating: 4.4848 })
   )
   .expectBadge({ label: 'rating', message: '4.5/5' })
 
 t.create('rating stars')
   .get('/stars/11941.json')
-  .intercept(
-    nock =>
-      nock('https://plugins.jetbrains.com')
-        .get('/plugins/list?pluginId=11941')
-        .reply(
-          200,
-          `<?xml version="1.0" encoding="UTF-8"?>
-            <plugin-repository>
-              <category name="User Interface">
-                <idea-plugin downloads="1714" size="208537" date="1586449109000" updatedDate="1586449109000" url="">
-                  <rating>4.5</rating>
-                </idea-plugin>
-              </category>
-            </plugin-repository>`
-        ),
-    {
-      'Content-Type': 'text/xml;charset=UTF-8',
-    }
+  .intercept(nock =>
+    nock('https://plugins.jetbrains.com')
+      .get('/api/plugins/11941/rating')
+      .reply(200, { meanRating: 4.4848 })
   )
   .expectBadge({ label: 'rating', message: '★★★★½' })

--- a/services/jetbrains/jetbrains-version.service.js
+++ b/services/jetbrains/jetbrains-version.service.js
@@ -4,7 +4,7 @@ const Joi = require('joi')
 const { renderVersionBadge } = require('../version')
 const JetbrainsBase = require('./jetbrains-base')
 
-const schema = Joi.object({
+const intelliJschema = Joi.object({
   'plugin-repository': Joi.object({
     category: Joi.object({
       'idea-plugin': Joi.array()
@@ -20,6 +20,15 @@ const schema = Joi.object({
   }).required(),
 }).required()
 
+const jetbrainsSchema = Joi.array()
+  .min(1)
+  .items(
+    Joi.object({
+      version: Joi.string().required(),
+    }).required()
+  )
+  .required()
+
 module.exports = class JetbrainsVersion extends JetbrainsBase {
   static category = 'version'
 
@@ -30,9 +39,9 @@ module.exports = class JetbrainsVersion extends JetbrainsBase {
 
   static examples = [
     {
-      title: 'JetBrains IntelliJ Plugins',
+      title: 'JetBrains Plugins',
       namedParams: {
-        pluginId: '9630-a8translate',
+        pluginId: '9630',
       },
       staticPreview: this.render({ version: 'v1.7' }),
     },
@@ -45,9 +54,26 @@ module.exports = class JetbrainsVersion extends JetbrainsBase {
   }
 
   async handle({ pluginId }) {
-    const pluginData = await this.fetchPackageData({ pluginId, schema })
-    const version =
-      pluginData['plugin-repository'].category['idea-plugin'][0].version
+    let version
+    if (this.constructor._isLegacyPluginId(pluginId)) {
+      const intelliJPluginData = await this.fetchIntelliJPluginData({
+        pluginId,
+        schema: intelliJschema,
+      })
+      version =
+        intelliJPluginData['plugin-repository'].category['idea-plugin'][0]
+          .version
+    } else {
+      const jetbrainsPluginData = await this._requestJson({
+        schema: jetbrainsSchema,
+        url: `https://plugins.jetbrains.com/api/plugins/${this.constructor._cleanPluginId(
+          pluginId
+        )}/updates`,
+        errorMessages: { 400: 'not found' },
+      })
+      version = jetbrainsPluginData[0].version
+    }
+
     return this.constructor.render({ version })
   }
 }

--- a/services/jetbrains/jetbrains-version.tester.js
+++ b/services/jetbrains/jetbrains-version.tester.js
@@ -22,7 +22,7 @@ t.create('version (number as a plugin id)').get('/7495.json').expectBadge({
   message: isVPlusDottedVersionNClauses,
 })
 
-t.create('version')
+t.create('version (numeric id)')
   .get('/9435.json')
   .intercept(nock =>
     nock('https://plugins.jetbrains.com')
@@ -31,14 +31,37 @@ t.create('version')
   )
   .expectBadge({ label: 'jetbrains plugin', message: 'v1.0' })
 
-t.create('version for unknown plugin (string)')
+t.create('version (strong id)')
+  .get('/io.harply.plugin.json')
+  .intercept(
+    nock =>
+      nock('https://plugins.jetbrains.com')
+        .get('/plugins/list?pluginId=io.harply.plugin')
+        .reply(
+          200,
+          `<?xml version="1.0" encoding="UTF-8"?>
+            <plugin-repository>
+              <category name="Code editing">
+                <idea-plugin downloads="2" size="13159" date="1485601807000" url="">
+                  <version>1.0</version>
+                </idea-plugin>
+              </category>
+            </plugin-repository>`
+        ),
+    {
+      'Content-Type': 'text/xml;charset=UTF-8',
+    }
+  )
+  .expectBadge({ label: 'jetbrains plugin', message: 'v1.0' })
+
+t.create('version for unknown plugin (string id)')
   .get('/unknown-plugin.json')
   .expectBadge({ label: 'jetbrains plugin', message: 'not found' })
 
-t.create('version for unknown plugin (numeric)')
+t.create('version for unknown plugin (numeric id)')
   .get('/9999999999999.json')
   .expectBadge({ label: 'jetbrains plugin', message: 'not found' })
 
-t.create('unknown plugin (mixed)')
+t.create('unknown plugin (mixed id)')
   .get('/9999999999999-abc.json')
   .expectBadge({ label: 'jetbrains plugin', message: 'not found' })

--- a/services/jetbrains/jetbrains-version.tester.js
+++ b/services/jetbrains/jetbrains-version.tester.js
@@ -24,27 +24,21 @@ t.create('version (number as a plugin id)').get('/7495.json').expectBadge({
 
 t.create('version')
   .get('/9435.json')
-  .intercept(
-    nock =>
-      nock('https://plugins.jetbrains.com')
-        .get('/plugins/list?pluginId=9435')
-        .reply(
-          200,
-          `<?xml version="1.0" encoding="UTF-8"?>
-            <plugin-repository>
-              <category name="Code editing">
-                <idea-plugin downloads="2" size="13159" date="1485601807000" url="">
-                  <version>1.0</version>
-                </idea-plugin>
-              </category>
-            </plugin-repository>`
-        ),
-    {
-      'Content-Type': 'text/xml;charset=UTF-8',
-    }
+  .intercept(nock =>
+    nock('https://plugins.jetbrains.com')
+      .get('/api/plugins/9435/updates')
+      .reply(200, [{ version: '1.0' }])
   )
   .expectBadge({ label: 'jetbrains plugin', message: 'v1.0' })
 
-t.create('version for unknown plugin')
+t.create('version for unknown plugin (string)')
   .get('/unknown-plugin.json')
+  .expectBadge({ label: 'jetbrains plugin', message: 'not found' })
+
+t.create('version for unknown plugin (numeric)')
+  .get('/9999999999999.json')
+  .expectBadge({ label: 'jetbrains plugin', message: 'not found' })
+
+t.create('unknown plugin (mixed)')
+  .get('/9999999999999-abc.json')
   .expectBadge({ label: 'jetbrains plugin', message: 'not found' })


### PR DESCRIPTION
This PR implements the solution I suggested in https://github.com/badges/shields/issues/5946#issuecomment-748237206 - use the new API if we've got a numeric ID. Fall back to the old (IntelliJ only) API otherwise.

This is a bit messy because the old API is XML-based whereas the new one uses JSON so I've made a base class that inherits from `BaseXmlService` and given it some methods to call/parse/validate JSON. At some point in future when the XML API is deprecated and we drop the string ID format we can just switch everything to inherit from `BaseJsonService` and tidy this up a bit.

closes #5946 