### PR TITLE
[freecodecamp]: allow + symbol in username

### DIFF
--- a/services/freecodecamp/freecodecamp-points.service.js
+++ b/services/freecodecamp/freecodecamp-points.service.js
@@ -2,11 +2,17 @@ import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { BaseJsonService, InvalidResponse, NotFound } from '../index.js'
 
+/**
+ * Validates that the schema response is what we're expecting.
+ * The username pattern should match the freeCodeCamp repository.
+ *
+ * @see https://github.com/freeCodeCamp/freeCodeCamp/blob/main/utils/validate.js#L14
+ */
 const schema = Joi.object({
   entities: Joi.object({
     user: Joi.object()
       .required()
-      .pattern(/^\w+$/, {
+      .pattern(/^[a-zA-Z0-9\-_+]*$/, {
         points: Joi.number().allow(null).required(),
       }),
   }).optional(),


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

### Related
* Fixes https://github.com/badges/shields/issues/6998

### Problem
The pattern I used in the `schema` instance in `freecodecamp-points.service.js` was wrong.

I used `\w` because I thought usernames could only have letters, numbers, hyphens and underscores. I wasn't aware they could have plus until now. Then `allowAndStripUnknownKeys` kicked off and removed the properties that didn't match the pattern defined, including usernames with a `+` in it.

### Solution
I stole the pattern used to validate usernames from the official freeCodeCamp repository this time, so it should match this time.

> ```js
> const validCharsRE = /^[a-zA-Z0-9\-_+]*$/;
> ```
> 
> — https://github.com/freeCodeCamp/freeCodeCamp/blob/main/utils/validate.js#L14

Now it handles `+` symbols correctly.