### PR TITLE
increase [SecurityHeaders] timeout

### DIFF
--- a/services/security-headers/security-headers.tester.js
+++ b/services/security-headers/security-headers.tester.js
@@ -2,9 +2,11 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('grade of https://shields.io')
+  .timeout(15000)
   .get('/security-headers.json?url=https://shields.io')
   .expectBadge({ label: 'security headers', message: 'F', color: 'red' })
 
 t.create('grade of https://httpstat.us/301 as redirect')
+  .timeout(15000)
   .get('/security-headers.json?ignoreRedirects&url=https://httpstat.us/301')
   .expectBadge({ label: 'security headers', message: 'R', color: 'blue' })


### PR DESCRIPTION
This seems to often need to trigger a full scan which in my local env is taking a tad north of 10 seconds fairly frequently, which in turn explains the recurring test failures.

If this is fairly common behavior then it does make me question how useful the badges are, but for now just want to get these off the regularly-failing list in the daily test runs