### PR TITLE
improve workflow job names

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -5,7 +5,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  auto-close:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-docker-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -8,7 +8,7 @@ permissions:
   contents: write
 
 jobs:
-  build-and-deploy:
+  deploy-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  draft-release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/enforce-dependency-review.yml
+++ b/.github/workflows/enforce-dependency-review.yml
@@ -2,7 +2,7 @@ name: 'Dependency Review'
 on: [pull_request]
 
 jobs:
-  dependency-review:
+  enforce-dependency-review:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'

--- a/.github/workflows/publish-docker-next.yml
+++ b/.github/workflows/publish-docker-next.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 jobs:
-  build:
+  publish-docker-next:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
I wanted to add `build-docker-image` as a required build to merge to master. Given we deploy to fly using that image now, I think that should be an essential check.

GitHub lists the checks you can use as a branch protection rule by job name, which is unhelpful if you've got 4 different jobs which are all called `build`. This PR gives each job a unique name which is the same as the name of the workflow file.