### PR TITLE
fix [gitlab] auth

### DIFF
--- a/services/gitlab/gitlab-base.js
+++ b/services/gitlab/gitlab-base.js
@@ -8,7 +8,7 @@ export default class GitLabBase extends BaseJsonService {
 
   async fetch({ url, options, schema, errorMessages }) {
     return this._requestJson(
-      this.authHelper.withBasicAuth({
+      this.authHelper.withBearerAuthHeader({
         schema,
         url,
         options,

--- a/services/gitlab/gitlab-license.tester.js
+++ b/services/gitlab/gitlab-license.tester.js
@@ -1,6 +1,9 @@
 import { licenseToColor } from '../licenses.js'
 import { createServiceTester } from '../tester.js'
+import { noToken } from '../test-helpers.js'
+import _noGitLabToken from './gitlab-license.service.js'
 export const t = await createServiceTester()
+const noGitLabToken = noToken(_noGitLabToken)
 
 const publicDomainLicenseColor = licenseToColor('MIT License')
 const unknownLicenseColor = licenseToColor()
@@ -54,4 +57,13 @@ t.create('Mocking License')
     label: 'license',
     message: 'Apache License 2.0',
     color: unknownLicenseColor,
+  })
+
+t.create('License (private repo)')
+  .skipWhen(noGitLabToken)
+  .get('/shields-ops-group/test.json')
+  .expectBadge({
+    label: 'license',
+    message: 'MIT License',
+    color: `${publicDomainLicenseColor}`,
   })

--- a/services/gitlab/gitlab-tag.spec.js
+++ b/services/gitlab/gitlab-tag.spec.js
@@ -26,7 +26,7 @@ describe('GitLabTag', function () {
         .get('/api/v4/projects/foo%2Fbar/repository/tags?order_by=updated')
         // This ensures that the expected credentials are actually being sent with the HTTP request.
         // Without this the request wouldn't match and the test would fail.
-        .basicAuth({ user: '', pass: fakeToken })
+        .matchHeader('Authorization', `Bearer ${fakeToken}`)
         .reply(200, [{ name: '1.9' }])
 
       expect(


### PR DESCRIPTION
Fixes the overwhelming majority, but not totality, of #8143.

I also added a dummy license to our private test repo under the shields-ops-group