### PR TITLE
add [PUB] popularity badge

### DIFF
--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -1,0 +1,56 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+
+const documentation = `<p>A measure of how many developers use a package, providing insight into what other developers are using.</p>`
+
+const keywords = ['dart', 'flutter']
+
+const schema = Joi.object({
+  popularityScore: Joi.number().min(0).max(1).required(),
+}).required()
+
+const title = 'Pub Popularity'
+
+export default class PubPopularity extends BaseJsonService {
+  static category = 'rating'
+
+  static route = { base: 'pub/popularity', pattern: ':packageName' }
+
+  static examples = [
+    {
+      title,
+      keywords,
+      documentation,
+      namedParams: { packageName: 'analysis_options' },
+      staticPreview: {
+        label: 'popularity',
+        message: '100%',
+        color: 'brightgreen',
+      },
+    },
+  ]
+
+  static defaultBadgeData = { label: 'popularity' }
+
+  static render({ popularityScore, packageName }) {
+    return {
+      label: 'popularity',
+      message: `${Math.round(popularityScore * 100)}%`,
+      color: 'brightgreen',
+      link: `https://pub.dev/packages/${packageName}`,
+    }
+  }
+
+  async fetch({ packageName }) {
+    return this._requestJson({
+      schema,
+      url: `https://pub.dev/api/packages/${packageName}/score`,
+    })
+  }
+
+  async handle({ packageName }) {
+    const score = await this.fetch({ packageName })
+    const popularityScore = score.popularityScore
+    return this.constructor.render({ popularityScore, packageName })
+  }
+}

--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -22,22 +22,17 @@ export default class PubPopularity extends BaseJsonService {
       keywords,
       documentation,
       namedParams: { packageName: 'analysis_options' },
-      staticPreview: {
-        label: 'popularity',
-        message: '100%',
-        color: 'brightgreen',
-      },
+      staticPreview: this.render({ popularityScore: 0.9 }),
     },
   ]
 
   static defaultBadgeData = { label: 'popularity' }
 
-  static render({ popularityScore, packageName }) {
+  static render({ popularityScore }) {
     return {
       label: 'popularity',
       message: `${Math.round(popularityScore * 100)}%`,
-      color: 'brightgreen',
-      link: `https://pub.dev/packages/${packageName}`,
+      color: 'blue',
     }
   }
 
@@ -51,6 +46,6 @@ export default class PubPopularity extends BaseJsonService {
   async handle({ packageName }) {
     const score = await this.fetch({ packageName })
     const popularityScore = score.popularityScore
-    return this.constructor.render({ popularityScore, packageName })
+    return this.constructor.render({ popularityScore })
   }
 }

--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { floorCount } from '../color-formatters.js'
 import { BaseJsonService } from '../index.js'
 
 const documentation = `<p>A measure of how many developers use a package, providing insight into what other developers are using.</p>`
@@ -29,10 +30,11 @@ export default class PubPopularity extends BaseJsonService {
   static defaultBadgeData = { label: 'popularity' }
 
   static render({ popularityScore }) {
+    const roundedScore = Math.round(popularityScore * 100)
     return {
       label: 'popularity',
-      message: `${Math.round(popularityScore * 100)}%`,
-      color: 'blue',
+      message: `${roundedScore}%`,
+      color: floorCount(roundedScore, 40, 60, 80),
     }
   }
 

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -1,0 +1,26 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('pub popularity (valid)')
+  .get('/analysis_options.json')
+  .expectBadge({
+    label: 'popularity',
+    message: Joi.string().regex(/^\d+%$/),
+    color: 'brightgreen',
+  })
+
+t.create('pub popularity (not found)')
+  .get('/analysisoptions.json')
+  .expectBadge({
+    label: 'popularity',
+    message: 'not found',
+    color: 'red',
+  })
+
+t.create('pub popularity (invalid)').get('/analysis-options.json').expectBadge({
+  label: 'popularity',
+  message: 'invalid',
+  color: 'lightgrey',
+})

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -6,7 +6,6 @@ export const t = await createServiceTester()
 t.create('pub popularity (valid)').get('/analysis_options.json').expectBadge({
   label: 'popularity',
   message: isIntegerPercentage,
-  color: 'blue',
 })
 
 t.create('pub popularity (not found)')

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -1,15 +1,13 @@
-import Joi from 'joi'
+import { isIntegerPercentage } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('pub popularity (valid)')
-  .get('/analysis_options.json')
-  .expectBadge({
-    label: 'popularity',
-    message: Joi.string().regex(/^\d+%$/),
-    color: 'brightgreen',
-  })
+t.create('pub popularity (valid)').get('/analysis_options.json').expectBadge({
+  label: 'popularity',
+  message: isIntegerPercentage,
+  color: 'blue',
+})
 
 t.create('pub popularity (not found)')
   .get('/analysisoptions.json')


### PR DESCRIPTION
- Add a badge for `PUB` to show the popularity for `Dart/Flutter` packages and plugins.
- Fix #7919.