### PR TITLE
Add config for testing status code in [website] service

### DIFF
--- a/services/website-status.js
+++ b/services/website-status.js
@@ -5,6 +5,8 @@ const queryParamSchema = Joi.object({
   down_message: Joi.string(),
   up_color: Joi.alternatives(Joi.string(), Joi.number()),
   down_color: Joi.alternatives(Joi.string(), Joi.number()),
+  status_code_less_than: Joi.number(),
+  status_code_more_than: Joi.number(),
 }).required()
 
 const exampleQueryParams = {
@@ -12,6 +14,8 @@ const exampleQueryParams = {
   up_color: 'blue',
   down_message: 'offline',
   down_color: 'lightgrey',
+  status_code_less_than: '400',
+  status_code_more_than: '199',
 }
 
 function renderWebsiteStatus({
@@ -20,6 +24,8 @@ function renderWebsiteStatus({
   downMessage = 'down',
   upColor = 'brightgreen',
   downColor = 'red',
+  statusCodeLessThan = 310,
+  statusCodeMoreThan = 0,
 }) {
   if (isUp) {
     return { message: upMessage, color: upColor }

--- a/services/website-status.js
+++ b/services/website-status.js
@@ -5,8 +5,8 @@ const queryParamSchema = Joi.object({
   down_message: Joi.string(),
   up_color: Joi.alternatives(Joi.string(), Joi.number()),
   down_color: Joi.alternatives(Joi.string(), Joi.number()),
-  status_code_less_than: Joi.number(),
-  status_code_more_than: Joi.number(),
+  status_code_less_than: Joi.number().integer().min(1).max(999),
+  status_code_more_than: Joi.number().integer().min(0).max(998),
 }).required()
 
 const exampleQueryParams = {

--- a/services/website/website.service.js
+++ b/services/website/website.service.js
@@ -94,7 +94,15 @@ export default class Website extends BaseService {
       // statusCodeLessThan = 310
       // statusCodeMoreThan = 0
       // Meaning we consider all HTTP status codes below 310, other than 0, as success.
-      isUp = statusCode < statusCodeLessThan && statusCode > statusCodeMoreThan
+      if (typeof statusCodeLessThan === 'undefined') {
+        statusCodeLessThan = 310
+      }
+      if (typeof statusCodeMoreThan === 'undefined') {
+        statusCodeMoreThan = 0
+      }
+      isUp =
+        statusCode < parseInt(statusCodeLessThan) &&
+        statusCode > parseInt(statusCodeMoreThan)
     } catch (e) {
       // Catch all errors thrown by the request.
       isUp = false
@@ -106,6 +114,8 @@ export default class Website extends BaseService {
       downMessage,
       upColor,
       downColor,
+      statusCodeLessThan,
+      statusCodeMoreThan,
     })
   }
 }

--- a/services/website/website.service.js
+++ b/services/website/website.service.js
@@ -75,6 +75,8 @@ export default class Website extends BaseService {
       down_message: downMessage,
       up_color: upColor,
       down_color: downColor,
+      status_code_less_than: statusCodeLessThan,
+      status_code_more_than: statusCodeMoreThan,
       url,
     }
   ) {
@@ -88,8 +90,11 @@ export default class Website extends BaseService {
           method: 'HEAD',
         },
       })
-      // We consider all HTTP status codes below 310 as success.
-      isUp = statusCode < 310
+      // By default:
+      // statusCodeLessThan = 310
+      // statusCodeMoreThan = 0
+      // Meaning we consider all HTTP status codes below 310, other than 0, as success.
+      isUp = statusCode < statusCodeLessThan && statusCode > statusCodeMoreThan
     } catch (e) {
       // Catch all errors thrown by the request.
       isUp = false

--- a/services/website/website.tester.js
+++ b/services/website/website.tester.js
@@ -46,8 +46,12 @@ t.create('status is down if response code is 401')
   .intercept(nock => nock('http://offline.com').head('/').reply(401))
   .expectBadge({ label: 'website', message: 'down' })
 
-t.create('status is up if response code is 401 and less than is 402 and more than is 400')
-  .get('/website.json?url=http://offline.com&status_code_more_than=400&status_code_less_than=402')
+t.create(
+  'status is up if response code is 401 and less than is 402 and more than is 400'
+)
+  .get(
+    '/website.json?url=http://offline.com&status_code_more_than=400&status_code_less_than=402'
+  )
   .intercept(nock => nock('http://offline.com').head('/').reply(401))
   .expectBadge({ label: 'website', message: 'up' })
 

--- a/services/website/website.tester.js
+++ b/services/website/website.tester.js
@@ -46,6 +46,11 @@ t.create('status is down if response code is 401')
   .intercept(nock => nock('http://offline.com').head('/').reply(401))
   .expectBadge({ label: 'website', message: 'down' })
 
+t.create('status is up if response code is 401 and less than is 402 and more than is 400')
+  .get('/website.json?url=http://offline.com&status_code_more_than=400&status_code_less_than=402')
+  .intercept(nock => nock('http://offline.com').head('/').reply(401))
+  .expectBadge({ label: 'website', message: 'up' })
+
 t.create('custom online label, online message and online color')
   .get(
     '/website.json?url=http://online.com&up_message=up&down_message=down&up_color=green&down_color=grey'


### PR DESCRIPTION
This change adds two optional parameters for the `website` service to specify the expected status code(s) of responses:
- `status_code_less_than` default = 310
- `status_code_more_than` default = 0

Added an additional test using the new parameters.
