### PR TITLE
test: add generic metric helper [BitbucketIssues BitbucketPullRequest GithubMilestoneDetail AmoDownloads DubDownloads EclipseMarketplaceDownloads GithubCommitActivity hexpm HomebrewDownloads JsDelivrHitsGitHub JsDelivrHitsNPM NpmDownloads packagecontrol PackagistDownloads PypiDownloads Sourceforge StackExchangeMonthlyQuestions wordpress]

### DIFF
--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -64,16 +64,24 @@ const isStarRating = withRegex(
 // Required to be > 0, because accepting zero masks many problems.
 const isMetric = withRegex(/^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])$/)
 
-const isMetricOpenIssues = withRegex(
-  /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) open$/
+/**
+ * @param {RegExp} nestedRegexp Pattern that must appear after the metric.
+ * @returns {Function} A function that returns a RegExp that matches a metric followed by another pattern.
+ */
+const isMetricWithPattern = nestedRegexp => {
+  const pattern = `^([1-9][0-9]*[kMGTPEZY]?|[1-9]\\.[1-9][kMGTPEZY])${nestedRegexp.source}$`
+  const regexp = new RegExp(pattern)
+  return withRegex(regexp)
+}
+
+const isMetricOpenIssues = isMetricWithPattern(/ open/)
+
+const isMetricOverMetric = isMetricWithPattern(
+  /\/([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])/
 )
 
-const isMetricOverMetric = withRegex(
-  /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])\/([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])$/
-)
-
-const isMetricOverTimePeriod = withRegex(
-  /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])\/(year|month|four weeks|quarter|week|day)$/
+const isMetricOverTimePeriod = isMetricWithPattern(
+  /\/(year|month|four weeks|quarter|week|day)/
 )
 
 const isZeroOverTimePeriod = withRegex(
@@ -151,6 +159,7 @@ module.exports = {
   isPhpVersionReduction,
   isStarRating,
   isMetric,
+  isMetricWithPattern,
   isMetricOpenIssues,
   isMetricOverMetric,
   isMetricOverTimePeriod,


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

In #6677 I suggested the following:

> ```js
> const isMetricWithText = text => {
>   const pattern = `^([1-9][0-9]*[kMGTPEZY]?|[1-9]\\.[1-9][kMGTPEZY]) ${text}$`
>   const regexp = new RegExp(pattern)
>   return withRegex(regexp)
> }
> 
> const isMetricOpenIssues = isMetricWithText('open')
> ```
> \- https://github.com/badges/shields/pull/6677#issuecomment-869208336

I did not implement the exact suggestion, but this attempts to achieve the same result.
This creates a new helper function called `isMetricWithPattern`.

Usage:
```js
t.create('Translations')
  .get('/user/nijel/translations.json?server=https://hosted.weblate.org')
  .expectBadge({ label: 'weblate', message: isMetricWithPattern(/ translations/) })
```

Matches:
* `246 translations`
* `32k translations`

This also modifies other metric test helpers to build on-top of it to reduce duplication.

I opted to make it use a pattern instead of text because JavaScript does not support the `\Q` and `\Z` (quote) syntax. Rather than handle escaping the input, I thought it'd be better to just accept a pattern. There is a use-case for this anyway (the lines immediately below it) so I think it's a valid approach.

#### Possible Alternatives
* Currently, it takes a RegExp which will just be converted to a string to build a new RegExp anyway. This could be scrapped so it just takes a string parameter. (However, this would reduce compile-time validation.)
* What do you think of this solution, or would you prefer something closer to the initial suggestion and that I not touch the other methods?