### PR TITLE
[Ansible] Add collection badge

### DIFF
--- a/services/ansible/ansible-collection.service.js
+++ b/services/ansible/ansible-collection.service.js
@@ -8,17 +8,7 @@ const ansibleCollectionSchema = Joi.object({
   }),
 }).required()
 
-class AnsibleGalaxyCollection extends BaseJsonService {
-  async fetch({ collectionId }) {
-    const url = `https://galaxy.ansible.com/api/v2/collections/${collectionId}/`
-    return this._requestJson({
-      url,
-      schema: ansibleCollectionSchema,
-    })
-  }
-}
-
-class AnsibleGalaxyCollectionName extends AnsibleGalaxyCollection {
+class AnsibleGalaxyCollectionName extends BaseJsonService {
   static category = 'other'
   static route = { base: 'ansible/collection', pattern: ':collectionId' }
 
@@ -36,6 +26,14 @@ class AnsibleGalaxyCollectionName extends AnsibleGalaxyCollection {
 
   static render({ name }) {
     return { message: name, color: 'blue' }
+  }
+
+  async fetch({ collectionId }) {
+    const url = `https://galaxy.ansible.com/api/v2/collections/${collectionId}/`
+    return this._requestJson({
+      url,
+      schema: ansibleCollectionSchema,
+    })
   }
 
   async handle({ collectionId }) {

--- a/services/ansible/ansible-collection.service.js
+++ b/services/ansible/ansible-collection.service.js
@@ -1,0 +1,48 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+
+const ansibleCollectionSchema = Joi.object({
+  name: Joi.string().required(),
+  namespace: Joi.object({
+    name: Joi.string().required(),
+  }),
+}).required()
+
+class AnsibleGalaxyCollection extends BaseJsonService {
+  async fetch({ collectionId }) {
+    const url = `https://galaxy.ansible.com/api/v2/collections/${collectionId}/`
+    return this._requestJson({
+      url,
+      schema: ansibleCollectionSchema,
+    })
+  }
+}
+
+class AnsibleGalaxyCollectionName extends AnsibleGalaxyCollection {
+  static category = 'other'
+  static route = { base: 'ansible/collection', pattern: ':collectionId' }
+
+  static examples = [
+    {
+      title: 'Ansible Collection',
+      namedParams: { collectionId: '278' },
+      staticPreview: this.render({
+        name: 'community.general',
+      }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'collection' }
+
+  static render({ name }) {
+    return { message: name, color: 'blue' }
+  }
+
+  async handle({ collectionId }) {
+    const json = await this.fetch({ collectionId })
+    const name = `${json.namespace.name}.${json.name}`
+    return this.constructor.render({ name })
+  }
+}
+
+export { AnsibleGalaxyCollectionName }

--- a/services/ansible/ansible-collection.tester.js
+++ b/services/ansible/ansible-collection.tester.js
@@ -5,10 +5,10 @@ export const t = new ServiceTester({
   pathPrefix: '/ansible/collection',
 })
 
-t.create('role name (valid)')
+t.create('collection name (valid)')
   .get('/278.json')
-  .expectBadge({ label: 'role', message: 'community.general' })
+  .expectBadge({ label: 'collection', message: 'community.general' })
 
-t.create('role name (not found)')
+t.create('collection name (not found)')
   .get('/000.json')
-  .expectBadge({ label: 'role', message: 'not found' })
+  .expectBadge({ label: 'collection', message: 'not found' })

--- a/services/ansible/ansible-collection.tester.js
+++ b/services/ansible/ansible-collection.tester.js
@@ -1,0 +1,14 @@
+import { ServiceTester } from '../tester.js'
+export const t = new ServiceTester({
+  id: 'AnsibleCollection',
+  title: 'AnsibleCollection',
+  pathPrefix: '/ansible/collection',
+})
+
+t.create('role name (valid)')
+  .get('/278.json')
+  .expectBadge({ label: 'role', message: 'community.general' })
+
+t.create('role name (not found)')
+  .get('/000.json')
+  .expectBadge({ label: 'role', message: 'not found' })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Add a badge for Ansible collections, almost identical to those for Ansible roles.

Unfortuntately, the `/api/v2/collections` endpoint (as opposed to `/api/v1/roles`) of Ansible Galaxy exposes neither download numbers nor quality scores, so there's only the name badge for now.