### PR TITLE
[Flathub] Relabel new download badge

### DIFF
--- a/services/flathub/flathub-downloads.service.js
+++ b/services/flathub/flathub-downloads.service.js
@@ -19,7 +19,7 @@ export default class FlathubDownloads extends BaseJsonService {
     },
   ]
 
-  static defaultBadgeData = { label: 'downloads' }
+  static defaultBadgeData = { label: 'installs' }
 
   async handle({ packageName }) {
     const data = await this._requestJson({

--- a/services/flathub/flathub-downloads.tester.js
+++ b/services/flathub/flathub-downloads.tester.js
@@ -5,10 +5,10 @@ export const t = await createServiceTester()
 t.create('Flathub Downloads (valid)')
   .get('/org.mozilla.firefox.json')
   .expectBadge({
-    label: 'downloads',
+    label: 'installs',
     message: isMetric,
   })
 
 t.create('Flathub Downloads  (not found)')
   .get('/not.a.package.json')
-  .expectBadge({ label: 'downloads', message: 'not found' })
+  .expectBadge({ label: 'installs', message: 'not found' })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Expands on #7724
Related https://github.com/badges/shields/issues/5506#issuecomment-1125903576

Naming was not 100% clear. Users have a certain understanding when reading "download".
It's not obvious that in this case it's only a subset of all downloads (only fresh installs, excluding downloads for updates).