### PR TITLE
Add JSON path support for [endpoint] (also check we didn't break [dynamic])

### DIFF
--- a/services/dynamic/dynamic-json.service.js
+++ b/services/dynamic/dynamic-json.service.js
@@ -1,7 +1,7 @@
 import { MetricNames } from '../../core/base-service/metric-helper.js'
 import { BaseJsonService } from '../index.js'
 import { createRoute } from './dynamic-helpers.js'
-import jsonPath from './json-path.js'
+import { jsonPath } from './json-path.js'
 
 export default class DynamicJson extends jsonPath(BaseJsonService) {
   static enabledMetrics = [MetricNames.SERVICE_RESPONSE_SIZE]

--- a/services/dynamic/dynamic-yaml.service.js
+++ b/services/dynamic/dynamic-yaml.service.js
@@ -1,7 +1,7 @@
 import { MetricNames } from '../../core/base-service/metric-helper.js'
 import { BaseYamlService } from '../index.js'
 import { createRoute } from './dynamic-helpers.js'
-import jsonPath from './json-path.js'
+import { jsonPath } from './json-path.js'
 
 export default class DynamicYaml extends jsonPath(BaseYamlService) {
   static enabledMetrics = [MetricNames.SERVICE_RESPONSE_SIZE]

--- a/services/dynamic/json-path.spec.js
+++ b/services/dynamic/json-path.spec.js
@@ -1,6 +1,6 @@
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import jsonPath from './json-path.js'
+import { jsonPath } from './json-path.js'
 const { expect } = chai
 chai.use(chaiAsPromised)
 

--- a/services/endpoint-common.js
+++ b/services/endpoint-common.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import validate from '../core/base-service/validate.js'
+import { filterJsonPathData } from './dynamic/json-path.js'
 import { InvalidResponse } from './index.js'
 
 const optionalStringWhenNamedLogoPresent = Joi.alternatives().conditional(
@@ -58,14 +59,17 @@ const anySchema = Joi.any()
 
 async function fetchEndpointData(
   serviceInstance,
-  { url, errorMessages, validationPrettyErrorMessage, includeKeys }
+  { url, errorMessages, validationPrettyErrorMessage, includeKeys, query }
 ) {
-  const json = await serviceInstance._requestJson({
+  let json = await serviceInstance._requestJson({
     schema: anySchema,
     url,
     errorMessages,
     options: { gzip: true },
   })
+  if (query) {
+    json = filterJsonPathData(json, query)[0]
+  }
   return validateEndpointData(json, {
     prettyErrorMessage: validationPrettyErrorMessage,
     includeKeys,

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -9,6 +9,7 @@ const blockedDomains = ['github.com', 'shields.io']
 
 const queryParamSchema = Joi.object({
   url: optionalUrl.required(),
+  query: Joi.string(),
 }).required()
 
 export default class Endpoint extends BaseJsonService {
@@ -52,7 +53,7 @@ export default class Endpoint extends BaseJsonService {
     }
   }
 
-  async handle(namedParams, { url }) {
+  async handle(namedParams, { url, query }) {
     let protocol, hostname
     try {
       const parsedUrl = new URL(url)
@@ -73,6 +74,7 @@ export default class Endpoint extends BaseJsonService {
       errorMessages,
       validationPrettyErrorMessage: 'invalid properties',
       includeKeys: true,
+      query,
     })
 
     return this.constructor.render(validated)

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -281,3 +281,23 @@ t.create('gzipped endpoint')
       )
   )
   .expectBadge({ label: '', message: 'yo' })
+
+t.create('endpoint+query')
+  .get('.json?url=https://example.com/badge&query=$.badgeOne')
+  .intercept(nock =>
+    nock('https://example.com/')
+      .get('/badge')
+      .reply(200, {
+        badgeOne: {
+          schemaVersion: 1,
+          label: 'Badge One',
+          message: 'yo',
+        },
+        badgeTwo: {
+          schemaVersion: 1,
+          label: 'Badge Two',
+          message: 'hey',
+        },
+      })
+  )
+  .expectBadge({ label: 'Badge One', message: 'yo' })


### PR DESCRIPTION
This implements my feature request from #6786.

- Split jsonPath into two bits
- Have endpoint take a query parameter and filter based on it
- Tests for endpoint plus query

