### PR TITLE
deprecate [DockerBuild] service

### DIFF
--- a/services/docker/docker-build.service.js
+++ b/services/docker/docker-build.service.js
@@ -1,57 +1,13 @@
 'use strict'
 
-const Joi = require('joi')
-const { anyInteger } = require('../validators')
-const { BaseJsonService } = require('..')
-const {
-  dockerBlue,
-  buildDockerUrl,
-  getDockerHubUser,
-} = require('./docker-helpers')
+const { deprecatedService } = require('..')
 
-const buildSchema = Joi.object({
-  results: Joi.array()
-    .items(Joi.object({ status: anyInteger }).required())
-    .required(),
-}).required()
-
-module.exports = class DockerBuild extends BaseJsonService {
-  static category = 'build'
-  static route = buildDockerUrl('build')
-  static examples = [
-    {
-      title: 'Docker Build Status',
-      namedParams: {
-        user: 'jrottenberg',
-        repo: 'ffmpeg',
-      },
-      staticPreview: this.render({ status: 10 }),
-    },
-  ]
-
-  static defaultBadgeData = { label: 'docker build' }
-
-  static render({ status }) {
-    if (status === 10) {
-      return { message: 'passing', color: 'brightgreen' }
-    } else if (status < 0) {
-      return { message: 'failing', color: 'red' }
-    }
-    return { message: 'building', color: dockerBlue }
-  }
-
-  async fetch({ user, repo }) {
-    return this._requestJson({
-      schema: buildSchema,
-      url: `https://registry.hub.docker.com/v2/repositories/${getDockerHubUser(
-        user
-      )}/${repo}/buildhistory`,
-      errorMessages: { 404: 'repo not found' },
-    })
-  }
-
-  async handle({ user, repo }) {
-    const data = await this.fetch({ user, repo })
-    return this.constructor.render({ status: data.results[0].status })
-  }
-}
+module.exports = deprecatedService({
+  category: 'build',
+  route: {
+    base: 'docker/build',
+    pattern: ':various*',
+  },
+  label: 'docker build',
+  dateAdded: new Date('2021-05-24'),
+})

--- a/services/docker/docker-build.tester.js
+++ b/services/docker/docker-build.tester.js
@@ -1,51 +1,14 @@
 'use strict'
 
-const { isBuildStatus } = require('../build-status')
-const t = (module.exports = require('../tester').createServiceTester())
-const { dockerBlue } = require('./docker-helpers')
+const { ServiceTester } = require('../tester')
 
-t.create('docker build status (valid, user)')
-  .get('/jrottenberg/ffmpeg.json')
-  .expectBadge({
-    label: 'docker build',
-    message: isBuildStatus,
-  })
+const t = (module.exports = new ServiceTester({
+  id: 'dockerbuild',
+  title: 'DockerBuild',
+  pathPrefix: '/docker/build',
+}))
 
-t.create('docker build status (not found)')
-  .get('/_/not-a-real-repo.json')
-  .expectBadge({ label: 'docker build', message: 'repo not found' })
-
-t.create('docker build status (passing)')
-  .get('/_/ubuntu.json')
-  .intercept(nock =>
-    nock('https://registry.hub.docker.com/')
-      .get('/v2/repositories/library/ubuntu/buildhistory')
-      .reply(200, { results: [{ status: 10 }] })
-  )
-  .expectBadge({
-    label: 'docker build',
-    message: 'passing',
-    color: 'brightgreen',
-  })
-
-t.create('docker build status (failing)')
-  .get('/_/ubuntu.json')
-  .intercept(nock =>
-    nock('https://registry.hub.docker.com/')
-      .get('/v2/repositories/library/ubuntu/buildhistory')
-      .reply(200, { results: [{ status: -1 }] })
-  )
-  .expectBadge({ label: 'docker build', message: 'failing', color: 'red' })
-
-t.create('docker build status (building)')
-  .get('/_/ubuntu.json')
-  .intercept(nock =>
-    nock('https://registry.hub.docker.com/')
-      .get('/v2/repositories/library/ubuntu/buildhistory')
-      .reply(200, { results: [{ status: 1 }] })
-  )
-  .expectBadge({
-    label: 'docker build',
-    message: 'building',
-    color: `#${dockerBlue}`,
-  })
+t.create('no longer available').get('/jrottenberg/ffmpeg.json').expectBadge({
+  label: 'docker build',
+  message: 'no longer available',
+})


### PR DESCRIPTION
These badges have been broken since at least January of this year (refs #6107), and accordingly the respective service tests have been failing for that long as well. Even when this badge was working it was only geared towards _really_ old repositories that predated the DockerHub merge, and just about every user was forced to use the "newer" DockerCloudBuild anyway.

I see no point in keeping this badge around in a broken state, particularly since there's been zero news or movement from the upstream provider for 4 months now.

Closes #6107 

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
