### PR TITLE
Fix GitHub Deployments example color

### DIFF
--- a/services/github/github-deployments.service.js
+++ b/services/github/github-deployments.service.js
@@ -58,7 +58,7 @@ export default class GithubDeployments extends GithubAuthV4Service {
         environment: 'shields-staging',
       },
       staticPreview: this.render({
-        state: 'success',
+        state: 'SUCCESS',
       }),
       documentation,
     },


### PR DESCRIPTION
The example color currently appears as grey on the homepage:
![Screenshot 2022-03-06 124250](https://user-images.githubusercontent.com/10694593/156921520-c90b5dce-9911-40e6-a1e1-318eff19a167.png)

`render` expects the state to be passed in as uppercase.
