### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   create-release:
     if: |

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - master
+
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,6 +5,10 @@ on:
     # At 01:00 on the first day of every month
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/enforce-dependency-review.yml
+++ b/.github/workflows/enforce-dependency-review.yml
@@ -1,9 +1,6 @@
 name: 'Dependency Review'
 on: [pull_request]
 
-permissions:
-  contents: read
-
 jobs:
   dependency-review:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Following on from @naveensrinivasan 's suggestion in #7888 I agree with minimising the possible harm from token exposure but I think the approach we should actually adopt here is:

- Change our repo settings in https://github.com/badges/shields/settings/actions so that actions get "Read repository contents permission" by default (i.e: all actions get `contents: read` unless otherwise specified). This would bring us into line with GitHub's default for new repos. I haven't done this yet.
- Explicitly elevate permissions for the workflows that need more access (which I _think_ I've done correctly in this PR)
