### PR TITLE
fix: Support WAITING status for [GitHubDeployments]

### DIFF
--- a/services/github/github-deployments.service.js
+++ b/services/github/github-deployments.service.js
@@ -7,7 +7,7 @@ import { documentation, transformErrors } from './github-helpers.js'
 const greenStates = ['SUCCESS']
 const redStates = ['ERROR', 'FAILURE']
 const blueStates = ['INACTIVE']
-const otherStates = ['IN_PROGRESS', 'QUEUED', 'PENDING', 'NO_STATUS']
+const otherStates = ['IN_PROGRESS', 'QUEUED', 'PENDING', 'NO_STATUS', 'WAITING']
 
 const stateToMessageMappings = {
   IN_PROGRESS: 'in progress',

--- a/services/github/github-deployments.spec.js
+++ b/services/github/github-deployments.spec.js
@@ -22,6 +22,12 @@ describe('GithubDeployments', function () {
       color: undefined,
     })
     given({
+      state: 'WAITING',
+    }).expect({
+      message: 'waiting',
+      color: undefined,
+    })
+    given({
       state: 'NO_STATUS',
     }).expect({
       message: 'no status yet',


### PR DESCRIPTION
Fix "invalid response data" badge label for GitHub deployments pending approval.

## Scenario

If a deployment is pending manual approval:

![image](https://user-images.githubusercontent.com/1439341/195608076-56301695-814b-48c5-bfb3-f0f3cd250b93.png)

Then the GraphQL API reports the status as `PENDING`:

### Request

```
query {
  repository(owner: "martincostello", name: "api") {
    deployments(last: 1, environments: ["production"]) {
      nodes {
        latestStatus {
          state
        }
      }
    }
  }
}
```

### Response

```
{
  "data": {
    "repository": {
      "deployments": {
        "nodes": [
          {
            "latestStatus": {
              "state": "WAITING"
            }
          }
        ]
      }
    }
  }
}
```

This then produces a badge that looks like this:

![image](https://user-images.githubusercontent.com/1439341/195608285-2c819169-596d-427d-97ca-09ec8c9305a6.png)

The status doesn't appear to be consistently documented, but definitely exists: https://github.com/octokit/webhooks.net/pull/52