### PR TITLE
[greasyfork] Greasy Fork daily downloads minor example fix

### DIFF
--- a/services/greasyfork/greasyfork-downloads.service.js
+++ b/services/greasyfork/greasyfork-downloads.service.js
@@ -10,7 +10,7 @@ export default class GreasyForkInstalls extends BaseGreasyForkService {
       title: 'Greasy Fork',
       pattern: 'dd/:scriptId',
       namedParams: { scriptId: '407466' },
-      staticPreview: renderDownloadsBadge({ downloads: 17 }),
+      staticPreview: renderDownloadsBadge({ downloads: 17, interval: 'day' }),
     },
     {
       title: 'Greasy Fork',


### PR DESCRIPTION
Noticing now that the daily downloads example is missing the "/day". The actual badge itself displays correctly, it is just an issue with the example.

![image](https://user-images.githubusercontent.com/20955511/174137146-c4807979-5d8b-4a0f-9d20-a518d549f1be.png)

![image](https://user-images.githubusercontent.com/20955511/174137088-66897a88-cf8d-4846-b776-6ee570048c1a.png)