### PR TITLE
Added [GitLabTag] service

### DIFF
--- a/services/gitlab/gitlab-tag.service.js
+++ b/services/gitlab/gitlab-tag.service.js
@@ -41,6 +41,9 @@ module.exports = class GitlabTag extends BaseJsonService {
     return this._requestJson({
       schema,
       url: `https://gitlab.com/api/v4/projects/${user}%2F${repo}/repository/tags`,
+      errorMessages: {
+        404: 'repo not found',
+      },
     })
   }
 

--- a/services/gitlab/gitlab-tag.service.js
+++ b/services/gitlab/gitlab-tag.service.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const Joi = require('joi')
+const { BaseJsonService } = require('..')
+
+const schema = Joi.array().items(
+  Joi.object({
+    name: Joi.string().required(),
+  })
+)
+
+module.exports = class GitlabTag extends BaseJsonService {
+  static category = 'version'
+
+  static route = {
+    base: 'gitlab/tag',
+    pattern: ':user/:repo',
+  }
+
+  static examples = [
+    {
+      title: 'GitLab tag (latest by date)',
+      namedParams: {
+        user: 'fdroid',
+        repo: 'fdroidclient',
+      },
+      staticPreview: this.render({ name: '1.12.1' }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'tag' }
+
+  static render({ name }) {
+    return {
+      message: name,
+      color: 'blue',
+    }
+  }
+
+  async fetch({ user, repo }) {
+    return this._requestJson({
+      schema,
+      url: `https://gitlab.com/api/v4/projects/${user}%2F${repo}/repository/tags`,
+    })
+  }
+
+  async handle({ user, repo }) {
+    const json = await this.fetch({ user, repo })
+    const { name } = json[0]
+    return this.constructor.render({ name })
+  }
+}

--- a/services/gitlab/gitlab-tag.service.js
+++ b/services/gitlab/gitlab-tag.service.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('joi')
-const { BaseJsonService } = require('..')
+const { BaseJsonService, NotFound } = require('..')
 
 const schema = Joi.array().items(
   Joi.object({
@@ -45,8 +45,10 @@ module.exports = class GitlabTag extends BaseJsonService {
   }
 
   async handle({ user, repo }) {
-    const json = await this.fetch({ user, repo })
-    const { name } = json[0]
+    const tags = await this.fetch({ user, repo })
+    if (tags.length === 0)
+      throw new NotFound({ prettyMessage: 'no tags found' })
+    const { name } = tags[0]
     return this.constructor.render({ name })
   }
 }

--- a/services/gitlab/gitlab-tag.tester.js
+++ b/services/gitlab/gitlab-tag.tester.js
@@ -7,6 +7,10 @@ t.create('Tag (latest by date)')
   .get('/fdroid/fdroidclient.json')
   .expectBadge({ label: 'tag', message: Joi.string(), color: 'blue' })
 
+t.create('Tag (repo not found)')
+  .get('/fdroid/nonexistant.json')
+  .expectBadge({ label: 'tag', message: 'repo not found' })
+
 t.create('Tag (no tags)')
   .get('/fdroid/fdroiddata.json')
   .expectBadge({ label: 'tag', message: 'no tags found' })

--- a/services/gitlab/gitlab-tag.tester.js
+++ b/services/gitlab/gitlab-tag.tester.js
@@ -1,0 +1,8 @@
+'use strict'
+
+const Joi = require('joi')
+const t = (module.exports = require('../tester').createServiceTester())
+
+t.create('Tag (latest by date)')
+  .get('/fdroid/fdroidclient.json')
+  .expectBadge({ label: 'tag', message: Joi.string(), color: 'blue' })

--- a/services/gitlab/gitlab-tag.tester.js
+++ b/services/gitlab/gitlab-tag.tester.js
@@ -6,3 +6,7 @@ const t = (module.exports = require('../tester').createServiceTester())
 t.create('Tag (latest by date)')
   .get('/fdroid/fdroidclient.json')
   .expectBadge({ label: 'tag', message: Joi.string(), color: 'blue' })
+
+t.create('Tag (no tags)')
+  .get('/fdroid/fdroiddata.json')
+  .expectBadge({ label: 'tag', message: 'no tags found' })


### PR DESCRIPTION
Added GitLab Tag (latest by date) service, equivalent to GitHub Tag (latest by date) but for gitlab.com instead of github.com.

I created issue #6388 for this, but it is closed as a duplicate of #4867 (which asks to replicate all GitHub Tags and Releases services for GitLab. Right now my priority is this badge, but I promise to to include the rest in the future.