### PR TITLE
increase [reuse] service test timeout

### DIFF
--- a/services/reuse/reuse-compliance.tester.js
+++ b/services/reuse/reuse-compliance.tester.js
@@ -62,7 +62,10 @@ t.create('valid repo -- unregistered')
     color: COLOR_MAP.unregistered,
   })
 
-t.create('invalid repo').get('/github.com/repo/invalid-repo.json').expectBadge({
-  label: 'reuse',
-  message: 'Not a Git repository',
-})
+t.create('invalid repo')
+  .timeout(10000)
+  .get('/github.com/repo/invalid-repo.json')
+  .expectBadge({
+    label: 'reuse',
+    message: 'Not a Git repository',
+  })


### PR DESCRIPTION
This has been failing consistently for a while, as apparently the not found scenarios take more than the default 5 seconds (hovering right around 7 seconds on my local machine)