### PR TITLE
ignore @types/node updates (for now)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       time: '12:00'
     open-pull-requests-limit: 99
     ignore:
+      # https://github.com/badges/shields/pull/7288#issuecomment-974699240
       - dependency-name: '@types/node'
 
   # badge-maker package dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
+    ignore:
+      - dependency-name: '@types/node'
 
   # badge-maker package dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
I don't see our circumstances changing to need/be ready for v17 any time soon, and the package is updated frequently enough that I think we need a global ignore so that we don't have to do the weekly routine (e.g. #7417)