### PR TITLE
remove disableStrictSsl param from [jenkins]

### DIFF
--- a/services/jenkins/jenkins-base.js
+++ b/services/jenkins/jenkins-base.js
@@ -12,15 +12,11 @@ export default class JenkinsBase extends BaseJsonService {
     schema,
     qs,
     errorMessages = { 404: 'instance or job not found' },
-    disableStrictSSL,
   }) {
     return this._requestJson(
       this.authHelper.withBasicAuth({
         url,
-        options: {
-          qs,
-          strictSSL: disableStrictSSL === undefined,
-        },
+        options: { qs },
         schema,
         errorMessages,
       })

--- a/services/jenkins/jenkins-build.service.js
+++ b/services/jenkins/jenkins-build.service.js
@@ -68,12 +68,11 @@ export default class JenkinsBuild extends JenkinsBase {
     return { status: colorStatusMap[json.color] }
   }
 
-  async handle(namedParams, { jobUrl, disableStrictSSL }) {
+  async handle(namedParams, { jobUrl }) {
     const json = await this.fetch({
       url: buildUrl({ jobUrl, lastCompletedBuild: false }),
       schema,
       qs: buildTreeParamQueryString('color'),
-      disableStrictSSL,
     })
     const { status } = this.transform({ json })
     return this.constructor.render({ status })

--- a/services/jenkins/jenkins-common.js
+++ b/services/jenkins/jenkins-common.js
@@ -1,10 +1,7 @@
 import Joi from 'joi'
 import { optionalUrl } from '../validators.js'
 
-const queryParamSchema = Joi.object({
-  disableStrictSSL: Joi.equal(''),
-  jobUrl: optionalUrl,
-}).required()
+const queryParamSchema = Joi.object({ jobUrl: optionalUrl }).required()
 
 const buildRedirectUrl = ({ protocol, host, job }) => {
   const jobPrefix = job.indexOf('/') > -1 ? '' : 'job/'

--- a/services/jenkins/jenkins-coverage.service.js
+++ b/services/jenkins/jenkins-coverage.service.js
@@ -112,14 +112,13 @@ export default class JenkinsCoverage extends JenkinsBase {
     }
   }
 
-  async handle({ format }, { jobUrl, disableStrictSSL }) {
+  async handle({ format }, { jobUrl }) {
     const { schema, transform, treeQueryParam, pluginSpecificPath } =
       formatMap[format]
     const json = await this.fetch({
       url: buildUrl({ jobUrl, plugin: pluginSpecificPath }),
       schema,
       qs: buildTreeParamQueryString(treeQueryParam),
-      disableStrictSSL,
       errorMessages: {
         404: 'job or coverage not found',
       },

--- a/services/jenkins/jenkins-tests.service.js
+++ b/services/jenkins/jenkins-tests.service.js
@@ -107,7 +107,6 @@ export default class JenkinsTests extends JenkinsBase {
   async handle(
     namedParams,
     {
-      disableStrictSSL,
       jobUrl,
       compact_message: compactMessage,
       passed_label: passedLabel,
@@ -119,7 +118,6 @@ export default class JenkinsTests extends JenkinsBase {
       url: buildUrl({ jobUrl }),
       schema,
       qs: buildTreeParamQueryString('actions[failCount,skipCount,totalCount]'),
-      disableStrictSSL,
     })
     const { passed, failed, skipped, total } = this.transform({ json })
     return this.constructor.render({


### PR DESCRIPTION
After posting https://github.com/badges/shields/issues/4655#issuecomment-897061551 yesterday, I started looking at the strictSSL/proxy thing and on digging into it.. it might be a non issue. There are two services where we currently do something with the `strictSSL` param, and I think they're both now pointless. In this PR: jenkins

I was looking into how to test this param and I realised this param has actaully been broken for a very long time. Any attempt to use this will throw "strict ssl is required" e.g: https://img.shields.io/jenkins/build.svg?disableStrictSSL&jobUrl=https%3A%2F%2Fjenkins-oss.wixpress.com%2Fjob%2Fmulti-detox-master In order to make it work, you have to remove https://github.com/badges/shields/blob/23c0406bedfc6930735e8f5ea75dfe34faf1f290/core/base-service/auth-helper.js#L118
We broke this over a year ago in https://github.com/badges/shields/pull/4729 and nobody has raised an issue about it. Given this was never documented anywhere and has been broken for over a year without anyone noticing, I reckon we can just quietly drop this param rather than fixing it. Clearly nobody is using it.