### PR TITLE
Add [Weblate] badges

### DIFF
--- a/services/weblate/weblate-component-license.service.js
+++ b/services/weblate/weblate-component-license.service.js
@@ -12,12 +12,9 @@ const queryParamSchema = Joi.object({
   server: optionalUrl.required(),
 }).required()
 
-const documentation = `
-  <p>
-    This badge displays the license of a component on a Weblate instance.
-  </p>
-`
-
+/**
+ * This badge displays the license of a component on a Weblate instance.
+ */
 module.exports = class WeblateComponentLicense extends BaseJsonService {
   static category = 'license'
   static route = {
@@ -32,12 +29,11 @@ module.exports = class WeblateComponentLicense extends BaseJsonService {
       namedParams: { project: 'godot-engine', component: 'godot' },
       queryParams: { server: 'https://hosted.weblate.org' },
       staticPreview: this.render({ license: 'MIT' }),
-      documentation,
       keywords: ['i18n', 'translation', 'internationalization'],
     },
   ]
 
-  static defaultBadgeData = { label: 'license', color: 'blue' }
+  static defaultBadgeData = { label: 'license', color: 'informational' }
 
   static render({ license }) {
     return { message: `${license}` }
@@ -48,8 +44,8 @@ module.exports = class WeblateComponentLicense extends BaseJsonService {
       schema,
       url: `${server}/api/components/${project}/${component}/`,
       errorMessages: {
-        403: 'access denied',
-        404: 'not found',
+        403: 'access denied by remote server',
+        404: 'component not found',
         429: 'rate limited by remote server',
       },
     })

--- a/services/weblate/weblate-component-license.service.js
+++ b/services/weblate/weblate-component-license.service.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const Joi = require('joi')
+const { BaseJsonService } = require('..')
+const { optionalUrl } = require('../validators')
+
+const schema = Joi.object({
+  license: Joi.string().required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  server: optionalUrl.required(),
+}).required()
+
+const documentation = `
+  <p>
+    This badge displays the license of a component on a Weblate instance.
+  </p>
+`
+
+module.exports = class WeblateComponentLicense extends BaseJsonService {
+  static category = 'license'
+  static route = {
+    base: 'weblate/license',
+    pattern: ':project/:component',
+    queryParamSchema,
+  }
+
+  static examples = [
+    {
+      title: 'Weblate component license',
+      namedParams: { project: 'godot-engine', component: 'godot' },
+      queryParams: { server: 'https://hosted.weblate.org' },
+      staticPreview: this.render({ license: 'MIT' }),
+      documentation,
+      keywords: ['i18n', 'translation', 'internationalization'],
+    },
+  ]
+
+  static defaultBadgeData = { label: 'license', color: 'blue' }
+
+  static render({ license }) {
+    return { message: `${license}` }
+  }
+
+  async fetch({ project, component, server }) {
+    return this._requestJson({
+      schema,
+      url: `${server}/api/components/${project}/${component}/`,
+      errorMessages: {
+        403: 'access denied',
+        404: 'not found',
+        429: 'rate limited by remote server',
+      },
+    })
+  }
+
+  async handle({ project, component }, { server }) {
+    const { license } = await this.fetch({ project, component, server })
+    return this.constructor.render({ license })
+  }
+}

--- a/services/weblate/weblate-component-license.tester.js
+++ b/services/weblate/weblate-component-license.tester.js
@@ -1,15 +1,11 @@
 'use strict'
 
-const { ServiceTester } = require('../tester')
-
 const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('License')
-  .get('/license/godot-engine/godot.json?server=https://hosted.weblate.org')
+  .get('/godot-engine/godot.json?server=https://hosted.weblate.org')
   .expectBadge({ label: 'license', message: 'MIT' })
 
 t.create("Component Doesn't Exist")
-  .get(
-    '/license/fake-project/fake-component.json?server=https://hosted.weblate.org'
-  )
-  .expectBadge({ label: 'license', message: 'not found' })
+  .get('/fake-project/fake-component.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'license', message: 'component not found' })

--- a/services/weblate/weblate-component-license.tester.js
+++ b/services/weblate/weblate-component-license.tester.js
@@ -2,10 +2,7 @@
 
 const { ServiceTester } = require('../tester')
 
-const t = (module.exports = new ServiceTester({
-  id: 'weblate',
-  title: 'Weblate',
-}))
+const t = (module.exports = require('../tester').createServiceTester())
 
 t.create('License')
   .get('/license/godot-engine/godot.json?server=https://hosted.weblate.org')

--- a/services/weblate/weblate-component-license.tester.js
+++ b/services/weblate/weblate-component-license.tester.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+
+const t = (module.exports = new ServiceTester({
+  id: 'weblate',
+  title: 'Weblate',
+}))
+
+t.create('License')
+  .get('/license/godot-engine/godot.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'license', message: 'MIT' })
+
+t.create("Component Doesn't Exist")
+  .get(
+    '/license/fake-project/fake-component.json?server=https://hosted.weblate.org'
+  )
+  .expectBadge({ label: 'license', message: 'not found' })

--- a/services/weblate/weblate-entity-count.service.js
+++ b/services/weblate/weblate-entity-count.service.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const Joi = require('joi')
+const camelcase = require('camelcase')
+const { BaseJsonService } = require('..')
+const { nonNegativeInteger, optionalUrl } = require('../validators')
+
+const schema = Joi.object({
+  count: nonNegativeInteger,
+}).required()
+
+const queryParamSchema = Joi.object({
+  server: optionalUrl.required(),
+}).required()
+
+class WeblateEntityCountBase extends BaseJsonService {
+  static category = 'other'
+
+  static buildRoute(entityName) {
+    return {
+      base: 'weblate',
+      pattern: entityName,
+      queryParamSchema,
+    }
+  }
+
+  static defaultBadgeData = { label: 'weblate', color: 'brightgreen' }
+
+  async fetch({ entityName, server }) {
+    return this._requestJson({
+      schema,
+      url: `${server}/api/${entityName}/`,
+      errorMessages: {
+        403: 'access denied',
+        429: 'rate limited by remote server',
+      },
+    })
+  }
+}
+
+function WeblateEntityCountFactory({ entityName, exampleValue }) {
+  return class WeblateEntityCountService extends WeblateEntityCountBase {
+    static name = camelcase(`Weblate ${entityName}`, { pascalCase: true })
+    static route = this.buildRoute(entityName)
+
+    static examples = [
+      {
+        title: `Weblate ${entityName}`,
+        namedParams: {},
+        queryParams: { server: 'https://hosted.weblate.org' },
+        staticPreview: this.render({ count: exampleValue }),
+        documentation: `<p>This badge displays the number of ${entityName} on a Weblate instance.</p>`,
+        keywords: ['i18n', 'internationalization'],
+      },
+    ]
+
+    static render({ count }) {
+      return { message: `${count} ${entityName}` }
+    }
+
+    async handle(routeParams, { server }) {
+      const { count } = await this.fetch({ entityName, server })
+      return this.constructor.render({ count })
+    }
+  }
+}
+
+const entityCounts = [
+  { entityName: 'components', exampleValue: 2799 },
+  { entityName: 'languages', exampleValue: 384 },
+  { entityName: 'projects', exampleValue: 533 },
+  { entityName: 'units', exampleValue: 16539728 },
+  { entityName: 'users', exampleValue: 33058 },
+].map(WeblateEntityCountFactory)
+
+module.exports = [...entityCounts]

--- a/services/weblate/weblate-entity-count.service.js
+++ b/services/weblate/weblate-entity-count.service.js
@@ -70,7 +70,6 @@ const entityCounts = [
   { entityName: 'components', exampleValue: 2799 },
   { entityName: 'languages', exampleValue: 384 },
   { entityName: 'projects', exampleValue: 533 },
-  { entityName: 'units', exampleValue: 16539728 },
   { entityName: 'users', exampleValue: 33058 },
 ].map(WeblateEntityCountFactory)
 

--- a/services/weblate/weblate-entity-count.service.js
+++ b/services/weblate/weblate-entity-count.service.js
@@ -25,14 +25,14 @@ class WeblateEntityCountBase extends BaseJsonService {
     }
   }
 
-  static defaultBadgeData = { label: 'weblate', color: 'brightgreen' }
+  static defaultBadgeData = { color: 'informational' }
 
   async fetch({ entityName, server }) {
     return this._requestJson({
       schema,
       url: `${server}/api/${entityName}/`,
       errorMessages: {
-        403: 'access denied',
+        403: 'access denied by remote server',
         429: 'rate limited by remote server',
       },
     })
@@ -50,13 +50,12 @@ function WeblateEntityCountFactory({ entityName, exampleValue }) {
         namedParams: {},
         queryParams: { server: 'https://hosted.weblate.org' },
         staticPreview: this.render({ count: exampleValue }),
-        documentation: `<p>This badge displays the number of ${entityName} on a Weblate instance.</p>`,
         keywords: ['i18n', 'internationalization'],
       },
     ]
 
     static render({ count }) {
-      return { message: `${metric(count)} ${entityName}` }
+      return { label: entityName, message: metric(count) }
     }
 
     async handle(routeParams, { server }) {
@@ -68,7 +67,6 @@ function WeblateEntityCountFactory({ entityName, exampleValue }) {
 
 const entityCounts = [
   { entityName: 'components', exampleValue: 2799 },
-  { entityName: 'languages', exampleValue: 384 },
   { entityName: 'projects', exampleValue: 533 },
   { entityName: 'users', exampleValue: 33058 },
 ].map(WeblateEntityCountFactory)

--- a/services/weblate/weblate-entity-count.service.js
+++ b/services/weblate/weblate-entity-count.service.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const camelcase = require('camelcase')
 const { BaseJsonService } = require('..')
 const { nonNegativeInteger, optionalUrl } = require('../validators')
+const { metric } = require('../text-formatters')
 
 const schema = Joi.object({
   count: nonNegativeInteger,
@@ -55,7 +56,7 @@ function WeblateEntityCountFactory({ entityName, exampleValue }) {
     ]
 
     static render({ count }) {
-      return { message: `${count} ${entityName}` }
+      return { message: `${metric(count)} ${entityName}` }
     }
 
     async handle(routeParams, { server }) {

--- a/services/weblate/weblate-entity-count.tester.js
+++ b/services/weblate/weblate-entity-count.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { ServiceTester } = require('../tester')
-const { withRegex } = require('../test-validators')
+const { isMetricWithPattern } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({
   id: 'weblate',
@@ -10,21 +10,24 @@ const t = (module.exports = new ServiceTester({
 
 t.create('Components')
   .get('/components.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ components$/) })
+  .expectBadge({
+    label: 'weblate',
+    message: isMetricWithPattern(/ components/),
+  })
 
 t.create('Languages')
   .get('/languages.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ languages$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ languages/) })
 
 t.create('Projects')
   .get('/projects.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ projects$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ projects/) })
 
 t.create('Units')
   .timeout(15000)
   .get('/units.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ units$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ units/) })
 
 t.create('Users')
   .get('/users.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ users$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ users/) })

--- a/services/weblate/weblate-entity-count.tester.js
+++ b/services/weblate/weblate-entity-count.tester.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const { withRegex } = require('../test-validators')
+
+const t = (module.exports = new ServiceTester({
+  id: 'weblate',
+  title: 'Weblate',
+}))
+
+t.create('Components')
+  .get('/components.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ components$/) })
+
+t.create('Languages')
+  .get('/languages.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ languages$/) })
+
+t.create('Projects')
+  .get('/projects.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ projects$/) })
+
+t.create('Units')
+  .timeout(15000)
+  .get('/units.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ units$/) })
+
+t.create('Users')
+  .get('/users.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ users$/) })

--- a/services/weblate/weblate-entity-count.tester.js
+++ b/services/weblate/weblate-entity-count.tester.js
@@ -1,28 +1,22 @@
 'use strict'
 
 const { ServiceTester } = require('../tester')
-const { isMetricWithPattern } = require('../test-validators')
+const { isMetric } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({
-  id: 'weblate',
-  title: 'Weblate',
+  id: 'WeblateEntity',
+  title: 'Weblate Entity',
+  pathPrefix: '/weblate',
 }))
 
 t.create('Components')
   .get('/components.json?server=https://hosted.weblate.org')
-  .expectBadge({
-    label: 'weblate',
-    message: isMetricWithPattern(/ components/),
-  })
-
-t.create('Languages')
-  .get('/languages.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ languages/) })
+  .expectBadge({ label: 'components', message: isMetric })
 
 t.create('Projects')
   .get('/projects.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ projects/) })
+  .expectBadge({ label: 'projects', message: isMetric })
 
 t.create('Users')
   .get('/users.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ users/) })
+  .expectBadge({ label: 'users', message: isMetric })

--- a/services/weblate/weblate-entity-count.tester.js
+++ b/services/weblate/weblate-entity-count.tester.js
@@ -23,11 +23,6 @@ t.create('Projects')
   .get('/projects.json?server=https://hosted.weblate.org')
   .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ projects/) })
 
-t.create('Units')
-  .timeout(15000)
-  .get('/units.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ units/) })
-
 t.create('Users')
   .get('/users.json?server=https://hosted.weblate.org')
   .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ users/) })

--- a/services/weblate/weblate-project-translated-percentage.service.js
+++ b/services/weblate/weblate-project-translated-percentage.service.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const Joi = require('joi')
+const { BaseJsonService } = require('..')
+const { optionalUrl } = require('../validators')
+
+const schema = Joi.object({
+  translated_percent: Joi.number().required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  server: optionalUrl.required(),
+}).required()
+
+const documentation = `
+  <p>
+    This badge displays the percentage of strings translated on a project on a
+    Weblate instance.
+  </p>
+`
+
+module.exports = class WeblateProjectTranslatedPercentage extends (
+  BaseJsonService
+) {
+  static category = 'other'
+  static route = { base: 'weblate', pattern: ':project', queryParamSchema }
+
+  static examples = [
+    {
+      title: 'Weblate project translated',
+      namedParams: { project: 'godot-engine' },
+      queryParams: { server: 'https://hosted.weblate.org' },
+      staticPreview: this.render({ translatedPercent: 20.5 }),
+      documentation,
+      keywords: ['i18n', 'translation', 'internationalization'],
+    },
+  ]
+
+  static defaultBadgeData = { label: 'translated' }
+
+  /**
+   * Takes a percentage and maps it to a message and color.
+   *
+   * The colors are determined based on how Weblate does it internally.
+   * {@link https://github.com/WeblateOrg/weblate/blob/main/weblate/trans/widgets.py Weblate on GitHub}
+   *
+   * @param {*} translatedPercent The percentage of translations translated.
+   * @returns {object} Format for the badge.
+   */
+  static render({ translatedPercent }) {
+    if (translatedPercent >= 90)
+      return { message: `${translatedPercent}%`, color: 'success' }
+
+    if (translatedPercent >= 75)
+      return { message: `${translatedPercent}%`, color: 'yellow' }
+
+    return { message: `${translatedPercent}%`, color: 'critical' }
+  }
+
+  async fetch({ project, server }) {
+    return this._requestJson({
+      schema,
+      url: `${server}/api/projects/${project}/statistics/`,
+      errorMessages: {
+        403: 'access denied',
+        404: 'not found',
+        429: 'rate limited by remote server',
+      },
+    })
+  }
+
+  async handle({ project }, { server }) {
+    const { translated_percent } = await this.fetch({ project, server })
+    return this.constructor.render({ translatedPercent: translated_percent })
+  }
+}

--- a/services/weblate/weblate-project-translated-percentage.service.js
+++ b/services/weblate/weblate-project-translated-percentage.service.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const { BaseJsonService } = require('..')
 const { optionalUrl } = require('../validators')
+const { colorScale } = require('../color-formatters')
 
 const schema = Joi.object({
   translated_percent: Joi.number().required(),
@@ -48,13 +49,8 @@ module.exports = class WeblateProjectTranslatedPercentage extends (
    * @returns {object} Format for the badge.
    */
   static render({ translatedPercent }) {
-    if (translatedPercent >= 90)
-      return { message: `${translatedPercent}%`, color: 'success' }
-
-    if (translatedPercent >= 75)
-      return { message: `${translatedPercent}%`, color: 'yellow' }
-
-    return { message: `${translatedPercent}%`, color: 'critical' }
+    const color = colorScale([75, 90])(translatedPercent)
+    return { message: `${translatedPercent}%`, color }
   }
 
   async fetch({ project, server }) {

--- a/services/weblate/weblate-project-translated-percentage.service.js
+++ b/services/weblate/weblate-project-translated-percentage.service.js
@@ -13,13 +13,10 @@ const queryParamSchema = Joi.object({
   server: optionalUrl.required(),
 }).required()
 
-const documentation = `
-  <p>
-    This badge displays the percentage of strings translated on a project on a
-    Weblate instance.
-  </p>
-`
-
+/**
+ * This badge displays the percentage of strings translated on a project on a
+ * Weblate instance.
+ */
 module.exports = class WeblateProjectTranslatedPercentage extends (
   BaseJsonService
 ) {
@@ -32,7 +29,6 @@ module.exports = class WeblateProjectTranslatedPercentage extends (
       namedParams: { project: 'godot-engine' },
       queryParams: { server: 'https://hosted.weblate.org' },
       staticPreview: this.render({ translatedPercent: 20.5 }),
-      documentation,
       keywords: ['i18n', 'translation', 'internationalization'],
     },
   ]
@@ -50,7 +46,7 @@ module.exports = class WeblateProjectTranslatedPercentage extends (
    */
   static render({ translatedPercent }) {
     const color = colorScale([75, 90])(translatedPercent)
-    return { message: `${translatedPercent}%`, color }
+    return { message: `${translatedPercent.toFixed(0)}%`, color }
   }
 
   async fetch({ project, server }) {
@@ -58,8 +54,8 @@ module.exports = class WeblateProjectTranslatedPercentage extends (
       schema,
       url: `${server}/api/projects/${project}/statistics/`,
       errorMessages: {
-        403: 'access denied',
-        404: 'not found',
+        403: 'access denied by remote server',
+        404: 'project not found',
         429: 'rate limited by remote server',
       },
     })

--- a/services/weblate/weblate-project-translated-percentage.tester.js
+++ b/services/weblate/weblate-project-translated-percentage.tester.js
@@ -1,12 +1,8 @@
 'use strict'
 
-const { ServiceTester } = require('../tester')
-const { isPercentage } = require('../test-validators')
+const t = (module.exports = require('../tester').createServiceTester())
 
-const t = (module.exports = new ServiceTester({
-  id: 'weblate',
-  title: 'Weblate',
-}))
+const { isPercentage } = require('../test-validators')
 
 t.create('License')
   .get('/godot-engine.json?server=https://hosted.weblate.org')
@@ -14,4 +10,4 @@ t.create('License')
 
 t.create('Not Valid')
   .get('/fake-project.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'translated', message: 'not found' })
+  .expectBadge({ label: 'translated', message: 'project not found' })

--- a/services/weblate/weblate-project-translated-percentage.tester.js
+++ b/services/weblate/weblate-project-translated-percentage.tester.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const { isPercentage } = require('../test-validators')
+
+const t = (module.exports = new ServiceTester({
+  id: 'weblate',
+  title: 'Weblate',
+}))
+
+t.create('License')
+  .get('/godot-engine.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'translated', message: isPercentage })
+
+t.create('Not Valid')
+  .get('/fake-project.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'translated', message: 'not found' })

--- a/services/weblate/weblate-user-statistics.service.js
+++ b/services/weblate/weblate-user-statistics.service.js
@@ -29,15 +29,15 @@ class WeblateUserStatisticBase extends BaseJsonService {
     }
   }
 
-  static defaultBadgeData = { label: 'weblate', color: 'brightgreen' }
+  static defaultBadgeData = { color: 'informational' }
 
   async fetch({ user, server }) {
     return this._requestJson({
       schema,
       url: `${server}/api/users/${user}/statistics/`,
       errorMessages: {
-        403: 'access denied',
-        404: 'not found',
+        403: 'access denied by remote server',
+        404: 'user not found',
         429: 'rate limited by remote server',
       },
     })
@@ -67,7 +67,7 @@ function WeblateUserStatisticFactory({
     ]
 
     static render({ count }) {
-      return { message: `${metric(count)} ${statisticName}` }
+      return { label: statisticName, message: metric(count) }
     }
 
     async handle({ user }, { server }) {
@@ -84,8 +84,6 @@ const userStatistics = [
     exampleValue: 30585,
   },
   { statisticName: 'suggestions', property: 'suggested', exampleValue: 7 },
-  { statisticName: 'uploads', property: 'uploaded', exampleValue: 12 },
-  { statisticName: 'comments', property: 'commented', exampleValue: 152 },
   { statisticName: 'languages', property: 'languages', exampleValue: 1 },
 ].map(WeblateUserStatisticFactory)
 

--- a/services/weblate/weblate-user-statistics.service.js
+++ b/services/weblate/weblate-user-statistics.service.js
@@ -4,6 +4,7 @@ const Joi = require('joi')
 const camelcase = require('camelcase')
 const { BaseJsonService } = require('..')
 const { nonNegativeInteger, optionalUrl } = require('../validators')
+const { metric } = require('../text-formatters')
 
 const schema = Joi.object({
   translated: nonNegativeInteger,
@@ -66,7 +67,7 @@ function WeblateUserStatisticFactory({
     ]
 
     static render({ count }) {
-      return { message: `${count} ${statisticName}` }
+      return { message: `${metric(count)} ${statisticName}` }
     }
 
     async handle({ user }, { server }) {

--- a/services/weblate/weblate-user-statistics.service.js
+++ b/services/weblate/weblate-user-statistics.service.js
@@ -1,0 +1,91 @@
+'use strict'
+
+const Joi = require('joi')
+const camelcase = require('camelcase')
+const { BaseJsonService } = require('..')
+const { nonNegativeInteger, optionalUrl } = require('../validators')
+
+const schema = Joi.object({
+  translated: nonNegativeInteger,
+  suggested: nonNegativeInteger,
+  uploaded: nonNegativeInteger,
+  commented: nonNegativeInteger,
+  languages: nonNegativeInteger,
+}).required()
+
+const queryParamSchema = Joi.object({
+  server: optionalUrl.required(),
+}).required()
+
+class WeblateUserStatisticBase extends BaseJsonService {
+  static category = 'other'
+
+  static buildRoute(statistic) {
+    return {
+      base: 'weblate/user',
+      pattern: `:user/${statistic}`,
+      queryParamSchema,
+    }
+  }
+
+  static defaultBadgeData = { label: 'weblate', color: 'brightgreen' }
+
+  async fetch({ user, server }) {
+    return this._requestJson({
+      schema,
+      url: `${server}/api/users/${user}/statistics/`,
+      errorMessages: {
+        403: 'access denied',
+        404: 'not found',
+        429: 'rate limited by remote server',
+      },
+    })
+  }
+}
+
+function WeblateUserStatisticFactory({
+  statisticName,
+  property,
+  exampleValue,
+}) {
+  return class WeblateUserStatistic extends WeblateUserStatisticBase {
+    static name = camelcase(`Weblate user ${statisticName}`, {
+      pascalCase: true,
+    })
+
+    static route = this.buildRoute(statisticName)
+
+    static examples = [
+      {
+        title: `Weblate user ${statisticName}`,
+        namedParams: { user: 'nijel' },
+        queryParams: { server: 'https://hosted.weblate.org' },
+        staticPreview: this.render({ count: exampleValue }),
+        keywords: ['i18n', 'internationalization'],
+      },
+    ]
+
+    static render({ count }) {
+      return { message: `${count} ${statisticName}` }
+    }
+
+    async handle({ user }, { server }) {
+      const data = await this.fetch({ user, server })
+      return this.constructor.render({ count: data[property] })
+    }
+  }
+}
+
+const userStatistics = [
+  {
+    statisticName: 'translations',
+    property: 'translated',
+    exampleValue: 30585,
+  },
+  { statisticName: 'suggestions', property: 'suggested', exampleValue: 7 },
+  { statisticName: 'uploads', property: 'uploaded', exampleValue: 12 },
+  { statisticName: 'comments', property: 'commented', exampleValue: 152 },
+  { statisticName: 'languages', property: 'languages', exampleValue: 1 },
+].map(WeblateUserStatisticFactory)
+
+module.exports = [...userStatistics]

--- a/services/weblate/weblate-user-statistics.tester.js
+++ b/services/weblate/weblate-user-statistics.tester.js
@@ -1,39 +1,22 @@
 'use strict'
 
 const { ServiceTester } = require('../tester')
-const { isMetricWithPattern } = require('../test-validators')
+const { isMetric } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({
-  id: 'weblate',
-  title: 'Weblate',
+  id: 'WeblateUserStatistic',
+  title: 'Weblate User Statistic',
+  pathPrefix: '/weblate',
 }))
 
 t.create('Translations')
   .get('/user/nijel/translations.json?server=https://hosted.weblate.org')
-  .expectBadge({
-    label: 'weblate',
-    message: isMetricWithPattern(/ translations/),
-  })
+  .expectBadge({ label: 'translations', message: isMetric })
 
 t.create('Suggestions')
   .get('/user/nijel/suggestions.json?server=https://hosted.weblate.org')
-  .expectBadge({
-    label: 'weblate',
-    message: isMetricWithPattern(/ suggestions/),
-  })
-
-t.create('Uploads')
-  .get('/user/nijel/uploads.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ uploads/) })
-
-t.create('Comments')
-  .get('/user/nijel/comments.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ comments/) })
+  .expectBadge({ label: 'suggestions', message: isMetric })
 
 t.create('Languages')
   .get('/user/nijel/languages.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ languages/) })
-
-t.create('Invalid Protocol')
-  .get('/user/nijel/translations.json?server=ftp://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: 'invalid query parameter: server' })
+  .expectBadge({ label: 'languages', message: isMetric })

--- a/services/weblate/weblate-user-statistics.tester.js
+++ b/services/weblate/weblate-user-statistics.tester.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { ServiceTester } = require('../tester')
+const { withRegex } = require('../test-validators')
+
+const t = (module.exports = new ServiceTester({
+  id: 'weblate',
+  title: 'Weblate',
+}))
+
+t.create('Translations')
+  .get('/user/nijel/translations.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ translations$/) })
+
+t.create('Suggestions')
+  .get('/user/nijel/suggestions.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ suggestions$/) })
+
+t.create('Uploads')
+  .get('/user/nijel/uploads.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ uploads$/) })
+
+t.create('Comments')
+  .get('/user/nijel/comments.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ comments$/) })
+
+t.create('Languages')
+  .get('/user/nijel/languages.json?server=https://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ languages$/) })
+
+t.create('Invalid Protocol')
+  .get('/user/nijel/translations.json?server=ftp://hosted.weblate.org')
+  .expectBadge({ label: 'weblate', message: 'invalid query parameter: server' })

--- a/services/weblate/weblate-user-statistics.tester.js
+++ b/services/weblate/weblate-user-statistics.tester.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { ServiceTester } = require('../tester')
-const { withRegex } = require('../test-validators')
+const { isMetricWithPattern } = require('../test-validators')
 
 const t = (module.exports = new ServiceTester({
   id: 'weblate',
@@ -10,23 +10,29 @@ const t = (module.exports = new ServiceTester({
 
 t.create('Translations')
   .get('/user/nijel/translations.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ translations$/) })
+  .expectBadge({
+    label: 'weblate',
+    message: isMetricWithPattern(/ translations/),
+  })
 
 t.create('Suggestions')
   .get('/user/nijel/suggestions.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ suggestions$/) })
+  .expectBadge({
+    label: 'weblate',
+    message: isMetricWithPattern(/ suggestions/),
+  })
 
 t.create('Uploads')
   .get('/user/nijel/uploads.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ uploads$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ uploads/) })
 
 t.create('Comments')
   .get('/user/nijel/comments.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ comments$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ comments/) })
 
 t.create('Languages')
   .get('/user/nijel/languages.json?server=https://hosted.weblate.org')
-  .expectBadge({ label: 'weblate', message: withRegex(/^\d+ languages$/) })
+  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ languages/) })
 
 t.create('Invalid Protocol')
   .get('/user/nijel/translations.json?server=ftp://hosted.weblate.org')


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

This adds [Weblate](https://weblate.org/en/) badges to the repository.
Weblate is a free and open-source crowd translation platform.

Currently, it adds 8 badges:
| Name | Description |
|---|---|
| Weblate project translated | The number of strings of a project that has been translated. |
| Weblate component license | The license that a particular project component is under. |
| Weblate components/projects/users | The total that exist on a Weblate instance. |
| Weblate user translations/suggestions/languages | The number of user has made/done. |

Examples:
![image](https://user-images.githubusercontent.com/22801583/124133171-d8ed5180-da81-11eb-949d-e4d8f5df86e4.png)

I might make more badges later, but for now, I wanted to get these right.

### Related
* Depends on https://github.com/badges/shields/pull/6684