### PR TITLE
[GitHubReleaseDate] - published_at field

### DIFF
--- a/services/github/github-release-date.service.js
+++ b/services/github/github-release-date.service.js
@@ -93,17 +93,10 @@ export default class GithubReleaseDate extends GithubAuthV3Service {
   async handle({ variant, user, repo }, queryParams) {
     const body = await this.fetch({ variant, user, repo })
     if (Array.isArray(body)) {
-      if (queryParams.display_date === 'published_at') {
-        return this.constructor.render({ date: body[0].published_at })
-      }
-
-      return this.constructor.render({ date: body[0].created_at })
+      return this.constructor.render({
+        date: body[0][queryParams.display_date],
+      })
     }
-
-    if (queryParams.display_date === 'published_at') {
-      return this.constructor.render({ date: body.published_at })
-    }
-
-    return this.constructor.render({ date: body.created_at })
+    return this.constructor.render({ date: body[queryParams.display_date] })
   }
 }

--- a/services/github/github-release-date.service.js
+++ b/services/github/github-release-date.service.js
@@ -21,7 +21,9 @@ const schema = Joi.alternatives(
 )
 
 const queryParamSchema = Joi.object({
-  published_at: Joi.equal(''),
+  display_date: Joi.string()
+    .valid('created_at', 'published_at')
+    .default('created_at'),
 }).required()
 
 export default class GithubReleaseDate extends GithubAuthV3Service {
@@ -60,7 +62,7 @@ export default class GithubReleaseDate extends GithubAuthV3Service {
         user: 'microsoft',
         repo: 'vscode',
       },
-      queryParams: { published_at: null },
+      queryParams: { display_date: 'published_at' },
       staticPreview: this.render({ date: '2022-10-17T07:50:27.000Z' }),
       documentation,
     },
@@ -91,14 +93,14 @@ export default class GithubReleaseDate extends GithubAuthV3Service {
   async handle({ variant, user, repo }, queryParams) {
     const body = await this.fetch({ variant, user, repo })
     if (Array.isArray(body)) {
-      if (typeof queryParams.published_at !== 'undefined') {
+      if (queryParams.display_date === 'published_at') {
         return this.constructor.render({ date: body[0].published_at })
       }
 
       return this.constructor.render({ date: body[0].created_at })
     }
 
-    if (typeof queryParams.published_at !== 'undefined') {
+    if (queryParams.display_date === 'published_at') {
       return this.constructor.render({ date: body.published_at })
     }
 

--- a/services/github/github-release-date.service.js
+++ b/services/github/github-release-date.service.js
@@ -55,11 +55,12 @@ export default class GithubReleaseDate extends GithubAuthV3Service {
     },
     {
       title: 'GitHub Release Date - Published_At',
-      pattern: 'release-date/:user/:repo?published_at',
+      pattern: 'release-date/:user/:repo',
       namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
+        user: 'microsoft',
+        repo: 'vscode',
       },
+      queryParams: { published_at: null },
       staticPreview: this.render({ date: '2022-10-17T07:50:27.000Z' }),
       documentation,
     },

--- a/services/github/github-release-date.tester.js
+++ b/services/github/github-release-date.tester.js
@@ -9,11 +9,25 @@ t.create('Release Date. e.g release date|today')
     message: isFormattedDate,
   })
 
-t.create('Release Date - by `published_at` field')
-  .get('/release-date/microsoft/vscode.json?published_at')
+t.create('Release Date - display_date by `created_at` (default)')
+  .get('/release-date/microsoft/vscode.json?display_date=created_at')
   .expectBadge({
     label: 'release date',
     message: isFormattedDate,
+  })
+
+t.create('Release Date - display_date by `published_at`')
+  .get('/release-date/microsoft/vscode.json?display_date=published_at')
+  .expectBadge({
+    label: 'release date',
+    message: isFormattedDate,
+  })
+
+t.create('Release Date - display_date by `published_at`, incorrect query param')
+  .get('/release-date/microsoft/vscode.json?display_date=published_attttttttt')
+  .expectBadge({
+    label: 'release date',
+    message: 'invalid query parameter: display_date',
   })
 
 t.create(

--- a/services/github/github-release-date.tester.js
+++ b/services/github/github-release-date.tester.js
@@ -9,6 +9,13 @@ t.create('Release Date. e.g release date|today')
     message: isFormattedDate,
   })
 
+t.create('Release Date - by `published_at` field')
+  .get('/release-date/microsoft/vscode.json?published_at')
+  .expectBadge({
+    label: 'release date',
+    message: isFormattedDate,
+  })
+
 t.create(
   'Release Date - Should return `no releases or repo not found` for invalid repo'
 )


### PR DESCRIPTION
closes #6309

For the GitHub Release Date badge by default we still use the `created_at` field.
Now, if the user gives the `display_date=published_at` query param, that field from the API response would be used.

https://api.github.com/repos/microsoft/vscode/releases/latest 
![3](https://user-images.githubusercontent.com/31891675/196266677-627fc47e-6619-493d-840c-edddac0c9fe5.jpg)

http://localhost:8080/github/release-date/microsoft/vscode

http://localhost:8080/github/release-date/microsoft/vscode?display_date=published_at

![Screenshot_3](https://user-images.githubusercontent.com/31891675/196549544-687247fe-c77c-4633-9971-c990a1355043.jpg)

![Screenshot_2](https://user-images.githubusercontent.com/31891675/196549550-31a1956d-de18-48b4-b227-f5dfdbf9cbbc.jpg)

![a](https://user-images.githubusercontent.com/31891675/196549548-b4a735f5-6739-4c86-9fca-5d520cf22155.jpg)

