### PR TITLE
Fix missing conversion to `dayjs`, run [stackexchange]

### DIFF
--- a/services/stackexchange/stackexchange-monthlyquestions.service.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.service.js
@@ -1,4 +1,4 @@
-import moment from 'moment'
+import dayjs from 'dayjs'
 import Joi from 'joi'
 import { nonNegativeInteger } from '../validators.js'
 import { BaseJsonService } from '../index.js'
@@ -19,10 +19,10 @@ export default class StackExchangeMonthlyQuestions extends BaseJsonService {
   static examples = [
     {
       title: 'Stack Exchange monthly questions',
-      namedParams: { stackexchangesite: 'stackoverflow', query: 'momentjs' },
+      namedParams: { stackexchangesite: 'stackoverflow', query: 'dayjs' },
       staticPreview: this.render({
         stackexchangesite: 'stackoverflow',
-        query: 'momentjs',
+        query: 'dayjs',
         numValue: 2000,
       }),
       keywords: ['stackexchange', 'stackoverflow'],
@@ -41,12 +41,12 @@ export default class StackExchangeMonthlyQuestions extends BaseJsonService {
   }
 
   async handle({ stackexchangesite, query }) {
-    const today = moment().toDate()
-    const prevMonthStart = moment(today)
+    const today = dayjs().toDate()
+    const prevMonthStart = dayjs(today)
       .subtract(1, 'months')
       .startOf('month')
       .unix()
-    const prevMonthEnd = moment(today)
+    const prevMonthEnd = dayjs(today)
       .subtract(1, 'months')
       .endOf('month')
       .unix()

--- a/services/stackexchange/stackexchange-monthlyquestions.tester.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.tester.js
@@ -2,10 +2,10 @@ import { isMetricOverTimePeriod } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('Monthly Questions for StackOverflow Momentjs')
-  .get('/stackoverflow/qm/momentjs.json')
+t.create('Monthly Questions for StackOverflow dayjs')
+  .get('/stackoverflow/qm/dayjs.json')
   .expectBadge({
-    label: 'stackoverflow momentjs questions',
+    label: 'stackoverflow dayjs questions',
     message: isMetricOverTimePeriod,
   })
 


### PR DESCRIPTION
Should fix `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'moment' imported from /usr/src/app/services/stackexchange/stackexchange-monthlyquestions.service.js` from one file being missed in the PR #8192.