### PR TITLE
Update [Chocolatey] API endpoint URL

### DIFF
--- a/services/chocolatey/chocolatey.service.js
+++ b/services/chocolatey/chocolatey.service.js
@@ -3,7 +3,7 @@ import { createServiceFamily } from '../nuget/nuget-v2-service-family.js'
 export default createServiceFamily({
   defaultLabel: 'chocolatey',
   serviceBaseUrl: 'chocolatey',
-  apiBaseUrl: 'https://www.chocolatey.org/api/v2',
+  apiBaseUrl: 'https://community.chocolatey.org/api/v2',
   odataFormat: 'json',
   title: 'Chocolatey',
   examplePackageName: 'git',


### PR DESCRIPTION
Old API endpoint

1. returns bogus redirects for some reason
2. is no longer the Chocolatey Community Repository

Resolves #7931

See chocolatey/home#159

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
