### PR TITLE
fix: gitlab licence service docs and example

### DIFF
--- a/services/gitlab/gitlab-license.service.js
+++ b/services/gitlab/gitlab-license.service.js
@@ -21,7 +21,7 @@ const documentation = `
 
 const customDocumentation = `
 <p>
-  Note that only network-accessible jihulab.com and other self-hosted GitLab instances are supported.
+  Note that only internet-accessible GitLab instances are supported, for example https://jihulab.com, https://gitlab.gnome.org, or https://gitlab.com/.
   You may use your GitLab Project Id (e.g. 13953) or your Project Path (e.g. gitlab-cn/gitlab ) in <a href="https://jihulab.com">https://jihulab.com</a>
 </p>
 `

--- a/services/gitlab/gitlab-license.service.js
+++ b/services/gitlab/gitlab-license.service.js
@@ -15,15 +15,16 @@ const queryParamSchema = Joi.object({
 
 const documentation = `
 <p>
-  You may use your GitLab Project Id (e.g. 13083) or your Project Path (e.g. gitlab-org/gitlab-foss )
+  You may use your GitLab Project Id (e.g. 278964) or your Project Path (e.g. gitlab-org/gitlab )
 </p>
 `
-const commonProps = {
-  namedParams: {
-    project: 'gitlab-org/gitlab-foss',
-  },
-  documentation,
-}
+
+const customDocumentation = `
+<p>
+  Note that only network-accessible jihulab.com and other self-hosted GitLab instances are supported.
+  You may use your GitLab Project Id (e.g. 13953) or your Project Path (e.g. gitlab-cn/gitlab ) in <a href="https://jihulab.com">https://jihulab.com</a>
+</p>
+`
 
 export default class GitlabLicense extends GitLabBase {
   static category = 'license'
@@ -37,22 +38,28 @@ export default class GitlabLicense extends GitLabBase {
   static examples = [
     {
       title: 'GitLab',
-      ...commonProps,
+      namedParams: {
+        project: 'gitlab-org/gitlab',
+      },
       staticPreview: {
         label: 'license',
         message: 'MIT License',
         color: 'green',
       },
+      documentation,
     },
     {
       title: 'GitLab (custom server)',
-      ...commonProps,
+      namedParams: {
+        project: 'gitlab-cn/gitlab',
+      },
       queryParams: { gitlab_url: 'https://jihulab.com' },
       staticPreview: {
         label: 'license',
         message: 'MIT License',
         color: 'green',
       },
+      documentation: customDocumentation,
     },
   ]
 


### PR DESCRIPTION
re https://github.com/badges/shields/pull/8024#issuecomment-1153331982

Fixed the documentation and example of custom server, now they are displayed properly.

/assign @calebcartwright 