### PR TITLE
handle missing 'fly-client-ip'

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -319,6 +319,8 @@ class Server {
         // On Fly we can use the Fly-Client-IP header
         // https://fly.io/docs/reference/runtime-environment/#request-headers
         req.ip = req.headers['fly-client-ip']
+          ? req.headers['fly-client-ip']
+          : req.socket.remoteAddress
       } else {
         req.ip = req.socket.remoteAddress
       }


### PR DESCRIPTION
Refs https://sentry.io/organizations/shields/issues/3133159541/

I haven't really got to the bottom of why, but for some small subset of requests on fly (tens per hour) it seems the `fly-client-ip` header is not set which is causing us to throw an unhandled exception and crash the thread. Doing this will reject the request without throwing.
