### PR TITLE
fix [codecov] badge for non-default branch

### DIFF
--- a/services/codecov/codecov.service.js
+++ b/services/codecov/codecov.service.js
@@ -107,7 +107,7 @@ export default class Codecov extends BaseSvgScrapingService {
   async legacyFetch({ vcsName, user, repo, branch, token }) {
     // Codecov Docs: https://docs.codecov.io/reference#section-get-a-single-repository
     const url = `https://codecov.io/api/${vcsName}/${user}/${repo}${
-      branch ? `/branches/${branch}` : ''
+      branch ? `/branch/${branch}` : ''
     }`
     const { buffer } = await this._request({
       url,


### PR DESCRIPTION
closes #8545

Not sure if this has been wrong for a long time or if it is a recent change, but `/branch` is correct.