### PR TITLE
[Packagist] Update Packagist service to use v2 api

### DIFF
--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -2,6 +2,7 @@
 
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
+const { isStable, latest } = require('../php-version')
 
 const packageSchema = Joi.array().items(
   Joi.object({
@@ -35,6 +36,30 @@ class BasePackagistService extends BaseJsonService {
    */
   async fetch({ user, repo, schema, server = 'https://packagist.org' }) {
     const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}.json`
+
+    return this._requestJson({
+      schema,
+      url,
+    })
+  }
+
+  /**
+   * Fetch dev releases method.
+   *
+   * This method utilize composer metadata API which
+   * "... is the preferred way to access the data as it is always up to date,
+   * and dumped to static files so it is very efficient on our end." (comment from official documentation).
+   * For more information please refer to https://packagist.org/apidoc#get-package-data.
+   *
+   * @param {object} attrs Refer to individual attrs
+   * @param {string} attrs.user package user
+   * @param {string} attrs.repo package repository
+   * @param {Joi} attrs.schema Joi schema to validate the response transformed to JSON
+   * @param {string} attrs.server URL for the packagist registry server (Optional)
+   * @returns {object} Parsed response
+   */
+  async fetchDev({ user, repo, schema, server = 'https://packagist.org' }) {
+    const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}~dev.json`
 
     return this._requestJson({
       schema,
@@ -80,6 +105,43 @@ class BasePackagistService extends BaseJsonService {
 
   getPackageName(user, repo) {
     return `${user.toLowerCase()}/${repo.toLowerCase()}`
+  }
+
+  decompressResponse(json, packageName) {
+    const versions = json.packages[packageName]
+    const expanded = []
+    let expandedVersion = null
+
+    versions.forEach(versionData => {
+      if (!expandedVersion) {
+        expandedVersion = versionData
+        expanded.push(expandedVersion)
+      }
+
+      Object.entries(versionData).forEach(([key, value]) => {
+        if (value === '__unset') {
+          delete expandedVersion[key]
+        } else {
+          expandedVersion[key] = value
+        }
+      })
+
+      expandedVersion = { ...expandedVersion }
+
+      expanded.push(expandedVersion)
+    })
+
+    return expanded
+  }
+
+  findRelease(json, versions = []) {
+    json.forEach(version => {
+      versions.push(version.version)
+    })
+
+    const release = latest(versions.filter(isStable)) || latest(versions)
+
+    return json.filter(version => version.version === release)[0]
   }
 }
 

--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -3,11 +3,9 @@
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
 
-const packageSchema = Joi.object()
-  .pattern(
-    /^/,
+const packageSchema = Joi.array()
+  .items(
     Joi.object({
-      'default-branch': Joi.bool(),
       version: Joi.string(),
       require: Joi.object({
         php: Joi.string(),
@@ -38,7 +36,7 @@ class BasePackagistService extends BaseJsonService {
    * @returns {object} Parsed response
    */
   async fetch({ user, repo, schema, server = 'https://packagist.org' }) {
-    const url = `${server}/p/${user.toLowerCase()}/${repo.toLowerCase()}.json`
+    const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}.json`
 
     return this._requestJson({
       schema,

--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -3,16 +3,14 @@
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
 
-const packageSchema = Joi.array()
-  .items(
-    Joi.object({
-      version: Joi.string(),
-      require: Joi.object({
-        php: Joi.string(),
-      }),
-    }).required()
-  )
-  .required()
+const packageSchema = Joi.array().items(
+  Joi.object({
+    version: Joi.string(),
+    require: Joi.object({
+      php: Joi.string(),
+    }),
+  })
+)
 
 const allVersionsSchema = Joi.object({
   packages: Joi.object().pattern(/^/, packageSchema).required(),

--- a/services/packagist/packagist-license.service.js
+++ b/services/packagist/packagist-license.service.js
@@ -13,6 +13,7 @@ const {
 const packageSchema = Joi.array()
   .items(
     Joi.object({
+      version: Joi.string(),
       license: Joi.array(),
     }).required()
   )
@@ -59,7 +60,11 @@ module.exports = class PackagistLicense extends BasePackagistService {
   transform({ json, user, repo }) {
     const packageName = this.getPackageName(user, repo)
 
-    const license = json.packages[packageName][0].license
+    const decompressed = this.decompressResponse(json, packageName)
+
+    const version = this.findRelease(decompressed)
+
+    const license = version.license
 
     if (!license) {
       throw new NotFound({ prettyMessage: 'license not found' })

--- a/services/packagist/packagist-license.service.js
+++ b/services/packagist/packagist-license.service.js
@@ -12,7 +12,7 @@ const {
 const packageSchema = Joi.array()
   .items(
     Joi.object({
-      license: Joi.array().required(),
+      license: Joi.array(),
     }).required()
   )
   .required()

--- a/services/packagist/packagist-license.service.js
+++ b/services/packagist/packagist-license.service.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const { renderLicenseBadge } = require('../licenses')
 const { optionalUrl } = require('../validators')
+const { NotFound } = require('..')
 const {
   keywords,
   BasePackagistService,
@@ -59,6 +60,10 @@ module.exports = class PackagistLicense extends BasePackagistService {
     const packageName = this.getPackageName(user, repo)
 
     const license = json.packages[packageName][0].license
+
+    if (!license) {
+      throw new NotFound({ prettyMessage: 'license not found' })
+    }
 
     return { license }
   }

--- a/services/packagist/packagist-license.spec.js
+++ b/services/packagist/packagist-license.spec.js
@@ -32,6 +32,60 @@ describe('PackagistLicense', function () {
       .that.equals('MIT-latest')
   })
 
+  it('should return the license of the most recent stable release', function () {
+    const json = {
+      packages: {
+        'frodo/the-one-package': [
+          {
+            version: '1.2.4-RC1', // Pre-release
+            license: 'MIT-latest',
+          },
+          {
+            version: '1.2.3', // Stable release
+            license: 'MIT',
+          },
+        ],
+      },
+    }
+
+    expect(
+      PackagistLicense.prototype.transform({
+        json,
+        user: 'frodo',
+        repo: 'the-one-package',
+      })
+    )
+      .to.have.property('license')
+      .that.equals('MIT')
+  })
+
+  it('should return the license of the most recent pre-release if no stable releases', function () {
+    const json = {
+      packages: {
+        'frodo/the-one-package': [
+          {
+            version: '1.2.4-RC2',
+            license: 'MIT-latest',
+          },
+          {
+            version: '1.2.4-RC1',
+            license: 'MIT',
+          },
+        ],
+      },
+    }
+
+    expect(
+      PackagistLicense.prototype.transform({
+        json,
+        user: 'frodo',
+        repo: 'the-one-package',
+      })
+    )
+      .to.have.property('license')
+      .that.equals('MIT-latest')
+  })
+
   it('should throw NotFound when license key not in response', function () {
     const json = {
       packages: {

--- a/services/packagist/packagist-license.spec.js
+++ b/services/packagist/packagist-license.spec.js
@@ -1,46 +1,25 @@
 'use strict'
 
 const { expect } = require('chai')
-const { NotFound } = require('..')
 const PackagistLicense = require('./packagist-license.service')
 
 describe('PackagistLicense', function () {
-  it('should throw NotFound when default branch is missing', function () {
+  it('should return the version of the most recent release', function () {
     const json = {
       packages: {
-        'frodo/the-one-package': {
-          '1.0.x-dev': { license: 'MIT' },
-          '1.1.x-dev': { license: 'MIT' },
-          '2.0.x-dev': { license: 'MIT' },
-          '2.1.x-dev': { license: 'MIT' },
-        },
-      },
-    }
-    expect(() =>
-      PackagistLicense.prototype.transform({
-        json,
-        user: 'frodo',
-        repo: 'the-one-package',
-      })
-    )
-      .to.throw(NotFound)
-      .with.property('prettyMessage', 'default branch not found')
-  })
-
-  it('should return default branch when default branch is found', function () {
-    const json = {
-      packages: {
-        'frodo/the-one-package': {
-          '1.0.x-dev': { license: 'MIT' },
-          '1.1.x-dev': { license: 'MIT' },
-          '2.0.x-dev': {
-            license: 'MIT-default-branch',
-            'default-branch': true,
+        'frodo/the-one-package': [
+          {
+            version: '1.2.4',
+            license: 'MIT-latest',
           },
-          '2.1.x-dev': { license: 'MIT' },
-        },
+          {
+            version: '1.2.3',
+            license: 'MIT',
+          },
+        ],
       },
     }
+
     expect(
       PackagistLicense.prototype.transform({
         json,
@@ -49,6 +28,6 @@ describe('PackagistLicense', function () {
       })
     )
       .to.have.property('license')
-      .that.equals('MIT-default-branch')
+      .that.equals('MIT-latest')
   })
 })

--- a/services/packagist/packagist-license.spec.js
+++ b/services/packagist/packagist-license.spec.js
@@ -4,7 +4,7 @@ const { expect } = require('chai')
 const PackagistLicense = require('./packagist-license.service')
 
 describe('PackagistLicense', function () {
-  it('should return the version of the most recent release', function () {
+  it('should return the license of the most recent release', function () {
     const json = {
       packages: {
         'frodo/the-one-package': [

--- a/services/packagist/packagist-license.spec.js
+++ b/services/packagist/packagist-license.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { expect } = require('chai')
+const { NotFound } = require('..')
 const PackagistLicense = require('./packagist-license.service')
 
 describe('PackagistLicense', function () {
@@ -29,5 +30,30 @@ describe('PackagistLicense', function () {
     )
       .to.have.property('license')
       .that.equals('MIT-latest')
+  })
+
+  it('should throw NotFound when license key not in response', function () {
+    const json = {
+      packages: {
+        'frodo/the-one-package': [
+          {
+            version: '1.2.4',
+          },
+          {
+            version: '1.2.3',
+          },
+        ],
+      },
+    }
+
+    expect(() =>
+      PackagistLicense.prototype.transform({
+        json,
+        user: 'frodo',
+        repo: 'the-one-package',
+      })
+    )
+      .to.throw(NotFound)
+      .with.property('prettyMessage', 'license not found')
   })
 })

--- a/services/packagist/packagist-php-version.service.js
+++ b/services/packagist/packagist-php-version.service.js
@@ -68,25 +68,68 @@ module.exports = class PackagistPhpVersion extends BasePackagistService {
     }
   }
 
-  findVersionIndex(json, user, repo, version) {
-    const packageArr = json.packages[this.getPackageName(user, repo)]
-
-    return packageArr.findIndex(v => v.version === version)
+  findVersionIndex(json, version) {
+    return json.findIndex(v => v.version === version)
   }
 
-  transform({ json, user, repo, version = '' }) {
-    const packageVersion =
-      version === ''
-        ? json.packages[this.getPackageName(user, repo)][0]
-        : json.packages[this.getPackageName(user, repo)][
-            this.findVersionIndex(json, user, repo, version)
-          ]
+  async findSpecifiedVersion(json, user, repo, version, server) {
+    let release
+
+    if ((release = json[this.findVersionIndex(json, version)])) {
+      return release
+    } else {
+      try {
+        const allData = await this.fetchDev({
+          user,
+          repo,
+          schema: allVersionsSchema,
+          server,
+        })
+
+        const decompressed = this.decompressResponse(
+          allData,
+          this.getPackageName(user, repo)
+        )
+
+        return decompressed[this.findVersionIndex(decompressed, version)]
+      } catch (e) {
+        return release
+      }
+    }
+  }
+
+  async transform({ json, user, repo, version = '', server }) {
+    let packageVersion
+    const decompressed = this.decompressResponse(
+      json,
+      this.getPackageName(user, repo)
+    )
+
+    if (version === '') {
+      packageVersion = this.findRelease(decompressed)
+    } else {
+      try {
+        packageVersion = await this.findSpecifiedVersion(
+          decompressed,
+          user,
+          repo,
+          version,
+          server
+        )
+      } catch {
+        packageVersion = null
+      }
+    }
 
     if (!packageVersion) {
       throw new NotFound({ prettyMessage: 'invalid version' })
     }
 
-    if (!packageVersion.require || !packageVersion.require.php) {
+    if (
+      !packageVersion.require ||
+      !packageVersion.require.php ||
+      packageVersion.require.php === '__unset'
+    ) {
       throw new NotFound({ prettyMessage: 'version requirement not found' })
     }
 
@@ -100,11 +143,12 @@ module.exports = class PackagistPhpVersion extends BasePackagistService {
       schema: allVersionsSchema,
       server,
     })
-    const { phpVersion } = this.transform({
+    const { phpVersion } = await this.transform({
       json: allData,
       user,
       repo,
       version,
+      server,
     })
     return this.constructor.render({ php: phpVersion })
   }

--- a/services/packagist/packagist-php-version.service.js
+++ b/services/packagist/packagist-php-version.service.js
@@ -68,11 +68,19 @@ module.exports = class PackagistPhpVersion extends BasePackagistService {
     }
   }
 
+  findVersionIndex(json, user, repo, version) {
+    const packageArr = json.packages[this.getPackageName(user, repo)]
+
+    return packageArr.findIndex(v => v.version === version)
+  }
+
   transform({ json, user, repo, version = '' }) {
     const packageVersion =
       version === ''
-        ? this.getDefaultBranch(json, user, repo)
-        : json.packages[this.getPackageName(user, repo)][version]
+        ? json.packages[this.getPackageName(user, repo)][0]
+        : json.packages[this.getPackageName(user, repo)][
+            this.findVersionIndex(json, user, repo, version)
+          ]
 
     if (!packageVersion) {
       throw new NotFound({ prettyMessage: 'invalid version' })

--- a/services/packagist/packagist-php-version.spec.js
+++ b/services/packagist/packagist-php-version.spec.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const { expect } = require('chai')
-const { NotFound } = require('..')
 const PackagistPhpVersion = require('./packagist-php-version.service')
 
 describe('PackagistPhpVersion', function () {
@@ -24,20 +23,18 @@ describe('PackagistPhpVersion', function () {
     },
   }
 
-  it('should throw NotFound when package version is missing', function () {
-    expect(() =>
+  it('should throw NotFound when package version is missing', async function () {
+    await expect(
       PackagistPhpVersion.prototype.transform({
         json,
         user: 'frodo',
         repo: 'the-one-package',
         version: '4.0.0',
       })
-    )
-      .to.throw(NotFound)
-      .with.property('prettyMessage', 'invalid version')
+    ).to.be.rejectedWith('invalid version')
   })
 
-  it('should throw NotFound when PHP version not found on package when using default release', function () {
+  it('should throw NotFound when PHP version not found on package when using default release', async function () {
     const specJson = {
       packages: {
         'frodo/the-one-package': [
@@ -55,18 +52,16 @@ describe('PackagistPhpVersion', function () {
         ],
       },
     }
-    expect(() =>
+    await expect(
       PackagistPhpVersion.prototype.transform({
         json: specJson,
         user: 'frodo',
         repo: 'the-one-package',
       })
-    )
-      .to.throw(NotFound)
-      .with.property('prettyMessage', 'version requirement not found')
+    ).to.be.rejectedWith('version requirement not found')
   })
 
-  it('should throw NotFound when PHP version not found on package when using specified release', function () {
+  it('should throw NotFound when PHP version not found on package when using specified release', async function () {
     const specJson = {
       packages: {
         'frodo/the-one-package': [
@@ -80,25 +75,24 @@ describe('PackagistPhpVersion', function () {
           },
           {
             version: '1.0.0',
+            require: { php: '__unset' },
           },
         ],
       },
     }
-    expect(() =>
+    await expect(
       PackagistPhpVersion.prototype.transform({
         json: specJson,
         user: 'frodo',
         repo: 'the-one-package',
         version: '1.0.0',
       })
-    )
-      .to.throw(NotFound)
-      .with.property('prettyMessage', 'version requirement not found')
+    ).to.be.rejectedWith('version requirement not found')
   })
 
-  it('should return PHP version for the default release', function () {
+  it('should return PHP version for the default release', async function () {
     expect(
-      PackagistPhpVersion.prototype.transform({
+      await PackagistPhpVersion.prototype.transform({
         json,
         user: 'frodo',
         repo: 'the-one-package',
@@ -108,9 +102,9 @@ describe('PackagistPhpVersion', function () {
       .that.equals('^7.4 || 8')
   })
 
-  it('should return PHP version for the specified release', function () {
+  it('should return PHP version for the specified release', async function () {
     expect(
-      PackagistPhpVersion.prototype.transform({
+      await PackagistPhpVersion.prototype.transform({
         json,
         user: 'frodo',
         repo: 'the-one-package',

--- a/services/packagist/packagist-php-version.spec.js
+++ b/services/packagist/packagist-php-version.spec.js
@@ -7,20 +7,20 @@ const PackagistPhpVersion = require('./packagist-php-version.service')
 describe('PackagistPhpVersion', function () {
   const json = {
     packages: {
-      'frodo/the-one-package': {
-        '1.0.0': { require: { php: '^5.6 || ^7' } },
-        '2.0.0': { require: { php: '^7.2' } },
-        '3.0.0': { require: { php: '^7.4 || 8' } },
-        'dev-main': { require: { php: '^8' }, 'default-branch': true },
-      },
-      'samwise/gardening': {
-        '1.0.x-dev': {},
-        '2.0.x-dev': {},
-      },
-      'pippin/mischief': {
-        '1.0.0': {},
-        'dev-main': { require: {}, 'default-branch': true },
-      },
+      'frodo/the-one-package': [
+        {
+          version: '3.0.0',
+          require: { php: '^7.4 || 8' },
+        },
+        {
+          version: '2.0.0',
+          require: { php: '^7.2' },
+        },
+        {
+          version: '1.0.0',
+          require: { php: '^5.6 || ^7' },
+        },
+      ],
     },
   }
 
@@ -37,36 +37,58 @@ describe('PackagistPhpVersion', function () {
       .with.property('prettyMessage', 'invalid version')
   })
 
-  it('should throw NotFound when version not specified and no default branch found', function () {
+  it('should throw NotFound when PHP version not found on package when using default release', function () {
+    const specJson = {
+      packages: {
+        'frodo/the-one-package': [
+          {
+            version: '3.0.0',
+          },
+          {
+            version: '2.0.0',
+            require: { php: '^7.2' },
+          },
+          {
+            version: '1.0.0',
+            require: { php: '^5.6 || ^7' },
+          },
+        ],
+      },
+    }
     expect(() =>
       PackagistPhpVersion.prototype.transform({
-        json,
-        user: 'samwise',
-        repo: 'gardening',
-      })
-    )
-      .to.throw(NotFound)
-      .with.property('prettyMessage', 'invalid version')
-  })
-
-  it('should throw NotFound when PHP version not found on package when using default branch', function () {
-    expect(() =>
-      PackagistPhpVersion.prototype.transform({
-        json,
-        user: 'pippin',
-        repo: 'mischief',
+        json: specJson,
+        user: 'frodo',
+        repo: 'the-one-package',
       })
     )
       .to.throw(NotFound)
       .with.property('prettyMessage', 'version requirement not found')
   })
 
-  it('should throw NotFound when PHP version not found on package when using specified version', function () {
+  it('should throw NotFound when PHP version not found on package when using specified release', function () {
+    const specJson = {
+      packages: {
+        'frodo/the-one-package': [
+          {
+            version: '3.0.0',
+            require: { php: '^7.4 || 8' },
+          },
+          {
+            version: '2.0.0',
+            require: { php: '^7.2' },
+          },
+          {
+            version: '1.0.0',
+          },
+        ],
+      },
+    }
     expect(() =>
       PackagistPhpVersion.prototype.transform({
-        json,
-        user: 'pippin',
-        repo: 'mischief',
+        json: specJson,
+        user: 'frodo',
+        repo: 'the-one-package',
         version: '1.0.0',
       })
     )
@@ -74,28 +96,28 @@ describe('PackagistPhpVersion', function () {
       .with.property('prettyMessage', 'version requirement not found')
   })
 
-  it('should return PHP version for the default branch', function () {
+  it('should return PHP version for the default release', function () {
     expect(
       PackagistPhpVersion.prototype.transform({
         json,
         user: 'frodo',
         repo: 'the-one-package',
-      })
-    )
-      .to.have.property('phpVersion')
-      .that.equals('^8')
-  })
-
-  it('should return PHP version for the specified branch', function () {
-    expect(
-      PackagistPhpVersion.prototype.transform({
-        json,
-        user: 'frodo',
-        repo: 'the-one-package',
-        version: '3.0.0',
       })
     )
       .to.have.property('phpVersion')
       .that.equals('^7.4 || 8')
+  })
+
+  it('should return PHP version for the specified release', function () {
+    expect(
+      PackagistPhpVersion.prototype.transform({
+        json,
+        user: 'frodo',
+        repo: 'the-one-package',
+        version: '2.0.0',
+      })
+    )
+      .to.have.property('phpVersion')
+      .that.equals('^7.2')
   })
 })

--- a/services/packagist/packagist-php-version.tester.js
+++ b/services/packagist/packagist-php-version.tester.js
@@ -7,8 +7,8 @@ t.create('gets the package version of symfony')
   .get('/symfony/symfony.json')
   .expectBadge({ label: 'php', message: isComposerVersion })
 
-t.create('gets the package version of symfony 2.8')
-  .get('/symfony/symfony/v2.8.0.json')
+t.create('gets the package version of symfony 5.2.3')
+  .get('/symfony/symfony/v5.2.3.json')
   .expectBadge({ label: 'php', message: isComposerVersion })
 
 t.create('package with no requirements')

--- a/services/packagist/packagist-version.service.js
+++ b/services/packagist/packagist-version.service.js
@@ -12,14 +12,12 @@ const {
   customServerDocumentationFragment,
 } = require('./packagist-base')
 
-const packageSchema = Joi.array()
-  .items(
-    Joi.object({
-      version: Joi.string(),
-      extra: Joi.any(),
-    })
-  )
-  .required()
+const packageSchema = Joi.array().items(
+  Joi.object({
+    version: Joi.string(),
+    extra: Joi.any(),
+  })
+)
 
 const schema = Joi.object({
   packages: Joi.object().pattern(/^/, packageSchema).required(),

--- a/services/packagist/packagist-version.service.js
+++ b/services/packagist/packagist-version.service.js
@@ -12,15 +12,12 @@ const {
   customServerDocumentationFragment,
 } = require('./packagist-base')
 
-const packageSchema = Joi.object()
-  .pattern(
-    /^/,
+const packageSchema = Joi.array()
+  .items(
     Joi.object({
       version: Joi.string(),
-      extra: Joi.object({
-        'branch-alias': Joi.object().pattern(/^/, Joi.string()),
-      }),
-    }).required()
+      extra: Joi.any(),
+    })
   )
   .required()
 
@@ -90,25 +87,27 @@ class PackagistVersion extends BasePackagistService {
 
   transform({ includePrereleases, json, user, repo }) {
     const versionsData = json.packages[this.getPackageName(user, repo)]
-    let versions = Object.keys(versionsData)
+
+    let versions = []
     const aliasesMap = {}
-    versions.forEach(version => {
-      const versionData = versionsData[version]
-      if (
-        versionData.extra &&
-        versionData.extra['branch-alias'] &&
-        versionData.extra['branch-alias'][version]
-      ) {
+
+    versionsData.forEach(version => {
+      if (version.extra && version.extra['branch-alias']) {
         // eg, version is 'dev-master', mapped to '2.0.x-dev'.
-        const validVersion = versionData.extra['branch-alias'][version]
+        const validVersion =
+          version.extra['branch-alias'][
+            Object.keys(version.extra['branch-alias'])
+          ]
         if (
           aliasesMap[validVersion] === undefined ||
           compare(aliasesMap[validVersion], validVersion) < 0
         ) {
           versions.push(validVersion)
-          aliasesMap[validVersion] = version
+          aliasesMap[validVersion] = version.version
         }
       }
+
+      versions.push(version.version)
     })
 
     versions = versions.filter(version => !/^dev-/.test(version))


### PR DESCRIPTION
Packagist deprecated the original `packagist.org/p/username/package` endpoint in favor of v2 `packagist.org/p2/username/package` endpoint. Because of this, new packages aren't being found using v1.

This PR updates the Packagist service to use the new endpoint.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
