### PR TITLE
change routes for [gitlab] license and contributors badges

### DIFF
--- a/services/gitlab/gitlab-contributors-redirect.service.js
+++ b/services/gitlab/gitlab-contributors-redirect.service.js
@@ -1,0 +1,12 @@
+import { redirector } from '../index.js'
+
+// https://github.com/badges/shields/issues/8138
+export default redirector({
+  category: 'build',
+  route: {
+    base: 'gitlab/v/contributor',
+    pattern: ':project+',
+  },
+  transformPath: ({ project }) => `/gitlab/contributors/${project}`,
+  dateAdded: new Date('2022-06-29'),
+})

--- a/services/gitlab/gitlab-contributors-redirect.tester.js
+++ b/services/gitlab/gitlab-contributors-redirect.tester.js
@@ -1,0 +1,9 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Contributors redirect')
+  .get('/gitlab-org/gitlab', {
+    followRedirect: false,
+  })
+  .expectStatus(301)
+  .expectHeader('Location', '/gitlab/contributors/gitlab-org/gitlab.svg')

--- a/services/gitlab/gitlab-contributors.service.js
+++ b/services/gitlab/gitlab-contributors.service.js
@@ -25,7 +25,7 @@ const customDocumentation = `
 export default class GitlabContributors extends GitLabBase {
   static category = 'activity'
   static route = {
-    base: 'gitlab/v/contributor',
+    base: 'gitlab/contributors',
     pattern: ':project+',
     queryParamSchema,
   }

--- a/services/gitlab/gitlab-license-redirect.service.js
+++ b/services/gitlab/gitlab-license-redirect.service.js
@@ -1,0 +1,12 @@
+import { redirector } from '../index.js'
+
+// https://github.com/badges/shields/issues/8138
+export default redirector({
+  category: 'build',
+  route: {
+    base: 'gitlab/v/license',
+    pattern: ':project+',
+  },
+  transformPath: ({ project }) => `/gitlab/license/${project}`,
+  dateAdded: new Date('2022-06-29'),
+})

--- a/services/gitlab/gitlab-license-redirect.tester.js
+++ b/services/gitlab/gitlab-license-redirect.tester.js
@@ -1,0 +1,9 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('License redirect')
+  .get('/gitlab-org/gitlab', {
+    followRedirect: false,
+  })
+  .expectStatus(301)
+  .expectHeader('Location', '/gitlab/license/gitlab-org/gitlab.svg')

--- a/services/gitlab/gitlab-license.service.js
+++ b/services/gitlab/gitlab-license.service.js
@@ -30,7 +30,7 @@ export default class GitlabLicense extends GitLabBase {
   static category = 'license'
 
   static route = {
-    base: 'gitlab/v/license',
+    base: 'gitlab/license',
     pattern: ':project+',
     queryParamSchema,
   }

--- a/services/gitlab/gitlab-release.tester.js
+++ b/services/gitlab/gitlab-release.tester.js
@@ -36,7 +36,7 @@ t.create('Release (release display name)')
   .get('/gitlab-org/gitlab.json?display_name=release')
   .expectBadge({ label: 'release', message: isGitLabDisplayVersion })
 
-t.create('Release (custom instance')
+t.create('Release (custom instance)')
   .get('/GNOME/librsvg.json?gitlab_url=https://gitlab.gnome.org')
   .expectBadge({ label: 'release', message: isSemver, color: 'blue' })
 


### PR DESCRIPTION
closes #8138 

As well as removing the `/v` I am also suggesting we switch the route from `/contributor` to `/contributors`. This matches the github route and is more in line with our usual approach. We tend to use the plural if there can be more than one of the noun. e.g: `/stars`, `/dependencies`, `/issues` rather than `/star`, `/dependency`, `/issue`