### PR TITLE
conform to standard js quote rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -144,6 +144,8 @@ rules:
   func-style: ['error', 'declaration', { 'allowArrowFunctions': true }]
   new-cap: ['error', { 'capIsNew': true }]
   import/order: ['error', { 'newlines-between': 'never' }]
+  quotes:
+    ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': false }]
 
   # Account for destructuring responses from upstream services,
   # many of which do not follow camelcase

--- a/.github/actions/close-bot/index.js
+++ b/.github/actions/close-bot/index.js
@@ -27,7 +27,7 @@ async function run() {
           state: 'closed',
         })
 
-        core.debug(`Done.`)
+        core.debug('Done.')
       }
     }
   } catch (error) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -114,7 +114,7 @@ if (allFiles.length > 100) {
       if (diff.includes('authHelper') && !secretsDocs.modified) {
         warn(
           [
-            `:books: Remember to ensure any changes to \`config.private\` `,
+            ':books: Remember to ensure any changes to `config.private` ',
             `in \`${file}\` are reflected in the [server secrets documentation]`,
             '(https://github.com/badges/shields/blob/master/doc/server-secrets.md)',
           ].join('')

--- a/lib/load-simple-icons.js
+++ b/lib/load-simple-icons.js
@@ -18,8 +18,8 @@ function loadSimpleIcons() {
 
     icon.base64 = {
       default: svg2base64(icon.svg.replace('<svg', `<svg fill="#${hex}"`)),
-      light: svg2base64(icon.svg.replace('<svg', `<svg fill="whitesmoke"`)),
-      dark: svg2base64(icon.svg.replace('<svg', `<svg fill="#333"`)),
+      light: svg2base64(icon.svg.replace('<svg', '<svg fill="whitesmoke"')),
+      dark: svg2base64(icon.svg.replace('<svg', '<svg fill="#333"')),
     }
 
     // There are a few instances where multiple icons have the same title

--- a/scripts/capture-timings.js
+++ b/scripts/capture-timings.js
@@ -29,7 +29,7 @@ async function captureTimings(warmupIterations) {
 function logResults({ times, iterations, warmupIterations }) {
   if (isNaN(iterations)) {
     console.log(
-      `No timings captured. Have you included console.time statements in the badge creation code path?`
+      'No timings captured. Have you included console.time statements in the badge creation code path?'
     )
   } else {
     const timedIterations = iterations - warmupIterations

--- a/services/azure-devops/azure-devops-tests.tester.js
+++ b/services/azure-devops/azure-devops-tests.tester.js
@@ -8,7 +8,7 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('unknown build definition')
-  .get(`/swellaby/opensource/99999999.json`)
+  .get('/swellaby/opensource/99999999.json')
   .expectBadge({ label: 'tests', message: 'build pipeline not found' })
 
 t.create('404 latest build error response')
@@ -51,7 +51,7 @@ t.create('no test result summary response')
   })
 
 t.create('no build response')
-  .get(`/swellaby/opensource/174.json`)
+  .get('/swellaby/opensource/174.json')
   .expectBadge({ label: 'tests', message: 'build pipeline not found' })
 
 t.create('no tests in test result summary response')

--- a/services/bitbucket/bitbucket-pull-request.service.js
+++ b/services/bitbucket/bitbucket-pull-request.service.js
@@ -27,7 +27,7 @@ function pullRequestClassGenerator(raw) {
     static category = 'issue-tracking'
     static route = {
       base: `bitbucket/${routePrefix}`,
-      pattern: `:user/:repo`,
+      pattern: ':user/:repo',
       queryParamSchema,
     }
 

--- a/services/cii-best-practices/cii-best-practices.tester.js
+++ b/services/cii-best-practices/cii-best-practices.tester.js
@@ -3,32 +3,32 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('level known project')
-  .get(`/level/1.json`)
+  .get('/level/1.json')
   .expectBadge({
     label: 'cii',
     message: withRegex(/in progress|passing|silver|gold/),
   })
 
 t.create('percentage known project')
-  .get(`/percentage/29.json`)
+  .get('/percentage/29.json')
   .expectBadge({
     label: 'cii',
     message: withRegex(/([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-9][0-9]|300)%/),
   })
 
 t.create('summary known project')
-  .get(`/summary/33.json`)
+  .get('/summary/33.json')
   .expectBadge({
     label: 'cii',
     message: withRegex(/(in progress [0-9]|[1-9][0-9]%)|passing|silver|gold/),
   })
 
 t.create('unknown project')
-  .get(`/level/abc.json`)
+  .get('/level/abc.json')
   .expectBadge({ label: 'cii', message: 'project not found' })
 
 t.create('level: gold project')
-  .get(`/level/1.json`)
+  .get('/level/1.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/1/badge.json')
@@ -43,7 +43,7 @@ t.create('level: gold project')
   })
 
 t.create('level: silver project')
-  .get(`/level/34.json`)
+  .get('/level/34.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/34/badge.json')
@@ -58,7 +58,7 @@ t.create('level: silver project')
   })
 
 t.create('level: passing project')
-  .get(`/level/29.json`)
+  .get('/level/29.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/29/badge.json')
@@ -73,7 +73,7 @@ t.create('level: passing project')
   })
 
 t.create('level: in progress project')
-  .get(`/level/33.json`)
+  .get('/level/33.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/33/badge.json')
@@ -88,7 +88,7 @@ t.create('level: in progress project')
   })
 
 t.create('percentage: gold project')
-  .get(`/percentage/1.json`)
+  .get('/percentage/1.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/1/badge.json')
@@ -103,7 +103,7 @@ t.create('percentage: gold project')
   })
 
 t.create('percentage: silver project')
-  .get(`/percentage/34.json`)
+  .get('/percentage/34.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/34/badge.json')
@@ -118,7 +118,7 @@ t.create('percentage: silver project')
   })
 
 t.create('percentage: passing project')
-  .get(`/percentage/29.json`)
+  .get('/percentage/29.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/29/badge.json')
@@ -133,7 +133,7 @@ t.create('percentage: passing project')
   })
 
 t.create('percentage: in progress project')
-  .get(`/percentage/33.json`)
+  .get('/percentage/33.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/33/badge.json')
@@ -148,7 +148,7 @@ t.create('percentage: in progress project')
   })
 
 t.create('summary: gold project')
-  .get(`/summary/1.json`)
+  .get('/summary/1.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/1/badge.json')
@@ -163,7 +163,7 @@ t.create('summary: gold project')
   })
 
 t.create('summary: silver project')
-  .get(`/summary/34.json`)
+  .get('/summary/34.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/34/badge.json')
@@ -178,7 +178,7 @@ t.create('summary: silver project')
   })
 
 t.create('summary: passing project')
-  .get(`/summary/29.json`)
+  .get('/summary/29.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/29/badge.json')
@@ -193,7 +193,7 @@ t.create('summary: passing project')
   })
 
 t.create('summary: in progress project')
-  .get(`/summary/33.json`)
+  .get('/summary/33.json')
   .intercept(nock =>
     nock('https://bestpractices.coreinfrastructure.org/projects')
       .get('/33/badge.json')

--- a/services/codecov/codecov.tester.js
+++ b/services/codecov/codecov.tester.js
@@ -60,7 +60,7 @@ t.create('handles unauthorized private repository')
   .intercept(nock =>
     nock('https://codecov.io')
       .get('/github/codecov/private-example-python/graph/badge.svg')
-      .reply(200, `<g><text x="105.5" y="14">unknown</text></g>`, {
+      .reply(200, '<g><text x="105.5" y="14">unknown</text></g>', {
         'Content-Type': 'image/svg+xml',
       })
   )
@@ -110,7 +110,7 @@ t.create('gets coverage for private repository')
       .get(
         '/gh/codecov/private-example-python/graph/badge.svg?token=a1b2c3d4e5'
       )
-      .reply(200, `<g><text x="105.5" y="14">100%</text></g>`, {
+      .reply(200, '<g><text x="105.5" y="14">100%</text></g>', {
         'Content-Type': 'image/svg+xml',
       })
   )

--- a/services/discord/discord.spec.js
+++ b/services/discord/discord.spec.js
@@ -14,12 +14,12 @@ describe('Discord', function () {
       },
     }
 
-    const scope = nock(`https://discord.com`, {
+    const scope = nock('https://discord.com', {
       // This ensures that the expected credential is actually being sent with the HTTP request.
       // Without this the request wouldn't match and the test would fail.
-      reqheaders: { Authorization: `Bot password` },
+      reqheaders: { Authorization: 'Bot password' },
     })
-      .get(`/api/v6/guilds/12345/widget.json`)
+      .get('/api/v6/guilds/12345/widget.json')
       .reply(200, {
         presence_count: 125,
       })

--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -72,7 +72,7 @@ class DiscourseStatus extends DiscourseBase {
   static route = this.buildRoute('status')
   static examples = [
     {
-      title: `Discourse status`,
+      title: 'Discourse status',
       namedParams: {},
       queryParams: {
         server: 'https://meta.discourse.org',

--- a/services/docker/docker-cloud-automated.tester.js
+++ b/services/docker/docker-cloud-automated.tester.js
@@ -16,16 +16,16 @@ t.create('docker cloud automated build status (invalid, nonexisting user)')
   .get('/pavicsssss/magpie.json')
   .expectBadge({
     label: 'docker build',
-    message: `manual`,
+    message: 'manual',
   })
 
 t.create(
-  `docker cloud build status (valid user, but the 'objects' array from the response is empty)`
+  "docker cloud build status (valid user, but the 'objects' array from the response is empty)"
 )
   .get('/pavics/weaver.json')
   .expectBadge({
     label: 'docker build',
-    message: `manual`,
+    message: 'manual',
   })
 
 t.create('docker cloud automated build (not found)')

--- a/services/docker/docker-cloud-build.service.js
+++ b/services/docker/docker-cloud-build.service.js
@@ -34,7 +34,7 @@ export default class DockerCloudBuild extends BaseJsonService {
 
     if (data.objects.length === 0) {
       throw new NotFound({
-        prettyMessage: `automated builds not set up`,
+        prettyMessage: 'automated builds not set up',
       })
     }
     return this.constructor.render({ state: data.objects[0].state })

--- a/services/docker/docker-cloud-build.tester.js
+++ b/services/docker/docker-cloud-build.tester.js
@@ -14,16 +14,16 @@ t.create('docker cloud build status (invalid, nonexisting user)')
   .get('/pavicsssss/magpie.json')
   .expectBadge({
     label: 'docker build',
-    message: `automated builds not set up`,
+    message: 'automated builds not set up',
   })
 
 t.create(
-  `docker cloud build status (valid user, but the 'objects' array from the response is empty)`
+  "docker cloud build status (valid user, but the 'objects' array from the response is empty)"
 )
   .get('/pavics/weaver.json')
   .expectBadge({
     label: 'docker build',
-    message: `automated builds not set up`,
+    message: 'automated builds not set up',
   })
 
 t.create('docker cloud build status (not found)')

--- a/services/docker/docker-cloud-common-fetch.js
+++ b/services/docker/docker-cloud-common-fetch.js
@@ -14,7 +14,7 @@ const cloudBuildSchema = Joi.object({
 async function fetchBuild(serviceInstance, { user, repo }) {
   return serviceInstance._requestJson({
     schema: cloudBuildSchema,
-    url: `https://cloud.docker.com/api/build/v1/source`,
+    url: 'https://cloud.docker.com/api/build/v1/source',
     options: { searchParams: { image: `${user}/${repo}` } },
     errorMessages: { 404: 'repo not found' },
   })

--- a/services/drone/drone-build.spec.js
+++ b/services/drone/drone-build.spec.js
@@ -10,7 +10,7 @@ describe('DroneBuild', function () {
     const token = 'abc123'
 
     const scope = nock('https://cloud.drone.io', {
-      reqheaders: { Authorization: `Bearer abc123` },
+      reqheaders: { Authorization: 'Bearer abc123' },
     })
       .get(/.*/)
       .reply(200, { status: 'passing' })

--- a/services/freecodecamp/freecodecamp-points.service.js
+++ b/services/freecodecamp/freecodecamp-points.service.js
@@ -46,7 +46,7 @@ export default class FreeCodeCampPoints extends BaseJsonService {
   async fetch({ username }) {
     return this._requestJson({
       schema,
-      url: `https://api.freecodecamp.org/api/users/get-public-profile`,
+      url: 'https://api.freecodecamp.org/api/users/get-public-profile',
       options: {
         searchParams: {
           username,

--- a/services/github/github-auth-service.js
+++ b/services/github/github-auth-service.js
@@ -40,7 +40,7 @@ class GithubAuthV4Service extends BaseGraphqlService {
   }
 
   async _requestGraphql(attrs) {
-    const url = `/graphql`
+    const url = '/graphql'
 
     /*
     The Github v4 API requires us to query the rateLimit object to return

--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -160,7 +160,7 @@ export default class GithubHacktoberfestCombinedStatus extends GithubAuthV4Servi
       `repo:${user}/${repo}`,
       'is:pr',
       `created:${year}-10-01..${year}-10-31`,
-      `-label:invalid`,
+      '-label:invalid',
     ]
       .filter(Boolean)
       .join(' ')

--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -35,7 +35,7 @@ export default class GithubLabels extends GithubAuthV3Service {
     return this._requestJson({
       url: `/repos/${user}/${repo}/labels/${name}`,
       schema,
-      errorMessages: errorMessagesFor(`repo or label not found`),
+      errorMessages: errorMessagesFor('repo or label not found'),
     })
   }
 

--- a/services/github/github-milestone-detail.service.js
+++ b/services/github/github-milestone-detail.service.js
@@ -85,7 +85,7 @@ export default class GithubMilestoneDetail extends GithubAuthV3Service {
     return this._requestJson({
       url: `/repos/${user}/${repo}/milestones/${number}`,
       schema,
-      errorMessages: errorMessagesFor(`repo or milestone not found`),
+      errorMessages: errorMessagesFor('repo or milestone not found'),
     })
   }
 

--- a/services/github/github-milestone.service.js
+++ b/services/github/github-milestone.service.js
@@ -70,7 +70,7 @@ export default class GithubMilestone extends GithubAuthV3Service {
     return this._requestJson({
       url: `/repos/${user}/${repo}/milestones?state=${variant}`,
       schema,
-      errorMessages: errorMessagesFor(`repo not found`),
+      errorMessages: errorMessagesFor('repo not found'),
     })
   }
 

--- a/services/github/github-total-star.service.js
+++ b/services/github/github-total-star.service.js
@@ -108,7 +108,7 @@ const query = gql`
 
 const affiliationsAllowedValues = [
   'OWNER',
-  `COLLABORATOR`,
+  'COLLABORATOR',
   'ORGANIZATION_MEMBER',
 ]
 /**

--- a/services/gradle-plugin-portal/gradle-plugin-portal.service.js
+++ b/services/gradle-plugin-portal/gradle-plugin-portal.service.js
@@ -26,7 +26,7 @@ export default redirector({
       documentation,
     },
   ],
-  transformPath: () => `/maven-metadata/v`,
+  transformPath: () => '/maven-metadata/v',
   transformQueryParams: ({ pluginId }) => {
     const groupPath = pluginId.replace(/\./g, '/')
     const artifactId = `${pluginId}.gradle.plugin`

--- a/services/hsts/hsts.service.js
+++ b/services/hsts/hsts.service.js
@@ -55,7 +55,7 @@ export default class HSTS extends BaseJsonService {
   async fetch({ domain }) {
     return this._requestJson({
       schema,
-      url: `https://hstspreload.org/api/v2/status`,
+      url: 'https://hstspreload.org/api/v2/status',
       options: { searchParams: { domain } },
     })
   }

--- a/services/maintenance/maintenance.service.js
+++ b/services/maintenance/maintenance.service.js
@@ -34,7 +34,7 @@ export default class Maintenance extends BaseService {
     }
 
     return {
-      message: `${isStale ? `stale` : 'no!'} (as of ${targetYear})`,
+      message: `${isStale ? 'stale' : 'no!'} (as of ${targetYear})`,
       color: isStale ? undefined : 'red',
     }
   }

--- a/services/maven-central/maven-central.service.js
+++ b/services/maven-central/maven-central.service.js
@@ -28,7 +28,7 @@ export default redirector({
       documentation,
     },
   ],
-  transformPath: () => `/maven-metadata/v`,
+  transformPath: () => '/maven-metadata/v',
   transformQueryParams: ({ groupId, artifactId, versionPrefix }) => {
     const group = encodeURIComponent(groupId).replace(/\./g, '/')
     const artifact = encodeURIComponent(artifactId)

--- a/services/mozilla-observatory/mozilla-observatory.service.js
+++ b/services/mozilla-observatory/mozilla-observatory.service.js
@@ -99,7 +99,7 @@ export default class MozillaObservatory extends BaseJsonService {
   async fetch({ host, publish }) {
     return this._requestJson({
       schema,
-      url: `https://http-observatory.security.mozilla.org/api/v1/analyze`,
+      url: 'https://http-observatory.security.mozilla.org/api/v1/analyze',
       options: {
         method: 'POST',
         searchParams: { host },

--- a/services/node/node-current.service.js
+++ b/services/node/node-current.service.js
@@ -12,5 +12,6 @@ export default class NodeCurrentVersion extends NodeVersionBase {
 
   static colorResolver = versionColorForRangeCurrent
 
-  static documentation = `This badge indicates whether the package supports the <b>latest</b> release of node`
+  static documentation =
+    'This badge indicates whether the package supports the <b>latest</b> release of node'
 }

--- a/services/node/node-current.tester.js
+++ b/services/node/node-current.tester.js
@@ -25,7 +25,7 @@ t.create('engines satisfies current node version')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node', message: `>=0.4.0`, color: `brightgreen` })
+  .expectBadge({ label: 'node', message: '>=0.4.0', color: 'brightgreen' })
 
 t.create('engines does not satisfy current node version')
   .get('/passport.json')
@@ -36,7 +36,7 @@ t.create('engines does not satisfy current node version')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node', message: `12`, color: `yellow` })
+  .expectBadge({ label: 'node', message: '12', color: 'yellow' })
 
 t.create('gets the node version of @stdlib/stdlib')
   .get('/@stdlib/stdlib.json')
@@ -57,7 +57,7 @@ t.create('engines satisfies current node version - scoped')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node', message: `>=0.4.0`, color: `brightgreen` })
+  .expectBadge({ label: 'node', message: '>=0.4.0', color: 'brightgreen' })
 
 t.create('engines does not satisfy current node version - scoped')
   .get('/@stdlib/stdlib.json')
@@ -71,7 +71,7 @@ t.create('engines does not satisfy current node version - scoped')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node', message: `12`, color: `yellow` })
+  .expectBadge({ label: 'node', message: '12', color: 'yellow' })
 
 t.create("gets the tagged release's node version version of ionic")
   .get('/ionic/testing.json')
@@ -92,8 +92,8 @@ t.create('engines satisfies current node version - tagged')
   .intercept(mockCurrentSha(13))
   .expectBadge({
     label: 'node@testing',
-    message: `>=0.4.0`,
-    color: `brightgreen`,
+    message: '>=0.4.0',
+    color: 'brightgreen',
   })
 
 t.create('engines does not satisfy current node version - tagged')
@@ -106,7 +106,7 @@ t.create('engines does not satisfy current node version - tagged')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node@testing', message: `12`, color: `yellow` })
+  .expectBadge({ label: 'node@testing', message: '12', color: 'yellow' })
 
 t.create("gets the tagged release's node version of @cycle/core")
   .get('/@cycle/core/canary.json')
@@ -128,8 +128,8 @@ t.create('engines satisfies current node version - scoped and tagged')
   .intercept(mockCurrentSha(13))
   .expectBadge({
     label: 'node@canary',
-    message: `>=0.4.0`,
-    color: `brightgreen`,
+    message: '>=0.4.0',
+    color: 'brightgreen',
   })
 
 t.create('engines does not satisfy current node version - scoped and tagged')
@@ -143,7 +143,7 @@ t.create('engines does not satisfy current node version - scoped and tagged')
     })
   )
   .intercept(mockCurrentSha(13))
-  .expectBadge({ label: 'node@canary', message: `12`, color: `yellow` })
+  .expectBadge({ label: 'node@canary', message: '12', color: 'yellow' })
 
 t.create('gets the node version of passport from a custom registry')
   .get('/passport.json?registry_uri=https://registry.npmjs.com')

--- a/services/node/node-lts.service.js
+++ b/services/node/node-lts.service.js
@@ -12,5 +12,6 @@ export default class NodeLtsVersion extends NodeVersionBase {
 
   static colorResolver = versionColorForRangeLts
 
-  static documentation = `This badge indicates whether the package supports <b>all</b> LTS node versions`
+  static documentation =
+    'This badge indicates whether the package supports <b>all</b> LTS node versions'
 }

--- a/services/node/node-lts.tester.js
+++ b/services/node/node-lts.tester.js
@@ -30,7 +30,7 @@ t.create('engines satisfies all lts node versions')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `10 - 12`, color: `brightgreen` })
+  .expectBadge({ label: 'node-lts', message: '10 - 12', color: 'brightgreen' })
 
 t.create('engines does not satisfy all lts node versions')
   .get('/passport.json')
@@ -42,7 +42,7 @@ t.create('engines does not satisfy all lts node versions')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `8`, color: `orange` })
+  .expectBadge({ label: 'node-lts', message: '8', color: 'orange' })
 
 t.create('engines satisfies some lts node versions')
   .get('/passport.json')
@@ -54,7 +54,7 @@ t.create('engines satisfies some lts node versions')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `10`, color: `yellow` })
+  .expectBadge({ label: 'node-lts', message: '10', color: 'yellow' })
 
 t.create('gets the node version of @stdlib/stdlib')
   .get('/@stdlib/stdlib.json')
@@ -74,7 +74,7 @@ t.create('engines satisfies all lts node versions - scoped')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `10 - 12`, color: `brightgreen` })
+  .expectBadge({ label: 'node-lts', message: '10 - 12', color: 'brightgreen' })
 
 t.create('engines does not satisfy all lts node versions - scoped')
   .get('/@stdlib/stdlib.json')
@@ -87,7 +87,7 @@ t.create('engines does not satisfy all lts node versions - scoped')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `8`, color: `orange` })
+  .expectBadge({ label: 'node-lts', message: '8', color: 'orange' })
 
 t.create('engines satisfies some lts node versions - scoped')
   .get('/@stdlib/stdlib.json')
@@ -100,7 +100,7 @@ t.create('engines satisfies some lts node versions - scoped')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts', message: `10`, color: `yellow` })
+  .expectBadge({ label: 'node-lts', message: '10', color: 'yellow' })
 
 t.create("gets the tagged release's node version version of ionic")
   .get('/ionic/testing.json')
@@ -122,8 +122,8 @@ t.create('engines satisfies all lts node versions - tagged')
   .intercept(mockVersionsSha())
   .expectBadge({
     label: 'node-lts@testing',
-    message: `10 - 12`,
-    color: `brightgreen`,
+    message: '10 - 12',
+    color: 'brightgreen',
   })
 
 t.create('engines does not satisfy all lts node versions - tagged')
@@ -137,7 +137,7 @@ t.create('engines does not satisfy all lts node versions - tagged')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts@testing', message: `8`, color: `orange` })
+  .expectBadge({ label: 'node-lts@testing', message: '8', color: 'orange' })
 
 t.create('engines satisfies some lts node versions - tagged')
   .get('/ionic/testing.json')
@@ -150,7 +150,7 @@ t.create('engines satisfies some lts node versions - tagged')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts@testing', message: `10`, color: `yellow` })
+  .expectBadge({ label: 'node-lts@testing', message: '10', color: 'yellow' })
 
 t.create("gets the tagged release's node version of @cycle/core")
   .get('/@cycle/core/canary.json')
@@ -173,8 +173,8 @@ t.create('engines satisfies all lts node versions - scoped and tagged')
   .intercept(mockVersionsSha())
   .expectBadge({
     label: 'node-lts@canary',
-    message: `10 - 12`,
-    color: `brightgreen`,
+    message: '10 - 12',
+    color: 'brightgreen',
   })
 
 t.create('engines does not satisfy all lts node versions - scoped and tagged')
@@ -189,7 +189,7 @@ t.create('engines does not satisfy all lts node versions - scoped and tagged')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts@canary', message: `8`, color: `orange` })
+  .expectBadge({ label: 'node-lts@canary', message: '8', color: 'orange' })
 
 t.create('engines satisfies some lts node versions - scoped and tagged')
   .get('/@cycle/core/canary.json')
@@ -203,7 +203,7 @@ t.create('engines satisfies some lts node versions - scoped and tagged')
     })
   )
   .intercept(mockVersionsSha())
-  .expectBadge({ label: 'node-lts@canary', message: `10`, color: `yellow` })
+  .expectBadge({ label: 'node-lts@canary', message: '10', color: 'yellow' })
 
 t.create('gets the node version of passport from a custom registry')
   .get('/passport.json?registry_uri=https://registry.npmjs.com')

--- a/services/node/node-version-color.js
+++ b/services/node/node-version-color.js
@@ -5,7 +5,7 @@ import { getCachedResource } from '../../core/base-service/resource-cache.js'
 const dateFormat = 'YYYY-MM-DD'
 
 async function getVersion(version) {
-  let semver = ``
+  let semver = ''
   if (version) {
     semver = `-${version}.x`
   }

--- a/services/node/testUtils/test-utils.js
+++ b/services/node/testUtils/test-utils.js
@@ -9,14 +9,14 @@ const templates = {
   packageJsonVersionsTemplate: fs.readFileSync(
     path.join(
       path.dirname(fileURLToPath(import.meta.url)),
-      `packageJsonVersionsTemplate.json`
+      'packageJsonVersionsTemplate.json'
     ),
     'utf-8'
   ),
   packageJsonTemplate: fs.readFileSync(
     path.join(
       path.dirname(fileURLToPath(import.meta.url)),
-      `packageJsonTemplate.json`
+      'packageJsonTemplate.json'
     ),
     'utf-8'
   ),
@@ -51,7 +51,7 @@ const mockPackageData =
 const mockCurrentSha = latestVersion => nock => {
   const latestSha = `node-v${latestVersion}.12.0-aix-ppc64.tar.gz`
   return nock('https://nodejs.org/dist/')
-    .get(`/latest/SHASUMS256.txt`)
+    .get('/latest/SHASUMS256.txt')
     .reply(200, latestSha)
 }
 
@@ -146,7 +146,7 @@ const mockReleaseSchedule = () => nock => {
     },
   }
   return nock('https://raw.githubusercontent.com/')
-    .get(`/nodejs/Release/master/schedule.json`)
+    .get('/nodejs/Release/master/schedule.json')
     .reply(200, schedule)
 }
 

--- a/services/npm/npm-type-definitions.tester.js
+++ b/services/npm/npm-type-definitions.tester.js
@@ -14,7 +14,7 @@ t.create('types (from files)')
   .get('/form-data-entries.json')
   .intercept(nock =>
     nock('https://registry.npmjs.org')
-      .get(`/form-data-entries/latest`)
+      .get('/form-data-entries/latest')
       .reply(200, {
         maintainers: [],
         files: ['index.js', 'index.d.ts'],

--- a/services/npms-io/npms-io-score.tester.js
+++ b/services/npms-io/npms-io-score.tester.js
@@ -13,7 +13,7 @@ t.create('should show color')
     nock.enableNetConnect()
 
     return nock('https://api.npms.io', { allowUnmocked: true })
-      .get(`/v2/package/mock-for-package-score`)
+      .get('/v2/package/mock-for-package-score')
       .reply(200, {
         score: {
           final: 0.89,

--- a/services/nycrc/nycrc.service.js
+++ b/services/nycrc/nycrc.service.js
@@ -74,7 +74,8 @@ export default class Nycrc extends ConditionalGithubAuthV3Service {
     if (preferredThreshold) {
       if (!validThresholds.includes(preferredThreshold)) {
         throw new InvalidParameter({
-          prettyMessage: `threshold must be "branches", "lines", or "functions"`,
+          prettyMessage:
+            'threshold must be "branches", "lines", or "functions"',
         })
       }
       if (!config[preferredThreshold]) {

--- a/services/opm/opm-version.service.js
+++ b/services/opm/opm-version.service.js
@@ -26,7 +26,7 @@ export default class OpmVersion extends BaseService {
 
   async fetch({ user, moduleName }) {
     const { res } = await this._request({
-      url: `https://opm.openresty.org/api/pkg/fetch`,
+      url: 'https://opm.openresty.org/api/pkg/fetch',
       options: {
         method: 'HEAD',
         searchParams: {

--- a/services/osslifecycle/osslifecycle.tester.js
+++ b/services/osslifecycle/osslifecycle.tester.js
@@ -46,7 +46,7 @@ t.create('oss metadata in unexpected format')
     nock =>
       nock('https://raw.githubusercontent.com')
         .get('/some-user/some-project/HEAD/OSSMETADATA')
-        .reply(200, `wrongkey=active`),
+        .reply(200, 'wrongkey=active'),
     {
       'Content-Type': 'text/plain;charset=UTF-8',
     }

--- a/services/pub/pub-likes.service.js
+++ b/services/pub/pub-likes.service.js
@@ -3,7 +3,8 @@ import { BaseJsonService } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 
-const documentation = `<p>A measure of how many developers have liked a package. This provides a raw measure of the overall sentiment of a package from peer developers.</p>`
+const documentation =
+  '<p>A measure of how many developers have liked a package. This provides a raw measure of the overall sentiment of a package from peer developers.</p>'
 
 const keywords = ['dart', 'flutter']
 

--- a/services/pub/pub-points.service.js
+++ b/services/pub/pub-points.service.js
@@ -3,7 +3,8 @@ import { floorCount } from '../color-formatters.js'
 import { BaseJsonService } from '../index.js'
 import { nonNegativeInteger } from '../validators.js'
 
-const documentation = `<p>A measure of quality. This includes several dimensions of quality such as code style, platform support, and maintainability.</p>`
+const documentation =
+  '<p>A measure of quality. This includes several dimensions of quality such as code style, platform support, and maintainability.</p>'
 
 const keywords = ['dart', 'flutter']
 

--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -2,7 +2,8 @@ import Joi from 'joi'
 import { floorCount } from '../color-formatters.js'
 import { BaseJsonService } from '../index.js'
 
-const documentation = `<p>A measure of how many developers use a package, providing insight into what other developers are using.</p>`
+const documentation =
+  '<p>A measure of how many developers use a package, providing insight into what other developers are using.</p>'
 
 const keywords = ['dart', 'flutter']
 

--- a/services/security-headers/security-headers.service.js
+++ b/services/security-headers/security-headers.service.js
@@ -72,7 +72,7 @@ export default class SecurityHeaders extends BaseService {
 
   async handle(namedParams, { url, ignoreRedirects }) {
     const { res } = await this._request({
-      url: `https://securityheaders.com`,
+      url: 'https://securityheaders.com',
       options: {
         method: 'HEAD',
         searchParams: {

--- a/services/spiget/spiget-download-size.service.js
+++ b/services/spiget/spiget-download-size.service.js
@@ -26,7 +26,7 @@ export default class SpigetDownloadSize extends BaseSpigetService {
   static render({ size, unit, type }) {
     if (type === 'external') {
       return {
-        message: `resource hosted externally`,
+        message: 'resource hosted externally',
         color: 'lightgrey',
       }
     }

--- a/services/stackexchange/stackexchange-monthlyquestions.service.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.service.js
@@ -63,7 +63,7 @@ export default class StackExchangeMonthlyQuestions extends BaseJsonService {
           tagged: query,
         },
       },
-      url: `https://api.stackexchange.com/2.2/questions`,
+      url: 'https://api.stackexchange.com/2.2/questions',
     })
 
     const numValue = parsedData.total

--- a/services/swagger/swagger-redirect.service.js
+++ b/services/swagger/swagger-redirect.service.js
@@ -8,7 +8,7 @@ export default [
       base: 'swagger/valid/2.0',
       pattern: ':scheme(http|https)/:url*',
     },
-    transformPath: () => `/swagger/valid/3.0`,
+    transformPath: () => '/swagger/valid/3.0',
     transformQueryParams: ({ scheme, url }) => {
       const suffix = /(yaml|yml|json)$/.test(url) ? '' : '.json'
       return { specUrl: `${scheme}://${url}${suffix}` }

--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -33,7 +33,7 @@ export default class TreewareTrees extends BaseJsonService {
   }
 
   async fetch({ reference }) {
-    const url = `https://public.offset.earth/users/treeware/trees`
+    const url = 'https://public.offset.earth/users/treeware/trees'
     return this._requestJson({
       url,
       schema: apiSchema,

--- a/services/twitch/twitch-base.js
+++ b/services/twitch/twitch-base.js
@@ -39,7 +39,7 @@ export default class TwitchBase extends BaseJsonService {
         { userKey: 'client_id', passKey: 'client_secret' },
         {
           schema: tokenSchema,
-          url: `https://id.twitch.tv/oauth2/token`,
+          url: 'https://id.twitch.tv/oauth2/token',
           options: {
             method: 'POST',
             searchParams: {

--- a/services/twitch/twitch-extension-version.service.js
+++ b/services/twitch/twitch-extension-version.service.js
@@ -34,7 +34,7 @@ export default class TwitchExtensionVersion extends TwitchBase {
   async fetch({ extensionId }) {
     const data = this._requestJson({
       schema: helixSchema,
-      url: `https://api.twitch.tv/helix/extensions/released`,
+      url: 'https://api.twitch.tv/helix/extensions/released',
       options: {
         searchParams: { extension_id: extensionId },
       },

--- a/services/twitch/twitch.service.js
+++ b/services/twitch/twitch.service.js
@@ -51,7 +51,7 @@ export default class TwitchStatus extends TwitchBase {
     // which we consider not worth it.
     const streams = this._requestJson({
       schema: helixSchema,
-      url: `https://api.twitch.tv/helix/streams`,
+      url: 'https://api.twitch.tv/helix/streams',
       options: {
         searchParams: { user_login: user },
       },

--- a/services/twitter/twitter-redirect.service.js
+++ b/services/twitter/twitter-redirect.service.js
@@ -8,7 +8,7 @@ export default [
       base: 'twitter/url',
       pattern: ':protocol(https|http)/:hostAndPath+',
     },
-    transformPath: () => `/twitter/url`,
+    transformPath: () => '/twitter/url',
     transformQueryParams: ({ protocol, hostAndPath }) => ({
       url: `${protocol}://${hostAndPath}`,
     }),

--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -99,7 +99,7 @@ class TwitterFollow extends BaseJsonService {
   async fetch({ user }) {
     return this._requestJson({
       schema,
-      url: `http://cdn.syndication.twimg.com/widgets/followbutton/info.json`,
+      url: 'http://cdn.syndication.twimg.com/widgets/followbutton/info.json',
       options: { searchParams: { screen_names: user } },
     })
   }

--- a/services/vaadin-directory/vaadin-directory-base.js
+++ b/services/vaadin-directory/vaadin-directory-base.js
@@ -16,7 +16,7 @@ class BaseVaadinDirectoryService extends BaseJsonService {
   async fetch({ packageName }) {
     return this._requestJson({
       schema,
-      url: `https://vaadin.com/vaadincom/directory-service/components/search/findByUrlIdentifier`,
+      url: 'https://vaadin.com/vaadincom/directory-service/components/search/findByUrlIdentifier',
       options: {
         searchParams: {
           projection: 'summary',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-azure-devops-installs.tester.js
@@ -62,7 +62,7 @@ t.create('total installs')
   .get('/total/swellaby.cobertura-transform.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, mockResponse)
   )
   .expectBadge({
@@ -75,7 +75,7 @@ t.create('services installs')
   .get('/services/swellaby.cobertura-transform.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, mockResponse)
   )
   .expectBadge({
@@ -88,7 +88,7 @@ t.create('onprem installs')
   .get('/onprem/swellaby.cobertura-transform.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, mockResponse)
   )
   .expectBadge({
@@ -101,7 +101,7 @@ t.create('zero installs')
   .get('/total/swellaby.cobertura-transform.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-downloads.tester.js
@@ -62,7 +62,7 @@ t.create('installs')
   .get('/visual-studio-marketplace/i/swellaby.rust-pack.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, mockResponse)
   )
   .expectBadge({
@@ -75,7 +75,7 @@ t.create('zero installs')
   .get('/visual-studio-marketplace/i/swellaby.rust-pack.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {
@@ -105,7 +105,7 @@ t.create('downloads')
   .get('/visual-studio-marketplace/d/swellaby.rust-pack.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, mockResponse)
   )
   .expectBadge({

--- a/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-rating.tester.js
@@ -22,7 +22,7 @@ t.create('rating')
   .get('/visual-studio-marketplace/r/ritwickdey.LiveServer.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {
@@ -61,7 +61,7 @@ t.create('zero rating')
   .get('/visual-studio-marketplace/r/ritwickdey.LiveServer.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {
@@ -91,7 +91,7 @@ t.create('stars')
   .get('/visual-studio-marketplace/stars/ritwickdey.LiveServer.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {

--- a/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-version.tester.js
@@ -15,7 +15,7 @@ t.create('version')
   .get('/visual-studio-marketplace/v/ritwickdey.LiveServer.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {
@@ -45,7 +45,7 @@ t.create('pre-release version')
   .get('/visual-studio-marketplace/v/swellaby.vscode-rust-test-adapter.json')
   .intercept(nock =>
     nock('https://marketplace.visualstudio.com/_apis/public/gallery/')
-      .post(`/extensionquery/`)
+      .post('/extensionquery/')
       .reply(200, {
         results: [
           {

--- a/services/weblate/weblate-entities.service.js
+++ b/services/weblate/weblate-entities.service.js
@@ -18,7 +18,7 @@ export default class WeblateEntities extends WeblateBase {
 
   static examples = [
     {
-      title: `Weblate entities`,
+      title: 'Weblate entities',
       namedParams: { type: 'projects' },
       queryParams: { server: 'https://hosted.weblate.org' },
       staticPreview: this.render({ type: 'projects', count: 533 }),

--- a/services/weblate/weblate-user-statistic.service.js
+++ b/services/weblate/weblate-user-statistic.service.js
@@ -31,7 +31,7 @@ export default class WeblateUserStatistic extends WeblateBase {
 
   static examples = [
     {
-      title: `Weblate user statistic`,
+      title: 'Weblate user statistic',
       namedParams: { statistic: 'translations', user: 'nijel' },
       queryParams: { server: 'https://hosted.weblate.org' },
       staticPreview: this.render({ statistic: 'translations', count: 30585 }),

--- a/services/wercker/wercker.service.js
+++ b/services/wercker/wercker.service.js
@@ -42,14 +42,14 @@ export default class Wercker extends BaseJsonService {
 
   static examples = [
     {
-      title: `Wercker CI Run`,
+      title: 'Wercker CI Run',
       pattern: 'ci/:applicationId',
       namedParams: { applicationId: '559e33c8e982fc615500b357' },
       staticPreview: this.render({ result: 'passed' }),
       documentation: werckerCIDocumentation,
     },
     {
-      title: `Wercker CI Run (branch)`,
+      title: 'Wercker CI Run (branch)',
       pattern: 'ci/:applicationId/:branch',
       namedParams: {
         applicationId: '559e33c8e982fc615500b357',
@@ -59,7 +59,7 @@ export default class Wercker extends BaseJsonService {
       documentation: werckerCIDocumentation,
     },
     {
-      title: `Wercker Build`,
+      title: 'Wercker Build',
       pattern: 'build/:userName/:applicationName',
       namedParams: {
         userName: 'wercker',
@@ -68,7 +68,7 @@ export default class Wercker extends BaseJsonService {
       staticPreview: this.render({ result: 'passed' }),
     },
     {
-      title: `Wercker Build (branch)`,
+      title: 'Wercker Build (branch)',
       pattern: 'build/:userName/:applicationName/:branch',
       namedParams: {
         userName: 'wercker',

--- a/services/wikiapiary/wikiapiary-installs.service.js
+++ b/services/wikiapiary/wikiapiary-installs.service.js
@@ -75,7 +75,7 @@ export default class WikiapiaryInstalls extends BaseJsonService {
   async fetch({ variant, name }) {
     return this._requestJson({
       schema,
-      url: `https://wikiapiary.com/w/api.php`,
+      url: 'https://wikiapiary.com/w/api.php',
       options: {
         searchParams: {
           action: 'ask',

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -67,7 +67,7 @@ class WordpressPluginTestedVersion extends BaseWordpress {
   static category = 'platform-support'
 
   static route = {
-    base: `wordpress/plugin/tested`,
+    base: 'wordpress/plugin/tested',
     pattern: ':slug',
   }
 


### PR DESCRIPTION
I'm not really sure where this crept in (quite a while ago by the looks of it), but we should be following the standard js rules for quotes: https://github.com/standard/eslint-config-standard/blob/bcd019906cd379be04ef8e6347e108bad4fc448d/.eslintrc.json#L201
..so using backtick quotes should be allowed if there is a variable substitution but not otherwise. i.e:

```js
const foo = `bar ${baz}` // OK

const foo = `bar baz`    // lint error
```

I guess some other plugin we are using is overriding the rule. Not 100% sure.

Anyway, this PR explicitly re-enables the rule in our eslint config and re-formats all the places where we are using backtick strings with no templating. In general, I don't like to spend a lot of time bikeshedding lint config but I think this is an improvement.