### PR TITLE
Start a changelog, create a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Note: this changelog is for the shields.io server. The changelog for the badge-maker NPM package is at https://github.com/badges/shields/blob/master/badge-maker/CHANGELOG.md
+
+---
+
 ## server-2021-01-18
 
 - Gotta start somewhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## server-2021-01-18
+
+- Gotta start somewhere


### PR DESCRIPTION
Refs #5866 #6069

The reason why I'm submitting this is that for the next part of #5866 I am going to write an action which

- Looks at what changed since our last `server-YY-MM-DD` tag
- Generates a changelog entry

This will be easier to develop if we can assume there is already a changelog file we can append to and the repo already has one `server-YYYY-MM-DD` tag (hence the release label). This PR just creates that baseline to work from.