### PR TITLE
Use release/latest fields of [mavenmetadata] instead of last version in the versions, add according query parameter

### DIFF
--- a/services/maven-metadata/maven-metadata.service.js
+++ b/services/maven-metadata/maven-metadata.service.js
@@ -7,14 +7,14 @@ const { BaseXmlService } = require('..')
 
 const queryParamSchema = Joi.object({
   metadataUrl: optionalUrl.required(),
+  latestOrRelease: Joi.string().valid('release', 'latest').optional(),
 }).required()
 
 const schema = Joi.object({
   metadata: Joi.object({
     versioning: Joi.object({
-      versions: Joi.object({
-        version: Joi.array().items(Joi.string().required()).single().required(),
-      }).required(),
+      latest: Joi.string().required(),
+      release: Joi.string().required(),
     }).required(),
   }).required(),
 }).required()
@@ -35,6 +35,7 @@ module.exports = class MavenMetadata extends BaseXmlService {
       queryParams: {
         metadataUrl:
           'https://repo1.maven.org/maven2/com/google/code/gson/gson/maven-metadata.xml',
+        latestOrRelease: 'latest',
       },
       staticPreview: renderVersionBadge({ version: '2.8.5' }),
     },
@@ -52,10 +53,19 @@ module.exports = class MavenMetadata extends BaseXmlService {
     })
   }
 
-  async handle(_namedParams, { metadataUrl }) {
+  async handle(_namedParams, { metadataUrl, latestOrRelease }) {
     const data = await this.fetch({ metadataUrl })
+    let v
+    if (
+      latestOrRelease === 'latest' ||
+      typeof latestOrRelease === 'undefined'
+    ) {
+      v = data.metadata.versioning.latest
+    } else if (latestOrRelease === 'release') {
+      v = data.metadata.versioning.release
+    }
     return renderVersionBadge({
-      version: data.metadata.versioning.versions.version.slice(-1)[0],
+      version: v,
     })
   }
 }

--- a/services/maven-metadata/maven-metadata.tester.js
+++ b/services/maven-metadata/maven-metadata.tester.js
@@ -39,6 +39,34 @@ t.create('version ending with zero')
   )
   .expectBadge({ label: 'maven', message: 'v1.30' })
 
+t.create('release version is handled properly')
+  .get(
+    '/v.json?metadataUrl=https://repo1.maven.org/maven2/mocked-group-id/mocked-artifact-id/maven-metadata.xml&latestOrRelease=release'
+  )
+  .intercept(nock =>
+    nock('https://repo1.maven.org/maven2')
+      .get('/mocked-group-id/mocked-artifact-id/maven-metadata.xml')
+      .reply(
+        200,
+        `
+      <metadata>
+        <groupId>mocked-group-id</groupId>
+        <artifactId>mocked-artifact-id</artifactId>
+        <versioning>
+          <latest>1.30</latest>
+          <release>1.29</release>
+          <versions>
+            <version>1.29</version>
+            <version>1.30</version>
+          </versions>
+          <lastUpdated>20190902002617</lastUpdated>
+        </versioning>
+      </metadata>
+      `
+      )
+  )
+  .expectBadge({ label: 'maven', message: 'v1.29' })
+
 t.create('invalid maven-metadata.xml uri')
   .get(
     '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/google/code/gson/gson/foobar.xml'


### PR DESCRIPTION
The problem is that it is invalid to just take the last field from Maven metadata. 

This PR solves it by taking `latest` field by default and `release` field if the new query parameter is specified so.

resolves #6188