### PR TITLE
Return string instead of object from getDependencyVersion function; affects [githubpackagejson npmdependencyversion]

### DIFF
--- a/services/github/github-package-json.service.js
+++ b/services/github/github-package-json.service.js
@@ -175,7 +175,7 @@ class GithubPackageJsonDependencyVersion extends ConditionalGithubAuthV3Service 
     })
 
     const wantedDependency = scope ? `${scope}/${packageName}` : packageName
-    const { range } = getDependencyVersion({
+    const range = getDependencyVersion({
       kind,
       wantedDependency,
       dependencies,

--- a/services/npm/npm-dependency-version.service.js
+++ b/services/npm/npm-dependency-version.service.js
@@ -127,7 +127,7 @@ export default class NpmDependencyVersion extends NpmBase {
         registryUrl,
       })
 
-    const { range } = getDependencyVersion({
+    const range = getDependencyVersion({
       kind,
       wantedDependency,
       dependencies,

--- a/services/package-json-helpers.js
+++ b/services/package-json-helpers.js
@@ -45,7 +45,7 @@ const isPackageJsonWithDependencies = Joi.object({
  * @param {object} attrs.optionalDependencies - Map of optional dependencies
  * @throws {string} - Error message if unknown dependency type provided
  * @throws {InvalidParameter} - Error if wanted dependency is not present
- * @returns {object} Object containing semver range of the wanted dependency (eg. ~2.1.6 or >=3.0.0 or <4.0.0)
+ * @returns {string} Semver range of the wanted dependency (eg. ~2.1.6 or >=3.0.0 or <4.0.0)
  */
 function getDependencyVersion({
   kind = 'prod',
@@ -72,7 +72,7 @@ function getDependencyVersion({
     })
   }
 
-  return { range }
+  return range
 }
 
 export { isDependencyMap, isPackageJsonWithDependencies, getDependencyVersion }

--- a/services/package-json-helpers.spec.js
+++ b/services/package-json-helpers.spec.js
@@ -8,9 +8,8 @@ describe('Package json helpers', function () {
       dependencies: { 'left-pad': '~1.2.3' },
       devDependencies: {},
       peerDependencies: {},
-    }).expect({
-      range: '~1.2.3',
-    })
+    }).expect('~1.2.3')
+
     given({
       kind: 'dev',
       wantedDependency: 'left-pad',
@@ -18,24 +17,23 @@ describe('Package json helpers', function () {
       devDependencies: {},
       peerDependencies: {},
     }).expectError('Invalid Parameter')
+
     given({
       kind: 'dev',
       wantedDependency: 'left-pad',
       dependencies: {},
       devDependencies: { 'left-pad': '~1.2.3' },
       peerDependencies: {},
-    }).expect({
-      range: '~1.2.3',
-    })
+    }).expect('~1.2.3')
+
     given({
       kind: 'peer',
       wantedDependency: 'left-pad',
       dependencies: {},
       devDependencies: {},
       peerDependencies: { 'left-pad': '~1.2.3' },
-    }).expect({
-      range: '~1.2.3',
-    })
+    }).expect('~1.2.3')
+
     given({
       kind: 'notreal',
       wantedDependency: 'left-pad',


### PR DESCRIPTION
Cleanup for https://github.com/badges/shields/pull/8373#discussion_r962304386
> This function does currently return an object, but it doesn't really need to. I expect this is an artefact of some past refactoring. A nice cleanup we could do here would be to update this so it just returns a string and update the handful of places it is called accordingly.