### PR TITLE
use the right version of NPM in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package-lock.json /usr/src/app/
 # Without the badge-maker package.json and CLI script in place, `npm ci` will fail.
 COPY badge-maker /usr/src/app/badge-maker/
 
+RUN npm install -g "npm@>=7"
 # We need dev deps to build the front end. We don't need Cypress, though.
 RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci
 


### PR DESCRIPTION
Docker build was running using NPM 6. It was probably fine but generating some warnings. This ensures we're running 7 or above and `lockfileVersion: 2` will definitely be parsed correctly.