### PR TITLE
add a github action to create tags from labelled PR

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,31 @@
+name: Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  tag-release:
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date --rfc-3339=date)"
+
+      - name: Checkout branch "master"
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+
+      - name: Tag Release
+        uses: tvdias/github-tagger@v0.0.2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          tag: server-${{ steps.date.outputs.date }}


### PR DESCRIPTION
This is one of the bits we need for issue #5866
Also refs #6049

When we merge a PR which is labelled with "release", this will create a tag called `server-YYYY-MM-DD` (for today's date). To show this working (and test it), I set up a demo repo using the action:

- https://github.com/chris48s/release-action-test
- https://github.com/chris48s/release-action-test/pull/1
- https://github.com/chris48s/release-action-test/pull/2
- https://github.com/chris48s/release-action-test/actions
- https://github.com/chris48s/release-action-test/releases

I have also created a release label for use with this: https://github.com/badges/shields/labels?q=release

