### PR TITLE
Add [GitHubLastCommit] by committer badge

### DIFF
--- a/services/github/github-last-commit.service.js
+++ b/services/github/github-last-commit.service.js
@@ -24,7 +24,9 @@ const schema = Joi.array()
   .required()
 
 const queryParamSchema = Joi.object({
-  by_committer: Joi.equal(''),
+  display_timestamp: Joi.string()
+    .valid('author', 'committer')
+    .default('author'),
 }).required()
 
 export default class GithubLastCommit extends GithubAuthV3Service {
@@ -64,7 +66,7 @@ export default class GithubLastCommit extends GithubAuthV3Service {
         user: 'google',
         repo: 'skia',
       },
-      queryParams: { by_committer: null },
+      queryParams: { display_timestamp: 'committer' },
       staticPreview: this.render({ commitDate: '2022-10-15T20:01:41Z' }),
       ...commonExampleAttrs,
     },
@@ -91,12 +93,8 @@ export default class GithubLastCommit extends GithubAuthV3Service {
   async handle({ user, repo, branch }, queryParams) {
     const body = await this.fetch({ user, repo, branch })
 
-    if (typeof queryParams.by_committer !== 'undefined') {
-      return this.constructor.render({
-        commitDate: body[0].commit.committer.date,
-      })
-    }
-
-    return this.constructor.render({ commitDate: body[0].commit.author.date })
+    return this.constructor.render({
+      commitDate: body[0].commit[queryParams.display_timestamp].date,
+    })
   }
 }

--- a/services/github/github-last-commit.tester.js
+++ b/services/github/github-last-commit.tester.js
@@ -14,6 +14,10 @@ t.create('last commit (on branch)')
   .get('/badges/badgr.co/shielded.json')
   .expectBadge({ label: 'last commit', message: 'july 2013' })
 
+t.create('last commit (by committer)')
+  .get('/badges/badgr.co/shielded.json?by_committer')
+  .expectBadge({ label: 'last commit', message: 'july 2013' })
+
 t.create('last commit (repo not found)')
   .get('/badges/helmets.json')
   .expectBadge({ label: 'last commit', message: 'repo not found' })

--- a/services/github/github-last-commit.tester.js
+++ b/services/github/github-last-commit.tester.js
@@ -15,7 +15,7 @@ t.create('last commit (on branch)')
   .expectBadge({ label: 'last commit', message: 'july 2013' })
 
 t.create('last commit (by committer)')
-  .get('/badges/badgr.co/shielded.json?by_committer')
+  .get('/badges/badgr.co/shielded.json?display_timestamp=committer')
   .expectBadge({ label: 'last commit', message: 'july 2013' })
 
 t.create('last commit (repo not found)')


### PR DESCRIPTION
closes #6236

I added  the `display_timestamp` queryParam, with options `author` and `committer`, defaulting to `author`.



```js

const queryParamSchema = Joi.object({
  display_timestamp: Joi.string()
    .valid('author', 'committer')
    .default('author'),
}).required()

...

  async handle({ user, repo, branch }, queryParams) {
    const body = await this.fetch({ user, repo, branch })

    return this.constructor.render({
      commitDate: body[0].commit[queryParams.display_timestamp].date,
    })
  }
```

I checked a couple of repos (for example https://api.github.com/repos/zero-to-mastery/start-here-guidelines/commits) but I couldn't find an example with a different date for `author` and `committer`.

http://localhost:8080/github/last-commit/google/skia/infra/config?display_timestamp=committer

![image](https://user-images.githubusercontent.com/31891675/196984660-5a296d95-0ec1-46c7-98a0-acf95d76b7ea.png)


