### PR TITLE
set a longer cacheLength on [librariesio] badges

### DIFF
--- a/services/librariesio/librariesio-dependencies.service.js
+++ b/services/librariesio/librariesio-dependencies.service.js
@@ -81,6 +81,8 @@ class LibrariesIoProjectDependencies extends LibrariesIoBase {
     },
   ]
 
+  static _cacheLength = 900
+
   async handle({ platform, scope, packageName, version = 'latest' }) {
     const url = `/${encodeURIComponent(platform)}/${
       scope ? encodeURIComponent(`${scope}/`) : ''
@@ -115,6 +117,8 @@ class LibrariesIoRepoDependencies extends LibrariesIoBase {
       staticPreview: renderDependenciesBadge({ outdatedCount: 325 }),
     },
   ]
+
+  static _cacheLength = 900
 
   async handle({ user, repo }) {
     const url = `/github/${encodeURIComponent(user)}/${encodeURIComponent(

--- a/services/librariesio/librariesio-dependent-repos.service.js
+++ b/services/librariesio/librariesio-dependent-repos.service.js
@@ -32,6 +32,8 @@ export default class LibrariesIoDependentRepos extends LibrariesIoBase {
     },
   ]
 
+  static _cacheLength = 900
+
   static defaultBadgeData = {
     label: 'dependent repos',
   }

--- a/services/librariesio/librariesio-dependents.service.js
+++ b/services/librariesio/librariesio-dependents.service.js
@@ -32,6 +32,8 @@ export default class LibrariesIoDependents extends LibrariesIoBase {
     },
   ]
 
+  static _cacheLength = 900
+
   static defaultBadgeData = {
     label: 'dependents',
   }


### PR DESCRIPTION
We currently run with two libraries.io tokens, which is mostly enough.
Another useful thing we can do is reduce the number of requests we need to make in the first place by cacheing badges longer.

The bower license/version and libraries.io sourcerank badges already have a `cacheLength` set on them based on the category. There's also a bunch of libraries.io badges that don't have any specific `cacheLength` set so they just use the default. All the data on libraries.io gets fetched from other platforms/registries on a schedule. Changes take a while to propagate so I'm not concerned about setting a bit of a longer `cacheLength` on these. Not sure if 900 seconds is enough to make much of a difference but lets give it a go.

This isn't a fix for #7445. Independently I need to work that out and fix it, but this should hopefully reduce the chance of us running out of rate limit.