### PR TITLE
update docs on production hosting

### DIFF
--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -16,9 +16,8 @@ Production hosting is managed by the Shields ops team:
 
 | Component                     | Subcomponent                    | People with access                                              |
 | ----------------------------- | ------------------------------- | --------------------------------------------------------------- |
-| shields-production-us         | Account owner                   | @calebcartwright, @paulmelnikow                                 |
-| shields-production-us         | Full access                     | @calebcartwright, @chris48s, @paulmelnikow, @pyvesb             |
-| shields-production-us         | Access management               | @calebcartwright, @chris48s, @paulmelnikow, @pyvesb             |
+| shields-io-production         | Full access                     | @calebcartwright, @chris48s, @paulmelnikow                      |
+| shields-io-production         | Access management               | @calebcartwright, @chris48s, @paulmelnikow                      |
 | Compose.io Redis              | Account owner                   | @paulmelnikow                                                   |
 | Compose.io Redis              | Account access                  | @paulmelnikow                                                   |
 | Compose.io Redis              | Database connection credentials | @calebcartwright, @chris48s, @paulmelnikow, @pyvesb             |
@@ -95,13 +94,10 @@ The raster server `raster.shields.io` (a.k.a. the rasterizing proxy) is
 hosted on Heroku. It's managed in the
 [squint](https://github.com/badges/squint/) repo.
 
-### Heroku Deployment
+### Fly.io Deployment
 
-Both the badge server and frontend are served from Heroku.
-
-After merging a commit to master, heroku should create a staging deploy. Check this has deployed correctly in the `shields-staging` pipeline and review https://shields-staging.herokuapp.com/
-
-If we're happy with it, "promote to production". This will deploy what's on staging to the `shields-production-eu` and `shields-production-us` pieplines.
+Both the badge server and frontend are served from Fly.io. Deployments are
+triggered using GitHub actions in a private repo.
 
 ## DNS
 
@@ -109,19 +105,15 @@ DNS is registered with [DNSimple][].
 
 [dnsimple]: https://dnsimple.com/
 
-## Logs
-
-Logs can be retrieved [from heroku](https://devcenter.heroku.com/articles/logging#log-retrieval).
-
 ## Error reporting
 
 [Error reporting][sentry] is one of the most useful tools we have for monitoring
 the server. It's generously donated by [Sentry][sentry home]. We bundle
-[`raven`][raven] into the application, and the Sentry DSN is configured via
-`local-shields-io-production.yml` (see [documentation][sentry configuration]).
+[`@sentry/node`][sentry-node] into the application, and the Sentry DSN is configured
+via `local-shields-io-production.yml` (see [documentation][sentry configuration]).
 
 [sentry]: https://sentry.io/shields/
-[raven]: https://www.npmjs.com/package/raven
+[sentry-node]: https://www.npmjs.com/package/@sentry/node
 [sentry home]: https://sentry.io/shields/
 [sentry configuration]: https://github.com/badges/shields/blob/master/doc/self-hosting.md#sentry
 

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -119,7 +119,7 @@ machine.
 
 If you want to host PNG badges, you can also self-host a [raster server][]
 which points to your badge server. It's a docker container. We host it on
-Heroku but should be possible to host on a wide variety of platforms.
+Fly.io but should be possible to host on a wide variety of platforms.
 
 - In your raster instance, set `BASE_URL` to your Shields instance, e.g.
   `https://shields.example.co`.


### PR DESCRIPTION
There was actually less to update here than I thought.

There are a few bits of heroku-specific code knocking about like:

- https://github.com/badges/shields/blob/master/Procfile
- https://github.com/badges/shields/blob/6dff32138b7316228dbde6feffbf23610ec14570/package.json#L106
- https://github.com/badges/shields/blob/8821ff85fcd494ebb802bf9bb26ddcba11d21ec8/core/server/server.js#L312-L317
- https://github.com/badges/shields/blob/99bffd3a86cb85f4ca20a22599e64be6abf7efcb/core/base-service/got-config.js#L20-L22

I have decided to just leave them all where they are because we have documented heroku buildpack-based (as opposed to docker-based) deployment as a self-hosting option for a long time

https://github.com/badges/shields/blob/6dff32138b7316228dbde6feffbf23610ec14570/doc/self-hosting.md?plain=1#L50-L61

and I don't see a strong reason to break backwards compatibility for the sake of removing a few lines.