### PR TITLE
update [bugzilla] not found test

### DIFF
--- a/services/bugzilla/bugzilla.tester.js
+++ b/services/bugzilla/bugzilla.tester.js
@@ -27,5 +27,5 @@ t.create('Bugzilla valid bug status with custom baseUrl')
   })
 
 t.create('Bugzilla invalid bug status')
-  .get('/102.json?baseUrl=https://bugzilla.gnome.org')
+  .get('/001.json')
   .expectBadge({ label: 'bugzilla', message: 'not found' })


### PR DESCRIPTION
This has been failing because https://bugzilla.gnome.org/ is no longer  a bugzilla instance. Replaced with a different example that gives us a 404