### PR TITLE
fix [swagger] service tests (allow array of 0 items)

### DIFF
--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -8,7 +8,7 @@ const schema = Joi.object()
       Joi.object({
         level: Joi.string().required(),
         message: Joi.string().required(),
-      }).required()
+      })
     ),
   })
   .required()


### PR DESCRIPTION
This one is odd. I'm not sure how we never hit this, but the existing code required the array to have >=1 items in it. I think what has happened is:

- Every schema we were testing against had at least one warning
- The upstream API has stopped returning warnings in the response, or stopped returning them by default

~~OR~~

- ~~There was a behaviour change in Joi at some point~~

~~but it is kinda hard to tell at this point.~~

I've checked some invalid examples and the upstream API does still seem to be returning errors. We don't need any additional error handling to account for this being `[]`. The `handle()` code itself was already expecting it as a possible value, but the schema was rejecting it.

edit: closes #8566