### PR TITLE
[Spack] Package Manager: Update Endpoint

### DIFF
--- a/services/spack/spack.service.js
+++ b/services/spack/spack.service.js
@@ -17,7 +17,7 @@ export default class SpackVersion extends BaseJsonService {
     {
       title: 'Spack',
       namedParams: { packageName: 'adios2' },
-      staticPreview: this.render({ version: '2.3.1' }),
+      staticPreview: this.render({ version: '2.8.0' }),
       keywords: ['hpc'],
     },
   ]
@@ -29,10 +29,9 @@ export default class SpackVersion extends BaseJsonService {
   }
 
   async fetch({ packageName }) {
-    const firstLetter = packageName[0]
     return this._requestJson({
       schema,
-      url: `https://packages.spack.io/api/${firstLetter}/${packageName}.json`,
+      url: `https://spack.github.io/packages/data/packages/${packageName}.json`,
       errorMessages: {
         404: 'package not found',
       },


### PR DESCRIPTION
We transition our endpoints in Spack to a new location. This adjusts the new JSON files that we can query for shields.

- [x] depends on a Spack PR to add `latest_version` to the new endpoint, too: https://github.com/spack/packages/commit/bad802813536f35db1bbb6986ffa69690a29b750

cc Spack: @tgamblin @vsoch