### PR TITLE
add generic [GithubIssuesSearch] badges

### DIFF
--- a/services/github/github-issues-search.service.js
+++ b/services/github/github-issues-search.service.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const gql = require('graphql-tag')
+const Joi = require('joi')
+const { metric } = require('../text-formatters')
+const { nonNegativeInteger } = require('../validators')
+const { GithubAuthV4Service } = require('./github-auth-service')
+const { documentation, transformErrors } = require('./github-helpers')
+
+const issueCountSchema = Joi.object({
+  data: Joi.object({
+    search: Joi.object({
+      issueCount: nonNegativeInteger,
+    }).required(),
+  }).required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  query: Joi.string().required(),
+}).required()
+
+class BaseGithubIssuesSearch extends GithubAuthV4Service {
+  static category = 'issue-tracking'
+  static defaultBadgeData = { label: 'query', color: 'informational' }
+
+  static render({ issueCount }) {
+    return { message: metric(issueCount) }
+  }
+
+  async fetch({ query }) {
+    const data = await this._requestGraphql({
+      query: gql`
+        query($query: String!) {
+          search(query: $query, type: ISSUE) {
+            issueCount
+          }
+        }
+      `,
+      variables: { query },
+      schema: issueCountSchema,
+      transformErrors,
+    })
+    return data.data.search.issueCount
+  }
+}
+
+class GithubIssuesSearch extends BaseGithubIssuesSearch {
+  static route = {
+    base: 'github',
+    pattern: 'issues-search',
+    queryParamSchema,
+  }
+
+  static examples = [
+    {
+      title: 'GitHub issue custom search',
+      namedParams: {},
+      queryParams: {
+        query: 'repo:badges/shields is:closed label:bug author:app/sentry-io',
+      },
+      staticPreview: {
+        label: 'query',
+        message: '10',
+        color: 'blue',
+      },
+      documentation,
+    },
+  ]
+
+  async handle(namedParams, { query }) {
+    const issueCount = await this.fetch({ query })
+    return this.constructor.render({ issueCount })
+  }
+}
+
+class GithubRepoIssuesSearch extends BaseGithubIssuesSearch {
+  static route = {
+    base: 'github',
+    pattern: 'issues-search/:user/:repo',
+    queryParamSchema,
+  }
+
+  static examples = [
+    {
+      title: 'GitHub issue custom search in repo',
+      namedParams: {
+        user: 'badges',
+        repo: 'shields',
+      },
+      queryParams: {
+        query: 'is:closed label:bug author:app/sentry-io',
+      },
+      staticPreview: {
+        label: 'query',
+        message: '10',
+        color: 'blue',
+      },
+      documentation,
+    },
+  ]
+
+  async handle({ user, repo }, { query }) {
+    query = `repo:${user}/${repo} ${query}`
+    const issueCount = await this.fetch({ query })
+    return this.constructor.render({ issueCount })
+  }
+}
+
+module.exports = {
+  GithubIssuesSearch,
+  GithubRepoIssuesSearch,
+}

--- a/services/github/github-issues-search.tester.js
+++ b/services/github/github-issues-search.tester.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const { isMetric } = require('../test-validators')
+const { ServiceTester } = require('../tester')
+const t = (module.exports = new ServiceTester({
+  id: 'GithubIssuesSearch',
+  title: 'Github Issues Search',
+  pathPrefix: '/github',
+}))
+
+t.create('GitHub issue search (valid query string)')
+  .get(
+    '/issues-search.json?query=repo%3Abadges%2Fshields%20is%3Aclosed%20label%3Ablocker%20'
+  )
+  .expectBadge({
+    label: 'query',
+    message: isMetric,
+  })
+
+t.create('GitHub issue search (invalid query string)')
+  .get('/issues-search.json?query=')
+  .expectBadge({
+    label: 'query',
+    message: 'invalid query parameter: query',
+  })
+
+t.create('GitHub Repo issue search (valid query string)')
+  .get(
+    '/issues-search/badges/shields.json?query=is%3Aclosed%20label%3Ablocker%20'
+  )
+  .expectBadge({
+    label: 'query',
+    message: isMetric,
+  })
+
+t.create('GitHub Repo issue search (invalid query string)')
+  .get('/issues-search/badges/shields.json?query=')
+  .expectBadge({
+    label: 'query',
+    message: 'invalid query parameter: query',
+  })
+
+t.create('GitHub Repo issue search (invalid repo)')
+  .get(
+    '/issues-search/badges/helmets.json?query=is%3Aclosed%20label%3Ablocker%20'
+  )
+  .expectBadge({
+    label: 'query',
+    message: '0',
+  })


### PR DESCRIPTION
Refs #5948

Open to feedback on this, but I decided to implement two variants of this badge:

* `/issues-search?query=`
* `/issues-search/:user/:repo?query=`

`/issues-search?query=` is more general. Because it doesn't require a repo to be specified, it allows you to implement queries like "all issues raised by user X in any repo" or "all issues with label Y in organization Z" for example.

I decided to also add a special-case route for `/issues-search/:user/:repo?query=`. This is less flexible, but I think it is worth having a route that allows the query param you paste in to be the exact same query you will construct in the filter box on your issues page (https://github.com/badges/shields/issues ) without having to remember to append `repo:badges/shields` to the query. All our existing issue/PR badges are about querying issues within a repo so I think its fair to say this is the most common case.

`/issues-search/badges/shields?query=is%3Aopen%20label%3Ablocker` and
`/issues-search?query=repo%3Abadges%2Fshields%20is%3Aopen%20label%3Ablocker` do the same thing.

For now, I've decided to just start by adding this badge. I haven't done anything to the existing badges yet. I've left an inline comment explaining why it isn't quite a one-to-one tradeoff to switch from the `repository` API to the `search` API. Either way I think this should be pretty handy and provide an answer for a whole class of feature requests.