### PR TITLE
increase max-age for download and social badges; affects [twitch]

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -143,6 +143,8 @@ class BaseService {
       license: 3600,
       version: 300,
       debug: 60,
+      downloads: 900,
+      social: 900,
     }
     return cacheLengths[this.category]
   }

--- a/services/twitch/twitch.service.js
+++ b/services/twitch/twitch.service.js
@@ -30,6 +30,8 @@ module.exports = class TwitchStatus extends TwitchBase {
     },
   ]
 
+  static _cacheLength = 30
+
   static defaultBadgeData = {
     label: 'twitch',
     namedLogo: 'twitch',


### PR DESCRIPTION
We serve a lot of download and social badges (collectively download and social categories account for ~25% of the traffic we serve from Heroku) and we serve them with the default max-age (2 mins).
In a lot of cases the upstream providers cache these totals and we also often present them as rounded numbers e.g:

* `downloads | 20k`
* `stars | 3k`

I think we can get away with cacheing these for longer and serve more of these badge requests from downstream cache without noticeably downgrading service for most users. Lets try setting them to 15 mins and see how it goes.
I've decided to manually exclude twitch status from this and actually set a shorter max-age on it as "live now" seems like it need to be more immediate to be useful. I think all other download and social badges can use the new default.