### PR TITLE
cache [pub] publisher badge for an hour

### DIFF
--- a/services/pub/pub-publisher.service.js
+++ b/services/pub/pub-publisher.service.js
@@ -22,6 +22,8 @@ export class PubPublisher extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 3600
+
   static defaultBadgeData = { label: 'publisher' }
 
   static render({ publisher }) {


### PR DESCRIPTION
We discussed at the time that we would expect this value to change quite infrequently so we can cache it for the same amount of time we cache a license badge for.
