### PR TITLE
Try out dependency-review-action

### DIFF
--- a/.github/workflows/enforce-dependency-review.yml
+++ b/.github/workflows/enforce-dependency-review.yml
@@ -1,0 +1,14 @@
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v3
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v1


### PR DESCRIPTION
There have been a number of high-profile supply chain attacks or issues in the NPM ecosystem, either due to packages being compromised by an attacker or sabotaged by their maintainer e.g:

- [node-ipc](https://security.snyk.io/vuln/SNYK-JS-NODEIPC-2426370)
- [faker/colors](https://github.com/advisories/GHSA-gh88-3pxp-6fm8)
- [coa](https://github.com/advisories/GHSA-73qr-pfmq-6rp8)
- [rc](https://github.com/advisories/GHSA-g2q5-5433-rhrf)
- [ua-parser-js](https://github.com/advisories/GHSA-pjwm-rvh2-c87w)
- [eslint-config-eslint/eslint-scope](https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes)
- [event-stream](https://snyk.io/blog/malicious-code-found-in-npm-package-event-stream/)
- etc

Shields has mercifully not been directly affected by any of these, but this is more through luck than judgement. Like most javascript projects with a large dependency tree we simply don't have enough hours in the day to fully review every dependency bump. One potentially exciting project in this field is Socket.dev, but its early days for that.

In a similar nitch, but attacking the problem from a different angle, Github have recently released this more fully formed action aimed at flagging dependency bumps with known issues.

Further reading:
- https://github.blog/2022-04-06-prevent-introduction-known-vulnerabilities-into-your-code/
- https://github.com/actions/dependency-review-action
- https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review

I have not played with this at all yet, but I'm going to suggest we enable it ahead of this weeks barrage of dependency bumps (but lets not make it a requirement for merging just yet) and try it out.