### PR TITLE
Allow links only for social badges, affects [GitHubMilestone Dependabot]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ There are three places to get help:
   used by developers or which are widely used by developers.
 - The left-hand side of a badge should not advertise. It should be a lowercase _noun_
   succinctly describing the meaning of the right-hand side.
-- Except for badges using the `social` style, logos should be _turned off by
+- Except for badges using the `social` style, logos and links should be _turned off by
   default_.
 - Badges should not obtain data from undocumented or reverse-engineered API endpoints.
 - Badges should not obtain data by scraping web pages - these are likely to break frequently.

--- a/frontend/components/usage.tsx
+++ b/frontend/components/usage.tsx
@@ -378,8 +378,10 @@ export default function Usage({ baseUrl }: { baseUrl: string }): JSX.Element {
           <QueryParam
             documentation={
               <span>
-                Specify what clicking on the left/right of a badge should do
-                (esp. for social badge style)
+                Specify what clicking on the left/right of a badge should do.
+                Note that this only works when integrating your badge in an
+                <StyledCode>&lt;object&gt;</StyledCode> HTML tag, but not an
+                <StyledCode>&lt;img&gt;</StyledCode> tag or a markup language.
               </span>
             }
             key="link"

--- a/services/dependabot/dependabot.service.js
+++ b/services/dependabot/dependabot.service.js
@@ -58,7 +58,6 @@ module.exports = class DependabotSemverCompatibility extends BaseJsonService {
     return {
       color: json.colour,
       message: json.status,
-      link: this._getLink({ packageManager, dependencyName }),
     }
   }
 }

--- a/services/dependabot/dependabot.service.js
+++ b/services/dependabot/dependabot.service.js
@@ -46,13 +46,6 @@ module.exports = class DependabotSemverCompatibility extends BaseJsonService {
     })
   }
 
-  _getLink({ packageManager, dependencyName }) {
-    const qs = new url.URLSearchParams(
-      this._getQuery({ packageManager, dependencyName })
-    )
-    return `https://dependabot.com/compatibility-score.html?${qs.toString()}`
-  }
-
   async handle({ packageManager, dependencyName }) {
     const json = await this.fetch({ packageManager, dependencyName })
     return {

--- a/services/dependabot/dependabot.service.js
+++ b/services/dependabot/dependabot.service.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const url = require('url')
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
 

--- a/services/dependabot/dependabot.tester.js
+++ b/services/dependabot/dependabot.tester.js
@@ -3,15 +3,10 @@
 const { isIntegerPercentage } = require('../test-validators')
 const t = (module.exports = require('../tester').createServiceTester())
 
-t.create('semver stability (valid)')
-  .get('/bundler/puma.json')
-  .expectBadge({
-    label: 'semver stability',
-    message: isIntegerPercentage,
-    link: [
-      'https://dependabot.com/compatibility-score.html?package-manager=bundler&dependency-name=puma&version-scheme=semver',
-    ],
-  })
+t.create('semver stability (valid)').get('/bundler/puma.json').expectBadge({
+  label: 'semver stability',
+  message: isIntegerPercentage,
+})
 
 t.create('semver stability (invalid error)')
   .get('/invalid-manager/puma.json')

--- a/services/github/github-milestone-detail.service.js
+++ b/services/github/github-milestone-detail.service.js
@@ -80,7 +80,6 @@ module.exports = class GithubMilestoneDetail extends GithubAuthV3Service {
       label: `${milestone.title} ${label}`,
       message: metric(milestoneMetric),
       color,
-      link: [`https://github.com/${user}/${repo}/milestone/${number}`],
     }
   }
 

--- a/services/github/github-milestone-detail.tester.js
+++ b/services/github/github-milestone-detail.tester.js
@@ -12,7 +12,6 @@ t.create('Milestone Open Issues')
   .expectBadge({
     label: 'openWithOneOpenIssue open issues',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestone/1`],
   })
 
 t.create('Milestone Closed Issues')
@@ -20,7 +19,6 @@ t.create('Milestone Closed Issues')
   .expectBadge({
     label: 'closedWithOneClosedIssue closed issues',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestone/3`],
   })
 
 t.create('Milestone Total Issues')
@@ -28,7 +26,6 @@ t.create('Milestone Total Issues')
   .expectBadge({
     label: 'openWithOneOpenOneClosedIssue issues',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestone/2`],
   })
 
 t.create('Milestone Progress')
@@ -36,7 +33,6 @@ t.create('Milestone Progress')
   .expectBadge({
     label: 'openWithOneOpenOneClosedIssue',
     message: isMetricOverMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestone/2`],
   })
 
 t.create('Milestone Progress (Percent)')
@@ -44,7 +40,6 @@ t.create('Milestone Progress (Percent)')
   .expectBadge({
     label: 'openWithOneOpenOneClosedIssue',
     message: isIntegerPercentage,
-    link: [`https://github.com/MacroPower/milestone-test/milestone/2`],
   })
 
 t.create('Milestones (repo or milestone not found)')

--- a/services/github/github-milestone.service.js
+++ b/services/github/github-milestone.service.js
@@ -65,7 +65,6 @@ module.exports = class GithubMilestone extends GithubAuthV3Service {
       label: `${label} milestones`,
       message: metric(milestoneLength),
       color,
-      link: [`https://github.com/${user}/${repo}/milestones`],
     }
   }
 

--- a/services/github/github-milestone.tester.js
+++ b/services/github/github-milestone.tester.js
@@ -8,7 +8,6 @@ t.create('All Milestones')
   .expectBadge({
     label: 'milestones',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestones`],
   })
 
 t.create('Open Milestones')
@@ -16,7 +15,6 @@ t.create('Open Milestones')
   .expectBadge({
     label: 'active milestones',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestones`],
   })
 
 t.create('Closed Milestones')
@@ -24,7 +22,6 @@ t.create('Closed Milestones')
   .expectBadge({
     label: 'completed milestones',
     message: isMetric,
-    link: [`https://github.com/MacroPower/milestone-test/milestones`],
   })
 
 t.create('Milestones (repo not found)')

--- a/spec/SPECIFICATION.md
+++ b/spec/SPECIFICATION.md
@@ -8,7 +8,7 @@ This document specifies the visual design of Shields badges.
 - **semantic**: the purpose of the information provided by a badge should be self-evident
 - **non-promotional**: badges should refrain from advertising a service but instead provide value through the badge's information instead
 - **concise**: one descriptive word on the left (the key), one piece of data on the right (the value)
-- **hyperlinked**: badges can link to a third-party website providing more information, either related to the metadata provided by the badge or about the project the badge was used for (e.g. an open source library)
+- **hyperlinked**: badges with style 'social' can link to a third-party website providing more information, either related to the metadata provided by the badge or about the project the badge was used for (e.g. an open source library)
 
 ### Example
 


### PR DESCRIPTION
Related to #6096.

Twitch is also another badge that doesn't follow this, however, I'm suggesting #6158 as a resolution instead.