### PR TITLE
improve debug output for API calls with query strings

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -213,7 +213,18 @@ class BaseService {
 
   async _request({ url, options = {}, errorMessages = {} }) {
     const logTrace = (...args) => trace.logTrace('fetch', ...args)
-    logTrace(emojic.bowAndArrow, 'Request', url, '\n', options)
+    let logUrl = url
+    const logOptions = Object.assign({}, options)
+    if ('qs' in options) {
+      const params = new URLSearchParams(options.qs)
+      logUrl = `${url}?${params.toString()}`
+      delete logOptions.qs
+    }
+    logTrace(
+      emojic.bowAndArrow,
+      'Request',
+      `${logUrl}\n${JSON.stringify(logOptions, null, 2)}`
+    )
     const { res, buffer } = await this._requestFetcher(url, options)
     await this._meterResponse(res, buffer)
     logTrace(emojic.dart, 'Response status code', res.statusCode)

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -463,9 +463,7 @@ describe('BaseService', function () {
         'fetch',
         sinon.match.string,
         'Request',
-        url,
-        '\n',
-        options
+        `${url}\n${JSON.stringify(options, null, 2)}`
       )
       expect(trace.logTrace).to.be.calledWithMatch(
         'fetch',


### PR DESCRIPTION
I was trying to debug an issue earlier and spotted this issue - if we're making an API call with a query string, we don't display it properly in the logging output so we have to add debug statements to the code and assemble it by hand. I think I've actually hit this before, but today it annoyed me enough to actually fix it :)


Before:

```
...
 Request  🏹 
 https://repo.magicmq.dev/service/rest/v1/search
 Response status code  🎯 
 200
...
```

After:

```
...
 Request  🏹 
 https://repo.magicmq.dev/service/rest/v1/search?group=dev.magicmq&name=itemapi&sort=version&prerelease=false
{
  "headers": {
    "Accept": "application/json"
  }
}
 Response status code  🎯 
 200
...
```