### PR TITLE
generate links without trailing : if port not set

### DIFF
--- a/frontend/constants.ts
+++ b/frontend/constants.ts
@@ -25,6 +25,9 @@ export function getBaseUrl(): string {
     if (['shields.io', 'www.shields.io'].includes(hostname)) {
       return 'https://img.shields.io'
     }
+    if (!port) {
+      return `${protocol}//${hostname}`
+    }
     return `${protocol}//${hostname}:${port}`
   } catch (e) {
     // server-side rendering


### PR DESCRIPTION
This is a minor thing, but at the moment our staging app and review apps generate links like this:
https://shields-staging.herokuapp.com:/appveyor/build/gruntjs/grunt
https://shields-staging-pr-7633.herokuapp.com:/galaxy-toolshed/v/sra_tools/iuc/fastq_dump
(with a trailing `:` character after the `.com`). They work, but I find it a minor irritation