### PR TITLE
Add [DockerDate] service

### DIFF
--- a/services/docker/docker-date.service.js
+++ b/services/docker/docker-date.service.js
@@ -1,0 +1,138 @@
+'use strict'
+
+const Joi = require('joi')
+const { nonNegativeInteger } = require('../validators')
+const { BaseJsonService, NotFound } = require('..')
+const { formatRelativeDate } = require('../text-formatters')
+const {
+  buildDockerUrl,
+  getDockerHubUser,
+  getMultiPageData,
+} = require('./docker-helpers')
+
+const buildSchema = Joi.object({
+  count: nonNegativeInteger.required(),
+  results: Joi.array().items(
+    Joi.object({
+      last_updated: Joi.date().iso().required(),
+      name: Joi.string().required(),
+      images: Joi.array().items(
+        Joi.object({
+          digest: Joi.string(),
+          architecture: Joi.string().required(),
+        })
+      ),
+    })
+  ),
+}).required()
+
+const queryParamSchema = Joi.object({
+  arch: Joi.string()
+    // Valid architecture values: https://golang.org/doc/install/source#environment (GOARCH)
+    .valid(
+      'amd64',
+      'arm',
+      'arm64',
+      's390x',
+      '386',
+      'ppc64',
+      'ppc64le',
+      'wasm',
+      'mips',
+      'mipsle',
+      'mips64',
+      'mips64le'
+    )
+    .default('amd64'),
+}).required()
+
+module.exports = class DockerDate extends BaseJsonService {
+  static category = 'version'
+  static route = { ...buildDockerUrl('date', true), queryParamSchema }
+  static examples = [
+    {
+      title: 'Docker Image Date (latest)',
+      pattern: ':user/:repo',
+      namedParams: { user: '_', repo: 'alpine' },
+      queryParams: { arch: 'amd64' },
+      staticPreview: this.render({
+        version: new Date(new Date() - 2 * 24 * 60 * 60 * 1000),
+      }),
+    },
+    {
+      title: 'Docker Image Date (tag)',
+      pattern: ':user/:repo/:tag',
+      namedParams: { user: '_', repo: 'alpine', tag: '3.6' },
+      staticPreview: this.render({
+        version: new Date(new Date() - 3 * 24 * 60 * 60 * 1000),
+      }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'latest docker image', color: 'blue' }
+
+  static render({ version }) {
+    return {
+      label: undefined,
+      message: formatRelativeDate(version),
+      color: 'blue',
+    }
+  }
+
+  async fetch({ user, repo, page }) {
+    page = page ? `&page=${page}` : ''
+    return this._requestJson({
+      schema: buildSchema,
+      url: `https://registry.hub.docker.com/v2/repositories/${getDockerHubUser(
+        user
+      )}/${repo}/tags?page_size=100&ordering=last_updated${page}`,
+      errorMessages: { 404: 'repository or tag not found' },
+    })
+  }
+
+  transform({ tag, data, pagedData, arch = 'amd64' }) {
+    let version
+    if (!tag) {
+      version = data.results[0]
+      return { version: version.last_updated }
+    } else {
+      version = data.find(d => d.name === tag)
+      if (!version) {
+        throw new NotFound({ prettyMessage: 'tag not found' })
+      }
+      return { version: version.last_updated }
+    }
+  }
+
+  async handle({ user, repo, tag }, { arch }) {
+    let data, pagedData
+
+    if (!tag) {
+      data = await this.fetch({ user, repo })
+      if (data.count === 0) {
+        throw new NotFound({ prettyMessage: 'repository not found' })
+      }
+      if (data.results[0].name === 'latest') {
+        pagedData = await getMultiPageData({
+          user,
+          repo,
+          fetch: this.fetch.bind(this),
+        })
+      }
+    } else {
+      data = await getMultiPageData({
+        user,
+        repo,
+        fetch: this.fetch.bind(this),
+      })
+    }
+
+    const { version } = await this.transform({
+      tag,
+      data,
+      pagedData,
+      arch,
+    })
+    return this.constructor.render({ version })
+  }
+}

--- a/services/docker/docker-date.service.js
+++ b/services/docker/docker-date.service.js
@@ -106,10 +106,11 @@ module.exports = class DockerDate extends BaseJsonService {
   async handle({ user, repo, tag }, { arch }) {
     let data
 
-    data = (await this.fetch({ user, repo })).results
+    data = await this.fetch({ user, repo })
     if (data.count === 0) {
       throw new NotFound({ prettyMessage: 'repository not found' })
     }
+    data = data.results
     if (tag && !data.find(d => d.name === tag)) {
       data = await getMultiPageData({
         user,

--- a/services/docker/docker-date.tester.js
+++ b/services/docker/docker-date.tester.js
@@ -1,0 +1,44 @@
+'use strict'
+
+const t = (module.exports = require('../tester').createServiceTester())
+const { isRelativeFormattedDate } = require('../test-validators')
+
+t.create('docker date (valid, library)').get('/_/alpine.json').expectBadge({
+  label: 'latest docker image',
+  message: isRelativeFormattedDate,
+})
+
+t.create('docker date (valid, library with tag)')
+  .get('/_/alpine/latest.json')
+  .expectBadge({
+    label: 'latest docker image',
+    message: isRelativeFormattedDate,
+  })
+
+t.create('docker date (valid, user)')
+  .get('/jrottenberg/ffmpeg.json')
+  .expectBadge({
+    label: 'latest docker image',
+    message: isRelativeFormattedDate,
+  })
+
+t.create('docker date (valid, user with tag)')
+  .get('/jrottenberg/ffmpeg/3.2-alpine.json')
+  .expectBadge({
+    label: 'latest docker image',
+    message: isRelativeFormattedDate,
+  })
+
+t.create('docker date (invalid, incorrect tag)')
+  .get('/_/alpine/wrong-tag.json')
+  .expectBadge({
+    label: 'latest docker image',
+    message: 'tag not found',
+  })
+
+t.create('docker date (invalid, unknown repository)')
+  .get('/_/not-a-real-repo.json')
+  .expectBadge({
+    label: 'latest docker image',
+    message: 'repository not found',
+  })

--- a/services/text-formatters.js
+++ b/services/text-formatters.js
@@ -119,6 +119,9 @@ function formatDate(d) {
 }
 
 function formatRelativeDate(timestamp) {
+  if (timestamp instanceof Date) {
+    timestamp = timestamp.getTime() / 1000
+  }
   return moment()
     .to(moment.unix(parseInt(timestamp, 10)))
     .toLowerCase()


### PR DESCRIPTION
This addresses #6016

Currently, paged data is not used at all. I don't quite get why the paged data is only used in the transform method when tag is undefined, and then only to match digests? Maybe someone can enlighten me here.