### PR TITLE
Support "github.io" group id for jitpack.io version badge

### DIFF
--- a/frontend/lib/pattern-helpers.ts
+++ b/frontend/lib/pattern-helpers.ts
@@ -3,9 +3,9 @@ import { parse } from 'path-to-regexp'
 // Given a patternToRegex `pattern` with multiple-choice options like
 // `foo|bar|baz`, return an array with the options. If it can't be described
 // as multiple-choice options, return `undefined`.
-const basicChars = /^[A-za-z0-9-]+$/
+const basicChars = /^[A-Za-z0-9-.]+$/
 export function patternToOptions(pattern: string): string[] | undefined {
-  const split = pattern.split('|')
+  const split = pattern.replace(/\\(.)/g, '$1').split('|')
   if (split.some(part => !part.match(basicChars))) {
     return undefined
   } else {

--- a/services/jitpack/jitpack-version.service.js
+++ b/services/jitpack/jitpack-version.service.js
@@ -12,7 +12,7 @@ export default class JitPackVersion extends BaseJsonService {
 
   static route = {
     base: 'jitpack/v',
-    pattern: ':vcs(github|bitbucket|gitlab|gitee)/:user/:repo',
+    pattern: ':vcs(github|github\\.io|bitbucket|gitlab|gitee)/:user/:repo',
   }
 
   static examples = [
@@ -31,7 +31,9 @@ export default class JitPackVersion extends BaseJsonService {
   static defaultBadgeData = { label: 'jitpack' }
 
   async fetch({ vcs, user, repo }) {
-    const url = `https://jitpack.io/api/builds/com.${vcs}.${user}/${repo}/latest`
+    vcs = vcs.includes('.') ? vcs.split('.').reverse().join('.') : `com.${vcs}`
+
+    const url = `https://jitpack.io/api/builds/${vcs}.${user}/${repo}/latest`
 
     return this._requestJson({
       schema,


### PR DESCRIPTION
Currently, the jitpack.io version badge only supports the "com.github" group id for GitHub projects. This pull request adds support for "io.github" as group id. On the jitpack.io side, support was added in jitpack/jitpack.io#1102. The version badge now uses the "io.github" variant if selected. If just "github" is selected, "com.github" is used as the group id (which is compatible with existing badges).

The pull request also enables options that contain dots in the drop-down list of the web frontend.