### PR TITLE
Docker: use multi-stage build to reduce size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:14-alpine AS Builder
 
 RUN mkdir -p /usr/src/app
 RUN mkdir /usr/src/app/private
@@ -16,8 +16,13 @@ RUN npm run build
 RUN npm prune --production
 RUN npm cache clean --force
 
+# Use multi-stage build to reduce size
+FROM node:14-alpine
 # Run the server using production configs.
 ENV NODE_ENV production
+
+WORKDIR /usr/src/app
+COPY --from=Builder /usr/src/app /usr/src/app
 
 CMD node server
 


### PR DESCRIPTION
Hi, the current container size is too large, the local image size is close to 1GB.

```bash
docker images | grep shields                                                                                                                                                   
shieldsio/shields           server-2021-07-01              c567959e0651   7 weeks ago     848MB
```

And I've test the local build, the size is almost close to 1GB.

```bash
shields                                       latest                              83a611869ad9   7 minutes ago   919MB
```

For images used in the production environment, it is recommended to use docker multi-stage build, which can significantly **reduce the size of the image in actual local use and reduce the size when pushed to dockerhub**.

```bash
shields                                       latest                              c925e98df538   4 seconds ago   255MB
```