### PR TITLE
Update the Modrinth API to v2

### DIFF
--- a/services/modrinth/modrinth.service.js
+++ b/services/modrinth/modrinth.service.js
@@ -28,7 +28,7 @@ export default class Modrinth extends BaseJsonService {
   async fetch({ modId }) {
     return this._requestJson({
       schema,
-      url: `https://api.modrinth.com/api/v1/mod/${modId}`,
+      url: `https://api.modrinth.com/v2/project/${modId}`,
     })
   }
 


### PR DESCRIPTION
Updates the usage of the Modrinth API to v2.
The relevant documentation can be found [here](https://docs.modrinth.com/api-spec/#tag/projects/operation/getProject).