### PR TITLE
enforce strict SSL checking for [coverity]

### DIFF
--- a/services/coverity/coverity-scan.service.js
+++ b/services/coverity/coverity-scan.service.js
@@ -48,14 +48,6 @@ export default class CoverityScan extends BaseJsonService {
     const json = await this._requestJson({
       url,
       schema,
-      options: {
-        // Coverity has an issue in their certificate chain that requires
-        // disabling the default strict SSL check in order to call their API.
-        // For more information see:
-        // https://github.com/badges/shields/issues/3334
-        // https://github.com/badges/shields/pull/3336
-        strictSSL: false,
-      },
       errorMessages: {
         // At the moment Coverity returns an HTTP 200 with an HTML page
         // displaying the text 404 when project is not found.


### PR DESCRIPTION
After posting https://github.com/badges/shields/issues/4655#issuecomment-897061551 yesterday, I started looking at the strictSSL/proxy thing and on digging into it.. it might be a non issue. There are two services where we currently do something with the `strictSSL` param, and I think they're both now pointless. In this PR: coverity

We added this in https://github.com/badges/shields/pull/3336 to work around an upstream issue with coverity's SSL cert. This issue now appears to be fixed upstream: https://www.ssllabs.com/ssltest/analyze.html?d=scan.coverity.com&hideResults=on and the tests pass without it. I think it can just be dropped.