### PR TITLE
support gitlab token via env var

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -79,6 +79,7 @@ private:
   gh_client_id: 'GH_CLIENT_ID'
   gh_client_secret: 'GH_CLIENT_SECRET'
   gh_token: 'GH_TOKEN'
+  gitlab_token: 'GITLAB_TOKEN'
   jenkins_user: 'JENKINS_USER'
   jenkins_pass: 'JENKINS_PASS'
   jira_user: 'JIRA_USER'


### PR DESCRIPTION
Was banging my head against the desk trying to figure out why the Shields.io prod environment wasn't sending the auth info with gitlab.com bound requests... only to discover I left out this crucial piece :man_facepalming: 

I've been meaning to suggest some documentation for adding new server secrets, as I think it'd be a helpful reference for folks, plus I've clearly forgotten it myself on more than one occasion!