### PR TITLE
Fix [feedz] service in case the registrations page gets paginated

### DIFF
--- a/services/feedz/feedz.service.js
+++ b/services/feedz/feedz.service.js
@@ -22,7 +22,6 @@ const schema = Joi.object({
         ),
       }).required()
     )
-    .max(1)
     .default([]),
 }).required()
 
@@ -84,10 +83,10 @@ class FeedzVersionService extends BaseJsonService {
   }
 
   transform({ json, includePrereleases }) {
-    if (json.items.length === 1 && json.items[0].items.length > 0) {
-      const versions = json.items[0].items.map(i =>
-        stripBuildMetadata(i.catalogEntry.version)
-      )
+    const versions = json.items.flatMap(tl =>
+      tl.items.map(i => stripBuildMetadata(i.catalogEntry.version))
+    )
+    if (versions.length >= 1) {
       return selectVersion(versions, includePrereleases)
     } else {
       throw new NotFound({ prettyMessage: 'package not found' })

--- a/services/feedz/feedz.service.spec.js
+++ b/services/feedz/feedz.service.spec.js
@@ -5,15 +5,13 @@ const { FeedzVersionService } = require('./feedz.service')
 
 function json(versions) {
   return {
-    items: [
-      {
-        items: versions.map(v => ({
-          catalogEntry: {
-            version: v,
-          },
-        })),
-      },
-    ],
+    items: versions.map(topLevel => ({
+      items: topLevel.map(v => ({
+        catalogEntry: {
+          version: v,
+        },
+      })),
+    })),
   }
 }
 
@@ -31,32 +29,63 @@ describe('Feedz service', function () {
   })
 
   test(FeedzVersionService.prototype.transform, () => {
-    given({ json: json(['1.0.0']), includePrereleases: false }).expect('1.0.0')
-    given({ json: json(['1.0.0', '1.0.1']), includePrereleases: false }).expect(
-      '1.0.1'
+    given({ json: json([['1.0.0']]), includePrereleases: false }).expect(
+      '1.0.0'
     )
     given({
-      json: json(['1.0.0', '1.0.1-beta1']),
+      json: json([['1.0.0', '1.0.1']]),
+      includePrereleases: false,
+    }).expect('1.0.1')
+    given({
+      json: json([['1.0.0', '1.0.1-beta1']]),
       includePrereleases: false,
     }).expect('1.0.0')
     given({
-      json: json(['1.0.0', '1.0.1-beta1']),
+      json: json([['1.0.0', '1.0.1-beta1']]),
       includePrereleases: true,
     }).expect('1.0.1-beta1')
 
     given({
-      json: json(['1.0.0+1', '1.0.1-beta1+1']),
+      json: json([['1.0.0'], ['1.0.1']]),
+      includePrereleases: false,
+    }).expect('1.0.1')
+    given({ json: json([['1.0.1'], []]), includePrereleases: false }).expect(
+      '1.0.1'
+    )
+    given({ json: json([[], ['1.0.1']]), includePrereleases: false }).expect(
+      '1.0.1'
+    )
+    given({
+      json: json([['1.0.0'], ['1.0.1-beta1']]),
       includePrereleases: false,
     }).expect('1.0.0')
     given({
-      json: json(['1.0.0+1', '1.0.1-beta1+1']),
+      json: json([['1.0.0'], ['1.0.1-beta1']]),
+      includePrereleases: true,
+    }).expect('1.0.1-beta1')
+
+    given({
+      json: json([['1.0.0+1', '1.0.1-beta1+1']]),
+      includePrereleases: false,
+    }).expect('1.0.0')
+    given({
+      json: json([['1.0.0+1', '1.0.1-beta1+1']]),
       includePrereleases: true,
     }).expect('1.0.1-beta1')
 
     given({ json: json([]), includePrereleases: false }).expectError(
       'Not Found: package not found'
     )
+    given({ json: json([[]]), includePrereleases: false }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: json([[], []]), includePrereleases: false }).expectError(
+      'Not Found: package not found'
+    )
     given({ json: json([]), includePrereleases: true }).expectError(
+      'Not Found: package not found'
+    )
+    given({ json: json([[]]), includePrereleases: true }).expectError(
       'Not Found: package not found'
     )
     given({ json: noItemsJson(), includePrereleases: false }).expectError(

--- a/services/feedz/feedz.tester.js
+++ b/services/feedz/feedz.tester.js
@@ -12,6 +12,7 @@ const t = (module.exports = new ServiceTester({
 //  - Shields.NoV1: 0.1.0
 //  - Shields.TestPackage: 0.0.1, 0.1.0-pre, 1.0.0
 //  - Shields.TestPreOnly: 0.1.0-pre
+//  - Shields.MultiPage: 0.1.0-0.1.100 plus 1.0.0 but the response has multiple top-level `items`
 // The source code of these packages is here: https://github.com/jakubfijalkowski/shields-test-packages
 
 // version
@@ -37,6 +38,14 @@ t.create('version (orange badge)')
     label: 'feedz',
     message: 'v0.1.0',
     color: 'orange',
+  })
+
+t.create('multi-page')
+  .get('/feedz/v/shieldstests/public/Shields.MultiPage.json')
+  .expectBadge({
+    label: 'feedz',
+    message: 'v1.0.0',
+    color: 'blue',
   })
 
 t.create('repository (not found)')
@@ -74,6 +83,14 @@ t.create('version (pre) (orange badge)')
     label: 'feedz',
     message: 'v0.1.0',
     color: 'orange',
+  })
+
+t.create('multi-page (pre)')
+  .get('/feedz/vpre/shieldstests/public/Shields.MultiPage.json')
+  .expectBadge({
+    label: 'feedz',
+    message: 'v1.0.0',
+    color: 'blue',
   })
 
 t.create('repository (pre) (not found)')


### PR DESCRIPTION
:wave: 

[Last time](https://github.com/badges/shields/pull/5753) I missed one thing - the `items` in the registration response (at the first level) represent _pages_, and if you have enough versions, you will get multiple entries there.

This PR fixes that - it no longer expects a single page and it is now able to get versions from all the pages.