### PR TITLE
Add OSSF Scorecard badge

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -3,10 +3,10 @@ on:
   push:
     # Only the default branch is supported.
     branches:
-    - master
+      - master
   schedule:
     # Weekly on Saturdays.
-    - cron:  '30 1 * * 6'
+    - cron: '30 1 * * 6'
 
 permissions: read-all
 
@@ -18,28 +18,28 @@ jobs:
       security-events: write
       id-token: write
     steps:
-      - name: "Checkout code"
+      - name: 'Checkout code'
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: "Run analysis"
+      - name: 'Run analysis'
         uses: ossf/scorecard-action@3155d134e59d8f47261b1ae9d143034c69572227 # v2.0.0-beta.1
         with:
           results_file: results.sarif
           results_format: sarif
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Publish the results for public repositories to enable scorecard badges. For more details, see
-          # https://github.com/ossf/scorecard-action#publishing-results. 
-          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
           # of the value entered here.
           publish_results: true
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       # Optional.
-      - name: "Upload artifact"
+      - name: 'Upload artifact'
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      - name: "Upload SARIF results"
+      - name: 'Upload SARIF results'
         uses: github/codeql-action/upload-sarif@f5d822707ee6e8fb81b04a5c0040b736da22e587 # v1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,45 @@
+name: OSSF Scorecard
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+    - master
+  schedule:
+    # Weekly on Saturdays.
+    - cron:  '30 1 * * 6'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@3155d134e59d8f47261b1ae9d143034c69572227 # v2.0.0-beta.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results. 
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless 
+          # of the value entered here.
+          publish_results: true
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      # Optional.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+      - name: "Upload SARIF results"
+        uses: github/codeql-action/upload-sarif@f5d822707ee6e8fb81b04a5c0040b736da22e587 # v1
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
     <a href="https://lgtm.com/projects/g/badges/shields/alerts/">
         <img src="https://img.shields.io/lgtm/alerts/g/badges/shields"
             alt="Total alerts"/></a>
+    <a href="https://api.securityscorecards.dev/projects/github.com/badges/shields">
+        <img src="https://api.securityscorecards.dev/projects/github.com/badges/shields/badge" /></a>
     <a href="https://discord.gg/HjJCwm5">
         <img src="https://img.shields.io/discord/308323056592486420?logo=discord"
             alt="chat on Discord"></a>


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

This PR adds the OSSF Scorecard badge for badges/shields. The `ossf/scorecard-action` GitHub Action is needed to enable this badge since the result published by this action is used to update the badge result in a timely manner.

`badges/shields` repo is rated quite high in the [OSSF criticality_score](https://github.com/ossf/criticality_score) (criticality rate of 0.7 out of 1). So it would be great to have this repo enabled and running Scorecard.

Note to reviewers: the GitHub action steps which upload the SARIF results are totally optional and not needed for enabling the badge. It'll be useful to enable them because Scorecard will provide code scanning alerts for any issues it finds on the repository. 

PS: the Scorecard badge is powered by shields.io :) 
