### PR TITLE
fix: fix regex to match [codecov]'s flags

### DIFF
--- a/services/codecov/codecov.service.js
+++ b/services/codecov/codecov.service.js
@@ -22,8 +22,9 @@ const legacySchema = Joi.object({
 const queryParamSchema = Joi.object({
   token: Joi.string(),
   // https://docs.codecov.io/docs/flags
-  // Flags must be lowercase, alphanumeric, and not exceed 45 characters
-  flag: Joi.string().regex(/^[a-z0-9_]{1,45}$/),
+  // Flags Must consist only of alphanumeric characters, '_', '-', or '.' and 
+  // not exceed 45 characters.
+  flag: Joi.string().regex(/^[\w\.\-]{1,45}$/),
 }).required()
 
 const schema = Joi.object({

--- a/services/codecov/codecov.service.js
+++ b/services/codecov/codecov.service.js
@@ -24,7 +24,7 @@ const queryParamSchema = Joi.object({
   // https://docs.codecov.io/docs/flags
   // Flags Must consist only of alphanumeric characters, '_', '-', or '.' and 
   // not exceed 45 characters.
-  flag: Joi.string().regex(/^[\w\.\-]{1,45}$/),
+  flag: Joi.string().regex(/^[\w.-]{1,45}$/),
 }).required()
 
 const schema = Joi.object({

--- a/services/codecov/codecov.service.js
+++ b/services/codecov/codecov.service.js
@@ -22,8 +22,8 @@ const legacySchema = Joi.object({
 const queryParamSchema = Joi.object({
   token: Joi.string(),
   // https://docs.codecov.io/docs/flags
-  // Flags Must consist only of alphanumeric characters, '_', '-', or '.' and 
-  // not exceed 45 characters.
+  // Flags Must consist only of alphanumeric characters, '_', '-', or '.'
+  // and not exceed 45 characters.
   flag: Joi.string().regex(/^[\w.-]{1,45}$/),
 }).required()
 


### PR DESCRIPTION
Flags Must consist only of alphanumeric characters, '_', '-', or '.' and not exceed 45 characters. 

Flag names will be validated against the following regex. ^[\w\.\-]{1,45}$

re #6653
