### PR TITLE
Reclassify test for versionColorForWordpressVersion as an integration test

### DIFF
--- a/services/wordpress/wordpress-version-color.integration.js
+++ b/services/wordpress/wordpress-version-color.integration.js
@@ -1,0 +1,23 @@
+import { expect } from 'chai'
+import { versionColorForWordpressVersion } from './wordpress-version-color.js'
+
+describe('versionColorForWordpressVersion()', function () {
+  it('generates correct colours for given versions', async function () {
+    this.timeout(5e3)
+
+    expect(await versionColorForWordpressVersion('11.2.0')).to.equal(
+      'brightgreen'
+    )
+    expect(await versionColorForWordpressVersion('11.2')).to.equal(
+      'brightgreen'
+    )
+    expect(await versionColorForWordpressVersion('3.2.0')).to.equal('yellow')
+    expect(await versionColorForWordpressVersion('3.2')).to.equal('yellow')
+    expect(await versionColorForWordpressVersion('4.7-beta.3')).to.equal(
+      'yellow'
+    )
+    expect(await versionColorForWordpressVersion('cheese')).to.equal(
+      'lightgrey'
+    )
+  })
+})

--- a/services/wordpress/wordpress-version-color.spec.js
+++ b/services/wordpress/wordpress-version-color.spec.js
@@ -1,8 +1,5 @@
 import { expect } from 'chai'
-import {
-  toSemver,
-  versionColorForWordpressVersion,
-} from './wordpress-version-color.js'
+import { toSemver } from './wordpress-version-color.js'
 
 describe('toSemver() function', function () {
   it('coerces versions', function () {
@@ -11,26 +8,5 @@ describe('toSemver() function', function () {
     expect(toSemver('1.0.0-beta')).to.equal('1.0.0-beta')
     expect(toSemver('1.0-beta')).to.equal('1.0.0-beta')
     expect(toSemver('foobar')).to.equal('foobar')
-  })
-})
-
-describe('versionColorForWordpressVersion()', function () {
-  it('generates correct colours for given versions', async function () {
-    this.timeout(5e3)
-
-    expect(await versionColorForWordpressVersion('11.2.0')).to.equal(
-      'brightgreen'
-    )
-    expect(await versionColorForWordpressVersion('11.2')).to.equal(
-      'brightgreen'
-    )
-    expect(await versionColorForWordpressVersion('3.2.0')).to.equal('yellow')
-    expect(await versionColorForWordpressVersion('3.2')).to.equal('yellow')
-    expect(await versionColorForWordpressVersion('4.7-beta.3')).to.equal(
-      'yellow'
-    )
-    expect(await versionColorForWordpressVersion('cheese')).to.equal(
-      'lightgrey'
-    )
   })
 })


### PR DESCRIPTION
This test requires hitting a web URL, and doesn't work offline, so it seems better classified as an integration test.
