### PR TITLE
add a GH action to generate a changelog and submit a release PR

### DIFF
--- a/.github/actions/draft-release/Dockerfile
+++ b/.github/actions/draft-release/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:12-buster
+
+RUN apt-get update
+RUN apt-get install -y jq
+RUN apt-get install -y uuid-runtime
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/draft-release/action.yml
+++ b/.github/actions/draft-release/action.yml
@@ -1,0 +1,5 @@
+name: 'draft-release'
+description: 'Generate a changelog and propose a release PR'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/draft-release/entrypoint.sh
+++ b/.github/actions/draft-release/entrypoint.sh
@@ -34,8 +34,7 @@ sed -i "${INSERT_POINT} r temp-changes.txt" CHANGELOG.md
 rm temp-changes.txt
 
 # Run prettier (to ensure the markdown file doesn't fail CI)
-npm ci
-npm run prettier
+npx prettier@$(cat package.json | jq -r .devDependencies.prettier) --write "CHANGELOG.md"
 
 # Generate a unique branch name
 BRANCH_NAME="$RELEASE_NAME"-$(uuidgen | head -c 8)

--- a/.github/actions/draft-release/entrypoint.sh
+++ b/.github/actions/draft-release/entrypoint.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Set up a git user
+git config user.name "release[bot]"
+git config user.email "actions@users.noreply.github.com"
+
+# Find last server-YYYY-MM-DD tag
+git fetch --unshallow --tags
+LAST_TAG=$(git tag | grep server | tail -n 1)
+
+# Find the marker in CHANGELOG.md
+INSERT_POINT=$(grep -n "^\-\-\-$" CHANGELOG.md | cut -f1 -d:)
+INSERT_POINT=$((INSERT_POINT+1))
+
+# Generate a release name
+RELEASE_NAME="server-$(date --rfc-3339=date)"
+
+# Assemble changelog entry
+rm -f temp-changes.txt
+touch temp-changes.txt
+{
+    echo "## $RELEASE_NAME"
+    echo ""
+    git log "$LAST_TAG"..HEAD --no-merges --oneline --pretty="format:- %s" --perl-regexp --author='^((?!dependabot).*)$'
+    echo $'\n'
+} >> temp-changes.txt
+
+# Write the changelog
+sed -i "${INSERT_POINT} r temp-changes.txt" CHANGELOG.md
+
+# Cleanup
+rm temp-changes.txt
+
+# Run prettier (to ensure the markdown file doesn't fail CI)
+npm ci
+npm run prettier
+
+# Generate a unique branch name
+BRANCH_NAME="$RELEASE_NAME"-$(uuidgen | head -c 8)
+git checkout -b "$BRANCH_NAME"
+
+# Commit + push changelog
+git add CHANGELOG.md
+git commit -m "Update Changelog"
+git push origin "$BRANCH_NAME"
+
+# Submit a PR
+TITLE="Changelog for Release $RELEASE_NAME"
+PR_RESP=$(curl https://api.github.com/repos/"$REPO_NAME"/pulls \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    --data '{"title": "'"$TITLE"'", "body": "'"$TITLE"'", "head": "'"$BRANCH_NAME"'", "base": "master"}')
+
+# Add the 'release' label to the PR
+PR_API_URL=$(echo "$PR_RESP" | jq -r ._links.issue.href)
+curl "$PR_API_URL" \
+    -X POST \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    --data '{"labels":["release"]}'

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,19 @@
+name: Draft Release
+on:
+  schedule:
+    - cron: '0 1 1 * *'
+    # At 01:00 on the first day of every month
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Draft Release
+        uses: ./.github/actions/draft-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_NAME: ${{ github.repository }}


### PR DESCRIPTION
Refs #5866

This PR adds an action which will

* run once a month (but also allow us to trigger it manually)
* generate a changelog we can manually review
* open a PR tagged with "release" which we can review/merge

Coupled with https://github.com/badges/shields/blob/master/.github/workflows/tag-release.yml merging the PR will create the release tag.

This will generate a PR something like https://github.com/chris48s/release-action-test/pull/5 . The commit messages on this test repo are mostly junk from when I was debugging the action - ours will look like.

```md
- add a github action to create tags from labelled PR (#6069)
- fix [wordpress] 'Can't generate version color for false' (#6072)
- Update self-hosting.md documentation for running with Prometheus (#6052)
- fix: remove erroneous clearRequestCache call (#6067)
```

..or whatever. I'll leave some more notes inline.