### PR TITLE
Doc self hosting correction

### DIFF
--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -94,20 +94,27 @@ Sending build context to Docker daemon 3.923 MB
 Successfully built 4471b442c220
 ```
 
-Optionally, create a file called `shields.env` that contains the needed
-configuration. See [server-secrets.md](server-secrets.md) and [config/custom-environment-variables.yml](/config/custom-environment-variables.yml) for examples.
+Optionally, alter the default values for configuration via one of the two methods : through a configuration file (ex : `local.yml`) or through environnement variables.
+See [server-secrets.md](server-secrets.md) and [config/custom-environment-variables.yml](/config/custom-environment-variables.yml) for possible values.
+In [config/custom-environment-variables.yml](/config/custom-environment-variables.yml), environnement variable keys are defined in the quotes.
+
+```docker
+FROM shieldsio/shields:next
+COPY local.yml ./config/local.yml
+```
 
 Then run the container:
 
 ```console
-$ docker run --rm -p 8080:80 --name shields shields
-# or if you have shields.env file, run the following instead
-$ docker run --rm -p 8080:80 --env-file shields.env --name shields shields
+$ docker run --rm -p 8080:80 --name shields shieldsio/shields:next
+# Use the container you configured with your local.yml if you have configured it.
+# And for env var configurations : 
+$ docker run --rm -p 8080:8080 --env PORT=8080 --env METRICS_PROMETHEUS_ENABLED=true --env METRICS_PROMETHEUS_ENDPOINT_ENABLED=true --name shields shieldsio/shields:next
+# Note : for port configuration, use the same exposed port as the configured PORT inside shields for propre badges urls.
 
-> badge-maker@3.0.0 start /usr/src/app
-> node server.js
-
-http://[::1]/
+> Configuration:
+> ...
+> 0916211515 Server is starting up: http://0.0.0.0:8080/ 
 ```
 
 Assuming Docker is running locally, you should be able to get to the
@@ -117,7 +124,6 @@ If you run Docker in a virtual machine (such as boot2docker or Docker Machine)
 then you will need to replace `localhost` with the IP address of that virtual
 machine.
 
-[shields.example.env]: ../shields.example.env
 
 ## Raster server
 

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -96,7 +96,9 @@ Successfully built 4471b442c220
 
 Optionally, alter the default values for configuration via one of the two methods : through a configuration file (ex : `local.yml`) or through environnement variables.
 See [server-secrets.md](server-secrets.md) and [config/custom-environment-variables.yml](/config/custom-environment-variables.yml) for possible values.
-In [config/custom-environment-variables.yml](/config/custom-environment-variables.yml), environnement variable keys are defined in the quotes.
+In [config/custom-environment-variables.yml](/config/custom-environment-variables.yml), environnement variable keys are defined in the quotes in uppercase.
+
+Dockerfile to configure shields through a configuration file :
 
 ```docker
 FROM shieldsio/shields:next
@@ -107,14 +109,14 @@ Then run the container:
 
 ```console
 $ docker run --rm -p 8080:80 --name shields shieldsio/shields:next
-# Use the container you configured with your local.yml if you have configured it.
-# And for env var configurations : 
+# Use the container you configured with your local.yml that you have configured it eventually.
+# And with env var configurations :
 $ docker run --rm -p 8080:8080 --env PORT=8080 --env METRICS_PROMETHEUS_ENABLED=true --env METRICS_PROMETHEUS_ENDPOINT_ENABLED=true --name shields shieldsio/shields:next
-# Note : for port configuration, use the same exposed port as the configured PORT inside shields for propre badges urls.
+# Note : the port value configured should be the same as the one exposed outside shields to have propre badges urls.
 
-> Configuration:
-> ...
-> 0916211515 Server is starting up: http://0.0.0.0:8080/ 
+Configuration:
+...
+0916211515 Server is starting up: http://0.0.0.0:8080/
 ```
 
 Assuming Docker is running locally, you should be able to get to the


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Hi, 
I have tried to run shields following the self-hosting documentation but it was not working for configuration values (like the http port or other). After having retry many times, I finally find the reason in this discussion : https://github.com/badges/shields/discussions/5773

I think, the documentation did not follow the code since the doc was still referencing shields.env file which does not work any more...

So this pull request is to improve the documentation by explaining the 2 methods that I confirm work successfully.

I let you review this and merge if you think it is correctly explained. 
Sorry for my English that is not perfect (I am a french guy :) ).

