### PR TITLE
Update Simple Icons Versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "query-string": "^6.13.8",
     "request": "~2.88.2",
     "semver": "~7.3.4",
-    "simple-icons": "4.8.0",
+    "simple-icons": "^4.8.0",
     "webextension-store-meta": "^1.0.3",
     "xmldom": "~0.4.0",
     "xpath": "~0.0.32"


### PR DESCRIPTION
See: https://github.com/simple-icons/simple-icons/compare/4.8.0...4.10.0

**Shields** is currently missing the 40+ icon updates added in just the past 10 days.

Either:

* ~~The dependabot automation to update this specific version should be made more frequent (e.g. match the release cron for Simple Icons;  00:00 on Sunday)~~ *This option would likely get me shot for suggesting it*

or:

* The version should be set to all compatible versions (i.e. up to 5.0.0, when the version would need to be reevaluated anyway). *This options seems more reasonable to me*
