### PR TITLE
use got to push influx metrics

### DIFF
--- a/core/server/influx-metrics.spec.js
+++ b/core/server/influx-metrics.spec.js
@@ -150,7 +150,7 @@ describe('Influx metrics', function () {
           .and(
             sinon.match.has(
               'message',
-              'Cannot push metrics. Cause: NetConnectNotAllowedError: Nock: Disallowed net connect for "shields-metrics.io:80/metrics"'
+              'Cannot push metrics. Cause: RequestError: Nock: Disallowed net connect for "shields-metrics.io:80/metrics"'
             )
           )
       )


### PR DESCRIPTION
refs  #4655

Nice bit of low hanging fruit here :green_apple: 
Because this is stand-alone utility code and not part of the services I haven't routed it through `fetchFactory`/`sendRequest`. I've just gone straight from request to got.