### PR TITLE
Upate [RequiresIo] service test targets

### DIFF
--- a/services/requires/requires.tester.js
+++ b/services/requires/requires.tester.js
@@ -6,15 +6,34 @@ const isRequireStatus = Joi.string().regex(
   /^(up to date|outdated|insecure|unknown)$/
 )
 
-t.create('requirements (valid, without branch)')
-  .get('/github/zulip/zulip.json')
+// Package targets can be found at https://requires.io/public
+// However, there does seem to be some retention issues where
+// results for projects are purged after some number of days.
+// https://github.com/badges/shields/issues/7015
+// https://github.com/requires/api/issues/5
+t.create('requirements (valid GitHub, without branch)')
+  .get('/github/Hongbo-Miao/hongbomiao.com.json')
   .expectBadge({
     label: 'requirements',
     message: isRequireStatus,
   })
 
-t.create('requirements (valid, with branch)')
-  .get('/github/zulip/zulip/master.json')
+t.create('requirements (valid GitHub, with branch)')
+  .get('/github/Hongbo-Miao/hongbomiao.com/main.json')
+  .expectBadge({
+    label: 'requirements',
+    message: isRequireStatus,
+  })
+
+t.create('requirements (valid Bitbucket, without branch)')
+  .get('/bitbucket/code-orange/django-ispstack.json')
+  .expectBadge({
+    label: 'requirements',
+    message: isRequireStatus,
+  })
+
+t.create('requirements (valid Bitbucket, with branch)')
+  .get('/bitbucket/code-orange/django-ispstack/master.json')
   .expectBadge({
     label: 'requirements',
     message: isRequireStatus,


### PR DESCRIPTION
Refs #7015, but not closing it just yet. This PR in combination with #7080 would finally resolve all the long standing issues causing our test failures, so I'd like to get it in to give us a _chance_ at seeing green on the daily test runs again

Unfortunately no news on the reported issue upstream, but based on the behavior I'm seeing I'm increasingly convinced it's a temporal issue. It almost seems like the analyses are purged after some period of time (a week-ish I'd guess) and/or the API has started only returning data for the most recent X scans across all projects, and the results for other project targets roll out as new scans come in.
