### PR TITLE
update [flathub] error handling

### DIFF
--- a/services/flathub/flathub.service.js
+++ b/services/flathub/flathub.service.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const Joi = require('joi')
-const { InvalidResponse, NotFound } = require('..')
 const { renderVersionBadge } = require('../version')
 const { BaseJsonService } = require('..')
 
@@ -25,24 +24,10 @@ module.exports = class Flathub extends BaseJsonService {
   static defaultBadgeData = { label: 'flathub' }
 
   async handle({ packageName }) {
-    try {
-      const data = await this._requestJson({
-        schema,
-        url: `https://flathub.org/api/v1/apps/${encodeURIComponent(
-          packageName
-        )}`,
-      })
-      return renderVersionBadge({ version: data.currentReleaseVersion })
-    } catch (error) {
-      if (error instanceof InvalidResponse) {
-        // Note the 'not found' response from Flathub is:
-        // status code = 200,
-        // body = empty
-        throw new NotFound({
-          prettyMessage: `${packageName} not found`,
-        })
-      }
-      throw error
-    }
+    const data = await this._requestJson({
+      schema,
+      url: `https://flathub.org/api/v1/apps/${encodeURIComponent(packageName)}`,
+    })
+    return renderVersionBadge({ version: data.currentReleaseVersion })
   }
 }

--- a/services/flathub/flathub.tester.js
+++ b/services/flathub/flathub.tester.js
@@ -22,4 +22,4 @@ t.create('Flathub (valid)')
 
 t.create('Flathub (not found)')
   .get('/not.a.package.json')
-  .expectBadge({ label: 'flathub', message: 'not.a.package not found' })
+  .expectBadge({ label: 'flathub', message: 'not found' })


### PR DESCRIPTION
Flathub now throws a 404 for package not found, like a well-behaved API :)
