### PR TITLE
remove failing [lgtm] test case

### DIFF
--- a/services/lgtm/lgtm-alerts.tester.js
+++ b/services/lgtm/lgtm-alerts.tester.js
@@ -59,10 +59,3 @@ t.create('alerts: total alerts for a project with a github mapped host')
     label: 'lgtm alerts',
     message: Joi.string().regex(/^[0-9kM.]+$/),
   })
-
-t.create('alerts: total alerts for a project with a bitbucket mapped host')
-  .get('/bitbucket/atlassian/confluence-business-blueprints.json')
-  .expectBadge({
-    label: 'lgtm alerts',
-    message: Joi.string().regex(/^[0-9kM.]+$/),
-  })


### PR DESCRIPTION
The upstream project has disappeared and unfortunately I'm not able to find another public project which is hosted on bitbucket and using LGTM. Given that the response we expect from LGTM is identical regardless of where the source is hosted and there's no difference in the logic there is no value in replacing with a mocked test IMO. I suggest we can just drop it.