### PR TITLE
Correct the fetch URL for Github Actions workflow status badge

### DIFF
--- a/services/github/github-workflow-status.service.js
+++ b/services/github/github-workflow-status.service.js
@@ -80,7 +80,7 @@ export default class GithubWorkflowStatus extends BaseSvgScrapingService {
   async fetch({ user, repo, workflow, branch, event }) {
     const { message: status } = await this._requestSvg({
       schema,
-      url: `https://github.com/${user}/${repo}/workflows/${encodeURIComponent(
+      url: `https://github.com/${user}/${repo}/actions/workflows/${encodeURIComponent(
         workflow
       )}/badge.svg`,
       options: { searchParams: { branch, event } },


### PR DESCRIPTION
Fixes: #8309

The Github Actions workflow status badge fetches the wrong URL for the native badge SVG.

This PR prepends `/actions/` to `/workflows/` in the URL.