### PR TITLE
Fix [Testspace] with new "untested" value in case_counts array

### DIFF
--- a/services/testspace/testspace-base.js
+++ b/services/testspace/testspace-base.js
@@ -2,8 +2,8 @@ import Joi from 'joi'
 import { nonNegativeInteger } from '../validators.js'
 import { BaseJsonService, NotFound } from '../index.js'
 
-// https://help.testspace.com/docs/reference/web-api#list-results
-// case_counts|array|The contained cases [passed, failed, na, errored]|counters of result
+// https://help.testspace.com/reference/web-api#list-results
+// case_counts|array|The contained cases [passed, failed, na, errored, untested]|counters of result
 // session_* fields are for manual runs
 // There are instances where the api returns a 200 status code with an empty array
 // notably in cases where a space id is used
@@ -12,14 +12,14 @@ const schema = Joi.array()
     Joi.object({
       case_counts: Joi.array()
         .items(nonNegativeInteger)
-        .min(4)
-        .max(4)
+        .min(5)
+        .max(5)
         .required(),
     })
   )
   .required()
 
-// https://help.testspace.com/docs/dashboard/overview-navigate
+// https://help.testspace.com/dashboard/overview#navigate
 // Org is owner/account
 // Project is generally a repository
 // Space is a container, often a branch
@@ -49,11 +49,11 @@ export default class TestspaceBase extends BaseJsonService {
 
     const [
       {
-        case_counts: [passed, failed, skipped, errored],
+        case_counts: [passed, failed, skipped, errored, untested],
       },
     ] = json
-    const total = passed + failed + skipped + errored
+    const total = passed + failed + skipped + errored + untested
 
-    return { passed, failed, skipped, errored, total }
+    return { passed, failed, skipped, errored, untested, total }
   }
 }

--- a/services/testspace/testspace-test-count.service.js
+++ b/services/testspace/testspace-test-count.service.js
@@ -5,7 +5,7 @@ export default class TestspaceTestCount extends TestspaceBase {
   static route = {
     base: 'testspace',
     pattern:
-      ':metric(total|passed|failed|skipped|errored)/:org/:project/:space+',
+      ':metric(total|passed|failed|skipped|errored|untested)/:org/:project/:space+',
   }
 
   static examples = [
@@ -39,7 +39,7 @@ export default class TestspaceTestCount extends TestspaceBase {
   }
 
   transform({ json, metric }) {
-    const { passed, failed, skipped, errored, total } =
+    const { passed, failed, skipped, errored, untested, total } =
       this.transformCaseCounts(json)
     if (metric === 'total') {
       return { value: total }
@@ -49,6 +49,8 @@ export default class TestspaceTestCount extends TestspaceBase {
       return { value: failed }
     } else if (metric === 'skipped') {
       return { value: skipped }
+    } else if (metric === 'untested') {
+      return { value: untested }
     } else {
       return { value: errored }
     }

--- a/services/testspace/testspace-test-count.spec.js
+++ b/services/testspace/testspace-test-count.spec.js
@@ -38,5 +38,10 @@ describe('TestspaceTestCount', function () {
       message: '0',
       color: 'informational',
     })
+    given({ metric: 'untested', value: 0 }).expect({
+      label: 'untested tests',
+      message: '0',
+      color: 'informational',
+    })
   })
 })

--- a/services/testspace/testspace-test-count.tester.js
+++ b/services/testspace/testspace-test-count.tester.js
@@ -41,3 +41,10 @@ t.create('Errored')
     label: 'errored tests',
     message: isMetricAllowZero,
   })
+
+t.create('Untested')
+  .get('/untested/swellaby/swellaby:testspace-sample/main.json')
+  .expectBadge({
+    label: 'untested tests',
+    message: isMetricAllowZero,
+  })


### PR DESCRIPTION
Hello,

I noticed that all Testspace badges started returning "invalid response data" recently. The cause was a recent change in the response object of the Testspace web API: the `case_counts` array in the [Results object](https://help.testspace.com/reference/web-api#results) now has length 5 instead of 4. A new integer was appended to the end which represents the number of [untested](https://help.testspace.com/manual/execution-session#start) tests, which are [manual](https://help.testspace.com/manual/overview) tests that have not been run yet.

|Live example|Screenshot for posterity|
|---|---|
|![Testspace tests](https://img.shields.io/testspace/tests/swellaby/swellaby:testspace-sample/main)|![tests: invalid response data](https://user-images.githubusercontent.com/1417794/196314307-0b038778-671e-48e7-bee5-8ce0e5b64c7f.png)|

The API docs haven't been updated yet as of 2022-10-17, but I [contacted the Testspace developers and figured out what the new value means](https://github.com/testspace-com/testspace.support/discussions/29).

To fix the invalid error, this change updates the schema for the Testspace API response with the new array length. It also adds a new `metric` parameter value (`untested`) to the `TestspaceTestCount` service and includes it in the internal object returned by `TestspaceBase.transformCaseCounts()`, as well adding it to the `total` value in that object. The documentation URLs have also changed.

I didn't add `untested` to the `TestspacePassRatio` or `TestspaceTests` services, since those already didn't use `skipped` and `errored`, respectively, and it didn't seem like it would make sense to start including untested manual cases there.

I think I've covered all the requirements for contributing, but let me know if I missed anything or if any other changes need to be made.

Thanks!