### PR TITLE
deploy docs to gh-pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,26 @@
+name: Deploy Documentation
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+        with:
+          persist-credentials: false
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build-docs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: api-docs
+          CLEAN: true

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "e2e": "start-server-and-test start http://localhost:3000 test:e2e",
     "e2e-on-build": "cross-env CYPRESS_baseUrl=http://localhost:8080 start-server-and-test start:server:e2e-on-build http://localhost:8080 test:e2e",
     "badge": "cross-env NODE_CONFIG_ENV=test TRACE_SERVICES=true node scripts/badge-cli.js",
-    "build-docs": "rimraf api-docs/ && jsdoc --pedantic -c ./jsdoc.json ."
+    "build-docs": "rimraf api-docs/ && jsdoc --pedantic -c ./jsdoc.json . && echo 'contributing.shields.io' > api-docs/CNAME"
   },
   "lint-staged": {
     "**/*.@(js|ts|tsx)": [


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/5944

This bit adds an action to build the docs and push the output to gh-pages on a push to master. Once we get this merged, I'll look at swapping over the CNAME in CloudFlare and shutting down netlify (interestingly I think the docs have stopped deploying to netlify properly at some point and nobody noticed - hopefully putting them here will make it more obvious that they're working)

Note: its hard to verify this works in PR form, but I have tested this on a fork