### PR TITLE
fix [GitHubIssues] service test

### DIFF
--- a/services/github/github-issues.tester.js
+++ b/services/github/github-issues.tester.js
@@ -82,9 +82,9 @@ t.create('GitHub open issues by label (raw)')
 
 // https://github.com/badges/shields/issues/1870
 t.create('GitHub open issues by label including slash character (raw)')
-  .get('/issues-raw/IgorNovozhilov/ndk/@ndk/cfg.json')
+  .get('/issues-raw/calebcartwright/shields-service-test-target/@foo/bar.json')
   .expectBadge({
-    label: 'open @ndk/cfg issues',
+    label: 'open @foo/bar issues',
     // Not always > 0.
     message: Joi.alternatives(isMetric, Joi.equal('0')),
   })


### PR DESCRIPTION
Fixes #6105 

Seems the upstream repo and associated package have been yanked from the internet. I figured it would be easier to just create my own repo with a label to match the original case/bug report instead of perusing GH to find a repo that had the same type of label