### PR TITLE
style: unified self-managed [gitlab] instance name

### DIFF
--- a/services/gitlab/gitlab-contributors.service.js
+++ b/services/gitlab/gitlab-contributors.service.js
@@ -17,7 +17,7 @@ const documentation = `
 
 const customDocumentation = `
 <p>
-  Note that only network-accessible jihulab.com and other self-hosted GitLab instances are supported.
+  Note that only network-accessible jihulab.com and other self-managed GitLab instances are supported.
   You may use your GitLab Project Id (e.g. 13953) or your Project Path (e.g. gitlab-cn/gitlab ) in <a href="https://jihulab.com">https://jihulab.com</a>
 </p>
 `
@@ -40,7 +40,7 @@ export default class GitlabContributors extends GitLabBase {
       documentation,
     },
     {
-      title: 'GitLab (custom server) contributors',
+      title: 'GitLab (self-managed) contributors',
       queryParams: { gitlab_url: 'https://jihulab.com' },
       namedParams: {
         project: 'gitlab-cn/gitlab',

--- a/services/gitlab/gitlab-coverage.service.js
+++ b/services/gitlab/gitlab-coverage.service.js
@@ -68,14 +68,14 @@ export default class GitlabCoverage extends BaseSvgScrapingService {
       documentation,
     },
     {
-      title: 'Gitlab code coverage (self-hosted)',
+      title: 'Gitlab code coverage (self-managed)',
       namedParams: { user: 'GNOME', repo: 'at-spi2-core', branch: 'master' },
       queryParams: { gitlab_url: 'https://gitlab.gnome.org' },
       staticPreview: this.render({ coverage: 93 }),
       documentation,
     },
     {
-      title: 'Gitlab code coverage (self-hosted, specific job)',
+      title: 'Gitlab code coverage (self-managed, specific job)',
       namedParams: { user: 'GNOME', repo: 'libhandy', branch: 'master' },
       queryParams: {
         gitlab_url: 'https://gitlab.gnome.org',

--- a/services/gitlab/gitlab-license.service.js
+++ b/services/gitlab/gitlab-license.service.js
@@ -49,7 +49,7 @@ export default class GitlabLicense extends GitLabBase {
       documentation,
     },
     {
-      title: 'GitLab (custom server)',
+      title: 'GitLab (self-managed)',
       namedParams: {
         project: 'gitlab-cn/gitlab',
       },

--- a/services/gitlab/gitlab-pipeline-status.service.js
+++ b/services/gitlab/gitlab-pipeline-status.service.js
@@ -54,7 +54,7 @@ class GitlabPipelineStatus extends BaseSvgScrapingService {
       documentation,
     },
     {
-      title: 'Gitlab pipeline status (self-hosted)',
+      title: 'Gitlab pipeline status (self-managed)',
       namedParams: { project: 'GNOME/pango' },
       queryParams: { gitlab_url: 'https://gitlab.gnome.org', branch: 'master' },
       staticPreview: this.render({ status: 'passed' }),

--- a/services/gitlab/gitlab-release.service.js
+++ b/services/gitlab/gitlab-release.service.js
@@ -65,7 +65,7 @@ export default class GitLabRelease extends GitLabBase {
       staticPreview: renderVersionBadge({ version: 'v5.0.0-beta.1' }),
     },
     {
-      title: 'GitLab Release (custom instance)',
+      title: 'GitLab Release (self-managed)',
       namedParams: {
         project: 'GNOME/librsvg',
       },

--- a/services/gitlab/gitlab-tag.service.js
+++ b/services/gitlab/gitlab-tag.service.js
@@ -62,7 +62,7 @@ export default class GitlabTag extends GitLabBase {
       staticPreview: this.render({ version: 'v5.0.0-beta.1', sort: 'semver' }),
     },
     {
-      title: 'GitLab tag (custom instance)',
+      title: 'GitLab tag (self-managed)',
       namedParams: {
         project: 'GNOME/librsvg',
       },


### PR DESCRIPTION
At present, there is no unified naming for the self-managed instance fields in GItLab Service, and the names that appear are: `self-host`, `custom server`, `custom instance`, in order to reduce the burden on the user's mind, the naming is unified here.

The name has been standardized to `self-managed`, a reference to the official GItLab naming scheme.

reference: https://docs.gitlab.com/ee/subscriptions/self_managed/index.html