### PR TITLE
Increase server request rate limits

### DIFF
--- a/core/server/monitor.js
+++ b/core/server/monitor.js
@@ -8,9 +8,9 @@ function setRoutes({ rateLimit }, { server, metricInstance }) {
     // `curl --insecure -u ":shields-secret" https://s0.shields-server.com/sys/rate-limit`
     safelist: /^(?:192\.30\.252\.\d+)|(?:140\.82\.115\.\d+)$/,
   })
-  const badgeTypeRateLimit = new RateLimit({ maxHitsPerPeriod: 3000 })
+  const badgeTypeRateLimit = new RateLimit({ maxHitsPerPeriod: 6000 })
   const refererRateLimit = new RateLimit({
-    maxHitsPerPeriod: 300,
+    maxHitsPerPeriod: 600,
     safelist: /^https?:\/\/shields\.io\/$/,
   })
 

--- a/core/server/rate-limit.js
+++ b/core/server/rate-limit.js
@@ -7,7 +7,7 @@ module.exports = class RateLimit {
     // this.hits: Map from request parameters to the number of hits.
     this.hits = new Map()
     this.period = options.period || 200 // 3 min ⅓, in seconds
-    this.maxHitsPerPeriod = options.maxHitsPerPeriod || 500
+    this.maxHitsPerPeriod = options.maxHitsPerPeriod || 1000
     this.banned = new Set()
     this.bannedUrls = new Set()
     this.safelist = options.safelist || /(?!)/ // Matches nothing by default.


### PR DESCRIPTION
We are currently experimenting with less but larger servers to run Shields.io. The rate limit is not pooled across servers, therefore we need to increase it when running less of them.