### PR TITLE
Fix [Nexus] test

### DIFF
--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -313,7 +313,7 @@ t.create('Nexus 3 - search release version without snapshots')
   .get(
     // Limit the version from above, so that any later artifacts don't break this test.
     `/r/org.pentaho.adaptive/pdi-engines.json?server=https://nexus.pentaho.org&nexusVersion=3&queryOpt=${encodeURIComponent(
-      ':maven.baseVersion=<8.1.0.0'
+      ':maven.baseVersion=<8.0.0.1'
     )}`
   )
   .expectBadge({


### PR DESCRIPTION
Since #7472, version 8.0.0.5 was released despite 8.1.0.0 already being available, so the filter broke. Unless they decide to release `8.0.0.0-29`, this test should be fixed for good this time.