### PR TITLE
Address compliance issues with [YouTube] API Services Terms and Policies

### DIFF
--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -5,6 +5,10 @@ const { BaseJsonService, NotFound } = require('..')
 const { metric } = require('../text-formatters')
 const { nonNegativeInteger } = require('../validators')
 
+const documentation = `
+<p>By using the YouTube badges provided by Shields.io, you are agreeing to be bound by the YouTube Terms of Service. These can be found here:
+<code>https://www.youtube.com/t/terms</code></p>`
+
 const schema = Joi.object({
   items: Joi.array()
     .items(
@@ -20,7 +24,7 @@ const schema = Joi.object({
     .required(),
 }).required()
 
-module.exports = class YouTubeBase extends BaseJsonService {
+class YouTubeBase extends BaseJsonService {
   static category = 'social'
 
   static auth = {
@@ -68,3 +72,5 @@ module.exports = class YouTubeBase extends BaseJsonService {
     return this.constructor.render({ statistics, videoId }, queryParams)
   }
 }
+
+module.exports = { documentation, YouTubeBase }

--- a/services/youtube/youtube-comments.service.js
+++ b/services/youtube/youtube-comments.service.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const YouTubeBase = require('./youtube-base')
+const { documentation, YouTubeBase } = require('./youtube-base')
 
 module.exports = class YouTubeComments extends YouTubeBase {
   static route = {
@@ -20,6 +20,7 @@ module.exports = class YouTubeComments extends YouTubeBase {
         title: 'YouTube Video Comments',
         namedParams: { videoId: 'wGJHwc5ksMA' },
         staticPreview: preview,
+        documentation,
       },
     ]
   }

--- a/services/youtube/youtube-likes.service.js
+++ b/services/youtube/youtube-likes.service.js
@@ -2,7 +2,15 @@
 
 const Joi = require('joi')
 const { metric } = require('../text-formatters')
-const YouTubeBase = require('./youtube-base')
+const { documentation, YouTubeBase } = require('./youtube-base')
+
+const documentationWithDislikes = `
+  ${documentation}
+  <p>
+    When enabling the <code>withDislikes</code> option, 👍 corresponds to the number
+    of likes of a given video, 👎 corresponds to the number of dislikes.
+  </p>
+`
 
 const queryParamSchema = Joi.object({
   withDislikes: Joi.equal(''),
@@ -37,33 +45,34 @@ module.exports = class YouTubeLikes extends YouTubeBase {
         title: 'YouTube Video Likes',
         namedParams: { videoId: 'abBdk8bSPKU' },
         staticPreview: previewLikes,
+        documentation,
       },
       {
-        title: 'YouTube Video Votes',
+        title: 'YouTube Video Likes and Dislikes',
         namedParams: { videoId: 'pU9Q6oiQNd0' },
         staticPreview: previewVotes,
         queryParams: {
           withDislikes: null,
         },
+        documentation: documentationWithDislikes,
       },
     ]
   }
 
   static render({ statistics, videoId }, queryParams) {
-    if (queryParams && typeof queryParams.withDislikes !== 'undefined') {
-      return {
-        label: 'votes',
-        message: `${metric(statistics.likeCount)} 👍 ${metric(
-          statistics.dislikeCount
-        )} 👎`,
-        style: 'social',
-        link: `https://www.youtube.com/watch?v=${encodeURIComponent(videoId)}`,
-      }
-    }
-    return super.renderSingleStat({
+    let renderedBadge = super.renderSingleStat({
       statistics,
       statisticName: 'like',
       videoId,
     })
+    if (queryParams && typeof queryParams.withDislikes !== 'undefined') {
+      renderedBadge = {
+        ...renderedBadge,
+        message: `${metric(statistics.likeCount)} 👍 ${metric(
+          statistics.dislikeCount
+        )} 👎`,
+      }
+    }
+    return renderedBadge
   }
 }

--- a/services/youtube/youtube-likes.tester.js
+++ b/services/youtube/youtube-likes.tester.js
@@ -20,7 +20,7 @@ t.create('video vote count')
   .skipWhen(noYouTubeToken)
   .get('/pU9Q6oiQNd0.json?withDislikes')
   .expectBadge({
-    label: 'votes',
+    label: 'likes',
     message: Joi.string().regex(
       /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) 👍 ([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) 👎$/
     ),

--- a/services/youtube/youtube-views.service.js
+++ b/services/youtube/youtube-views.service.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const YouTubeBase = require('./youtube-base')
+const { documentation, YouTubeBase } = require('./youtube-base')
 
 module.exports = class YouTubeViews extends YouTubeBase {
   static route = {
@@ -20,6 +20,7 @@ module.exports = class YouTubeViews extends YouTubeBase {
         title: 'YouTube Video Views',
         namedParams: { videoId: 'abBdk8bSPKU' },
         staticPreview: preview,
+        documentation,
       },
     ]
   }


### PR DESCRIPTION
As part of #6276, I've submitted a request to increase our API quota for YouTube badges. As a response, they've raised three concerns about potential violations of the YouTube terms and services:
* they are unsure whether we're using one or multiple Google projects IDs for our API client. We're only using one, so I'll confirm that with them. This point should be resolved easily.
* they asked us to display a link to their Terms of Service:
  > API Clients must display a link to YouTube's Terms of Service (https://www.youtube.com/t/terms), and they must also state in their own terms of use that, by using those API Clients, users are agreeing to be bound by the YouTube Terms of Service.

  This seems like a fair thing to ask for, so I've done so in the documentation of all four badges.
* they reckon that the "YouTube Video Votes" badge (and only that one) violates the following:
  > API Clients must clearly indicate how user-provided data will be used on YouTube

  You're probably confused at this point, they do clarify things a little, the problem is that we've apparently changed the labels for Likes and Dislikes.  Despite being exactly what they use in their own UI, 👍 and 👎 are not actually the _labels_. Consequently, I've phased out the "Votes" word and clarified in the documentation what 👍 and 👎 map to in the YouTube label world.

  They give an example of non compliant behaviour in their Terms of Service: an API Client with a text box called "feedback" which would end up posting a comment on YouTube without that being clear to the user. This makes perfect sense, but it really doesn't seem relevant to the Shields.io case. In my opinion, they are taking things a little too far and I don't really agree with their interpretation of the ToS, but the proposed changes will hopefully resolve this issue.