### PR TITLE
fix [SpigetDownloadSize] service test

### DIFF
--- a/services/spiget/spiget-download-size.tester.js
+++ b/services/spiget/spiget-download-size.tester.js
@@ -2,16 +2,16 @@ import { isFileSize } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('EssentialsX (id 9089)')
-  .get('/9089.json')
+t.create('EssentialsX (hosted resource)')
+  .get('/771.json')
   .expectBadge({ label: 'size', message: isFileSize })
 
-t.create('Pet Master (id 15904)').get('/15904.json').expectBadge({
+t.create('Pet Master (external resource)').get('/15904.json').expectBadge({
   lavel: 'size',
   message: 'resource hosted externally',
 })
 
-t.create('Invalid Resource (id 1)').get('/1.json').expectBadge({
+t.create('Invalid Resource').get('/1.json').expectBadge({
   label: 'size',
   message: 'not found',
 })

--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -93,7 +93,9 @@ const isPercentage = Joi.alternatives().try(
   isDecimalPercentage
 )
 
-const isFileSize = withRegex(/^[0-9]*[.]?[0-9]+\s(B|kB|MB|GB|TB|PB|EB|ZB|YB)$/)
+const isFileSize = withRegex(
+  /^[0-9]*[.]?[0-9]+\s(B|kB|KB|MB|GB|TB|PB|EB|ZB|YB)$/
+)
 
 const isFormattedDate = Joi.alternatives().try(
   Joi.equal('today', 'yesterday'),


### PR DESCRIPTION
Forgot to open an issue, but this test has been failing for a while. Something changed upstream with the target we were using for the non-externally hosted resource scenario, and that target now is externally hosted (don't know enough about the service to know what that actually means, but was a straightforward root cause analysis).