### PR TITLE
feat: Dynamic badge text formatters [Dynamic]

### DIFF
--- a/core/badge-urls/make-badge-url.d.ts
+++ b/core/badge-urls/make-badge-url.d.ts
@@ -92,6 +92,7 @@ export function dynamicBadgeUrl({
   suffix,
   color,
   style,
+  formatter,
   format,
 }: {
   baseUrl?: string
@@ -103,6 +104,7 @@ export function dynamicBadgeUrl({
   suffix: string
   color?: string
   style?: string
+  formatter?: string
   format?: string
 }): string
 

--- a/core/badge-urls/make-badge-url.js
+++ b/core/badge-urls/make-badge-url.js
@@ -118,6 +118,7 @@ function dynamicBadgeUrl({
   suffix,
   color,
   style,
+  formatter,
   format = '',
 }) {
   const outExt = format.length ? `.${format}` : ''
@@ -137,6 +138,9 @@ function dynamicBadgeUrl({
   }
   if (suffix) {
     queryParams.suffix = suffix
+  }
+  if (formatter) {
+    queryParams.formatter = formatter
   }
 
   const outQueryString = queryString.stringify(queryParams)

--- a/core/badge-urls/make-badge-url.spec.js
+++ b/core/badge-urls/make-badge-url.spec.js
@@ -151,5 +151,28 @@ describe('Badge URL generation functions', function () {
         `&url=${encodeURIComponent(dataUrl)}`,
       ].join('')
     )
+    const formatter = 'metric'
+    given({
+      baseUrl: 'http://img.example.com',
+      datatype: 'json',
+      label: 'foo',
+      dataUrl,
+      query,
+      suffix,
+      color,
+      formatter,
+      style: 'plastic',
+    }).expect(
+      [
+        'http://img.example.com/badge/dynamic/json',
+        '?color=blue',
+        '&formatter=metric',
+        '&label=foo',
+        `&query=${encodeURIComponent(query)}`,
+        '&style=plastic',
+        `&suffix=${encodeURIComponent(suffix)}`,
+        `&url=${encodeURIComponent(dataUrl)}`,
+      ].join('')
+    )
   })
 })

--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -18,6 +18,7 @@ const globalQueryParams = new Set([
   'colorB',
   'color',
   'labelColor',
+  'formatter',
 ])
 
 function flattenQueryParams(queryParams) {

--- a/frontend/components/dynamic-badge-maker.tsx
+++ b/frontend/components/dynamic-badge-maker.tsx
@@ -10,6 +10,7 @@ type StateKey =
   | 'color'
   | 'prefix'
   | 'suffix'
+  | 'formatter'
 type State = Record<StateKey, string>
 
 interface InputDef {
@@ -24,6 +25,7 @@ const inputs = [
   { name: 'color' },
   { name: 'prefix' },
   { name: 'suffix' },
+  { name: 'formatter' },
 ] as InputDef[]
 
 export default function DynamicBadgeMaker({
@@ -39,6 +41,7 @@ export default function DynamicBadgeMaker({
     color: '',
     prefix: '',
     suffix: '',
+    formatter: '',
   })
 
   const isValid =
@@ -60,7 +63,16 @@ export default function DynamicBadgeMaker({
     function onSubmit(e: React.FormEvent): void {
       e.preventDefault()
 
-      const { datatype, label, dataUrl, query, color, prefix, suffix } = values
+      const {
+        datatype,
+        label,
+        dataUrl,
+        query,
+        color,
+        prefix,
+        suffix,
+        formatter,
+      } = values
       window.open(
         dynamicBadgeUrl({
           baseUrl,
@@ -71,6 +83,7 @@ export default function DynamicBadgeMaker({
           color,
           prefix,
           suffix,
+          formatter,
         }),
         '_blank'
       )

--- a/frontend/components/usage.tsx
+++ b/frontend/components/usage.tsx
@@ -261,7 +261,7 @@ export default function Usage({ baseUrl }: { baseUrl: string }): JSX.Element {
           >
             $.DATA.SUBDATA
           </a>
-          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;
+          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;&amp;formatter=&lt;FORMATTER&gt;
         </StyledCode>
       </p>
       <p>
@@ -276,7 +276,7 @@ export default function Usage({ baseUrl }: { baseUrl: string }): JSX.Element {
           >
             &#x2F;&#x2F;data/subdata
           </a>
-          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;
+          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;&amp;formatter=&lt;FORMATTER&gt;
         </StyledCode>
       </p>
       <p>
@@ -291,7 +291,7 @@ export default function Usage({ baseUrl }: { baseUrl: string }): JSX.Element {
           >
             $.DATA.SUBDATA
           </a>
-          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;
+          &gt;&amp;color=&lt;COLOR&gt;&amp;prefix=&lt;PREFIX&gt;&amp;suffix=&lt;SUFFIX&gt;&amp;formatter=&lt;FORMATTER&gt;
         </StyledCode>
       </p>
 

--- a/services/dynamic-common.js
+++ b/services/dynamic-common.js
@@ -9,7 +9,6 @@ import toArray from '../core/base-service/to-array.js'
 import validate from '../core/base-service/validate.js'
 import {
   starRating,
-  currencyFromCode,
   ordinalNumber,
   metric,
   omitv,
@@ -57,7 +56,6 @@ const compoundValueSchema = Joi.alternatives().try(
  */
 const formatters = {
   starRating,
-  currencyFromCode,
   ordinalNumber,
   metric,
   omitv,

--- a/services/dynamic-common.js
+++ b/services/dynamic-common.js
@@ -7,6 +7,16 @@
 import Joi from 'joi'
 import toArray from '../core/base-service/to-array.js'
 import validate from '../core/base-service/validate.js'
+import {
+  starRating,
+  currencyFromCode,
+  ordinalNumber,
+  metric,
+  omitv,
+  addv,
+  formatDate,
+  formatRelativeDate,
+} from './text-formatters.js'
 import { InvalidResponse } from './index.js'
 
 /**
@@ -39,6 +49,22 @@ const compoundValueSchema = Joi.alternatives().try(
   Joi.array().items(individualValueSchema).required(),
   Joi.array().length(0)
 )
+
+/**
+ * Map of formatter names and their corresponding functions.
+ *
+ * @type {object}
+ */
+const formatters = {
+  starRating,
+  currencyFromCode,
+  ordinalNumber,
+  metric,
+  omitv,
+  addv,
+  formatDate,
+  formatRelativeDate,
+}
 
 /**
  * Look up the value in the data object by key and validate the value against compoundValueSchema.
@@ -74,6 +100,7 @@ function transformAndValidate({ data, key }) {
  * @param {any} attrs.value Value or array of value to be used for the badge message
  * @param {string} [attrs.prefix] If provided then the badge message will use this value as a prefix
  * @param {string} [attrs.suffix] If provided then the badge message will use this value as a suffix
+ * @param {string} [attrs.formatter] If provided then the badge message will use this value as a formatter
  * @returns {object} Badge with label, message and color properties
  */
 function renderDynamicBadge({
@@ -82,9 +109,13 @@ function renderDynamicBadge({
   value,
   prefix = '',
   suffix = '',
+  formatter = '',
 }) {
-  const renderedValue =
+  let renderedValue =
     value === undefined ? 'not specified' : toArray(value).join(', ')
+  if (formatter in formatters) {
+    renderedValue = formatters[formatter](renderedValue)
+  }
   return {
     label: tag ? `${defaultLabel}@${tag}` : defaultLabel,
     message: `${prefix}${renderedValue}${suffix}`,

--- a/services/dynamic/dynamic-helpers.js
+++ b/services/dynamic/dynamic-helpers.js
@@ -6,6 +6,7 @@ const queryParamSchema = Joi.object({
   query: Joi.string().required(),
   prefix: Joi.alternatives().try(Joi.string(), Joi.number()),
   suffix: Joi.alternatives().try(Joi.string(), Joi.number()),
+  formatter: Joi.string(),
 })
   .rename('uri', 'url', { ignoreUndefined: true, override: true })
   .required()

--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import { expect } from 'chai'
 import { createServiceTester } from '../tester.js'
+import { isRelativeFormattedDate } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('No URL specified')
@@ -193,4 +194,110 @@ t.create('JSON contains a string')
     label: 'custom badge',
     message: 'resource must contain an object or array',
     color: 'lightgrey',
+  })
+
+t.create('formatter addv')
+  .get(
+    '.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version&formatter=addv'
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'v0.0.0',
+    color: 'blue',
+  })
+
+t.create('formatter omitv')
+  .get('.json?url=https://json-test/api.json&query=$.version&formatter=omitv')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ version: 'v0.0.0' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '0.0.0',
+    color: 'blue',
+  })
+
+t.create('formatter metric')
+  .get('.json?url=https://json-test/api.json&query=$.count&formatter=metric')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ count: 123456789 })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '123M',
+    color: 'blue',
+  })
+
+t.create('formatter starRating')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.rating&formatter=starRating'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ rating: 4.5 })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '★★★★½',
+    color: 'blue',
+  })
+
+t.create('formatter ordinalNumber')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.rank&formatter=ordinalNumber'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ rank: 9 })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '9ᵗʰ',
+    color: 'blue',
+  })
+
+t.create('formatter currencyFromCode')
+  .get('.json?url=https://json-test/api.json&query=$.date&formatter=formatDate')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ date: '2019-01-01' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'january 2019',
+    color: 'blue',
+  })
+
+t.create('formatter formatRelativeDate')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.timestamp&formatter=formatRelativeDate'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ timestamp: 1655158963 })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: isRelativeFormattedDate,
+    color: 'blue',
   })

--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -197,8 +197,13 @@ t.create('JSON contains a string')
   })
 
 t.create('formatter addv')
-  .get(
-    '.json?uri=https://github.com/badges/shields/raw/master/package.json&query=$.version&formatter=addv'
+  .get('.json?url=https://json-test/api.json&query=$.version&formatter=addv')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ version: '0.0.0' })
+      })
   )
   .expectBadge({
     label: 'custom badge',
@@ -270,7 +275,7 @@ t.create('formatter ordinalNumber')
     color: 'blue',
   })
 
-t.create('formatter currencyFromCode')
+t.create('formatter formatDate')
   .get('.json?url=https://json-test/api.json&query=$.date&formatter=formatDate')
   .intercept(nock =>
     nock('https://json-test')

--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -241,6 +241,21 @@ t.create('formatter metric')
     color: 'blue',
   })
 
+t.create('formatter metric invalid value')
+  .get('.json?url=https://json-test/api.json&query=$.count&formatter=metric')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ count: 'notanumber' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'notanumber',
+    color: 'blue',
+  })
+
 t.create('formatter starRating')
   .get(
     '.json?url=https://json-test/api.json&query=$.rating&formatter=starRating'
@@ -255,6 +270,23 @@ t.create('formatter starRating')
   .expectBadge({
     label: 'custom badge',
     message: '★★★★½',
+    color: 'blue',
+  })
+
+t.create('formatter starRating invalid value')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.rating&formatter=starRating'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ rating: 'notanumber' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '☆☆☆☆☆',
     color: 'blue',
   })
 
@@ -275,6 +307,23 @@ t.create('formatter ordinalNumber')
     color: 'blue',
   })
 
+t.create('formatter ordinalNumber invalid value')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.rank&formatter=ordinalNumber'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ rank: 'notanumber' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'notanumberᵗʰ',
+    color: 'blue',
+  })
+
 t.create('formatter formatDate')
   .get('.json?url=https://json-test/api.json&query=$.date&formatter=formatDate')
   .intercept(nock =>
@@ -287,6 +336,21 @@ t.create('formatter formatDate')
   .expectBadge({
     label: 'custom badge',
     message: 'january 2019',
+    color: 'blue',
+  })
+
+t.create('formatter formatDate invalid value')
+  .get('.json?url=https://json-test/api.json&query=$.date&formatter=formatDate')
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ date: 'notadate' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'invalid date',
     color: 'blue',
   })
 
@@ -304,5 +368,22 @@ t.create('formatter formatRelativeDate')
   .expectBadge({
     label: 'custom badge',
     message: isRelativeFormattedDate,
+    color: 'blue',
+  })
+
+t.create('formatter formatRelativeDate invalid value')
+  .get(
+    '.json?url=https://json-test/api.json&query=$.timestamp&formatter=formatRelativeDate'
+  )
+  .intercept(nock =>
+    nock('https://json-test')
+      .get('/api.json')
+      .reply(200, function (uri, requestBody) {
+        return JSON.stringify({ timestamp: 'notanumber' })
+      })
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'invalid date',
     color: 'blue',
   })

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -62,7 +62,10 @@ export default class DynamicXml extends BaseService {
     return { values }
   }
 
-  async handle(_namedParams, { url, query: pathExpression, prefix, suffix }) {
+  async handle(
+    _namedParams,
+    { url, query: pathExpression, prefix, suffix, formatter }
+  ) {
     const { buffer } = await this._request({
       url,
       options: { headers: { Accept: 'application/xml, text/xml' } },
@@ -74,6 +77,6 @@ export default class DynamicXml extends BaseService {
       buffer,
     })
 
-    return renderDynamicBadge({ value, prefix, suffix })
+    return renderDynamicBadge({ value, prefix, suffix, formatter })
   }
 }

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -1,5 +1,6 @@
 import queryString from 'query-string'
 import { createServiceTester } from '../tester.js'
+import { isRelativeFormattedDate } from '../test-validators.js'
 import { exampleXml } from './dynamic-response-fixtures.js'
 export const t = await createServiceTester()
 
@@ -213,5 +214,194 @@ t.create('query with type conversion to number')
   .expectBadge({
     label: 'custom badge',
     message: '44.95',
+    color: 'blue',
+  })
+
+t.create('formatter addv')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/version/text()',
+      formatter: 'addv',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <version>1.0.0</version>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'v1.0.0',
+    color: 'blue',
+  })
+
+t.create('formatter omitv')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/version/text()',
+      formatter: 'omitv',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <version>v1.0.0</version>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '1.0.0',
+    color: 'blue',
+  })
+
+t.create('formatter metric')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/count/text()',
+      formatter: 'metric',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <count>123456789</count>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '123M',
+    color: 'blue',
+  })
+
+t.create('formatter starRating')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/rating/text()',
+      formatter: 'starRating',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <rating>4.5</rating>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '★★★★½',
+    color: 'blue',
+  })
+
+t.create('formatter ordinalNumber')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/rank/text()',
+      formatter: 'ordinalNumber',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <rank>9</rank>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '9ᵗʰ',
+    color: 'blue',
+  })
+
+t.create('formatter formatDate')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/date/text()',
+      formatter: 'formatDate',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <date>2019-01-01</date>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'january 2019',
+    color: 'blue',
+  })
+
+t.create('formatter formatRelativeDate')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: '//project[1]/timestamp/text()',
+      formatter: 'formatRelativeDate',
+    })}`
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/example.xml')
+      .reply(
+        200,
+        `<?xml version="1.0"?>
+        <catalog>
+          <project id="prj1">
+            <timestamp>1655158963</timestamp>
+          </project>
+        </catalog>`
+      )
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: isRelativeFormattedDate,
     color: 'blue',
   })

--- a/services/dynamic/dynamic-yaml.tester.js
+++ b/services/dynamic/dynamic-yaml.tester.js
@@ -1,3 +1,4 @@
+import { isRelativeFormattedDate } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
@@ -110,4 +111,89 @@ t.create('YAML contains a string')
     label: 'custom badge',
     message: 'resource must contain an object or array',
     color: 'lightgrey',
+  })
+
+t.create('formatter addv')
+  .get('.json?url=https://example.test/yaml&query=$.version&formatter=addv')
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'version: "0.8.0"')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'v0.8.0',
+    color: 'blue',
+  })
+
+t.create('formatter omitv')
+  .get('.json?url=https://example.test/yaml&query=$.version&formatter=omitv')
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'version: "v0.8.0"')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '0.8.0',
+    color: 'blue',
+  })
+
+t.create('formatter metric')
+  .get('.json?url=https://example.test/yaml&query=$.count&formatter=metric')
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'count: 123456789')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '123M',
+    color: 'blue',
+  })
+
+t.create('formatter starRating')
+  .get(
+    '.json?url=https://example.test/yaml&query=$.rating&formatter=starRating'
+  )
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'rating: 4.5')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '★★★★½',
+    color: 'blue',
+  })
+
+t.create('formatter ordinalNumber')
+  .get(
+    '.json?url=https://example.test/yaml&query=$.rank&formatter=ordinalNumber'
+  )
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'rank: 9')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '9ᵗʰ',
+    color: 'blue',
+  })
+
+t.create('formatter formatDate')
+  .get('.json?url=https://example.test/yaml&query=$.date&formatter=formatDate')
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'date: "2019-01-01"')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'january 2019',
+    color: 'blue',
+  })
+
+t.create('formatter formatRelativeDate')
+  .get(
+    '.json?url=https://example.test/yaml&query=$.timestamp&formatter=formatRelativeDate'
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/yaml')
+      .reply(200, 'timestamp: "1655158963"')
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: isRelativeFormattedDate,
+    color: 'blue',
   })

--- a/services/dynamic/json-path.js
+++ b/services/dynamic/json-path.js
@@ -36,7 +36,10 @@ export default superclass =>
       )
     }
 
-    async handle(namedParams, { url, query: pathExpression, prefix, suffix }) {
+    async handle(
+      namedParams,
+      { url, query: pathExpression, prefix, suffix, formatter }
+    ) {
       const data = await this.fetch({
         schema: Joi.any(),
         url,
@@ -73,6 +76,6 @@ export default superclass =>
         throw new InvalidResponse({ prettyMessage: 'no result' })
       }
 
-      return renderDynamicBadge({ value: values, prefix, suffix })
+      return renderDynamicBadge({ value: values, prefix, suffix, formatter })
     }
   }


### PR DESCRIPTION
Fixes #8075 

If, for example, a JSON/XML/YAML API endpoint you want to use has a number or date, eg:

```json
{
    "count": 1234
}
```

When using this endpoint on a dynamic badge, it would be nice to be able to make use of the text formatters to make the appearance more similar to other badges from shields.io.

Eg, using the JSON above, you could make a badge:

```md
https://img.shields.io/badge/dynamic/json?formatter=metric&color=088&label=count&query=%24.count&url=https%3A%2F%2Fexample.com
```

Which would display like:

![image](https://user-images.githubusercontent.com/20955511/173279223-6b419276-0d91-4f76-8cbe-a67bbaa8de4e.png)

Instead of:

![image](https://user-images.githubusercontent.com/20955511/173279258-debb6167-fa91-4149-bd7e-b652fcc52e37.png)

### Text formatters

The following values are supported for the `formatter` parameter:

- metric
![image](https://user-images.githubusercontent.com/20955511/173463213-dac98d20-df5d-472c-9f06-f047f862ae28.png) ![image](https://user-images.githubusercontent.com/20955511/173462839-2f1c01b7-3204-4c2f-a2d0-76929c06af83.png)
- starRating
![image](https://user-images.githubusercontent.com/20955511/173463230-116ef6ef-ef18-4e2e-9090-cc539383a27f.png) ![image](https://user-images.githubusercontent.com/20955511/173462907-612b8230-ea61-4961-927d-4b6bcbc9246a.png)
- ordinalNumber
![image](https://user-images.githubusercontent.com/20955511/173463249-76a6cde0-0da6-4a50-9f2f-698ea786630f.png) ![image](https://user-images.githubusercontent.com/20955511/173462936-673e2471-55b4-4667-863d-92d7cc0b104a.png)
- omitv
![image](https://user-images.githubusercontent.com/20955511/173463292-429a63a1-ca89-4eba-aed1-363e48457c39.png) ![image](https://user-images.githubusercontent.com/20955511/173462963-3c7454f6-5ef6-4439-b0ba-ac9275e2e37d.png)
- addv
![image](https://user-images.githubusercontent.com/20955511/173463313-b6b6c79d-586d-4d3f-a569-8d45d146e2f1.png) ![image](https://user-images.githubusercontent.com/20955511/173462989-89523527-0d87-4634-ab32-0f098ae51661.png)
- formatDate
![image](https://user-images.githubusercontent.com/20955511/173463354-dde9a64a-6d8c-46b5-84b5-6f4faef6a8d3.png) ![image](https://user-images.githubusercontent.com/20955511/173463015-e70d2711-1343-4002-9eb4-2f12814a1242.png)
- formatRelativeDate
![image](https://user-images.githubusercontent.com/20955511/173463401-75c331ca-5e25-41d5-bdff-2a568e9d2534.png) ![image](https://user-images.githubusercontent.com/20955511/173463037-8027af81-7c43-46a9-bca4-9c7b5e97cbbb.png)
