### PR TITLE
migrate github badges to use got instead of request; affects [github librariesio]

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -450,8 +450,7 @@ class BaseService {
           const namedParams = namedParamsForMatch(captureNames, match, this)
           const serviceData = await this.invoke(
             {
-              sendAndCacheRequest: fetcher,
-              sendAndCacheRequestWithCallbacks: request,
+              sendAndCacheRequest: fetcher, // TODO: rename sendAndCacheRequest
               githubApiProvider,
               librariesIoApiProvider,
               metricHelper,

--- a/core/base-service/got.js
+++ b/core/base-service/got.js
@@ -64,7 +64,8 @@ async function sendRequest(gotWrapper, url, options) {
   }
 }
 
-function fetchFactory(fetchLimitBytes) {
+const TEN_MB = 10485760
+function fetchFactory(fetchLimitBytes = TEN_MB) {
   const gotWithLimit = got.extend({
     handlers: [
       (options, next) => {

--- a/services/github/github-api-provider.integration.js
+++ b/services/github/github-api-provider.integration.js
@@ -1,7 +1,8 @@
 import { expect } from 'chai'
 import config from 'config'
-import request from 'request'
+import { fetchFactory } from '../../core/base-service/got.js'
 import GithubApiProvider from './github-api-provider.js'
+const requestFetcher = fetchFactory()
 
 describe('Github API provider', function () {
   const baseUrl = process.env.GITHUB_URL || 'https://api.github.com'
@@ -30,8 +31,8 @@ describe('Github API provider', function () {
     it('should be able to run 10 requests', async function () {
       this.timeout('20s')
       for (let i = 0; i < 10; ++i) {
-        await githubApiProvider.requestAsPromise(
-          request,
+        await githubApiProvider.fetch(
+          requestFetcher,
           '/repos/rust-lang/rust',
           {}
         )
@@ -52,8 +53,8 @@ describe('Github API provider', function () {
 
     const headers = []
     async function performOneRequest() {
-      const { res } = await githubApiProvider.requestAsPromise(
-        request,
+      const { res } = await githubApiProvider.fetch(
+        requestFetcher,
         '/repos/rust-lang/rust',
         {}
       )

--- a/services/github/github-api-provider.spec.js
+++ b/services/github/github-api-provider.spec.js
@@ -21,47 +21,35 @@ describe('Github API provider', function () {
   })
 
   context('a search API request', function () {
-    const mockRequest = (options, callback) => {
-      callback()
-    }
-    it('should obtain an appropriate token', function (done) {
-      provider.request(mockRequest, '/search', {}, (err, res, buffer) => {
-        expect(err).to.be.undefined
-        expect(provider.searchTokens.next).to.have.been.calledOnce
-        expect(provider.standardTokens.next).not.to.have.been.called
-        expect(provider.graphqlTokens.next).not.to.have.been.called
-        done()
-      })
+    it('should obtain an appropriate token', async function () {
+      const mockResponse = { res: { headers: {} } }
+      const mockRequest = sinon.stub().resolves(mockResponse)
+      await provider.fetch(mockRequest, '/search', {})
+      expect(provider.searchTokens.next).to.have.been.calledOnce
+      expect(provider.standardTokens.next).not.to.have.been.called
+      expect(provider.graphqlTokens.next).not.to.have.been.called
     })
   })
 
   context('a graphql API request', function () {
-    const mockRequest = (options, callback) => {
-      callback()
-    }
-    it('should obtain an appropriate token', function (done) {
-      provider.request(mockRequest, '/graphql', {}, (err, res, buffer) => {
-        expect(err).to.be.undefined
-        expect(provider.searchTokens.next).not.to.have.been.called
-        expect(provider.standardTokens.next).not.to.have.been.called
-        expect(provider.graphqlTokens.next).to.have.been.calledOnce
-        done()
-      })
+    it('should obtain an appropriate token', async function () {
+      const mockResponse = { res: { headers: {} } }
+      const mockRequest = sinon.stub().resolves(mockResponse)
+      await provider.fetch(mockRequest, '/graphql', {})
+      expect(provider.searchTokens.next).not.to.have.been.called
+      expect(provider.standardTokens.next).not.to.have.been.called
+      expect(provider.graphqlTokens.next).to.have.been.calledOnce
     })
   })
 
   context('a core API request', function () {
-    const mockRequest = (options, callback) => {
-      callback()
-    }
-    it('should obtain an appropriate token', function (done) {
-      provider.request(mockRequest, '/repo', {}, (err, res, buffer) => {
-        expect(err).to.be.undefined
-        expect(provider.searchTokens.next).not.to.have.been.called
-        expect(provider.standardTokens.next).to.have.been.calledOnce
-        expect(provider.graphqlTokens.next).not.to.have.been.called
-        done()
-      })
+    it('should obtain an appropriate token', async function () {
+      const mockResponse = { res: { headers: {} } }
+      const mockRequest = sinon.stub().resolves(mockResponse)
+      await provider.fetch(mockRequest, '/repo', {})
+      expect(provider.searchTokens.next).not.to.have.been.called
+      expect(provider.standardTokens.next).to.have.been.calledOnce
+      expect(provider.graphqlTokens.next).not.to.have.been.called
     })
   })
 
@@ -70,40 +58,32 @@ describe('Github API provider', function () {
     const remaining = 7955
     const nextReset = 123456789
     const mockResponse = {
-      statusCode: 200,
-      headers: {
-        'x-ratelimit-limit': rateLimit,
-        'x-ratelimit-remaining': remaining,
-        'x-ratelimit-reset': nextReset,
+      res: {
+        statusCode: 200,
+        headers: {
+          'x-ratelimit-limit': rateLimit,
+          'x-ratelimit-remaining': remaining,
+          'x-ratelimit-reset': nextReset,
+        },
+        buffer: Buffer.alloc(0),
       },
     }
-    const mockBuffer = Buffer.alloc(0)
-    const mockRequest = (...args) => {
-      const callback = args.pop()
-      callback(null, mockResponse, mockBuffer)
-    }
+    const mockRequest = sinon.stub().resolves(mockResponse)
 
-    it('should invoke the callback', function (done) {
-      provider.request(mockRequest, '/foo', {}, (err, res, buffer) => {
-        expect(err).to.equal(null)
-        expect(Object.is(res, mockResponse)).to.be.true
-        expect(Object.is(buffer, mockBuffer)).to.be.true
-        done()
-      })
+    it('should return the response', async function () {
+      const res = await provider.fetch(mockRequest, '/repo', {})
+      expect(Object.is(res, mockResponse)).to.be.true
     })
 
-    it('should update the token with the expected values', function (done) {
-      provider.request(mockRequest, '/foo', {}, (err, res, buffer) => {
-        expect(err).to.equal(null)
-        const expectedUsesRemaining =
-          remaining - Math.ceil(reserveFraction * rateLimit)
-        expect(mockStandardToken.update).to.have.been.calledWith(
-          expectedUsesRemaining,
-          nextReset
-        )
-        expect(mockStandardToken.invalidate).not.to.have.been.called
-        done()
-      })
+    it('should update the token with the expected values', async function () {
+      await provider.fetch(mockRequest, '/foo', {})
+      const expectedUsesRemaining =
+        remaining - Math.ceil(reserveFraction * rateLimit)
+      expect(mockStandardToken.update).to.have.been.calledWith(
+        expectedUsesRemaining,
+        nextReset
+      )
+      expect(mockStandardToken.invalidate).not.to.have.been.called
     })
   })
 
@@ -112,9 +92,10 @@ describe('Github API provider', function () {
     const remaining = 7955
     const nextReset = 123456789
     const mockResponse = {
-      statusCode: 200,
-      headers: {},
-      body: `{
+      res: {
+        statusCode: 200,
+        headers: {},
+        body: `{
         "data": {
           "rateLimit": {
             "limit": 12500,
@@ -124,67 +105,46 @@ describe('Github API provider', function () {
           }
         }
       }`,
+      },
     }
-    const mockBuffer = Buffer.alloc(0)
-    const mockRequest = (...args) => {
-      const callback = args.pop()
-      callback(null, mockResponse, mockBuffer)
-    }
+    const mockRequest = sinon.stub().resolves(mockResponse)
 
-    it('should invoke the callback', function (done) {
-      provider.request(mockRequest, '/graphql', {}, (err, res, buffer) => {
-        expect(err).to.equal(null)
-        expect(Object.is(res, mockResponse)).to.be.true
-        expect(Object.is(buffer, mockBuffer)).to.be.true
-        done()
-      })
+    it('should return the response', async function () {
+      const res = await provider.fetch(mockRequest, '/graphql', {})
+      expect(Object.is(res, mockResponse)).to.be.true
     })
 
-    it('should update the token with the expected values', function (done) {
-      provider.request(mockRequest, '/graphql', {}, (err, res, buffer) => {
-        expect(err).to.equal(null)
-        const expectedUsesRemaining =
-          remaining - Math.ceil(reserveFraction * rateLimit)
-        expect(mockGraphqlToken.update).to.have.been.calledWith(
-          expectedUsesRemaining,
-          nextReset
-        )
-        expect(mockGraphqlToken.invalidate).not.to.have.been.called
-        done()
-      })
+    it('should update the token with the expected values', async function () {
+      await provider.fetch(mockRequest, '/graphql', {})
+      const expectedUsesRemaining =
+        remaining - Math.ceil(reserveFraction * rateLimit)
+      expect(mockGraphqlToken.update).to.have.been.calledWith(
+        expectedUsesRemaining,
+        nextReset
+      )
+      expect(mockGraphqlToken.invalidate).not.to.have.been.called
     })
   })
 
   context('an unauthorized response', function () {
-    const mockResponse = { statusCode: 401 }
-    const mockBuffer = Buffer.alloc(0)
-    const mockRequest = (...args) => {
-      const callback = args.pop()
-      callback(null, mockResponse, mockBuffer)
-    }
-
-    it('should invoke the callback and update the token with the expected values', function (done) {
-      provider.request(mockRequest, '/foo', {}, (err, res, buffer) => {
-        expect(err).to.equal(null)
-        expect(mockStandardToken.invalidate).to.have.been.calledOnce
-        expect(mockStandardToken.update).not.to.have.been.called
-        done()
-      })
+    it('should invoke the callback and update the token with the expected values', async function () {
+      const mockResponse = { res: { statusCode: 401, headers: {} } }
+      const mockRequest = sinon.stub().resolves(mockResponse)
+      await provider.fetch(mockRequest, '/foo', {})
+      expect(mockStandardToken.invalidate).to.have.been.calledOnce
+      expect(mockStandardToken.update).not.to.have.been.called
     })
   })
 
   context('a connection error', function () {
-    const mockRequest = (...args) => {
-      const callback = args.pop()
-      callback(Error('connection timeout'))
-    }
-
-    it('should pass the error to the callback', function (done) {
-      provider.request(mockRequest, '/foo', {}, (err, res, buffer) => {
-        expect(err).to.be.an.instanceof(Error)
-        expect(err.message).to.equal('connection timeout')
-        done()
-      })
+    it('should throw an exception', function () {
+      const msg = 'connection timeout'
+      const requestError = new Error(msg)
+      const mockRequest = sinon.stub().rejects(requestError)
+      return expect(provider.fetch(mockRequest, '/foo', {})).to.be.rejectedWith(
+        Error,
+        'connection timeout'
+      )
     })
   })
 })

--- a/services/github/github-auth-service.js
+++ b/services/github/github-auth-service.js
@@ -2,21 +2,15 @@ import gql from 'graphql-tag'
 import { mergeQueries } from '../../core/base-service/graphql.js'
 import { BaseGraphqlService, BaseJsonService } from '../index.js'
 
-function createRequestFetcher(context, config) {
-  const { sendAndCacheRequestWithCallbacks, githubApiProvider } = context
-
-  return async (url, options) =>
-    githubApiProvider.requestAsPromise(
-      sendAndCacheRequestWithCallbacks,
-      url,
-      options
-    )
+function createRequestFetcher(context) {
+  const { sendAndCacheRequest, githubApiProvider } = context
+  return githubApiProvider.fetch.bind(githubApiProvider, sendAndCacheRequest)
 }
 
 class GithubAuthV3Service extends BaseJsonService {
   constructor(context, config) {
     super(context, config)
-    this._requestFetcher = createRequestFetcher(context, config)
+    this._requestFetcher = createRequestFetcher(context)
     this.staticAuthConfigured = true
   }
 }
@@ -30,7 +24,7 @@ class ConditionalGithubAuthV3Service extends BaseJsonService {
   constructor(context, config) {
     super(context, config)
     if (context.githubApiProvider.globalToken) {
-      this._requestFetcher = createRequestFetcher(context, config)
+      this._requestFetcher = createRequestFetcher(context)
       this.staticAuthConfigured = true
     } else {
       this.staticAuthConfigured = false
@@ -41,7 +35,7 @@ class ConditionalGithubAuthV3Service extends BaseJsonService {
 class GithubAuthV4Service extends BaseGraphqlService {
   constructor(context, config) {
     super(context, config)
-    this._requestFetcher = createRequestFetcher(context, config)
+    this._requestFetcher = createRequestFetcher(context)
     this.staticAuthConfigured = true
   }
 

--- a/services/librariesio/librariesio-api-provider.spec.js
+++ b/services/librariesio/librariesio-api-provider.spec.js
@@ -119,14 +119,10 @@ describe('LibrariesIoApiProvider', function () {
     const requestError = new Error(msg)
     const mockRequest = sinon.stub().rejects(requestError)
 
-    it('should pass the error to the callback', async function () {
-      try {
-        await provider.fetch(mockRequest, '/npm/badge-maker')
-        expect(false).to.be.true
-      } catch (err) {
-        expect(err).to.be.an.instanceof(Error)
-        expect(err.message).to.equal(msg)
-      }
+    it('should throw an exception', async function () {
+      return expect(
+        provider.fetch(mockRequest, '/npm/badge-maker', {})
+      ).to.be.rejectedWith(Error, 'connection timeout')
     })
   })
 })

--- a/services/librariesio/librariesio-base.js
+++ b/services/librariesio/librariesio-base.js
@@ -10,17 +10,14 @@ const projectSchema = Joi.object({
   rank: anyInteger,
 }).required()
 
-function createRequestFetcher(context, config) {
-  const { sendAndCacheRequest, librariesIoApiProvider } = context
-
-  return async (url, options) =>
-    await librariesIoApiProvider.fetch(sendAndCacheRequest, url, options)
-}
-
 export default class LibrariesIoBase extends BaseJsonService {
   constructor(context, config) {
     super(context, config)
-    this._requestFetcher = createRequestFetcher(context, config)
+    const { sendAndCacheRequest, librariesIoApiProvider } = context
+    this._requestFetcher = librariesIoApiProvider.fetch.bind(
+      librariesIoApiProvider,
+      sendAndCacheRequest
+    )
   }
 
   async fetchProject({ platform, scope, packageName }) {

--- a/services/suggest.js
+++ b/services/suggest.js
@@ -5,7 +5,8 @@
 // This endpoint is called from frontend/components/suggestion-and-search.js.
 
 import { URL } from 'url'
-import request from 'request'
+import { fetchFactory } from '../core/base-service/got.js'
+const requestFetcher = fetchFactory()
 
 function twitterPage(url) {
   if (url.protocol === null) {
@@ -75,8 +76,8 @@ async function githubLicense(githubApiProvider, user, repo) {
 
   let link = `https://github.com/${repoSlug}`
 
-  const { buffer } = await githubApiProvider.requestAsPromise(
-    request,
+  const { buffer } = await githubApiProvider.fetch(
+    requestFetcher,
     `/repos/${repoSlug}/license`
   )
   try {


### PR DESCRIPTION
Refs #4655

This PR deals with migrating request --> got in:

- https://github.com/badges/shields/blob/master/core/base-service/base.js
- https://github.com/badges/shields/blob/master/services/github/github-api-provider.integration.js
- https://github.com/badges/shields/blob/master/services/suggest.js

A lot of what is changing here is just updating tests

I've also made a couple of tweaks to libraries.io in this Pr. These changes are not _strictly_ related but I spotted a couple of minor things there while using that code as a base for porting the github token pooling from callbacks to async/await

---

Remaining uses of request not addressed in this PR:

- https://github.com/badges/shields/blob/master/services/github/auth/acceptor.js
- https://github.com/badges/shields/blob/master/services/php-version.js
- https://github.com/badges/shields/blob/master/core/legacy/regular-update.js
- https://github.com/badges/shields/blob/master/core/base-service/legacy-request-handler.js