### PR TITLE
run package tests on node 16, drop node 10 testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,15 +107,6 @@ package_steps: &package_steps
     - run:
         environment:
           mocha_reporter: mocha-junit-reporter
-          MOCHA_FILE: junit/badge-maker/v10/results.xml
-          NODE_VERSION: v10
-          CYPRESS_INSTALL_BINARY: 0
-        name: Run package tests on Node 10
-        command: scripts/run_package_tests.sh
-
-    - run:
-        environment:
-          mocha_reporter: mocha-junit-reporter
           MOCHA_FILE: junit/badge-maker/v12/results.xml
           NODE_VERSION: v12
           CYPRESS_INSTALL_BINARY: 0
@@ -129,6 +120,15 @@ package_steps: &package_steps
           NODE_VERSION: v14
           CYPRESS_INSTALL_BINARY: 0
         name: Run package tests on Node 14
+        command: scripts/run_package_tests.sh
+
+    - run:
+        environment:
+          mocha_reporter: mocha-junit-reporter
+          MOCHA_FILE: junit/badge-maker/v16/results.xml
+          NODE_VERSION: v16
+          CYPRESS_INSTALL_BINARY: 0
+        name: Run package tests on Node 16
         command: scripts/run_package_tests.sh
 
     - store_test_results:

--- a/scripts/run_package_tests.sh
+++ b/scripts/run_package_tests.sh
@@ -14,22 +14,21 @@ set -euo pipefail
 node --version
 
 # Install the shields.io dependencies.
-if [[ "$NODE_VERSION" == "v10" ]]; then
-    # Avoid a depcheck error.
-    npm ci --ignore-scripts
-else
-    npm ci
-fi
+npm ci
 
 # Run the package tests.
 npm run test:package
 npm run check-types:package
 
-# Delete the shields.io dependencies.
+# Delete the full shields.io dependency tree
 rm -rf node_modules/
+
 
 # Run a smoke test (render a badge with the CLI) with only the package
 # dependencies installed.
 cd badge-maker
+
+npm install # install only the package dependencies for this test
 npm link
 badge cactus grown :green @flat
+rm package-lock.json && rm -rf node_modules/ # clean up package dependencies


### PR DESCRIPTION
We dropped compatibility for node 10 in version 3.0.0 of badge-maker but we've still been running the tests on it. Meanwhile, Node 16 has been generally available for a couple of months. Time to update the CI build.