### PR TITLE
fix npm tagged version examples, run [npmversion]

### DIFF
--- a/services/npm/npm-version.service.js
+++ b/services/npm/npm-version.service.js
@@ -4,6 +4,7 @@ import { NotFound } from '../index.js'
 import NpmBase from './npm-base.js'
 
 const keywords = ['node']
+const defaultLabel = 'npm'
 
 // Joi.string should be a semver.
 const schema = Joi.object()
@@ -21,21 +22,25 @@ export default class NpmVersion extends NpmBase {
       title: 'npm',
       pattern: ':packageName',
       namedParams: { packageName: 'npm' },
-      staticPreview: this.render({ version: '6.3.0' }),
+      staticPreview: renderVersionBadge({ version: '6.3.0' }),
       keywords,
     },
     {
       title: 'npm (scoped)',
       pattern: ':scope/:packageName',
       namedParams: { scope: '@cycle', packageName: 'core' },
-      staticPreview: this.render({ version: '7.0.0' }),
+      staticPreview: renderVersionBadge({ version: '7.0.0' }),
       keywords,
     },
     {
       title: 'npm (tag)',
       pattern: ':packageName/:tag',
       namedParams: { packageName: 'npm', tag: 'next-8' },
-      staticPreview: this.render({ tag: 'latest', version: '6.3.0' }),
+      staticPreview: renderVersionBadge({
+        tag: 'latest',
+        version: '6.3.0',
+        defaultLabel,
+      }),
       keywords,
     },
     {
@@ -43,20 +48,28 @@ export default class NpmVersion extends NpmBase {
       pattern: ':packageName/:tag',
       namedParams: { packageName: 'npm', tag: 'next-8' },
       queryParams: { registry_uri: 'https://registry.npmjs.com' },
-      staticPreview: this.render({ tag: 'latest', version: '7.0.0' }),
+      staticPreview: renderVersionBadge({
+        tag: 'latest',
+        version: '7.0.0',
+        defaultLabel,
+      }),
       keywords,
     },
     {
       title: 'npm (scoped with tag)',
       pattern: ':scope/:packageName/:tag',
       namedParams: { scope: '@cycle', packageName: 'core', tag: 'canary' },
-      staticPreview: this.render({ tag: 'latest', version: '6.3.0' }),
+      staticPreview: renderVersionBadge({
+        tag: 'latest',
+        version: '6.3.0',
+        defaultLabel,
+      }),
       keywords,
     },
   ]
 
   static defaultBadgeData = {
-    label: 'npm',
+    label: defaultLabel,
   }
 
   static render({ tag, version }) {


### PR DESCRIPTION
Noticed while browsing the badge listings that a few of the npm version badges had a literal 'undefined' in the label:

![image](https://user-images.githubusercontent.com/13042488/177368783-135dcc69-eb20-4f7b-a0c6-5dbbd68e1aec.png)

After poking around it seems this occurs because the examples are using the classes render function, which grabs the label value from the default badge data when rendering a tagged version badge. However, `defaultBadgeData` is still an empty object when the render function is invoked for the examples. Not 100% sure why this is the case, but it seems to be dependent on the order in which the class members are defined. Moving the `defaultBadgeData` property above the `examples` property also resolved the issue, but that violates the member order we have specified in the lint config (side note, I wonder if it would be worth revisiting this ordering to move defaults above examples?)