### PR TITLE
Fix Request Timeout responses

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -481,11 +481,11 @@ class Server {
     if (this.config.public.requestTimeoutSeconds > 0) {
       camp.on('timeout', socket => {
         const maxAge = this.config.public.requestTimeoutMaxAgeSeconds
-        socket.write('HTTP/1.1 408 Request Timeout\n')
-        socket.write('Content-Type: text/html; charset=UTF-8\n')
-        socket.write('Content-Encoding: UTF-8\n')
-        socket.write(`Cache-Control: max-age=${maxAge}, s-maxage=${maxAge}\n`)
-        socket.write('Connection: close\n\n')
+        socket.write('HTTP/1.1 408 Request Timeout\r\n')
+        socket.write('Content-Type: text/html; charset=UTF-8\r\n')
+        socket.write('Content-Encoding: UTF-8\r\n')
+        socket.write(`Cache-Control: max-age=${maxAge}, s-maxage=${maxAge}\r\n`)
+        socket.write('Connection: close\r\n\r\n')
         socket.write('Request Timeout')
         socket.end()
       })


### PR DESCRIPTION
It is almost as if there is a good reason we don't usually write raw socket code :thinking: 

Turns out curl, got and firefox were all fine with `\n`. Heroku is not feeling it and throws a 503.

This now returns the correct error from heroku e.g:

```
curl --include "https://shields-staging-pr-6386.herokuapp.com/badge/dynamic/json.svg?label=CDN%20Data&url=https://yacdn.org/global-stats&query=$.cdnData&colorB=blue"
```

(I've set the `shields-staging-pr-6386` app up with a 5 sec timeout)

I think switching the timeouts to return this response was a red herring when it comes to the performance issue we saw today but if we hit a problem, we can roll back.