### PR TITLE
Set a higher default `cacheLength` on rating/star category

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -147,6 +147,7 @@ class BaseService {
       version: 300,
       debug: 60,
       downloads: 900,
+      rating: 900,
       social: 900,
     }
     return cacheLengths[this.category]


### PR DESCRIPTION
One of the things to come out of #7584 is that rating and star badges don't have any explicit `cacheLength` set on them so they just use the default (120 sec). I've never bothered setting one because we serve so few of these in the grand scheme of things. In terms of the way we characterise badges based on how often we expect the values to change and how precise the values need to be, it is probably most sensible to think of these in the same bucket as a download counts.
I don't expect this to make much difference to our performance/load because they make up such a small proportion of our traffic, but it will reduce the amount of traffic on upstream APIs a bit.