### PR TITLE
increase timeout for [reuse] not found test

### DIFF
--- a/services/reuse/reuse-compliance.tester.js
+++ b/services/reuse/reuse-compliance.tester.js
@@ -62,7 +62,10 @@ t.create('valid repo -- unregistered')
     color: COLOR_MAP.unregistered,
   })
 
-t.create('invalid repo').get('/github.com/repo/invalid-repo.json').expectBadge({
-  label: 'reuse',
-  message: 'Not a Git repository',
-})
+t.create('invalid repo')
+  .timeout(15000)
+  .get('/github.com/repo/invalid-repo.json')
+  .expectBadge({
+    label: 'reuse',
+    message: 'Not a Git repository',
+  })


### PR DESCRIPTION
The 'not found' case on this badge seems to consistently take > 5 seconds for this service. Not much we can do about the upstream, but I'd like to get rid of the noise from the service tests.
