### PR TITLE
Prevent duplication of parameters in badge examples

### DIFF
--- a/cypress/integration/main-page.spec.js
+++ b/cypress/integration/main-page.spec.js
@@ -62,4 +62,13 @@ describe('Main page', function () {
 
     cy.get(`img[src='${backendUrl}/github/issues/badges/shields?color=orange']`)
   })
+
+  it('Do not duplicate example parameters', function () {
+    cy.visit('/category/social')
+
+    cy.contains('GitHub Sponsors').click()
+    cy.get('[name="style"]').should($style => {
+      expect($style).to.have.length(1)
+    })
+  })
 })

--- a/frontend/components/customizer/query-string-builder.tsx
+++ b/frontend/components/customizer/query-string-builder.tsx
@@ -241,15 +241,21 @@ export default function QueryStringBuilder({
   const [queryParams, setQueryParams] = useState(() =>
     // For each of the custom query params defined in `exampleParams`,
     // create empty values in `queryParams`.
-    Object.entries(exampleParams).reduce((accum, [name, value]) => {
-      // Custom query params are either string or boolean. Inspect the example
-      // value to infer which one, and set empty values accordingly.
-      // Throughout the component, these two types are supported in the same
-      // manner: by inspecting this value type.
-      const isStringParam = typeof value === 'string'
-      accum[name] = isStringParam ? '' : true
-      return accum
-    }, {} as { [k: string]: string | boolean })
+    Object.entries(exampleParams)
+      .filter(
+        // If the example defines a value for one of the standard supported
+        // options, do not duplicate the corresponding parameter.
+        ([name]) => !supportedBadgeOptions.some(option => name === option.name)
+      )
+      .reduce((accum, [name, value]) => {
+        // Custom query params are either string or boolean. Inspect the example
+        // value to infer which one, and set empty values accordingly.
+        // Throughout the component, these two types are supported in the same
+        // manner: by inspecting this value type.
+        const isStringParam = typeof value === 'string'
+        accum[name] = isStringParam ? '' : true
+        return accum
+      }, {} as { [k: string]: string | boolean })
   )
   // For each of the standard badge options, create empty values in
   // `badgeOptions`. When `initialStyle` has been provided, use it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,12 +244,6 @@
             "node-releases": "^1.1.70"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001199",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
-          "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
-          "dev": true
-        },
         "chalk": {
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -774,12 +768,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
-          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -2419,12 +2407,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.681",
@@ -9659,12 +9641,6 @@
         "postcss-value-parser": "^4.1.0"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
-          "dev": true
-        },
         "postcss-value-parser": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
@@ -10356,12 +10332,6 @@
             "escalade": "^3.1.1",
             "node-releases": "^1.1.70"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
-          "dev": true
         },
         "core-js-compat": {
           "version": "3.9.1",
@@ -11410,9 +11380,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001051",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001051.tgz",
-      "integrity": "sha512-sw8UUnTlRevawTMZKN7vpfwSjCBVoiMPlYd8oT2VwNylyPCBdMAUmLGUApnYYTtIm5JXsQegUAY7GPHqgfDzjw==",
+      "version": "1.0.30001199",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001199.tgz",
+      "integrity": "sha512-ifbK2eChUCFUwGhlEzIoVwzFt1+iriSjyKKFYNfv6hN34483wyWpLLavYQXhnR036LhkdUYaSDpHg1El++VgHQ==",
       "dev": true
     },
     "caseless": {
@@ -18037,12 +18007,6 @@
               "dev": true
             }
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001196",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz",
-          "integrity": "sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==",
-          "dev": true
         },
         "cli-boxes": {
           "version": "2.2.1",


### PR DESCRIPTION
Fixes #6182.

When running the e2e tests, I noticed the following warning:
```
warning Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```

The changes to _package-lock.json_ should address that.