### PR TITLE
Clarify GitHub All Contributors badge

### DIFF
--- a/services/github/github-all-contributors.service.js
+++ b/services/github/github-all-contributors.service.js
@@ -17,7 +17,7 @@ export default class GithubAllContributorsService extends ConditionalGithubAuthV
 
   static examples = [
     {
-      title: 'Github All Contributors',
+      title: 'GitHub contributors (via allcontributors.org)',
       namedParams: {
         repo: 'all-contributors',
         user: 'all-contributors',

--- a/services/github/github-all-contributors.service.js
+++ b/services/github/github-all-contributors.service.js
@@ -2,7 +2,17 @@ import Joi from 'joi'
 import { renderContributorBadge } from '../contributor-count.js'
 import { ConditionalGithubAuthV3Service } from './github-auth-service.js'
 import { fetchJsonFromRepo } from './github-common-fetch.js'
-import { documentation } from './github-helpers.js'
+import { documentation as commonDocumentation } from './github-helpers.js'
+
+const documentation = `
+<p>
+  The All Contributors service allows you to recognize all your project
+  contributors, including those that don't push code. See
+  <a href="https://allcontributors.org">https://allcontributors.org</a>
+  for more information.
+</p>
+${commonDocumentation}
+`
 
 const schema = Joi.object({
   contributors: Joi.array().required(),


### PR DESCRIPTION
I was wondering what the difference was between these two badges and had to go digging through the code to figure things out:
![Screenshot 2022-03-06 121939](https://user-images.githubusercontent.com/10694593/156921151-190bc8cb-e3aa-4af8-be2d-5eb2d94d3c58.png)

Changing the title slightly should help clarify this.