### PR TITLE
support GitHub OAuth token scopes, run all [GitHub]

### DIFF
--- a/core/token-pooling/token-pool.js
+++ b/core/token-pooling/token-pool.js
@@ -188,6 +188,10 @@ class TokenPool {
     this.priorityQueue = new PriorityQueue(this.constructor.compareTokens)
   }
 
+  count() {
+    return this.tokenIds.size
+  }
+
   /**
    * compareTokens
    *

--- a/services/github/auth/acceptor.js
+++ b/services/github/auth/acceptor.js
@@ -3,7 +3,7 @@ import request from 'request'
 import { userAgent } from '../../../core/base-service/legacy-request-handler.js'
 import log from '../../../core/server/log.js'
 
-function setRoutes({ server, authHelper, onTokenAccepted }) {
+function setRoutes({ server, authHelper, onTokenAccepted, tokenScopes }) {
   const baseUrl = process.env.GATSBY_BASE_URL || 'https://img.shields.io'
 
   server.route(/^\/github-auth$/, (data, match, end, ask) => {
@@ -15,6 +15,7 @@ function setRoutes({ server, authHelper, onTokenAccepted }) {
       // it's not setting a bad example.
       client_id: authHelper._user,
       redirect_uri: `${baseUrl}/github-auth/done`,
+      scope: tokenScopes,
     })
     ask.res.setHeader(
       'Location',

--- a/services/github/auth/acceptor.spec.js
+++ b/services/github/auth/acceptor.spec.js
@@ -41,6 +41,7 @@ describe('Github token acceptor', function () {
       server: camp,
       authHelper: oauthHelper,
       onTokenAccepted,
+      tokenScopes: 'read:packages',
     })
   })
 
@@ -52,6 +53,7 @@ describe('Github token acceptor', function () {
     const qs = queryString.stringify({
       client_id: fakeClientId,
       redirect_uri: 'https://img.shields.io/github-auth/done',
+      scope: 'read:packages',
     })
     const expectedLocationHeader = `https://github.com/login/oauth/authorize?${qs}`
     expect(res.headers.location).to.equal(expectedLocationHeader)

--- a/services/github/github-api-provider.integration.js
+++ b/services/github/github-api-provider.integration.js
@@ -30,11 +30,10 @@ describe('Github API provider', function () {
     it('should be able to run 10 requests', async function () {
       this.timeout('20s')
       for (let i = 0; i < 10; ++i) {
-        await githubApiProvider.requestAsPromise(
+        await githubApiProvider.requestAsPromise({
           request,
-          '/repos/rust-lang/rust',
-          {}
-        )
+          url: '/repos/rust-lang/rust',
+        })
       }
     })
   })
@@ -52,11 +51,10 @@ describe('Github API provider', function () {
 
     const headers = []
     async function performOneRequest() {
-      const { res } = await githubApiProvider.requestAsPromise(
+      const { res } = await githubApiProvider.requestAsPromise({
         request,
-        '/repos/rust-lang/rust',
-        {}
-      )
+        url: '/repos/rust-lang/rust',
+      })
       expect(res.statusCode).to.equal(200)
       headers.push(res.headers)
     }

--- a/services/github/github-auth-service.js
+++ b/services/github/github-auth-service.js
@@ -2,21 +2,22 @@ import gql from 'graphql-tag'
 import { mergeQueries } from '../../core/base-service/graphql.js'
 import { BaseGraphqlService, BaseJsonService } from '../index.js'
 
-function createRequestFetcher(context, config) {
+function createRequestFetcher(context, config, neededScopes) {
   const { sendAndCacheRequestWithCallbacks, githubApiProvider } = context
 
   return async (url, options) =>
-    githubApiProvider.requestAsPromise(
-      sendAndCacheRequestWithCallbacks,
+    githubApiProvider.requestAsPromise({
+      request: sendAndCacheRequestWithCallbacks,
       url,
-      options
-    )
+      options,
+      neededScopes,
+    })
 }
 
 class GithubAuthV3Service extends BaseJsonService {
-  constructor(context, config) {
+  constructor(context, config, neededScopes) {
     super(context, config)
-    this._requestFetcher = createRequestFetcher(context, config)
+    this._requestFetcher = createRequestFetcher(context, config, neededScopes)
     this.staticAuthConfigured = true
   }
 }
@@ -27,10 +28,10 @@ class GithubAuthV3Service extends BaseJsonService {
 // useful when consuming GitHub endpoints which are not rate-limited: it
 // avoids wasting API quota on them in production.
 class ConditionalGithubAuthV3Service extends BaseJsonService {
-  constructor(context, config) {
+  constructor(context, config, neededScopes) {
     super(context, config)
     if (context.githubApiProvider.globalToken) {
-      this._requestFetcher = createRequestFetcher(context, config)
+      this._requestFetcher = createRequestFetcher(context, config, neededScopes)
       this.staticAuthConfigured = true
     } else {
       this.staticAuthConfigured = false
@@ -39,9 +40,9 @@ class ConditionalGithubAuthV3Service extends BaseJsonService {
 }
 
 class GithubAuthV4Service extends BaseGraphqlService {
-  constructor(context, config) {
+  constructor(context, config, neededScopes) {
     super(context, config)
-    this._requestFetcher = createRequestFetcher(context, config)
+    this._requestFetcher = createRequestFetcher(context, config, neededScopes)
     this.staticAuthConfigured = true
   }
 

--- a/services/github/github-constellation.spec.js
+++ b/services/github/github-constellation.spec.js
@@ -1,0 +1,208 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
+import log from '../../core/server/log.js'
+import RedisTokenPersistence from '../../core/token-pooling/redis-token-persistence.js'
+import GithubConstellation from './github-constellation.js'
+import GithubApiProvider from './github-api-provider.js'
+
+describe('GithubConstellation', function () {
+  const tokens = [
+    'abc123',
+    'def4567.scopes.read:packages%20read:user',
+    'def789.scopes.read:packages',
+    'ghi012',
+    'fff444.scopes.read:packages',
+    '555eee.scopes.read:packages',
+    'ddd666',
+    '777ccc',
+    'bbb888',
+    '999aaa',
+    '000111.scopes.read:packages',
+    '222333.scopes.read:packages',
+    '111111',
+    '888888',
+  ]
+  const config = {
+    private: {
+      redis_url: 'localhost',
+    },
+    service: {
+      debug: {
+        enabled: false,
+      },
+    },
+  }
+  const server = { ajax: { on: sinon.stub() } }
+
+  beforeEach(function () {
+    sinon.stub(log, 'log')
+    sinon
+      .stub(GithubConstellation, '_createOauthHelper')
+      .returns({ isConfigured: false })
+    sinon.stub(GithubConstellation.prototype, 'scheduleDebugLogging')
+    sinon.stub(RedisTokenPersistence.prototype, 'initialize').returns(tokens)
+    sinon.stub(RedisTokenPersistence.prototype, 'noteTokenAdded')
+    sinon.stub(RedisTokenPersistence.prototype, 'noteTokenRemoved')
+    sinon.spy(GithubApiProvider.prototype, 'addToken')
+    sinon.spy(GithubApiProvider.prototype, 'addReservedScopedToken')
+  })
+
+  afterEach(function () {
+    sinon.restore()
+  })
+
+  context('initialize', function () {
+    it('does not fetch tokens when pooling disabled', async function () {
+      const constellation = new GithubConstellation({
+        ...config,
+        ...{ private: { gh_token: 'secret' } },
+      })
+      await constellation.initialize(server)
+      expect(RedisTokenPersistence.prototype.initialize).not.to.have.been.called
+    })
+
+    it('loads both scoped and unscoped tokens', async function () {
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      expect(constellation.apiProvider.graphqlTokens.count()).to.equal(12)
+      expect(constellation.apiProvider.searchTokens.count()).to.equal(12)
+      expect(constellation.apiProvider.standardTokens.count()).to.equal(12)
+      expect(constellation.apiProvider.packageScopedTokens.count()).to.equal(2)
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.be.calledWithExactly('def4567', {
+        scopes: 'read:packages%20read:user',
+      })
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.be.calledWithExactly('def789', {
+        scopes: 'read:packages',
+      })
+    })
+  })
+
+  context('onTokenAdded', function () {
+    it('adds new scoped token with met reserves', async function () {
+      const token = 'shh_secret'
+      sinon
+        .stub(GithubApiProvider.prototype, 'numReservedScopedTokens')
+        .returns(2)
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      constellation._maxNumReservedScopedTokens = 2
+      constellation.onTokenAdded(token, 'read:packages')
+      await clock.tickAsync()
+      expect(GithubApiProvider.prototype.addToken).to.be.calledWithExactly(
+        token,
+        { scopes: 'read:packages' }
+      )
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.not.be.calledWith(token)
+      expect(RedisTokenPersistence.prototype.noteTokenAdded).to.be.calledWith(
+        `${token}.scopes.read:packages`
+      )
+      expect(RedisTokenPersistence.prototype.noteTokenRemoved).to.not.be.called
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(15)
+      expect(constellation._tokenScopes[token]).to.equal('read:packages')
+    })
+
+    it('adds new scoped token with unmet reserves', async function () {
+      const token = 'shh_secret'
+      sinon
+        .stub(GithubApiProvider.prototype, 'numReservedScopedTokens')
+        .returns(2)
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      constellation._maxNumReservedScopedTokens = 3
+      constellation.onTokenAdded(token, 'read:packages')
+      await clock.tickAsync()
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.be.calledWithExactly(token, { scopes: 'read:packages' })
+      expect(GithubApiProvider.prototype.addToken).to.not.be.calledWith(token)
+      expect(RedisTokenPersistence.prototype.noteTokenAdded).to.be.calledWith(
+        `${token}.scopes.read:packages`
+      )
+      expect(RedisTokenPersistence.prototype.noteTokenRemoved).to.not.be.called
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(15)
+      expect(constellation._tokenScopes[token]).to.equal('read:packages')
+    })
+
+    it('adds new unscoped token', async function () {
+      const token = '1234567890987654321'
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      constellation.onTokenAdded(token)
+      await clock.tickAsync()
+      expect(GithubApiProvider.prototype.addToken).to.be.calledWithExactly(
+        token,
+        { scopes: undefined }
+      )
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.not.be.calledWith(token)
+      expect(RedisTokenPersistence.prototype.noteTokenAdded).to.be.calledWith(
+        token
+      )
+      expect(RedisTokenPersistence.prototype.noteTokenRemoved).to.not.be.called
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(15)
+      expect(constellation._tokenScopes[token]).to.equal(null)
+    })
+
+    it('updates scopes on existing token', async function () {
+      const existingToken = 'abc123'
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      sinon
+        .stub(GithubApiProvider.prototype, 'numReservedScopedTokens')
+        .returns(1)
+      constellation.onTokenAdded(existingToken, 'read:packages')
+      await clock.tickAsync()
+      expect(
+        GithubApiProvider.prototype.addReservedScopedToken
+      ).to.be.calledWithExactly(existingToken, { scopes: 'read:packages' })
+      expect(GithubApiProvider.prototype.addToken.callCount).to.equal(12)
+      expect(RedisTokenPersistence.prototype.noteTokenAdded).to.be.calledWith(
+        `${existingToken}.scopes.read:packages`
+      )
+      expect(RedisTokenPersistence.prototype.noteTokenRemoved).to.be.calledWith(
+        existingToken
+      )
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(14)
+      expect(constellation._tokenScopes[existingToken]).to.equal(
+        'read:packages'
+      )
+    })
+  })
+
+  context('onTokenInvalidated', function () {
+    it('removes scoped token', async function () {
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      constellation.onTokenInvalidated('def789')
+      await clock.tickAsync()
+      expect(RedisTokenPersistence.prototype.noteTokenRemoved).to.be.calledWith(
+        'def789.scopes.read:packages'
+      )
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(13)
+    })
+
+    it('removes unscoped token', async function () {
+      const clock = sinon.useFakeTimers()
+      const constellation = new GithubConstellation(config)
+      await constellation.initialize(server)
+      constellation.onTokenInvalidated('888888')
+      await clock.tickAsync()
+      expect(
+        RedisTokenPersistence.prototype.noteTokenRemoved
+      ).to.be.calledWithExactly('888888')
+      expect(Object.keys(constellation._tokenScopes).length).to.equal(13)
+    })
+  })
+})

--- a/services/suggest.js
+++ b/services/suggest.js
@@ -75,10 +75,10 @@ async function githubLicense(githubApiProvider, user, repo) {
 
   let link = `https://github.com/${repoSlug}`
 
-  const { buffer } = await githubApiProvider.requestAsPromise(
+  const { buffer } = await githubApiProvider.requestAsPromise({
     request,
-    `/repos/${repoSlug}/license`
-  )
+    url: `/repos/${repoSlug}/license`,
+  })
   try {
     const data = JSON.parse(buffer)
     if ('html_url' in data) {


### PR DESCRIPTION
This would bring us to a resolution on #4169 (intentionally not using any close keywords just yet).

Two minor things to note on the PR, _tried_ to structure the commits in a way to facilitate review, and the diff is deceptively large. The actual app code change is ~70 lines, but I opted to add a lot of tests given the nature of the change.

I had originally intended to just take the first minor step of updating our requested scopes, but quickly remembered the associated challenge that we'd discussed elsewhere around having a pool of tokens with unknown scopes. As such I opted to go ahead and step through the looking glass and propose a full implementation. While I fully anticipate some dialog/additional changes needed/etc., I do think this has the potential to be a viable path, but at a minimum hope this at least gets the ball rolling.

As to the implementation :smile: Here's some things I considered, but decided against along with my thinking...

There's a high level binary decision at the top of whether or not we should _persist_ the corresponding scopes with each token vs. dynamically checking scopes on the fly. I decided against trying to dynamically check scopes because that'd require we either:

* Check scopes on the respective current token prior to using it for an API request
* Check scopes on all tokens at startup

Both of those options seem unacceptably excessive, as in the latter case every time a dyno started each dyno would have to fire off 20k+ requests, and the former would inherently require a sequential set of API calls to satisfy every request.

Accordingly, I'm of the opinion we do need to persist the associated scopes along with each token.

Our current persistence strategy utilizes Redis with a single key that has a [Set-type value](https://redis.io/topics/data-types#sets) with that value containing all the tokens. One option would've been introducing new key(s)/set(s) pairs in Redis, where we'd have something like:

currentKey = (Set of unscoped tokens)
newKey = (Set of read:packages scoped tokens)

That would seemingly have provided a simpler story, at least on the persistence side, but would make for a notably more complicated world if (and almost certainly when) GitHub introduces some new feature that requires some new token scope. E.g. would we need and additional `newerKey` for that next scope, how would we persist tokens that have multiple scopes, etc.

As such, I believe it'll be easier and more maintainable/flexible if our persisted tokens carry their associated scope directly vs. trying to use collection-based keys to imply scopes.

The next question was really about _how_ to represent the respective scopes on each token in Redis. Redis doesn't really have a first class recognition of "objects", so presuming we don't want to experiment with radically different data types (none of which would offer any real utility for our context IMO) then it's a matter of incorporating the scope information on each token element in the set. One approach could have been more object-based representations in code of the raw persisted token material which is then json-stringified for persistence, however, I believe that adds unnecessary noise and verbosity to the set, and also introduces serialization concerns.

Instead, I'd propose we simply append the scopes to the end of the token string for each element in the set, using a delimiter. I've opted for a `.scopes.` delimiter, producing something like:

`abc123UnscopedTokenExample  another_unscoped_token   defscoped_example.scopes.read:packages  another_scoped.scopes.read:packages%20read:user`

The actor which handles loading up the tokens and dealing with new/invalidated ones (GithubConstellation) then incorporates the responsibility of taking those persisted forms and mapping them to the form used with our `Token` and `TokenPool` classes internally, leveraging the existing (but unused) `data` property on the `Token` to capture scopes. Internally, the constellation also tracks a dictionary of tokens for simplicity/to avoid having to do full scans of all tokens in all pools in order to handle re-authorized/re-scoped tokens.

The final piece is the separate pooling of scoped and standard unscoped tokens in the GithubApiProvider, with a mechanism for the actual Github service classes to define any scopes they required from their constructor, which in turn will ensure that the provider selects the next token from the correct token pool. Because the tokens are truly batched into separate pools now, I've set a cap on the portion of the total token pool that get funneled into the scoped pool. My thinking is that for the foreseeable future the vast majority of our ~21k will remain unscoped, and as such we'll probably need to ensure that the subset of tokens that _are_ scoped are only used for requests requiring scopes (so we don't eat through them when unnecessary). However, we'll conceivably/hopefully start to see a tide shift some ways down the road as the ratio of scoped tokens increases, and will also need to prevent pool starvation for the unscoped requests. I think the distinct set of pools with a slideable ratio will give us the flexibiltiy we need to handle both of those concerns.

Last note/observation is that I've added this in a way such that if a token is re-authorized the pools are adjusted accordingly, at least on that dyno, so that corresponding token can be used correctly without that dyno needing to restart/reload from Redis. I realize that might be overkill, especially since our dynos don't have any form of token sharing anymore and our dynos are restarted at least once a day anyway. This seemed like a sane/useful thing to do, but there's probably a few statements that could be removed if we decide that's unnecessary