### PR TITLE
Add [Infracost] cloud cost badge

### DIFF
--- a/services/infracost/infracost.service.js
+++ b/services/infracost/infracost.service.js
@@ -1,0 +1,104 @@
+import Joi from 'joi'
+import BaseJsonService from '../../core/base-service/base-json.js'
+
+const queryParamSchema = Joi.object({
+  badgeToken: Joi.string().required(),
+  projectName: Joi.string(),
+}).required()
+
+const schema = Joi.object({
+  cost: Joi.string().required(),
+})
+
+const documentation = `
+  <p>
+    Show cost estimates for your repositories and project with the Infracost badge. 🚀
+  </p>
+  <p>
+  To display Infracost costs for a given branch in your repository, you'll need at least one run stored in Infracost Cloud against the branch. If you don't already have Infracost enabled in CI, follow one of our <a href="https://www.infracost.io/docs/integrations/cicd/" target="_blank">dedicated guides</a.
+  </p>
+  <p>
+  The token used to display the badge can be found under the settings tab of your repository in Infracost Cloud. This can be found by navigating to <b>Repos > {Your Repo} > Settings.</b>
+  </p>
+`
+
+export default class Infracost extends BaseJsonService {
+  static category = 'analysis'
+  static route = {
+    base: 'infracost',
+    pattern: ':vcsName/:user/:repo/:branch',
+    queryParamSchema,
+  }
+
+  static examples = [
+    {
+      title: 'Infracost repo cost',
+      namedParams: {
+        vcsName: 'github',
+        user: 'infracost',
+        repo: 'infracost',
+        branch: 'main',
+      },
+      queryParams: {
+        badgeToken: '59ed2f5f-75f9-42ac-ab94-e88cb24a2ad1',
+      },
+      staticPreview: this.render({ cost: '$3504' }),
+      documentation,
+    },
+    {
+      title: 'Infracost project cost',
+      namedParams: {
+        vcsName: 'github',
+        user: 'infracost',
+        repo: 'infracost',
+        branch: 'main',
+      },
+      queryParams: {
+        badgeToken: '25585702-75fc-43a7-8dfe-f463b62ae5f5',
+        projectName: 'production',
+      },
+      staticPreview: this.render({ cost: '$1762' }),
+      documentation,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'monthly cost' }
+
+  static render({ cost }) {
+    return {
+      message: cost,
+      color: 'purple',
+    }
+  }
+
+  async fetch({ vcsName, user, repo, branch, projectName, badgeToken }) {
+    const url = `https://dashboard.api.infracost.io/shields/repos/${vcsName}/${user}/${repo}/branch/${branch}`
+    return this._requestJson({
+      schema,
+      url,
+      options: {
+        headers: {
+          'X-Badge-Token': badgeToken,
+        },
+        searchParams: { projectName },
+      },
+      errorMessages: {
+        401: 'invalid Infracost badge token',
+        404: 'could not find a cost estimate, please make sure you have a run for this repository stored in Infracost Cloud.',
+        500: 'infracost badge service encountered an unexpected error',
+      },
+    })
+  }
+
+  async handle({ vcsName, user, repo, branch }, { badgeToken, projectName }) {
+    const { cost } = await this.fetch({
+      vcsName,
+      user,
+      repo,
+      branch,
+      badgeToken,
+      projectName,
+    })
+    return this.constructor.render({ cost })
+  }
+}

--- a/services/infracost/infracost.tester.js
+++ b/services/infracost/infracost.tester.js
@@ -1,0 +1,75 @@
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('passes api key as header')
+  .get('/github/infracost/infracost/main.json?badgeToken=test')
+  .intercept(nock =>
+    nock('https://dashboard.api.infracost.io', {
+      reqheaders: {
+        'X-Badge-Token': 'test',
+      },
+    })
+      .get('/shields/repos/github/infracost/infracost/branch/main')
+      .reply(200, { cost: '$50' })
+  )
+  .expectBadge({
+    label: 'monthly cost',
+    message: '$50',
+    color: 'purple',
+  })
+
+t.create('mock valid repo request')
+  .get('/github/infracost/infracost/main.json?badgeToken=test')
+  .intercept(nock =>
+    nock('https://dashboard.api.infracost.io')
+      .get('/shields/repos/github/infracost/infracost/branch/main')
+      .reply(200, { cost: '$50' })
+  )
+  .expectBadge({
+    label: 'monthly cost',
+    message: '$50',
+    color: 'purple',
+  })
+
+t.create('mock valid project request')
+  .get(
+    '/github/infracost/infracost/main.json?badgeToken=test&projectName=projecttest'
+  )
+  .intercept(nock =>
+    nock('https://dashboard.api.infracost.io')
+      .get('/shields/repos/github/infracost/infracost/branch/main')
+      .query({ projectName: 'projecttest' })
+      .reply(200, { cost: '$70' })
+  )
+  .expectBadge({
+    label: 'monthly cost',
+    message: '$70',
+    color: 'purple',
+  })
+
+t.create('mock invalid repo request')
+  .get('/github/infracost/infracost/main.json?badgeToken=test')
+  .intercept(nock =>
+    nock('https://dashboard.api.infracost.io')
+      .get('/shields/repos/github/infracost/infracost/branch/main')
+      .reply(404)
+  )
+  .expectBadge({
+    label: 'monthly cost',
+    message:
+      'could not find a cost estimate, please make sure you have a run for this repository stored in Infracost Cloud.',
+    color: 'red',
+  })
+
+t.create('mock invalid repo request')
+  .get('/github/infracost/infracost/main.json?badgeToken=test')
+  .intercept(nock =>
+    nock('https://dashboard.api.infracost.io')
+      .get('/shields/repos/github/infracost/infracost/branch/main')
+      .reply(401)
+  )
+  .expectBadge({
+    label: 'monthly cost',
+    message: 'invalid Infracost badge token',
+  })


### PR DESCRIPTION
Adds support for an Infracost cloud cost shield that can be broken down by repo or project.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
