### PR TITLE
remove old email from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   ],
   "homepage": "https://shields.io",
   "bugs": {
-    "url": "https://github.com/badges/shields/issues",
-    "email": "thaddee.tyl@gmail.com"
+    "url": "https://github.com/badges/shields/issues"
   },
   "license": "CC0-1.0",
   "author": "Thaddée Tyl <thaddee.tyl@gmail.com>",


### PR DESCRIPTION
Just noticed we still had this in here. Obviously the value is wrong, but have opted to drop it altogether as (a) I don't think we want bug reports going over email regardless, and even if we do, (b) I don't think we've got a good address for it (afaik we only have `ops`, `security`, and a few other addresses for CoC)