### PR TITLE
Use GitHub Sponsors logo instead GitHub logo

### DIFF
--- a/services/github/github-sponsors.service.js
+++ b/services/github/github-sponsors.service.js
@@ -36,7 +36,7 @@ module.exports = class GithubSponsors extends GithubAuthV4Service {
 
   static defaultBadgeData = {
     label: 'sponsors',
-    namedLogo: 'github',
+    namedLogo: 'github sponsors',
   }
 
   static render({ count }) {


### PR DESCRIPTION
As we discussed when I add [GitHub Sponsors badge](https://github.com/badges/shields/pull/5694#issuecomment-707836746), I added [Sponsors logo in simple-icons](https://github.com/simple-icons/simple-icons/pull/3730).

And then it released in [v4.4.0](https://github.com/simple-icons/simple-icons/releases/tag/4.4.0) and shields are now using `simple-icons@4.5.0`. 

So, I changed to GitHub Sponsors logo.

<img width="313" alt="스크린샷 2021-01-13 오전 4 07 06" src="https://user-images.githubusercontent.com/390146/104361146-6c26df00-5555-11eb-83c5-533144ae9565.png">
