### PR TITLE
add a missing redirect to [coveralls]

### DIFF
--- a/services/coveralls/coveralls-redirector.service.js
+++ b/services/coveralls/coveralls-redirector.service.js
@@ -25,7 +25,7 @@ export default [
     dateAdded: new Date('2021-02-23'),
   }),
   redirector({
-    name: 'CoverallsPreGitlabRedirect',
+    name: 'CoverallsPreGitlabRedirectWithBranch',
     category: 'coverage',
     route: {
       base: 'coveralls',
@@ -35,5 +35,16 @@ export default [
       `/coverallsCoverage/${vcsType}/${user}/${repo}`,
     transformQueryParams: ({ branch }) => ({ branch }),
     dateAdded: new Date('2022-11-10'),
+  }),
+  redirector({
+    name: 'CoverallsPreGitlabRedirectWithoutBranch',
+    category: 'coverage',
+    route: {
+      base: 'coveralls',
+      pattern: ':vcsType(github|bitbucket)/:user/:repo',
+    },
+    transformPath: ({ vcsType, user, repo }) =>
+      `/coverallsCoverage/${vcsType}/${user}/${repo}`,
+    dateAdded: new Date('2022-11-20'),
   }),
 ]

--- a/services/coveralls/coveralls-redirector.tester.js
+++ b/services/coveralls/coveralls-redirector.tester.js
@@ -21,9 +21,21 @@ t.create(
   .expectRedirect('/coverallsCoverage/github/jekyll/jekyll.svg?branch=master')
 
 t.create(
+  'Redirect from before branch was a query param - github, without specified branch'
+)
+  .get('/github/badges/shields')
+  .expectRedirect('/coverallsCoverage/github/badges/shields.svg')
+
+t.create(
   'Redirect from before branch was a query param - bitbucket, with specified branch'
 )
   .get('/bitbucket/pyKLIP/pyklip/master.svg')
   .expectRedirect(
     '/coverallsCoverage/bitbucket/pyKLIP/pyklip.svg?branch=master'
   )
+
+t.create(
+  'Redirect from before branch was a query param - bitbucket, without specified branch'
+)
+  .get('/bitbucket/pyKLIP/pyklip.svg')
+  .expectRedirect('/coverallsCoverage/bitbucket/pyKLIP/pyklip.svg')


### PR DESCRIPTION
https://img.shields.io/coveralls/github/badges/shields

<img width="473" alt="Zrzut ekranu 2022-11-20 o 13 21 12" src="https://user-images.githubusercontent.com/31891675/202902549-6d068212-fc8c-4746-a61f-9c093af2551d.png">

Hi @chris48s, 
I noticed that after my last changes to the Coveralls badge (PR https://github.com/badges/shields/pull/8584 ) there is one redirect missing (for the case without the specified branch).
I added it in this PR.

```js
  base: 'coveralls',
  pattern: ':vcsType(github|bitbucket)/:user/:repo',
```

EDIT:
Tested locally,
http://localhost:8080/coveralls/github/badges/shields 
correctly redirects to:
http://localhost:8080/coverallsCoverage/github/badges/shields.svg
<img width="567" alt="Zrzut ekranu 2022-11-20 o 14 27 12" src="https://user-images.githubusercontent.com/31891675/202904726-6c9e45ad-e4d6-4fc1-8bdd-123ab601e6fa.png">

Redirect for the option with specified branch also works correctly:
http://localhost:8080/coveralls/github/badges/shields/master ->
http://localhost:8080/coverallsCoverage/github/badges/shields.svg?branch=master 

<img width="657" alt="Zrzut ekranu 2022-11-20 o 14 40 45" src="https://user-images.githubusercontent.com/31891675/202905352-c1773811-7aa0-42c9-9762-41048ba4e426.png">



