### PR TITLE
Improve python version formatting 🐍 affects [pypi piwheels github]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@fontsource/lato": "^4.5.2",
         "@fontsource/lekton": "^4.5.3",
+        "@renovate/pep440": "^1.0.0",
         "@sentry/node": "^6.18.1",
         "@shields_io/camp": "^18.1.1",
         "badge-maker": "file:badge-maker",
@@ -3526,6 +3527,14 @@
         "hey-listen": "^1.0.8",
         "style-value-types": "^3.1.7",
         "tslib": "^1.10.0"
+      }
+    },
+    "node_modules/@renovate/pep440": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@renovate/pep440/-/pep440-1.0.0.tgz",
+      "integrity": "sha512-k3pZVxGEGpU7rpH507/9vxfFjuxX7qx4MSj9Fk+6zBsf/uZmAy8x97dNtZacbge7gP9TazbW1d7SEb5vsOmKlw==",
+      "dependencies": {
+        "xregexp": "4.4.1"
       }
     },
     "node_modules/@sentry/core": {
@@ -32406,6 +32415,14 @@
         "hey-listen": "^1.0.8",
         "style-value-types": "^3.1.7",
         "tslib": "^1.10.0"
+      }
+    },
+    "@renovate/pep440": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@renovate/pep440/-/pep440-1.0.0.tgz",
+      "integrity": "sha512-k3pZVxGEGpU7rpH507/9vxfFjuxX7qx4MSj9Fk+6zBsf/uZmAy8x97dNtZacbge7gP9TazbW1d7SEb5vsOmKlw==",
+      "requires": {
+        "xregexp": "4.4.1"
       }
     },
     "@sentry/core": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@fontsource/lato": "^4.5.2",
     "@fontsource/lekton": "^4.5.3",
+    "@renovate/pep440": "^1.0.0",
     "@sentry/node": "^6.18.1",
     "@shields_io/camp": "^18.1.1",
     "badge-maker": "file:badge-maker",

--- a/services/color-formatters.js
+++ b/services/color-formatters.js
@@ -3,6 +3,7 @@
  * including colours based off download count, version number, etc.
  */
 import moment from 'moment'
+import pep440 from '@renovate/pep440'
 
 function version(version) {
   if (typeof version !== 'string' && typeof version !== 'number') {
@@ -18,6 +19,17 @@ function version(version) {
   } else {
     return 'blue'
   }
+}
+
+function pep440VersionColor(version) {
+  if (!pep440.valid(version)) {
+    return 'lightgrey'
+  }
+  const parsedVersion = pep440.explain(version)
+  if (parsedVersion.is_prerelease || parsedVersion.public.startsWith('0.')) {
+    return 'orange'
+  }
+  return 'blue'
 }
 
 function floorCount(value, yellow, yellowgreen, green) {
@@ -106,6 +118,7 @@ function age(date) {
 
 export {
   version,
+  pep440VersionColor,
   downloadCount,
   coveragePercentage,
   floorCount,

--- a/services/color-formatters.spec.js
+++ b/services/color-formatters.spec.js
@@ -6,6 +6,7 @@ import {
   letterScore,
   age,
   version,
+  pep440VersionColor,
 } from './color-formatters.js'
 
 describe('Color formatters', function () {
@@ -105,5 +106,46 @@ describe('Color formatters', function () {
       Error,
       "Can't generate a version color for [object Object]"
     )
+  })
+
+  test(pep440VersionColor, () => {
+    forCases([
+      given('1.0.1'),
+      given('v2.1.6'),
+      given('1.0.1+abcd'),
+      given('1.0'),
+      given('v1'),
+      given(9),
+      given(1.0),
+    ]).expect('blue')
+
+    forCases([
+      given('1.0.1-rc1'),
+      given('1.0.1rc1'),
+      given('1.0.0-Beta'),
+      given('1.0.0Beta'),
+      given('1.1.0-alpha'),
+      given('1.1.0alpha'),
+      given('1.0.1-dev'),
+      given('1.0.1dev'),
+      given('2.1.6-b1'),
+      given('2.1.6b1'),
+      given('0.1.0'),
+      given('v0.1.0'),
+      given('v2.1.6-b1'),
+      given('0.1.0+abcd'),
+      given('2.1.6-b1+abcd'),
+      given('0.0.0'),
+      given(0.1),
+      given('0.9'),
+    ]).expect('orange')
+
+    forCases([
+      given('6.0.0-SNAPSHOT'),
+      given('2.1.6-prerelease'),
+      given(true),
+      given(null),
+      given('cheese'),
+    ]).expect('lightgrey')
   })
 })

--- a/services/github/github-pipenv.service.js
+++ b/services/github/github-pipenv.service.js
@@ -1,3 +1,4 @@
+import { pep440VersionColor } from '../color-formatters.js'
 import { renderVersionBadge } from '../version.js'
 import { isLockfile, getDependencyVersion } from '../pipenv-helpers.js'
 import { addv } from '../text-formatters.js'
@@ -80,6 +81,7 @@ class GithubPipenvLockedPythonVersion extends ConditionalGithubAuthV3Service {
       version,
       tag: branch,
       defaultLabel: 'python',
+      versionFormatter: pep440VersionColor,
     })
   }
 
@@ -147,7 +149,7 @@ class GithubPipenvLockedDependencyVersion extends ConditionalGithubAuthV3Service
     return {
       label: dependency,
       message: version ? addv(version) : ref,
-      color: 'blue',
+      color: version ? pep440VersionColor(version) : 'blue',
     }
   }
 

--- a/services/piwheels/piwheels-version.service.js
+++ b/services/piwheels/piwheels-version.service.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import { BaseJsonService, InvalidResponse } from '../index.js'
 import { renderVersionBadge } from '../version.js'
+import { pep440VersionColor } from '../color-formatters.js'
 
 const schema = Joi.object({
   releases: Joi.object()
@@ -46,7 +47,7 @@ export default class PiWheelsVersion extends BaseJsonService {
   static defaultBadgeData = { label: 'piwheels' }
 
   static render({ version }) {
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, versionFormatter: pep440VersionColor })
   }
 
   async fetch({ wheel }) {

--- a/services/pypi/pypi-version.service.js
+++ b/services/pypi/pypi-version.service.js
@@ -1,3 +1,4 @@
+import { pep440VersionColor } from '../color-formatters.js'
 import { renderVersionBadge } from '../version.js'
 import PypiBase from './pypi-base.js'
 
@@ -19,7 +20,7 @@ export default class PypiVersion extends PypiBase {
   static defaultBadgeData = { label: 'pypi' }
 
   static render({ version }) {
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, versionFormatter: pep440VersionColor })
   }
 
   async handle({ egg }) {

--- a/services/version.js
+++ b/services/version.js
@@ -152,11 +152,16 @@ function rangeStart(v) {
   return range.set[0][0].semver.version
 }
 
-function renderVersionBadge({ version, tag, defaultLabel }) {
+function renderVersionBadge({
+  version,
+  tag,
+  defaultLabel,
+  versionFormatter = versionColor,
+}) {
   return {
     label: tag ? `${defaultLabel}@${tag}` : undefined,
     message: addv(version),
-    color: versionColor(version),
+    color: versionFormatter(version),
   }
 }
 


### PR DESCRIPTION
After implementing the piwheels badge the other day I realised that I had just used `renderVersionBadge()` but our standard version formatter
https://github.com/badges/shields/blob/76a64a7896893bac4a1b52e683a0a542541b3bdb/services/color-formatters.js#L16-L20
isn't great for python packages because it will format something like `2.0.0rc1` or `2.0.0b2` as "stable".

Then I started pulling the thread and realised this problem actually also applies to some other python ecosystem badges.

so in this PR I have:

- Added a `pep440VersionColor()` formatter function which uses https://github.com/renovatebot/pep440 to parse versions
- Added the ability to pass `renderVersionBadge()` a custom formatter function as an optional param - this might be handy if we want to use a custom formatter for other package ecosystems.
- Used this in the badges for pypi, piwheels and github-pipenv