### PR TITLE
check engine and peer deps before installing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,9 @@ main_steps: &main_steps
 
     - run:
         name: Install dependencies
-        command: npm ci
+        command: |
+          npm install --engine-strict --strict-peer-deps --dry-run
+          npm ci
         environment:
           # https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation
           # We don't need to install the Cypress binary in jobs that aren't actually running Cypress.
@@ -47,7 +49,9 @@ integration_steps: &integration_steps
 
     - run:
         name: Install dependencies
-        command: npm ci
+        command: |
+          npm install --engine-strict --strict-peer-deps --dry-run
+          npm ci
         environment:
           CYPRESS_INSTALL_BINARY: 0
 
@@ -68,7 +72,9 @@ services_steps: &services_steps
 
     - run:
         name: Install dependencies
-        command: npm ci
+        command: |
+          npm install --engine-strict --strict-peer-deps --dry-run
+          npm ci
         environment:
           CYPRESS_INSTALL_BINARY: 0
 
@@ -169,7 +175,9 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm ci
+          command: |
+            npm install --engine-strict --strict-peer-deps --dry-run
+            npm ci
           environment:
             CYPRESS_INSTALL_BINARY: 0
 
@@ -189,7 +197,9 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm ci
+          command: |
+            npm install --engine-strict --strict-peer-deps --dry-run
+            npm ci
           environment:
             CYPRESS_INSTALL_BINARY: 0
 
@@ -247,7 +257,9 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm ci
+          command: |
+            npm install --engine-strict --strict-peer-deps --dry-run
+            npm ci
 
       - run:
           name: Frontend build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ main_steps: &main_steps
     - run:
         name: Install dependencies
         command: |
-          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -51,7 +50,6 @@ integration_steps: &integration_steps
     - run:
         name: Install dependencies
         command: |
-          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -75,7 +73,6 @@ services_steps: &services_steps
     - run:
         name: Install dependencies
         command: |
-          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -208,7 +205,6 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm config list
             npm install --dry-run
             npm ci
           environment:
@@ -275,7 +271,6 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm config list
             npm install --dry-run
             npm ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ main_steps: &main_steps
     - run:
         name: Install dependencies
         command: |
+          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -50,6 +51,7 @@ integration_steps: &integration_steps
     - run:
         name: Install dependencies
         command: |
+          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -73,6 +75,7 @@ services_steps: &services_steps
     - run:
         name: Install dependencies
         command: |
+          npm config list
           npm install --dry-run
           npm ci
         environment:
@@ -205,6 +208,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            npm config list
             npm install --dry-run
             npm ci
           environment:
@@ -271,6 +275,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            npm config list
             npm install --dry-run
             npm ci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ main_steps: &main_steps
     - run:
         name: Install dependencies
         command: |
-          npm install --engine-strict --strict-peer-deps --dry-run
+          npm install --dry-run
           npm ci
         environment:
           # https://docs.cypress.io/guides/getting-started/installing-cypress.html#Skipping-installation
@@ -50,7 +50,7 @@ integration_steps: &integration_steps
     - run:
         name: Install dependencies
         command: |
-          npm install --engine-strict --strict-peer-deps --dry-run
+          npm install --dry-run
           npm ci
         environment:
           CYPRESS_INSTALL_BINARY: 0
@@ -73,7 +73,7 @@ services_steps: &services_steps
     - run:
         name: Install dependencies
         command: |
-          npm install --engine-strict --strict-peer-deps --dry-run
+          npm install --dry-run
           npm ci
         environment:
           CYPRESS_INSTALL_BINARY: 0
@@ -144,6 +144,9 @@ jobs:
   main:
     docker:
       - image: circleci/node:16
+        environment:
+          NPM_CONFIG_ENGINE_STRICT: 'true'
+          NPM_CONFIG_STRICT_PEER_DEPS: 'true'
 
     <<: *main_steps
 
@@ -156,6 +159,9 @@ jobs:
   integration:
     docker:
       - image: circleci/node:16
+        environment:
+          NPM_CONFIG_ENGINE_STRICT: 'true'
+          NPM_CONFIG_STRICT_PEER_DEPS: 'true'
       - image: redis
 
     <<: *integration_steps
@@ -175,9 +181,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: |
-            npm install --engine-strict --strict-peer-deps --dry-run
-            npm ci
+          command: npm ci
           environment:
             CYPRESS_INSTALL_BINARY: 0
 
@@ -192,13 +196,16 @@ jobs:
   frontend:
     docker:
       - image: circleci/node:16
+        environment:
+          NPM_CONFIG_ENGINE_STRICT: 'true'
+          NPM_CONFIG_STRICT_PEER_DEPS: 'true'
     steps:
       - checkout
 
       - run:
           name: Install dependencies
           command: |
-            npm install --engine-strict --strict-peer-deps --dry-run
+            npm install --dry-run
             npm ci
           environment:
             CYPRESS_INSTALL_BINARY: 0
@@ -235,6 +242,9 @@ jobs:
   services:
     docker:
       - image: circleci/node:16
+        environment:
+          NPM_CONFIG_ENGINE_STRICT: 'true'
+          NPM_CONFIG_STRICT_PEER_DEPS: 'true'
 
     <<: *services_steps
 
@@ -247,6 +257,9 @@ jobs:
   e2e:
     docker:
       - image: cypress/base:16.13.0
+        environment:
+          NPM_CONFIG_ENGINE_STRICT: 'true'
+          NPM_CONFIG_STRICT_PEER_DEPS: 'true'
     steps:
       - checkout
 
@@ -258,7 +271,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            npm install --engine-strict --strict-peer-deps --dry-run
+            npm install --dry-run
             npm ci
 
       - run:


### PR DESCRIPTION
Not much code here, but it does require a bit of explanation :)

In our `package.json` we declare an engines key with our node/npm compatibility:
https://github.com/badges/shields/blob/24355a0773c4d4333399cbfcc4dec52cba62344f/package.json#L242-L245
By default if NPM installs a package which declares itself incompatible with our engines statement, NPM will just install anyway but emit an `EBADENGINE` warning. In general we tend to catch this because the tests fail but if the tests pass we either have to identify this ourselves from the changelog or the CI logs (dunno about anyone else, but I never read the install log for dependency bump PRs) or in some cases we might actually merge a package update which officially drops compatibility/testing with our target node version (probably not for a while now we are on 16 in prod, but point still stands).

NPM has a useful flag [`--engine-strict`](https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict) which will cause NPM to error (and fail the build) in this situation instead of emitting a warning, which seems a lot safer.

Another super-fun default NPM has is it will allow installation of packages with conflicting `peerDependencies`. Again, the default is install anyway and emit a warning. Again, there is a flag [`--strict-peer-deps`](https://docs.npmjs.com/cli/v8/using-npm/config#strict-peer-deps) which tells it to treat this as a failure instead of a warning.

So far so good. Unfortunately both of these flags work with `npm install` but [don't work with `npm ci`](https://github.com/npm/cli/issues/1219), so if we want to use `npm ci` and those flags we can use the `--dry-run` flag annd do `npm install --engine-strict --strict-peer-deps --dry-run` first (which will do the checks but not install anything) and then `npm ci` after if it passes.