### PR TITLE
Deprecate [Shippable] service

### DIFF
--- a/services/shippable/shippable.service.js
+++ b/services/shippable/shippable.service.js
@@ -1,80 +1,11 @@
-import Joi from 'joi'
-import { renderBuildStatusBadge } from '../build-status.js'
-import { BaseJsonService, NotFound, redirector } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-// source: https://github.com/badges/shields/pull/1362#discussion_r161693830
-const statusCodes = {
-  0: 'waiting',
-  10: 'queued',
-  20: 'processing',
-  30: 'success',
-  40: 'skipped',
-  50: 'unstable',
-  60: 'timeout',
-  70: 'cancelled',
-  80: 'failed',
-  90: 'stopped',
-}
-
-const schema = Joi.array()
-  .items(
-    Joi.object({
-      branchName: Joi.string().required(),
-      statusCode: Joi.number()
-        .valid(...Object.keys(statusCodes).map(key => parseInt(key)))
-        .required(),
-    }).required()
-  )
-  .required()
-
-class Shippable extends BaseJsonService {
-  static category = 'build'
-
-  static route = {
-    base: 'shippable',
-    pattern: ':projectId/:branch+',
-  }
-
-  static examples = [
-    {
-      title: 'Shippable',
-      namedParams: {
-        projectId: '5444c5ecb904a4b21567b0ff',
-        branch: 'master',
-      },
-      staticPreview: this.render({ code: 30 }),
-    },
-  ]
-
-  static defaultBadgeData = { label: 'shippable' }
-
-  static render({ code }) {
-    return renderBuildStatusBadge({ label: 'build', status: statusCodes[code] })
-  }
-
-  async fetch({ projectId }) {
-    const url = `https://api.shippable.com/projects/${projectId}/branchRunStatus`
-    return this._requestJson({ schema, url })
-  }
-
-  async handle({ projectId, branch }) {
-    const data = await this.fetch({ projectId })
-    const builds = data.filter(result => result.branchName === branch)
-    if (builds.length === 0) {
-      throw new NotFound({ prettyMessage: 'branch not found' })
-    }
-    return this.constructor.render({ code: builds[0].statusCode })
-  }
-}
-
-const ShippableRedirect = redirector({
+export default deprecatedService({
   category: 'build',
   route: {
     base: 'shippable',
-    pattern: ':projectId',
+    format: '(?:.+?)',
   },
-  transformPath: ({ projectId }) => `/shippable/${projectId}/master`,
-  dateAdded: new Date('2020-07-18'),
+  label: 'shippable',
+  dateAdded: new Date('2022-03-12'),
 })
-
-export { Shippable, ShippableRedirect }

--- a/services/shippable/shippable.tester.js
+++ b/services/shippable/shippable.tester.js
@@ -1,35 +1,20 @@
-import { isBuildStatus } from '../build-status.js'
 import { ServiceTester } from '../tester.js'
+
 export const t = new ServiceTester({
-  id: 'Shippable',
+  id: 'shippable',
   title: 'Shippable',
-  pathPrefix: '/shippable',
 })
 
-t.create('build status (valid)')
+t.create('no longer available (previously build status with branch)')
   .get('/5444c5ecb904a4b21567b0ff/master.json')
   .expectBadge({
-    label: 'build',
-    message: isBuildStatus,
+    label: 'shippable',
+    message: 'no longer available',
   })
 
-t.create('build status (branch not found)')
-  .get('/5444c5ecb904a4b21567b0ff/not-a-branch.json')
-  .expectBadge({ label: 'shippable', message: 'branch not found' })
-
-t.create('build status (build not found)')
-  .get('/not-a-build/master.json')
-  .expectBadge({ label: 'shippable', message: 'not found' })
-
-t.create('build status (unexpected status code)')
-  .get('/5444c5ecb904a4b21567b0ff/master.json')
-  .intercept(nock =>
-    nock('https://api.shippable.com/')
-      .get('/projects/5444c5ecb904a4b21567b0ff/branchRunStatus')
-      .reply(200, '[{ "branchName": "master", "statusCode": 63 }]')
-  )
-  .expectBadge({ label: 'shippable', message: 'invalid response data' })
-
-t.create('build status (no branch redirect)')
-  .get('/5444c5ecb904a4b21567b0ff.svg')
-  .expectRedirect('/shippable/5444c5ecb904a4b21567b0ff/master.svg')
+t.create('no longer available (previously build status without branch)')
+  .get('/5444c5ecb904a4b21567b0ff.json')
+  .expectBadge({
+    label: 'shippable',
+    message: 'no longer available',
+  })


### PR DESCRIPTION
Service tests for Shippable have been failing for a few weeks. Turns out that the company was bought by JFrog and the service was shut down last year (https://twitter.com/BeShippable/status/1356355435029127171). I'm guessing the API endpoints were still kept running for a while longer.
