### PR TITLE
add [PUB] likes badge

### DIFF
--- a/services/pub/pub-likes.service.js
+++ b/services/pub/pub-likes.service.js
@@ -1,12 +1,14 @@
 import Joi from 'joi'
 import { BaseJsonService } from '../index.js'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
 
 const documentation = `<p>A measure of how many developers have liked a package. This provides a raw measure of the overall sentiment of a package from peer developers.</p>`
 
 const keywords = ['dart', 'flutter']
 
 const schema = Joi.object({
-  likeCount: Joi.number().min(0).required(),
+  likeCount: nonNegativeInteger,
 }).required()
 
 const title = 'Pub Likes'
@@ -22,22 +24,17 @@ export default class PubLikes extends BaseJsonService {
       keywords,
       documentation,
       namedParams: { packageName: 'analysis_options' },
-      staticPreview: {
-        label: 'likes',
-        message: '1',
-        color: 'brightgreen',
-      },
+      staticPreview: this.render({ likeCount: 1000 }),
     },
   ]
 
   static defaultBadgeData = { label: 'likes' }
 
-  static render({ likeCount, packageName }) {
+  static render({ likeCount }) {
     return {
       label: 'likes',
-      message: `${likeCount}`,
-      color: 'brightgreen',
-      link: `https://pub.dev/packages/${packageName}`,
+      message: metric(likeCount),
+      color: 'blue',
     }
   }
 
@@ -51,6 +48,6 @@ export default class PubLikes extends BaseJsonService {
   async handle({ packageName }) {
     const score = await this.fetch({ packageName })
     const likeCount = score.likeCount
-    return this.constructor.render({ likeCount, packageName })
+    return this.constructor.render({ likeCount })
   }
 }

--- a/services/pub/pub-likes.service.js
+++ b/services/pub/pub-likes.service.js
@@ -1,0 +1,56 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+
+const documentation = `<p>A measure of how many developers have liked a package. This provides a raw measure of the overall sentiment of a package from peer developers.</p>`
+
+const keywords = ['dart', 'flutter']
+
+const schema = Joi.object({
+  likeCount: Joi.number().min(0).required(),
+}).required()
+
+const title = 'Pub Likes'
+
+export default class PubLikes extends BaseJsonService {
+  static category = 'rating'
+
+  static route = { base: 'pub/likes', pattern: ':packageName' }
+
+  static examples = [
+    {
+      title,
+      keywords,
+      documentation,
+      namedParams: { packageName: 'analysis_options' },
+      staticPreview: {
+        label: 'likes',
+        message: '1',
+        color: 'brightgreen',
+      },
+    },
+  ]
+
+  static defaultBadgeData = { label: 'likes' }
+
+  static render({ likeCount, packageName }) {
+    return {
+      label: 'likes',
+      message: `${likeCount}`,
+      color: 'brightgreen',
+      link: `https://pub.dev/packages/${packageName}`,
+    }
+  }
+
+  async fetch({ packageName }) {
+    return this._requestJson({
+      schema,
+      url: `https://pub.dev/api/packages/${packageName}/score`,
+    })
+  }
+
+  async handle({ packageName }) {
+    const score = await this.fetch({ packageName })
+    const likeCount = score.likeCount
+    return this.constructor.render({ likeCount, packageName })
+  }
+}

--- a/services/pub/pub-likes.tester.js
+++ b/services/pub/pub-likes.tester.js
@@ -1,15 +1,13 @@
-import Joi from 'joi'
+import { isMetric } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('pub likes (valid)')
-  .get('/analysis_options.json')
-  .expectBadge({
-    label: 'likes',
-    message: Joi.string().regex(/^\d+$/),
-    color: 'brightgreen',
-  })
+t.create('pub likes (valid)').get('/analysis_options.json').expectBadge({
+  label: 'likes',
+  message: isMetric,
+  color: 'blue',
+})
 
 t.create('pub likes (not found)').get('/analysisoptions.json').expectBadge({
   label: 'likes',

--- a/services/pub/pub-likes.tester.js
+++ b/services/pub/pub-likes.tester.js
@@ -1,0 +1,24 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('pub likes (valid)')
+  .get('/analysis_options.json')
+  .expectBadge({
+    label: 'likes',
+    message: Joi.string().regex(/^\d+$/),
+    color: 'brightgreen',
+  })
+
+t.create('pub likes (not found)').get('/analysisoptions.json').expectBadge({
+  label: 'likes',
+  message: 'not found',
+  color: 'red',
+})
+
+t.create('pub likes (invalid)').get('/analysis-options.json').expectBadge({
+  label: 'likes',
+  message: 'invalid',
+  color: 'lightgrey',
+})


### PR DESCRIPTION
- Add a badge for `PUB` to show the likes for `Dart/Flutter` packages and plugins.
- Fix #7915.