### PR TITLE
fixes for integration test rate limit issues

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,5 +1,7 @@
 name: Auto close
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened]
 
 permissions:
   pull-requests: write

--- a/.github/workflows/enforce-dependency-review.yml
+++ b/.github/workflows/enforce-dependency-review.yml
@@ -1,5 +1,7 @@
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   enforce-dependency-review:

--- a/.github/workflows/test-integration-17.yml
+++ b/.github/workflows/test-integration-17.yml
@@ -1,6 +1,7 @@
 name: Integration@node 17
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-integration-17.yml
+++ b/.github/workflows/test-integration-17.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-integration-17:

--- a/.github/workflows/test-integration-17.yml
+++ b/.github/workflows/test-integration-17.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-integration-17:
     runs-on: ubuntu-latest
+    env:
+      PAT_EXISTS: ${{ secrets.GH_PAT != '' }}
 
     services:
       redis:
@@ -32,7 +34,14 @@ jobs:
         env:
           NPM_CONFIG_ENGINE_STRICT: 'false'
 
-      - name: Integration Tests
+      - name: Integration Tests (with PAT)
+        if: ${{ env.PAT_EXISTS == 'true' }}
+        uses: ./.github/actions/integration-tests
+        with:
+          github-token: '${{ secrets.GH_PAT }}'
+
+      - name: Integration Tests (with workflow token)
+        if: ${{ env.PAT_EXISTS == 'false' }}
         uses: ./.github/actions/integration-tests
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test-integration:
     runs-on: ubuntu-latest
+    env:
+      PAT_EXISTS: ${{ secrets.GH_PAT != '' }}
 
     services:
       redis:
@@ -30,7 +32,14 @@ jobs:
         with:
           node-version: 16
 
-      - name: Integration Tests
+      - name: Integration Tests (with PAT)
+        if: ${{ env.PAT_EXISTS == 'true' }}
+        uses: ./.github/actions/integration-tests
+        with:
+          github-token: '${{ secrets.GH_PAT }}'
+
+      - name: Integration Tests (with workflow token)
+        if: ${{ env.PAT_EXISTS == 'false' }}
         uses: ./.github/actions/integration-tests
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,6 +1,7 @@
 name: Integration
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-integration:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-lint:

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,6 +1,7 @@
 name: Lint
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-main-17.yml
+++ b/.github/workflows/test-main-17.yml
@@ -1,6 +1,7 @@
 name: Main@node 17
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-main-17.yml
+++ b/.github/workflows/test-main-17.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-main-17:

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,6 +1,7 @@
 name: Main
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-main:

--- a/.github/workflows/test-package-cli.yml
+++ b/.github/workflows/test-package-cli.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 # Smoke test (render a badge with the CLI) with only the package
 # dependencies installed.

--- a/.github/workflows/test-package-cli.yml
+++ b/.github/workflows/test-package-cli.yml
@@ -1,6 +1,7 @@
 name: Package CLI
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-package-lib.yml
+++ b/.github/workflows/test-package-lib.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'gh-pages'
+      - 'dependabot/**'
 
 jobs:
   test-package-lib:

--- a/.github/workflows/test-package-lib.yml
+++ b/.github/workflows/test-package-lib.yml
@@ -1,6 +1,7 @@
 name: Package Library
 on:
   pull_request:
+    types: [opened, edited, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'


### PR DESCRIPTION
closes #8535

Right. A few things going on here:

First 2 commits should be pretty clear. Just trying to run fewer pointless builds really. Regardless of if the builds are consuming rate limit or not, this is good. Less noise, faster builds, etc

The crucial commit is actually the third one though. What I've done is set a Personal Access Token as both a [repo secret](https://github.com/badges/shields/settings/secrets/actions) and a [dependabot secret](https://github.com/badges/shields/settings/secrets/dependabot). Then in the build, we use the PAT if it is available, or fall back to the standard action token (which has the lower rate limit of 1000/hour) otherwise. This will mean PRs submitted from forks can use the standard token without us having to expose a PAT while pushes to master, dependabot PRs, etc can use the PAT with the higher rate limit. That should stop dependabot/repo ranger from completely smashing our rate limit.