### PR TITLE
[ProtonDB] Add reports badge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,7 @@ Prettier before a commit by default.
 When adding or changing a service [please write tests][service-tests], and ensure the [title of your Pull Requests follows the required conventions](#running-service-tests-in-pull-requests) to ensure your tests are executed.
 When changing other code, please add unit tests.
 
-To run the integration tests, you must have redis installed and in your PATH.
+To run the integration tests, you must have Redis installed and in your PATH.
 Use `brew install redis`, `yum install redis`, etc. The test runner will
 start the server automatically.
 

--- a/services/freecodecamp/freecodecamp-points.service.js
+++ b/services/freecodecamp/freecodecamp-points.service.js
@@ -4,9 +4,10 @@ import { BaseJsonService, InvalidResponse, NotFound } from '../index.js'
 
 /**
  * Validates that the schema response is what we're expecting.
- * The username pattern should match the freeCodeCamp repository.
+ * The username pattern should match the requirements in the freeCodeCamp
+ * repository.
  *
- * @see https://github.com/freeCodeCamp/freeCodeCamp/blob/main/utils/validate.js#L14
+ * @see https://github.com/freeCodeCamp/freeCodeCamp/blob/main/utils/validate.js
  */
 const schema = Joi.object({
   entities: Joi.object({

--- a/services/protondb/protondb.service.js
+++ b/services/protondb/protondb.service.js
@@ -1,0 +1,71 @@
+import Joi from 'joi'
+import { metric } from '../text-formatters.js'
+import { BaseJsonService } from '../index.js'
+
+const documentation = `
+  <div>
+    <p>
+      You can obtain a user's ID once a <a href="https://www.protondb.com/help/site-questions#why-are-my-reports-not-showing-up-on-game-pages">content refresh</a>
+      has occurred after they've filed their first report. This can take a few days.
+    </p>
+    <p>
+      Once the user has a published report, their profile becomes publicly accessible by clicking on the left-side of their reports.
+      Profile URLs are formatted like <code>/users/:id</code>, take the ID from here.
+    </p>
+  </div>
+  `
+
+/**
+ * Validates that the schema response is what we're expecting.
+ */
+const schema = Joi.object({
+  reports: Joi.array().required(),
+}).required()
+
+/**
+ * This badge displays the total number of reports someone has submitted
+ * to ProtonDB.
+ */
+export default class ProtonDbPoints extends BaseJsonService {
+  static category = 'other'
+  static route = {
+    base: 'protondb/reports',
+    pattern: ':id',
+  }
+
+  static examples = [
+    {
+      title: 'ProtonDB reports',
+      namedParams: { id: '938767784' },
+      staticPreview: this.render({ reports: 12 }),
+      documentation,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'reports', color: 'info' }
+
+  static render({ reports }) {
+    return { message: metric(reports) }
+  }
+
+  async fetch({ id }) {
+    return this._requestJson({
+      schema,
+      url: `https://www.protondb.com/data/users/by_id/${id}.json`,
+      errorMessages: {
+        404: 'profile not found',
+      },
+    })
+  }
+
+  static transform(response) {
+    const { reports } = response
+    return reports.length
+  }
+
+  async handle({ id }) {
+    const response = await this.fetch({ id })
+    const reports = this.constructor.transform(response)
+    return this.constructor.render({ reports })
+  }
+}

--- a/services/protondb/protondb.tester.js
+++ b/services/protondb/protondb.tester.js
@@ -1,0 +1,12 @@
+import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
+
+export const t = await createServiceTester()
+
+t.create('Total Contributions Valid')
+  .get('/938767784.json')
+  .expectBadge({ label: 'reports', message: isMetric })
+
+t.create('Total Contributions Invalid')
+  .get('/invalid_id.json')
+  .expectBadge({ label: 'reports', message: 'profile not found' })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Adds a new badge to Shields.io for ProtonDB reports.

[Proton](https://github.com/ValveSoftware/Proton/) is a compatibility layer to get Windows applications running on Linux.

[ProtonDB](https://www.protondb.com/) is a third-party website with community recognition, that allows users to authenticate via Steam and file reports with how games performed on Linux using Proton.

This badge displays the total number of reports a user has contributed to the website and [open dataset](https://github.com/bdefore/protondb-data).

![image](https://user-images.githubusercontent.com/22801583/193523662-aeabe5e4-51ee-4910-99f9-1f726c955c0a.png)
> User on ProtonDB with 15 reports.

![image](https://user-images.githubusercontent.com/22801583/193529730-51e1f6bf-fdc1-47da-9c7e-4f86ddfaec16.png)
> Using that user ID on Shield.io.

---

Also does small chores on the side:
* Fixes a typo in CONTRIBUTING.md, Redis is a noun and so should start uppercase.
* Rewords the freeCodeCamp docs and updates the link, so it's not to a specific line. (Since that gets outdated pretty quickly.)