### PR TITLE
[factorio-mod-portal] services

### DIFF
--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -2,11 +2,12 @@ import Joi from 'joi'
 import { BaseJsonService } from '../index.js'
 import { age } from '../color-formatters.js'
 import { formatDate } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
 import { renderDownloadsBadge } from '../downloads.js'
 import { renderVersionBadge } from '../version.js'
 
 const schema = Joi.object({
-  downloads_count: Joi.number().required(),
+  downloads_count: nonNegativeInteger,
   releases: Joi.array()
     .items(
       Joi.object({

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -51,7 +51,7 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
   static category = 'version'
 
   static route = {
-    base: 'factorio-mod-portal/latest-version',
+    base: 'factorio-mod-portal/v',
     pattern: ':modName',
   }
 

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -1,0 +1,53 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+import { renderVersionBadge } from '../version.js'
+
+const schema = Joi.object({
+  releases: Joi.array()
+    .items(
+      Joi.object({
+        version: Joi.string().required(),
+      })
+    )
+    .min(1)
+    .required(),
+}).required()
+
+class BaseFactorioModPortalService extends BaseJsonService {
+  async fetch({ modName }) {
+    return this._requestJson({
+      schema,
+      url: `https://mods.factorio.com/api/mods/${modName}`,
+      errorMessages: {
+        404: 'mod not found',
+      },
+    })
+  }
+}
+
+class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
+  static category = 'version'
+
+  static route = { base: 'factorio-mod-portal/v', pattern: ':modName' }
+  static examples = [
+    {
+      title: 'Factorio Mod Portal',
+      namedParams: { modName: 'rso-mod' },
+      staticPreview: this.render({ version: '6.2.20' }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'latest version' }
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
+  async handle({ modName }) {
+    const { releases } = await this.fetch({ modName })
+    const version = releases[releases.length - 1].version
+    return this.constructor.render({ version })
+  }
+}
+
+export { FactorioModPortalLatestVersion }

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -1,5 +1,7 @@
 import Joi from 'joi'
 import { BaseJsonService } from '../index.js'
+import { age } from '../color-formatters.js'
+import { formatDate } from '../text-formatters.js'
 import { renderVersionBadge } from '../version.js'
 
 const schema = Joi.object({
@@ -7,6 +9,7 @@ const schema = Joi.object({
     .items(
       Joi.object({
         version: Joi.string().required(),
+        released_at: Joi.string().required(),
         info_json: Joi.object({
           factorio_version: Joi.string().required(),
         }).required(),
@@ -103,4 +106,41 @@ class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
   }
 }
 
-export { FactorioModPortalLatestVersion, FactorioModPortalFactorioVersions }
+class FactorioModPortalLastUpdated extends BaseFactorioModPortalService {
+  static category = 'activity'
+
+  static route = {
+    base: 'factorio-mod-portal/r',
+    pattern: ':modName',
+  }
+
+  static examples = [
+    {
+      title: 'Factorio Mod Portal mod',
+      namedParams: { modName: 'rso-mod' },
+      staticPreview: this.render({
+        last_updated: new Date(),
+      }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'last updated' }
+
+  static render({ last_updated }) {
+    return {
+      message: formatDate(last_updated),
+      color: age(last_updated),
+    }
+  }
+
+  async handle({ modName }) {
+    const { latest_release } = await this.fetch({ modName })
+    return this.constructor.render({ last_updated: latest_release.released_at })
+  }
+}
+
+export {
+  FactorioModPortalLatestVersion,
+  FactorioModPortalLastUpdated,
+  FactorioModPortalFactorioVersions,
+}

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -22,10 +22,6 @@ const schema = Joi.object({
     .required(),
 }).required()
 
-const queryParamSchema = Joi.object({
-  range: Joi.equal(''),
-}).required()
-
 // Factorio Mod portal API
 // @see https://wiki.factorio.com/Mod_portal_API
 class BaseFactorioModPortalService extends BaseJsonService {
@@ -40,7 +36,6 @@ class BaseFactorioModPortalService extends BaseJsonService {
 
     return {
       downloads_count,
-      first_release: releases[0],
       latest_release: releases[releases.length - 1],
     }
   }
@@ -76,52 +71,31 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
 }
 
 // Badge for mod's latest compatible Factorio version
-// Query 'range' to display range of compatible versions
-class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
+class FactorioModPortalFactorioVersion extends BaseFactorioModPortalService {
   static category = 'platform-support'
 
   static route = {
     base: 'factorio-mod-portal/factorio-version',
     pattern: ':modName',
-    queryParamSchema,
   }
 
   static examples = [
     {
       title: 'Factorio Mod Portal factorio versions',
       namedParams: { modName: 'rso-mod' },
-      staticPreview: this.render({ version: '0.14-1.1' }),
-      queryParams: {
-        range: 'range',
-      },
+      staticPreview: this.render({ version: '1.1' }),
     },
   ]
 
   static defaultBadgeData = { label: 'factorio version' }
 
   static render({ version }) {
-    return { message: version, color: 'blue' }
+    return renderVersionBadge({ version })
   }
 
-  transform({ earliest, latest }) {
-    let versions = ''
-    if (earliest === latest) {
-      versions = earliest
-    } else {
-      versions = `${earliest}-${latest}`
-    }
-    return versions
-  }
-
-  async handle({ modName }, queryParams) {
-    const { first_release, latest_release } = await this.fetch({ modName })
-    const range = queryParams.range !== undefined
-    const version = range
-      ? this.transform({
-          earliest: first_release.info_json.factorio_version,
-          latest: latest_release.info_json.factorio_version,
-        })
-      : latest_release.info_json.factorio_version
+  async handle({ modName }) {
+    const { latest_release } = await this.fetch({ modName })
+    const version = latest_release.info_json.factorio_version
     return this.constructor.render({ version })
   }
 }
@@ -194,6 +168,6 @@ class FactorioModPortalDownloads extends BaseFactorioModPortalService {
 export {
   FactorioModPortalLatestVersion,
   FactorioModPortalLastUpdated,
-  FactorioModPortalFactorioVersions,
+  FactorioModPortalFactorioVersion,
   FactorioModPortalDownloads,
 }

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -78,7 +78,7 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
 // Badge for mod's latest compatible Factorio version
 // Query 'range' to display range of compatible versions
 class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
-  static category = 'version'
+  static category = 'platform-support'
 
   static route = {
     base: 'factorio-mod-portal/factorio-version',

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -165,7 +165,7 @@ class FactorioModPortalDownloads extends BaseFactorioModPortalService {
   static category = 'downloads'
 
   static route = {
-    base: 'factorio-mod-portal/downloads',
+    base: 'factorio-mod-portal/dt',
     pattern: ':modName',
   }
 

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -7,6 +7,9 @@ const schema = Joi.object({
     .items(
       Joi.object({
         version: Joi.string().required(),
+        info_json: Joi.object({
+          factorio_version: Joi.string().required(),
+        }).required(),
       })
     )
     .min(1)
@@ -25,10 +28,10 @@ class BaseFactorioModPortalService extends BaseJsonService {
   }
 }
 
-class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
+class FactorioModPortalLatestModVersion extends BaseFactorioModPortalService {
   static category = 'version'
 
-  static route = { base: 'factorio-mod-portal/v', pattern: ':modName' }
+  static route = { base: 'factorio-mod-portal/mod/v', pattern: ':modName' }
   static examples = [
     {
       title: 'Factorio Mod Portal',
@@ -50,4 +53,29 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
   }
 }
 
-export { FactorioModPortalLatestVersion }
+class FactorioModPortalGameVersion extends BaseFactorioModPortalService {
+  static category = 'version'
+
+  static route = { base: 'factorio-mod-portal/game/v', pattern: ':modName' }
+  static examples = [
+    {
+      title: 'Factorio Mod Portal',
+      namedParams: { modName: 'rso-mod' },
+      staticPreview: this.render({ version: '1.1' }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'factorio version' }
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
+  async handle({ modName }) {
+    const { releases } = await this.fetch({ modName })
+    const version = releases[releases.length - 1].info_json.factorio_version
+    return this.constructor.render({ version })
+  }
+}
+
+export { FactorioModPortalLatestModVersion, FactorioModPortalGameVersion }

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -102,7 +102,7 @@ class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
     return { message: version, color: 'blue' }
   }
 
-  combine({ earliest, latest }) {
+  transform({ earliest, latest }) {
     let versions = ''
     if (earliest === latest) {
       versions = earliest
@@ -116,7 +116,7 @@ class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
     const { first_release, latest_release } = await this.fetch({ modName })
     const range = queryParams.range !== undefined
     const version = range
-      ? this.combine({
+      ? this.transform({
           earliest: first_release.info_json.factorio_version,
           latest: latest_release.info_json.factorio_version,
         })

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -21,6 +21,8 @@ const schema = Joi.object({
     .required(),
 }).required()
 
+// Factorio Mod portal API
+// @see https://wiki.factorio.com/Mod_portal_API
 class BaseFactorioModPortalService extends BaseJsonService {
   async fetch({ modName }) {
     const { releases, downloads_count } = await this._requestJson({
@@ -39,11 +41,12 @@ class BaseFactorioModPortalService extends BaseJsonService {
   }
 }
 
+// Badge for mod's latest updated version
 class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
   static category = 'version'
 
   static route = {
-    base: 'factorio-mod-portal/lv',
+    base: 'factorio-mod-portal/latest-version',
     pattern: ':modName',
   }
 
@@ -67,11 +70,12 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
   }
 }
 
+// Badge for mod's compatible Factorio versions
 class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
   static category = 'version'
 
   static route = {
-    base: 'factorio-mod-portal/fv',
+    base: 'factorio-mod-portal/factorio-version',
     pattern: ':modName',
   }
 
@@ -109,11 +113,12 @@ class FactorioModPortalFactorioVersions extends BaseFactorioModPortalService {
   }
 }
 
+// Badge for mod's last updated date
 class FactorioModPortalLastUpdated extends BaseFactorioModPortalService {
   static category = 'activity'
 
   static route = {
-    base: 'factorio-mod-portal/r',
+    base: 'factorio-mod-portal/last-updated',
     pattern: ':modName',
   }
 
@@ -142,17 +147,18 @@ class FactorioModPortalLastUpdated extends BaseFactorioModPortalService {
   }
 }
 
+// Badge for mod's total download count
 class FactorioModPortalDownloads extends BaseFactorioModPortalService {
   static category = 'downloads'
 
   static route = {
-    base: 'factorio-mod-portal/dt',
+    base: 'factorio-mod-portal/downloads',
     pattern: ':modName',
   }
 
   static examples = [
     {
-      title: 'Factorio Mod Portal mod',
+      title: 'Factorio Mod Portal mod downloads',
       namedParams: { modName: 'rso-mod' },
       staticPreview: this.render({
         downloads_count: 1694763,

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -42,9 +42,9 @@ t.create('Last Updated (mod not found)')
   .expectBadge({ label: 'last updated', message: 'mod not found' })
 
 t.create('Downloads (rso-mod, valid)')
-  .get('/downloads/rso-mod.json')
+  .get('/dt/rso-mod.json')
   .expectBadge({ label: 'downloads', message: isMetric })
 
 t.create('Downloads (mod not found)')
-  .get('/downloads/mod-that-doesnt-exist.json')
+  .get('/dt/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'downloads', message: 'mod not found' })

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -1,4 +1,8 @@
-import { isComposerVersion, withRegex } from '../test-validators.js'
+import {
+  isComposerVersion,
+  isFormattedDate,
+  withRegex,
+} from '../test-validators.js'
 import { ServiceTester } from '../tester.js'
 
 export const t = new ServiceTester({
@@ -23,3 +27,11 @@ t.create('Factorio Versions (rso-mod, valid)')
 t.create('Factorio Versions (mod not found)')
   .get('/fv/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'factorio version', message: 'mod not found' })
+
+t.create('Last Updated (rso-mod, valid)')
+  .get('/r/rso-mod.json')
+  .expectBadge({ label: 'last updated', message: isFormattedDate })
+
+t.create('Last Updated (mod not found)')
+  .get('/r/mod-that-doesnt-exist.json')
+  .expectBadge({ label: 'last updated', message: 'mod not found' })

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -14,33 +14,33 @@ export const t = new ServiceTester({
 const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
 
 t.create('Latest Version (rso-mod, valid)')
-  .get('/lv/rso-mod.json')
+  .get('/latest-version/rso-mod.json')
   .expectBadge({ label: 'latest version', message: isComposerVersion })
 
 t.create('Latest Version (mod not found)')
-  .get('/lv/mod-that-doesnt-exist.json')
+  .get('/latest-version/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'latest version', message: 'mod not found' })
 
 t.create('Factorio Versions (rso-mod, valid)')
-  .get('/fv/rso-mod.json')
+  .get('/factorio-version/rso-mod.json')
   .expectBadge({ label: 'factorio version', message: multipleVersions })
 
 t.create('Factorio Versions (mod not found)')
-  .get('/fv/mod-that-doesnt-exist.json')
+  .get('/factorio-version/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'factorio version', message: 'mod not found' })
 
 t.create('Last Updated (rso-mod, valid)')
-  .get('/r/rso-mod.json')
+  .get('/last-updated/rso-mod.json')
   .expectBadge({ label: 'last updated', message: isFormattedDate })
 
 t.create('Last Updated (mod not found)')
-  .get('/r/mod-that-doesnt-exist.json')
+  .get('/last-updated/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'last updated', message: 'mod not found' })
 
 t.create('Downloads (rso-mod, valid)')
-  .get('/dt/rso-mod.json')
+  .get('/downloads/rso-mod.json')
   .expectBadge({ label: 'downloads', message: isMetric })
 
 t.create('Downloads (mod not found)')
-  .get('/dt/mod-that-doesnt-exist.json')
+  .get('/downloads/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'downloads', message: 'mod not found' })

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -1,5 +1,5 @@
 import {
-  isComposerVersion,
+  isVPlusDottedVersionNClauses,
   isFormattedDate,
   isMetric,
   withRegex,
@@ -13,9 +13,10 @@ export const t = new ServiceTester({
 
 const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
 
-t.create('Latest Version (rso-mod, valid)')
-  .get('/v/rso-mod.json')
-  .expectBadge({ label: 'latest version', message: isComposerVersion })
+t.create('Latest Version (rso-mod, valid)').get('/v/rso-mod.json').expectBadge({
+  label: 'latest version',
+  message: isVPlusDottedVersionNClauses,
+})
 
 t.create('Latest Version (mod not found)')
   .get('/v/mod-that-doesnt-exist.json')
@@ -23,7 +24,10 @@ t.create('Latest Version (mod not found)')
 
 t.create('Factorio Version (rso-mod, valid)')
   .get('/factorio-version/rso-mod.json')
-  .expectBadge({ label: 'factorio version', message: isComposerVersion })
+  .expectBadge({
+    label: 'factorio version',
+    message: isVPlusDottedVersionNClauses,
+  })
 
 t.create('Factorio Version range (rso-mod, valid)')
   .get('/factorio-version/rso-mod.json?range')

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -2,7 +2,6 @@ import {
   isVPlusDottedVersionNClauses,
   isFormattedDate,
   isMetric,
-  withRegex,
 } from '../test-validators.js'
 import { ServiceTester } from '../tester.js'
 
@@ -10,8 +9,6 @@ export const t = new ServiceTester({
   id: 'factorio-mod-portal',
   title: 'Factorio Mod Portal',
 })
-
-const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
 
 t.create('Latest Version (rso-mod, valid)').get('/v/rso-mod.json').expectBadge({
   label: 'latest version',
@@ -28,10 +25,6 @@ t.create('Factorio Version (rso-mod, valid)')
     label: 'factorio version',
     message: isVPlusDottedVersionNClauses,
   })
-
-t.create('Factorio Version range (rso-mod, valid)')
-  .get('/factorio-version/rso-mod.json?range')
-  .expectBadge({ label: 'factorio version', message: multipleVersions })
 
 t.create('Factorio Version (mod not found)')
   .get('/factorio-version/mod-that-doesnt-exist.json')

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -14,11 +14,11 @@ export const t = new ServiceTester({
 const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
 
 t.create('Latest Version (rso-mod, valid)')
-  .get('/latest-version/rso-mod.json')
+  .get('/v/rso-mod.json')
   .expectBadge({ label: 'latest version', message: isComposerVersion })
 
 t.create('Latest Version (mod not found)')
-  .get('/latest-version/mod-that-doesnt-exist.json')
+  .get('/v/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'latest version', message: 'mod not found' })
 
 t.create('Factorio Version (rso-mod, valid)')

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -1,0 +1,25 @@
+import { isComposerVersion, withRegex } from '../test-validators.js'
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'factorio-mod-portal',
+  title: 'Factorio Mod Portal',
+})
+
+const multipleVersions = withRegex(/^([+]?\d*\.\d+)(-)([+]?\d*\.\d+)$/)
+
+t.create('Latest Version (rso-mod, valid)')
+  .get('/lv/rso-mod.json')
+  .expectBadge({ label: 'latest version', message: isComposerVersion })
+
+t.create('Latest Version (mod not found)')
+  .get('/lv/mod-that-doesnt-exist.json')
+  .expectBadge({ label: 'latest version', message: 'mod not found' })
+
+t.create('Factorio Versions (rso-mod, valid)')
+  .get('/fv/rso-mod.json')
+  .expectBadge({ label: 'factorio version', message: multipleVersions })
+
+t.create('Factorio Versions (mod not found)')
+  .get('/fv/mod-that-doesnt-exist.json')
+  .expectBadge({ label: 'factorio version', message: 'mod not found' })

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -1,6 +1,7 @@
 import {
   isComposerVersion,
   isFormattedDate,
+  isMetric,
   withRegex,
 } from '../test-validators.js'
 import { ServiceTester } from '../tester.js'
@@ -35,3 +36,11 @@ t.create('Last Updated (rso-mod, valid)')
 t.create('Last Updated (mod not found)')
   .get('/r/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'last updated', message: 'mod not found' })
+
+t.create('Downloads (rso-mod, valid)')
+  .get('/dt/rso-mod.json')
+  .expectBadge({ label: 'downloads', message: isMetric })
+
+t.create('Downloads (mod not found)')
+  .get('/dt/mod-that-doesnt-exist.json')
+  .expectBadge({ label: 'downloads', message: 'mod not found' })

--- a/services/factorio-mod-portal/factorio-mod-portal.tester.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.tester.js
@@ -21,11 +21,15 @@ t.create('Latest Version (mod not found)')
   .get('/latest-version/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'latest version', message: 'mod not found' })
 
-t.create('Factorio Versions (rso-mod, valid)')
+t.create('Factorio Version (rso-mod, valid)')
   .get('/factorio-version/rso-mod.json')
+  .expectBadge({ label: 'factorio version', message: isComposerVersion })
+
+t.create('Factorio Version range (rso-mod, valid)')
+  .get('/factorio-version/rso-mod.json?range')
   .expectBadge({ label: 'factorio version', message: multipleVersions })
 
-t.create('Factorio Versions (mod not found)')
+t.create('Factorio Version (mod not found)')
   .get('/factorio-version/mod-that-doesnt-exist.json')
   .expectBadge({ label: 'factorio version', message: 'mod not found' })
 


### PR DESCRIPTION
Saw this https://github.com/badges/shields/issues/8582 issue and thought I'd take a crack at closing it. I'm new to open-source contributions so I'm eager to hear any feedback/changes.

![image](https://user-images.githubusercontent.com/23709455/201573472-b283f10b-2eb8-44b9-9e4d-869a946236f9.png)

API: `https://mods.factorio.com/api/mods/{name}` where {name} is the name of the mod, e.g.
https://mods.factorio.com/api/mods/rso-mod

No authentication is required.
API is documented here: https://wiki.factorio.com/Mod_portal_API#/api/mods/