### PR TITLE
link to SimpleIcons update schedule on 'new issue' page

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 contact_links:
+  - name: 🎨 Simple Icons
+    url: https://github.com/badges/shields/discussions/5369
+    about: Please read this before posting a question about SimpleIcons
   - name: ❓ Support Question
     url: https://github.com/badges/shields/discussions
     about: Ask a question about Shields.io


### PR DESCRIPTION
We are seeing multiple issues per week asking "when will X icon be available" or "why doesn't Y icon work". While @calebcartwright  is exercising the patience of a saint replying to them all with a link to https://github.com/badges/shields/discussions/5369 maybe this will help :pray: 