### PR TITLE
🌱 Update OpenSSF Scorecard badge text

### DIFF
--- a/services/ossf-scorecard/ossf-scorecard.service.js
+++ b/services/ossf-scorecard/ossf-scorecard.service.js
@@ -21,7 +21,7 @@ export default class OSSFScorecard extends BaseJsonService {
 
   static examples = [
     {
-      title: 'OSSF-Scorecard Score',
+      title: 'OpenSSF Scorecard Score',
       namedParams: {
         host: 'github.com',
         orgName: 'rohankh532',

--- a/services/ossf-scorecard/ossf-scorecard.service.js
+++ b/services/ossf-scorecard/ossf-scorecard.service.js
@@ -31,7 +31,7 @@ export default class OSSFScorecard extends BaseJsonService {
     },
   ]
 
-  static defaultBadgeData = { label: 'OpenSSF Scorecard' }
+  static defaultBadgeData = { label: 'openssf scorecard' }
 
   static render({ score }) {
     return {

--- a/services/ossf-scorecard/ossf-scorecard.service.js
+++ b/services/ossf-scorecard/ossf-scorecard.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
 import { colorScale } from '../color-formatters.js'
+import { BaseJsonService } from '../index.js'
 
 const schema = Joi.object({
   score: Joi.number().min(0).required(),
@@ -14,7 +14,10 @@ const ossfScorecardColorScale = colorScale(
 export default class OSSFScorecard extends BaseJsonService {
   static category = 'analysis'
 
-  static route = { base: 'ossf-scorecard', pattern: ':host/:orgName/:repoName' }
+  static route = {
+    base: 'ossf-scorecard',
+    pattern: ':host/:orgName/:repoName',
+  }
 
   static examples = [
     {
@@ -28,7 +31,7 @@ export default class OSSFScorecard extends BaseJsonService {
     },
   ]
 
-  static defaultBadgeData = { label: 'score' }
+  static defaultBadgeData = { label: 'OpenSSF Scorecard' }
 
   static render({ score }) {
     return {


### PR DESCRIPTION
Current badge label for OpenSSF Scorecard only shows `score` which is very vague. So updating this to `openssf scorecard` (similar to other openssf badge, Best Practices - https://bestpractices.coreinfrastructure.org/projects/5621/badge)

Some lines were auto changed due to linters but do not affect functionality.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
