### PR TITLE
fix [DockerVersion] service test

### DIFF
--- a/services/docker/docker-version.tester.js
+++ b/services/docker/docker-version.tester.js
@@ -15,7 +15,7 @@ t.create('docker version (valid, library with tag)')
   })
 
 t.create('docker version (valid, user)')
-  .get('/datadog/agent.json')
+  .get('/datadog/dogstatsd.json')
   .expectBadge({
     label: 'version',
     message: isSemver,


### PR DESCRIPTION
This has been failing for a while as apparently a non-semver compatible tag was published. Long term I think these tests could be revisited to for example, account for both sort orders, don't require a valid semver when the sort is date, etc. but keeping this as-is for now, both to get the test passing again and because we'll presumably need a valid semver target anyway