### PR TITLE
Add badge4j to related projects section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,11 @@ Alumni:
 
 - [poser PHP library][poser]
 - [pybadges python library][pybadges]
+- [badge4j Java library][badge4j]
 
 [poser]: https://github.com/badges/poser
 [pybadges]: https://github.com/google/pybadges
+[badge4j]: https://github.com/silentsoft/badge4j
 
 ## License
 


### PR DESCRIPTION
I just made [badge4j](https://github.com/silentsoft/badge4j) which is Java implementation of the [badge-maker](https://github.com/badges/shields/tree/master/badge-maker) JavaScript library.

I hope this library will be helpful to anyone who wants to make badges using Java.