### PR TITLE
fix [pypi] badges when package has null license

### DIFF
--- a/services/pypi/pypi-base.js
+++ b/services/pypi/pypi-base.js
@@ -5,7 +5,8 @@ const schema = Joi.object({
   info: Joi.object({
     version: Joi.string().required(),
     // https://github.com/badges/shields/issues/2022
-    license: Joi.string().allow(''),
+    // https://github.com/badges/shields/issues/7728
+    license: Joi.string().allow('').allow(null),
     classifiers: Joi.array().items(Joi.string()).required(),
   }).required(),
   releases: Joi.object()

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -106,6 +106,12 @@ describe('PyPI helpers', function () {
     forCases([
       given({
         info: {
+          license: null,
+          classifiers: ['License :: OSI Approved :: MIT License'],
+        },
+      }),
+      given({
+        info: {
           license: '',
           classifiers: ['License :: OSI Approved :: MIT License'],
         },


### PR DESCRIPTION
Closes #7728
Having dug into it a bit, I think I'm not going to split the schema. Makes more sense to just handle `null` the same as empty string.