### PR TITLE
add info on releases to self-hosting docs

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -1,6 +1,19 @@
 # Hosting your own Shields server
 
-## Installation
+Some users may wish to host their own instance of shields. This is particularly useful if you want to serve badges for resources that require authentication or are not exposed to the internet (e.g: inside a corporate network). A variety of options are available either by installing from source or using a docker image.
+
+## Releases
+
+- https://github.com/badges/shields is a monorepo and hosts the shields frontend and server code as well as the [badge-maker](https://www.npmjs.com/package/badge-maker) NPM library.
+- The server uses [Calendar Versioning](https://calver.org/). Tags of the form `server-YYYY-MM-DD` are server releases (these are the tags that are relevant to self-hosting users).
+- Badge-maker uses [Semantic Versioning](https://semver.org/). Tags of the form `X.Y.Z` are badge-maker releases.
+- As well as [tags on GitHub](https://github.com/badges/shields/tags), server releases are also pushed to [DockerHub](https://registry.hub.docker.com/r/shieldsio/shields/tags). See the section on [Docker](#Docker) for more details.
+- We publish release notes for server releases in the [CHANGELOG](https://github.com/badges/shields/blob/master/CHANGELOG.md). There may occasionally be non-backwards compatible changes to be aware of.
+- We will normally put out one release per month. If there is a security patch or major bugfix affecting self-hosting users, we may put out an out-of-sequence release.
+- Releases are just a snapshot in time. We advise always tracking the latest release to ensure you are up-to-date with the latest bug fixes and security updates. There are no 'patch' releases - we don't backport fixes to old releases. Tagged versions just provide a convenient way to apply upgrades in a controlled way or roll back to an older version if necessary and communicate about versions.
+- You can stay on the bleeding edge by tracking the `master` branch for source installs or the `next` tag on DockerHub.
+
+## Installing from Source
 
 You will need Node 12 or later, which you can install using a
 [package manager][].
@@ -14,18 +27,19 @@ curl -sL https://deb.nodesource.com/setup_12.x | sudo -E bash -; sudo apt-get in
 ```sh
 git clone https://github.com/badges/shields.git
 cd shields
+git checkout $(git tag | grep server | tail -n 1)  # checkout the latest tag
 npm ci  # You may need sudo for this.
 ```
 
 [package manager]: https://nodejs.org/en/download/package-manager/
 
-## Build the frontend
+### Build the frontend
 
 ```sh
 npm run build
 ```
 
-## Start the server
+### Start the server
 
 ```sh
 sudo node server
@@ -44,7 +58,7 @@ The root gets redirected to https://shields.io.
 
 For testing purposes, you can go to `http://localhost/`.
 
-## Heroku
+### Deploying to Heroku
 
 Once you have installed the [Heroku CLI][]
 
@@ -57,9 +71,32 @@ heroku open
 
 [heroku cli]: https://devcenter.heroku.com/articles/heroku-cli
 
+### Deploying to Zeit Vercel
+
+To deploy using Zeit Vercel:
+
+```console
+npm run build  # Not sure why, but this needs to be run before deploying.
+vercel
+```
+
 ## Docker
 
-You can build and run the server locally using Docker. First build an image:
+### DockerHub
+
+We publish images to DockerHub at https://registry.hub.docker.com/r/shieldsio/shields
+
+The `next` tag is the latest build from `master`, or tagged releases are available
+https://registry.hub.docker.com/r/shieldsio/shields/tags
+
+```console
+$ docker pull shieldsio/shields:next
+$ docker run shieldsio/shields:next
+```
+
+### Building Docker Image Locally
+
+Alternatively, you can build and run the server locally using Docker. First build an image:
 
 ```console
 $ docker build -t shields .
@@ -113,15 +150,6 @@ preconfigured raster server.
 
 [raster server]: https://github.com/badges/svg-to-image-proxy
 [micro]: https://github.com/zeit/micro
-
-## Zeit Now
-
-To deploy using Zeit Now:
-
-```console
-npm run build  # Not sure why, but this needs to be run before deploying.
-now
-```
 
 ## Persistence
 
@@ -195,7 +223,7 @@ private:
 sudo node server
 ```
 
-### Prometheus
+## Prometheus
 
 Shields uses [prom-client](https://github.com/siimon/prom-client) to provide [default metrics](https://prometheus.io/docs/instrumenting/writing_clientlibs/#standard-and-runtime-collectors). These metrics are disabled by default.
 You can enable them by `METRICS_PROMETHEUS_ENABLED` and `METRICS_PROMETHEUS_ENDPOINT_ENABLED` environment variables.
@@ -206,7 +234,7 @@ METRICS_PROMETHEUS_ENABLED=true METRICS_PROMETHEUS_ENDPOINT_ENABLED=true npm sta
 
 Metrics are available at `/metrics` resource.
 
-### Cloudflare
+## Cloudflare
 
 Shields uses Cloudflare as a downstream CDN. If your installation does the same,
 you can configure your server to only accept requests coming from Cloudflare's IPs.


### PR DESCRIPTION
The main thing going on in this PR is adding docs about tagged releases, but I updated a couple of other things (grouped docs about deploying from source together and docs about deploying with docker together, updated "now" to "vercel").