### PR TITLE
Add [Movey] service

### DIFF
--- a/services/movey/movey-base.js
+++ b/services/movey/movey-base.js
@@ -1,0 +1,37 @@
+import Joi from 'joi'
+import { nonNegativeInteger } from '../validators.js'
+import { BaseJsonService } from '../index.js'
+
+const keywords = []
+
+const schema = Joi.object({
+  package_name: Joi.string().required(),
+  total_download_counts: nonNegativeInteger,
+  latest_version: Joi.string().required(),
+  versions: Joi.array()
+    .items(
+      Joi.object({
+        version: Joi.string().required(),
+        download_counts: nonNegativeInteger,
+      })
+    )
+    .min(1)
+    .required(),
+}).required()
+
+class BaseMoveyService extends BaseJsonService {
+  static defaultBadgeData = { label: 'Movey.Net' }
+
+  async fetch({ moveyPackage }) {
+    const url = `https://www.movey.net/api/v1/packages/${moveyPackage}/badge`
+    return this._requestJson({
+      schema,
+      url,
+      errorMessages: {
+        404: 'package not found',
+      },
+    })
+  }
+}
+
+export { BaseMoveyService, keywords }

--- a/services/movey/movey-downloads.service.js
+++ b/services/movey/movey-downloads.service.js
@@ -1,0 +1,57 @@
+import { renderDownloadsBadge } from '../downloads.js'
+import { NotFound } from '../../core/base-service/index.js'
+import { BaseMoveyService, keywords } from './movey-base.js'
+
+export default class MoveyDownloads extends BaseMoveyService {
+  static category = 'downloads'
+  static route = {
+    base: 'movey',
+    pattern: 'd/:moveyPackage/:version?',
+  }
+
+  static examples = [
+    {
+      title: 'Movey.net',
+      pattern: 'd/:moveyPackage',
+      namedParams: { moveyPackage: 'BasicCoin' },
+      staticPreview: this.render({ downloads: 5000000 }),
+      keywords,
+    },
+    {
+      title: 'Movey.net (version)',
+      pattern: 'd/:moveyPackage/:version',
+      namedParams: {
+        moveyPackage: 'BasicCoin',
+        version: '0.0.1',
+      },
+      staticPreview: this.render({ downloads: 2000000 }),
+      keywords,
+    },
+  ]
+
+  static render({ downloads, version }) {
+    const colorOverride = 'A1C93E'
+    let labelOverride = 'Movey.Net'
+    if (version) {
+      labelOverride = `${labelOverride}@${version}`
+    }
+    return renderDownloadsBadge({ downloads, colorOverride, labelOverride })
+  }
+
+  async handle({ moveyPackage, version }) {
+    const json = await this.fetch({ moveyPackage })
+
+    let downloads
+    if (version) {
+      const ver = json.versions.filter(ver => ver.version === version)[0]
+      if (ver) {
+        downloads = ver.download_counts
+      } else {
+        throw new NotFound({ prettyMessage: 'version not found' })
+      }
+    } else {
+      downloads = json.total_download_counts
+    }
+    return this.constructor.render({ downloads, version })
+  }
+}

--- a/services/movey/movey-downloads.tester.js
+++ b/services/movey/movey-downloads.tester.js
@@ -1,0 +1,25 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('total downloads').get('/d/MoveStdlib.json').expectBadge({
+  label: 'Movey.Net',
+  message: isMetric,
+  color: '#a1c93e',
+})
+
+t.create('total downloads for version')
+  .get('/d/MoveStdlib/1.5.0.json')
+  .expectBadge({
+    label: 'Movey.Net@1.5.0',
+    message: isMetric,
+    color: '#a1c93e',
+  })
+
+t.create('package not found')
+  .get('/d/not-a-real-package.json')
+  .expectBadge({ label: 'Movey.Net', message: 'package not found' })
+
+t.create('version not found')
+  .get('/d/MoveStdlib/0.0.0.json')
+  .expectBadge({ label: 'Movey.Net', message: 'version not found' })

--- a/services/movey/movey-downloads.tester.js
+++ b/services/movey/movey-downloads.tester.js
@@ -1,10 +1,10 @@
-import { isMetric } from '../test-validators.js'
+import { isMetricAllowNegative } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('total downloads').get('/d/MoveStdlib.json').expectBadge({
   label: 'Movey.Net',
-  message: isMetric,
+  message: isMetricAllowNegative,
   color: '#a1c93e',
 })
 
@@ -12,14 +12,16 @@ t.create('total downloads for version')
   .get('/d/MoveStdlib/1.5.0.json')
   .expectBadge({
     label: 'Movey.Net@1.5.0',
-    message: isMetric,
+    message: isMetricAllowNegative,
     color: '#a1c93e',
   })
 
-t.create('package not found')
-  .get('/d/not-a-real-package.json')
-  .expectBadge({ label: 'Movey.Net', message: 'package not found' })
+t.create('package not found').get('/d/not-a-real-package.json').expectBadge({
+  label: 'Movey.Net',
+  message: 'package not found',
+})
 
-t.create('version not found')
-  .get('/d/MoveStdlib/0.0.0.json')
-  .expectBadge({ label: 'Movey.Net', message: 'version not found' })
+t.create('version not found').get('/d/MoveStdlib/0.0.0.json').expectBadge({
+  label: 'Movey.Net',
+  message: 'version not found',
+})

--- a/services/movey/movey-version.service.js
+++ b/services/movey/movey-version.service.js
@@ -1,0 +1,29 @@
+import { renderVersionBadge } from '../version.js'
+import { BaseMoveyService, keywords } from './movey-base.js'
+
+export default class MoveyVersion extends BaseMoveyService {
+  static category = 'version'
+  static route = {
+    base: 'movey',
+    pattern: 'v/:moveyPackage',
+  }
+
+  static examples = [
+    {
+      title: 'Movey.Net',
+      namedParams: { moveyPackage: 'BasicCoin' },
+      staticPreview: renderVersionBadge({ version: '0.0.1' }),
+      keywords,
+    },
+  ]
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
+  async handle({ moveyPackage }) {
+    const json = await this.fetch({ moveyPackage })
+    const version = json.latest_version
+    return this.constructor.render({ version })
+  }
+}

--- a/services/movey/movey-version.tester.js
+++ b/services/movey/movey-version.tester.js
@@ -2,10 +2,12 @@ import { isSemver } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('version')
-  .get('/v/MoveStdlib.json')
-  .expectBadge({ label: 'Movey.Net', message: isSemver })
+t.create('version').get('/v/MoveStdlib.json').expectBadge({
+  label: 'Movey.Net',
+  message: isSemver,
+})
 
-t.create('version (not found)')
-  .get('/v/not-a-real-package.json')
-  .expectBadge({ label: 'Movey.Net', message: 'package not found' })
+t.create('version (not found)').get('/v/not-a-real-package.json').expectBadge({
+  label: 'Movey.Net',
+  message: 'package not found',
+})

--- a/services/movey/movey-version.tester.js
+++ b/services/movey/movey-version.tester.js
@@ -1,0 +1,11 @@
+import { isSemver } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('version')
+  .get('/v/MoveStdlib.json')
+  .expectBadge({ label: 'Movey.Net', message: isSemver })
+
+t.create('version (not found)')
+  .get('/v/not-a-real-package.json')
+  .expectBadge({ label: 'Movey.Net', message: 'package not found' })


### PR DESCRIPTION
## Description

This request is to add a badge for Movey ([Movey.net](https://www.movey.net/))
A [crates.io](https://crates.io/)-style repository of [Move](https://github.com/move-language/move) packages.
This badge will show the latest version of a package on Movey and its download counts.
We also provide data for any other versions and their perspective download count too.
[https://img.shields.io/badge/Movey-v1.0.0-green](https://img.shields.io/badge/Movey-v1.0.0-green)
https://img.shields.io/badge/download@v1.0.0-10k-brightgreen
## Data

Movey will be publishing a public badge endpoint at https://www.movey.net/api/v1/packages/%package%/badge
As of right now we do not have any plan to add apikey or rate limit this api just yet.
The API will return:
*example*
``` json
{
    "package_name": "rand",
    "total_download_counts": 100000,
    "latest_version": "1.1.0",
    "versions": [
        {
            "versions": "1.0.0",
            "download_counts": 0
        },
        {
            "versions": "1.1.0",
            "download_counts": 11111
        }
    ]
}
```

## Motivation
As we aim to be the Move language package repository, having a badge so that package owners can show off their statistics on their repos and let user know they are hosted on Movey would be tremendous