### PR TITLE
add [curseforge] downloads badge

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -77,6 +77,7 @@ private:
   bitbucket_password: 'BITBUCKET_PASS'
   bitbucket_server_username: 'BITBUCKET_SERVER_USER'
   bitbucket_server_password: 'BITBUCKET_SERVER_PASS'
+  curseforge_api_token: 'CURSEFORGE_API_TOKEN'
   discord_bot_token: 'DISCORD_BOT_TOKEN'
   drone_token: 'DRONE_TOKEN'
   gh_client_id: 'GH_CLIENT_ID'

--- a/config/local.template.yml
+++ b/config/local.template.yml
@@ -13,3 +13,4 @@ private:
   weblate_api_key: '...'
   wheelmap_token: '...'
   youtube_api_key: '...'
+  curseforge_api_token: '...'

--- a/core/base-service/auth-helper.js
+++ b/core/base-service/auth-helper.js
@@ -151,6 +151,11 @@ class AuthHelper {
       : undefined
   }
 
+  _apiKeyHeader(apiKeyHeader) {
+    const { _pass: pass } = this
+    return this.isConfigured ? { [apiKeyHeader]: pass } : undefined
+  }
+
   static _mergeHeaders(requestParams, headers) {
     const {
       options: { headers: existingHeaders, ...restOptions } = {},
@@ -166,6 +171,12 @@ class AuthHelper {
       },
       ...rest,
     }
+  }
+
+  withApiKeyHeader(requestParams, header = 'x-api-key') {
+    return this._withAnyAuth(requestParams, requestParams =>
+      this.constructor._mergeHeaders(requestParams, this._apiKeyHeader(header))
+    )
   }
 
   withBearerAuthHeader(

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -159,6 +159,7 @@ const publicConfigSchema = Joi.object({
 
 const privateConfigSchema = Joi.object({
   azure_devops_token: Joi.string(),
+  curseforge_api_token: Joi.string(),
   discord_bot_token: Joi.string(),
   drone_token: Joi.string(),
   gh_client_id: Joi.string(),

--- a/doc/server-secrets.md
+++ b/doc/server-secrets.md
@@ -97,6 +97,14 @@ self-hosted Shields installation access to private repositories hosted on bitbuc
 Bitbucket badges use basic auth. Provide a username and password to give your
 self-hosted Shields installation access to a private Bitbucket Server instance.
 
+### Curseforge
+
+- `CURSEFORGE_API_TOKEN` (yml: `private.curseforge_api_token`)
+
+A [Curseforge API Token][cf_api_token] is required for accessing the curseforge API.
+
+[cf_api_token]: https://support.curseforge.com/en/support/solutions/articles/9000208346-about-the-curseforge-api-and-how-to-apply-for-a-key#key
+
 ### Discord
 
 Using a token for Dicsord is optional but will allow higher API rates.

--- a/services/curseforge/curseforge.service.js
+++ b/services/curseforge/curseforge.service.js
@@ -1,0 +1,51 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../../core/base-service/index.js'
+import { renderDownloadsBadge } from '../downloads.js'
+import { nonNegativeInteger } from '../validators.js'
+
+const schema = Joi.object({
+  downloadCount: nonNegativeInteger,
+})
+
+export default class CurseforgeService extends BaseJsonService {
+  static category = 'downloads'
+
+  static route = {
+    base: 'curseforge/dt',
+    pattern: ':modId',
+  }
+
+  static auth = {
+    passKey: 'curseforge_api_token',
+    authorizedOrigins: ['https://api.curseforge.com'],
+  }
+
+  static examples = [
+    {
+      title: 'Curseforge',
+      namedParams: { modId: '000000' },
+      staticPreview: renderDownloadsBadge({ downloads: 120000 }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'downloads', color: 'orange' }
+
+  async fetch({ modId }) {
+    return (
+      await this._requestJson(
+        this.authHelper.withApiKeyHeader({
+          schema: Joi.object({ data: schema }).required(),
+          url: `https://api.curseforge.com/v1/mods/${modId}`,
+          errorMessages: {
+            403: 'API-Token missing',
+          },
+        })
+      )
+    ).data
+  }
+
+  async handle({ modId }) {
+    const { downloadCount } = await this.fetch({ modId })
+    return renderDownloadsBadge({ downloads: downloadCount })
+  }
+}

--- a/services/curseforge/curseforge.tester.js
+++ b/services/curseforge/curseforge.tester.js
@@ -1,0 +1,12 @@
+import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
+
+export const t = await createServiceTester()
+
+t.create('Downloads')
+  .get('/AANobbMI.json')
+  .expectBadge({ label: 'downloads', message: isMetric })
+
+t.create('Downloads (not found)')
+  .get('/not-existing.json')
+  .expectBadge({ label: 'downloads', message: 'not found', color: 'red' })


### PR DESCRIPTION
this PR adds the curseforge downloads badge requested in #4498

it includes:
- auth helpers
- documentation for the api token
- the curseforge downloads badge

it sadly requires an api token to work for which the process for acquiring can be found [here](https://support.curseforge.com/en/support/solutions/articles/9000208346-about-the-curseforge-api-and-how-to-apply-for-a-key)
