### PR TITLE
Support git hash in [nexus] SNAPSHOT version

### DIFF
--- a/services/nexus/nexus-version.js
+++ b/services/nexus/nexus-version.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function isSnapshotVersion(version) {
-  const pattern = /(\d+\.)*[0-9a-fA-F]-SNAPSHOT/
+  const pattern = /(\d+\.)*[0-9a-f]-SNAPSHOT/
   return version && version.match(pattern)
 }
 

--- a/services/nexus/nexus-version.js
+++ b/services/nexus/nexus-version.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function isSnapshotVersion(version) {
-  const pattern = /(\d+\.)*\d-SNAPSHOT/
+  const pattern = /(\d+\.)*[0-9a-fA-F]-SNAPSHOT/
   return version && version.match(pattern)
 }
 

--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -89,6 +89,22 @@ t.create('Nexus 2 - snapshot version with + in version')
     message: isVersion,
   })
 
+t.create('Nexus 2 - snapshot version with + and hex hash in version')
+  .get(
+    '/s/com.typesafe.akka/akka-stream-kafka_2.13.json?server=https://repository.jboss.org/nexus'
+  )
+  .intercept(nock =>
+    nock('https://repository.jboss.org/nexus')
+      .get('/service/local/lucene/search')
+      .query({ g: 'com.typesafe.akka', a: 'akka-stream-kafka_2.13' })
+      .reply(200, { data: [{ version: '2.1.0-M1+58-f25047fc-SNAPSHOT' }] })
+  )
+  .expectBadge({
+    label: 'nexus',
+    color: 'orange',
+    message: isVersion,
+  })
+
 t.create('Nexus 2 - search snapshot version not in latestSnapshot')
   .get(
     '/s/com.progress.fuse/fusehq.json?server=https://repository.jboss.org/nexus'


### PR DESCRIPTION
The SNAPSHOT version pre-check wouldn't match a SNAPSHOT version that includes a hash (git hash, a default convention when using [`sbt-dynver`](https://github.com/dwijnand/sbt-dynver)). Incidentally, it would match versions with hashes that end with `0-9`, but not with `a-f`.

There was a test in `nexus.tester.js` that tested a version with a hash that passed because the hash ended with `0-9`.

i.e.)

Match
```
7.0.1+19-8844c122-SNAPSHOT
```

No match
```
7.0.1+19-8844c12a-SNAPSHOT
```