### PR TITLE
fix [github] release/tag/download schema

### DIFF
--- a/services/github/github-common-release.js
+++ b/services/github/github-common-release.js
@@ -12,7 +12,7 @@ const releaseInfoSchema = Joi.object({
     })
     .required(),
   tag_name: Joi.string().required(),
-  name: Joi.string().allow(null),
+  name: Joi.string().allow(null).allow(''),
   prerelease: Joi.boolean().required(),
 }).required()
 


### PR DESCRIPTION
closes #7169
by default `Joi.string()` doesn't allow `''`