### PR TITLE
github auth endpoint improvements

### DIFF
--- a/services/github/auth/admin.js
+++ b/services/github/auth/admin.js
@@ -16,11 +16,13 @@ function setRoutes({ shieldsSecret }, { apiProvider, server }) {
   // password.
   //
   // e.g.
-  // curl --insecure -u ':very-very-secret' 'https://s0.servers.shields.io/$github-auth/tokens'
+  // curl --insecure -u ':very-very-secret' 'https://img.shields.io/$github-auth/tokens'
   server.ajax.on('github-auth/tokens', (json, end, ask) => {
     if (!secretIsValid(ask.password)) {
       // An unknown entity tries to connect. Let the connection linger for a minute.
       return setTimeout(() => {
+        ask.res.statusCode = 401
+        ask.res.setHeader('Cache-Control', 'private')
         end('Invalid secret.')
       }, 10000)
     }

--- a/services/github/auth/admin.spec.js
+++ b/services/github/auth/admin.spec.js
@@ -35,13 +35,17 @@ describe('GitHub admin route', function () {
 
   context('the password is correct', function () {
     it('returns a valid JSON response', async function () {
-      const { statusCode, body } = await got(`${baseUrl}/$github-auth/tokens`, {
-        username: '',
-        password: shieldsSecret,
-        responseType: 'json',
-      })
+      const { statusCode, body, headers } = await got(
+        `${baseUrl}/$github-auth/tokens`,
+        {
+          username: '',
+          password: shieldsSecret,
+          responseType: 'json',
+        }
+      )
       expect(statusCode).to.equal(200)
       expect(body).to.be.ok
+      expect(headers['cache-control']).to.equal('private')
     })
   })
 
@@ -54,9 +58,15 @@ describe('GitHub admin route', function () {
     context('the password is missing', function () {
       it('returns the expected message', async function () {
         this.timeout(11000)
-        const { statusCode, body } = await got(`${baseUrl}/$github-auth/tokens`)
-        expect(statusCode).to.equal(200)
+        const { statusCode, body, headers } = await got(
+          `${baseUrl}/$github-auth/tokens`,
+          {
+            throwHttpErrors: false,
+          }
+        )
+        expect(statusCode).to.equal(401)
         expect(body).to.equal('"Invalid secret."')
+        expect(headers['cache-control']).to.equal('private')
       })
     })
   }


### PR DESCRIPTION
I merged #5998 deployed and invalidated the relevant cache in CF. Turned out CF still caches the "Invalid secret" response, so if you hit the endpoint without auth, you then can't log in afterwards 🙃 This PR does a few more things:

- Serve the "Invalid secret" response with an appropriate status code (not 200 OK)
- Explicitly set `cache-control: private` on the "Invalid secret" response
- Fix an outdated comment
- Add some tests for this (note the 'password is missing' test only runs if you invoke with `SLOW=true`)
