### PR TITLE
fix [GitHubLerna] service test

### DIFF
--- a/services/github/github-lerna-json.tester.js
+++ b/services/github/github-lerna-json.tester.js
@@ -3,7 +3,7 @@
 const { isSemver } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('Lerna version').get('/babel/babel.json').expectBadge({
+t.create('Lerna version').get('/facebook/jest.json').expectBadge({
   label: 'lerna',
   message: isSemver,
 })
@@ -15,10 +15,12 @@ t.create('Lerna version (independent)')
     message: 'independent',
   })
 
-t.create('Lerna version (branch)').get('/babel/babel/master.json').expectBadge({
-  label: 'lerna@master',
-  message: isSemver,
-})
+t.create('Lerna version (branch)')
+  .get('/facebook/jest/master.json')
+  .expectBadge({
+    label: 'lerna@master',
+    message: isSemver,
+  })
 
 t.create('Lerna version (lerna.json missing)')
   .get('/PyvesB/empty-repo.json')


### PR DESCRIPTION
Fixes #6106 

Babel has stopped using Lerna, apparently. The test with the branch was still passing because Babel have switched from `master` to `main` already, and their older `master` branch still had the `lerna.json` file. Changing the target for both tests though to prevent future breakage, as there's no telling how long Babel may keep the old branch around