### PR TITLE
ensure redirect target path is correctly encoded

### DIFF
--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -82,7 +82,7 @@ module.exports = function redirector(attrs) {
         trace.logTrace('inbound', emojic.ticket, 'Named params', namedParams)
         trace.logTrace('inbound', emojic.crayon, 'Query params', queryParams)
 
-        const targetPath = transformPath(namedParams)
+        const targetPath = encodeURI(transformPath(namedParams))
         trace.logTrace('validate', emojic.dart, 'Target', targetPath)
 
         let urlSuffix = ask.uri.search || ''

--- a/core/base-service/redirector.spec.js
+++ b/core/base-service/redirector.spec.js
@@ -121,6 +121,20 @@ describe('Redirector', function () {
       )
     })
 
+    it('should correctly encode the redirect URL', async function () {
+      const { statusCode, headers } = await got(
+        `${baseUrl}/very/old/service/hello%0Dworld.svg?foobar=a%0Db`,
+        {
+          followRedirect: false,
+        }
+      )
+
+      expect(statusCode).to.equal(301)
+      expect(headers.location).to.equal(
+        '/new/service/hello%0Dworld.svg?foobar=a%0Db'
+      )
+    })
+
     describe('transformQueryParams', function () {
       const route = {
         base: 'another/old/service',


### PR DESCRIPTION
This fixes a bug that causes `setHeader()` to throw an unhandled `TypeError` if the path of the URL we are redirecting to contains unescaped characters which are invalid for a HTTP header.
Note this is only the url path affected. The querystring was already encoded correctly

Refs https://sentry.io/organizations/shields/issues/1867642393