### PR TITLE
chore: refactor weblate code [weblate]

### DIFF
--- a/services/weblate/weblate-component-license.tester.js
+++ b/services/weblate/weblate-component-license.tester.js
@@ -2,7 +2,7 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('License')
-  .get('/godot-engine/godot.json?server=https://hosted.weblate.org')
+  .get('/godot-engine/godot.json')
   .expectBadge({ label: 'license', message: 'MIT' })
 
 t.create("Component Doesn't Exist")

--- a/services/weblate/weblate-entities.tester.js
+++ b/services/weblate/weblate-entities.tester.js
@@ -3,13 +3,17 @@ import { isMetric } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('Components')
-  .get('/components.json?server=https://hosted.weblate.org')
+  .get('/components.json')
   .expectBadge({ label: 'components', message: isMetric })
 
 t.create('Projects')
-  .get('/projects.json?server=https://hosted.weblate.org')
+  .get('/projects.json')
   .expectBadge({ label: 'projects', message: isMetric })
 
 t.create('Users')
   .get('/users.json?server=https://hosted.weblate.org')
   .expectBadge({ label: 'users', message: isMetric })
+
+t.create('Components')
+  .get('/components.json?server=https://translate.mattermost.com')
+  .expectBadge({ label: 'components', message: isMetric })

--- a/services/weblate/weblate-project-translated-percentage.tester.js
+++ b/services/weblate/weblate-project-translated-percentage.tester.js
@@ -3,7 +3,7 @@ import { isPercentage } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('License')
-  .get('/godot-engine.json?server=https://hosted.weblate.org')
+  .get('/godot-engine.json')
   .expectBadge({ label: 'translated', message: isPercentage })
 
 t.create('Not Valid')

--- a/services/weblate/weblate-user-statistic.service.js
+++ b/services/weblate/weblate-user-statistic.service.js
@@ -15,6 +15,14 @@ const queryParamSchema = Joi.object({
   server: optionalUrl,
 }).required()
 
+const statisticKeyNames = {
+  translations: 'translated',
+  suggestions: 'suggested',
+  uploads: 'uploaded',
+  comments: 'commented',
+  languages: 'languages',
+}
+
 export default class WeblateUserStatistic extends BaseJsonService {
   static category = 'other'
   static route = {
@@ -53,29 +61,8 @@ export default class WeblateUserStatistic extends BaseJsonService {
   }
 
   async handle({ user, statistic }, { server }) {
-    let upstreamStatisticName
-
-    switch (statistic) {
-      case 'translations':
-        upstreamStatisticName = 'translated'
-        break
-      case 'suggestions':
-        upstreamStatisticName = 'suggested'
-        break
-      case 'uploads':
-        upstreamStatisticName = 'uploaded'
-        break
-      case 'comments':
-        upstreamStatisticName = 'commented'
-        break
-      default:
-        upstreamStatisticName = statistic
-    }
-
     const data = await this.fetch({ user, server })
-    return this.constructor.render({
-      statistic,
-      count: data[upstreamStatisticName],
-    })
+    const key = statisticKeyNames[statistic]
+    return this.constructor.render({ statistic, count: data[key] })
   }
 }

--- a/services/weblate/weblate-user-statistic.tester.js
+++ b/services/weblate/weblate-user-statistic.tester.js
@@ -3,11 +3,11 @@ import { isMetric } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('Translations')
-  .get('/translations/nijel.json?server=https://hosted.weblate.org')
+  .get('/translations/nijel.json')
   .expectBadge({ label: 'translations', message: isMetric })
 
 t.create('Suggestions')
-  .get('/suggestions/nijel.json?server=https://hosted.weblate.org')
+  .get('/suggestions/nijel.json')
   .expectBadge({ label: 'suggestions', message: isMetric })
 
 t.create('Languages')


### PR DESCRIPTION
Addresses the comments left in https://github.com/badges/shields/pull/6712

* In each test suite, change all tests to use the default server except 1.
* Add a test to a third-party server.
* Replace the transform/adapter logic to map our keys to the API. 

Hopefully, this time we'll be all good, then I'll just have to do add authentication.
Thanks for all the help/advice to help me get things right, @calebcartwright. 

Edit: Aaaa, I hate myself. Forgot "[weblate]" had to be in the name of the PR, may have to rerun CI.