### PR TITLE
fix [myget] downloads (tenant) test

### DIFF
--- a/services/myget/myget.tester.js
+++ b/services/myget/myget.tester.js
@@ -27,7 +27,7 @@ t.create('total downloads (valid)')
   })
 
 t.create('total downloads (tenant)')
-  .get('/cefsharp.myget/cefsharp/dt/CefSharp.Common.json')
+  .get('/vs-devcore.myget/vs-devcore/dt/MicroBuild.json')
   .expectBadge({
     label: 'downloads',
     message: isMetric,


### PR DESCRIPTION
I don't think there is any bug or upstream issue to chase down here. It seems this is another API where "total downloads" is actually downloads in the last N years. This test has been failing because the package we're using as an example has been reporting zero total downloads. I've updated the test to point at a more popular/active package.
