### PR TITLE
add 404 error message for dart's [pub]

### DIFF
--- a/services/pub/pub-publisher.service.js
+++ b/services/pub/pub-publisher.service.js
@@ -38,6 +38,9 @@ export class PubPublisher extends BaseJsonService {
     return this._requestJson({
       schema,
       url: `https://pub.dev/api/packages/${packageName}/publisher`,
+      errorMessages: {
+        404: 'invalid package name',
+      },
     })
   }
 

--- a/services/pub/pub-publisher.tester.js
+++ b/services/pub/pub-publisher.tester.js
@@ -12,7 +12,7 @@ t.create('package not verified publisher').get('/utf.json').expectBadge({
   color: 'lightgrey',
 })
 
-t.create('package not found').get('/doesnotexist.json').expectBadge({
+t.create('invalid package name').get('/doesnotexist.json').expectBadge({
   label: 'publisher',
-  message: 'not found',
+  message: 'invalid package name',
 })

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -41,6 +41,9 @@ class PubVersion extends BaseJsonService {
     return this._requestJson({
       schema,
       url: `https://pub.dartlang.org/packages/${packageName}.json`,
+      errorMessages: {
+        404: 'invalid package name',
+      },
     })
   }
 

--- a/services/pub/pub.tester.js
+++ b/services/pub/pub.tester.js
@@ -18,9 +18,9 @@ t.create('package pre-release version')
     message: isVPlusTripleDottedVersion,
   })
 
-t.create('package not found').get('/v/doesnotexist.json').expectBadge({
+t.create('invalid package name').get('/v/doesnotexist.json').expectBadge({
   label: 'pub',
-  message: 'not found',
+  message: 'invalid package name',
 })
 
 t.create('package version (legacy redirect: vpre)')


### PR DESCRIPTION
closes #7922 

@chris48s In #7921 you mentioned that it would be good to add the error message for 400:
```js
errorMessages: {
  400: 'invalid package name',
},
```

Now these 2 pub endpoints return a `404` when given an incorrect package name,
so I added this instead:
```js
errorMessages: {
  404: 'invalid package name',
},
```

ok: https://pub.dev/api/packages/path/publisher
404: https://pub.dev/api/packages/pat/publisher
 
http://localhost:8080/pub/publisher/path
http://localhost:8080/pub/publisher/pat 
 
ok: https://pub.dartlang.org/packages/path.json
404: https://pub.dartlang.org/packages/pat.json
 
http://localhost:8080/pub/v/path 
http://localhost:8080/pub/v/pat
 
 
services/pub/pub-publisher.service.js
services/pub/pub.service.js


![a](https://user-images.githubusercontent.com/31891675/199222139-4eea2780-99b0-4f31-8a0b-bcd0d1325392.jpg)
![b](https://user-images.githubusercontent.com/31891675/199222144-67e3c2b8-10b4-4d67-8163-b0ec83634a00.jpg)
![c](https://user-images.githubusercontent.com/31891675/199222149-f0de3933-c49b-4377-8c18-19c471481b85.jpg)
![dart4](https://user-images.githubusercontent.com/31891675/199222153-a276ff29-d556-4d6b-a9c8-adda1805291d.jpg)
![dart5](https://user-images.githubusercontent.com/31891675/199222154-38ea1fc8-f8f9-47a5-b148-894f02a3f013.jpg)
![dart6](https://user-images.githubusercontent.com/31891675/199222155-fdd34b66-fafd-46e4-b1db-fb471e270191.jpg)

