### PR TITLE
Custom domains for [JitPack] artifacts

### DIFF
--- a/services/jitpack/jitpack-version-redirector.service.js
+++ b/services/jitpack/jitpack-version-redirector.service.js
@@ -5,10 +5,20 @@ export default [
     category: 'version',
     route: {
       base: 'jitpack/v',
-      pattern: ':groupId/:artifactId',
+      pattern: ':user/:repo',
     },
-    transformPath: ({ groupId, artifactId }) =>
-      `/jitpack/v/github/${groupId}/${artifactId}`,
+    transformPath: ({ user, repo }) =>
+      `/jitpack/version/com.github.${user}/${repo}`,
     dateAdded: new Date('2019-03-31'),
+  }),
+  redirector({
+    category: 'version',
+    route: {
+      base: 'jitpack/v',
+      pattern: ':vcs(github|bitbucket|gitlab|gitee)/:user/:repo',
+    },
+    transformPath: ({ vcs, user, repo }) =>
+      `/jitpack/version/com.${vcs}.${user}/${repo}`,
+    dateAdded: new Date('2022-08-21'),
   }),
 ]

--- a/services/jitpack/jitpack-version-redirector.service.js
+++ b/services/jitpack/jitpack-version-redirector.service.js
@@ -3,16 +3,18 @@ import { redirector } from '../index.js'
 export default [
   redirector({
     category: 'version',
+    name: 'github as default vcs',
     route: {
       base: 'jitpack/v',
       pattern: ':user/:repo',
     },
     transformPath: ({ user, repo }) =>
       `/jitpack/version/com.github.${user}/${repo}`,
-    dateAdded: new Date('2019-03-31'),
+    dateAdded: new Date('2022-08-21'),
   }),
   redirector({
     category: 'version',
+    name: 'vcs',
     route: {
       base: 'jitpack/v',
       pattern: ':vcs(github|bitbucket|gitlab|gitee)/:user/:repo',

--- a/services/jitpack/jitpack-version-redirector.service.js
+++ b/services/jitpack/jitpack-version-redirector.service.js
@@ -3,7 +3,7 @@ import { redirector } from '../index.js'
 export default [
   redirector({
     category: 'version',
-    name: 'github as default vcs',
+    name: 'JitpackVersionGitHubRedirect',
     route: {
       base: 'jitpack/v',
       pattern: ':user/:repo',
@@ -14,7 +14,7 @@ export default [
   }),
   redirector({
     category: 'version',
-    name: 'vcs',
+    name: 'JitpackVersionVcsRedirect',
     route: {
       base: 'jitpack/v',
       pattern: ':vcs(github|bitbucket|gitlab|gitee)/:user/:repo',

--- a/services/jitpack/jitpack-version-redirector.tester.js
+++ b/services/jitpack/jitpack-version-redirector.tester.js
@@ -6,6 +6,10 @@ export const t = new ServiceTester({
   pathPrefix: '/jitpack/v',
 })
 
-t.create('jitpack version redirect')
+t.create('jitpack version redirect (no vcs)')
   .get('/jitpack/maven-simple.svg')
-  .expectRedirect('/jitpack/v/github/jitpack/maven-simple.svg')
+  .expectRedirect('/jitpack/version/com.github.jitpack/maven-simple.svg')
+
+t.create('jitpack version redirect (github)')
+  .get('/github/jitpack/maven-simple.svg')
+  .expectRedirect('/jitpack/version/com.github.jitpack/maven-simple.svg')

--- a/services/jitpack/jitpack-version.service.js
+++ b/services/jitpack/jitpack-version.service.js
@@ -12,7 +12,7 @@ export default class JitPackVersion extends BaseJsonService {
 
   static route = {
     base: 'jitpack/version',
-    pattern: ':groupId/:artifactId'
+    pattern: ':groupId/:artifactId',
   }
 
   static examples = [

--- a/services/jitpack/jitpack-version.service.js
+++ b/services/jitpack/jitpack-version.service.js
@@ -10,6 +10,8 @@ const schema = Joi.object({
 export default class JitPackVersion extends BaseJsonService {
   static category = 'version'
 
+  // Changed endpoint to allow any groupId, custom domains included
+  // See: https://github.com/badges/shields/issues/8312
   static route = {
     base: 'jitpack/version',
     pattern: ':groupId/:artifactId',

--- a/services/jitpack/jitpack-version.service.js
+++ b/services/jitpack/jitpack-version.service.js
@@ -11,17 +11,16 @@ export default class JitPackVersion extends BaseJsonService {
   static category = 'version'
 
   static route = {
-    base: 'jitpack/v',
-    pattern: ':vcs(github|bitbucket|gitlab|gitee)/:user/:repo',
+    base: 'jitpack/version',
+    pattern: ':groupId/:artifactId'
   }
 
   static examples = [
     {
       title: 'JitPack',
       namedParams: {
-        vcs: 'github',
-        user: 'jitpack',
-        repo: 'maven-simple',
+        groupId: 'com.github.jitpack',
+        artifactId: 'maven-simple',
       },
       staticPreview: renderVersionBadge({ version: 'v1.1' }),
       keywords: ['java', 'maven'],
@@ -30,8 +29,8 @@ export default class JitPackVersion extends BaseJsonService {
 
   static defaultBadgeData = { label: 'jitpack' }
 
-  async fetch({ vcs, user, repo }) {
-    const url = `https://jitpack.io/api/builds/com.${vcs}.${user}/${repo}/latestOk`
+  async fetch({ groupId, artifactId }) {
+    const url = `https://jitpack.io/api/builds/${groupId}/${artifactId}/latestOk`
 
     return this._requestJson({
       schema,
@@ -40,8 +39,8 @@ export default class JitPackVersion extends BaseJsonService {
     })
   }
 
-  async handle({ vcs, user, repo }) {
-    const { version } = await this.fetch({ vcs, user, repo })
+  async handle({ groupId, artifactId }) {
+    const { version } = await this.fetch({ groupId, artifactId })
     return renderVersionBadge({ version })
   }
 }

--- a/services/jitpack/jitpack-version.tester.js
+++ b/services/jitpack/jitpack-version.tester.js
@@ -6,9 +6,9 @@ export const t = await createServiceTester()
 const isAnyV = Joi.string().regex(/^v.+$/)
 
 t.create('version (groupId)')
-  .get('/github/erayerdin/kappdirs.json')
+  .get('/com.github.erayerdin/kappdirs.json')
   .expectBadge({ label: 'jitpack', message: isAnyV })
 
 t.create('unknown package')
-  .get('/github/some-bogus-user/project.json')
+  .get('/com.github.some-bogus-user/project.json')
   .expectBadge({ label: 'jitpack', message: 'project not found or private' })


### PR DESCRIPTION
closes #8312 

Introduced a new `jitpack/version` endpoint: `jitpack/v` redirects to it, either with no VCS (still defaulting to GitHub), or with a VCS previously supported.

It uses the full `groupId` from jitpack as input (usually `com.github.user`, but custom domains, like `io.jitpack`, as well).