### PR TITLE
handle workflow runs that do not have a conclusion in [githubactionsworkflowstatus]

### DIFF
--- a/services/github/github-actions-workflow-status.service.js
+++ b/services/github/github-actions-workflow-status.service.js
@@ -8,8 +8,23 @@ const schema = Joi.object({
   workflow_runs: Joi.array()
     .items(
       Joi.object({
+        status: Joi.equal(
+          'completed',
+          'action_required',
+          'cancelled',
+          'failure',
+          'neutral',
+          'skipped',
+          'stale',
+          'success',
+          'timed_out',
+          'in_progress',
+          'queued',
+          'requested',
+          'waiting'
+        ).required(),
         conclusion: Joi.alternatives()
-          .try(isBuildStatus, Joi.equal('no status'))
+          .try(isBuildStatus, Joi.equal('no status'), null)
           .required(),
       })
     )
@@ -96,6 +111,9 @@ export default class GithubActionsWorkflowStatus extends GithubAuthV3Service {
     if (data.workflow_runs.length === 0) {
       throw new NotFound({ prettyMessage: 'branch or event not found' })
     }
-    return renderBuildStatusBadge({ status: data.workflow_runs[0].conclusion })
+    const status = data.workflow_runs[0].conclusion
+      ? data.workflow_runs[0].conclusion
+      : data.workflow_runs[0].status.replace('_', ' ')
+    return renderBuildStatusBadge({ status })
   }
 }

--- a/services/github/github-actions-workflow-status.tester.js
+++ b/services/github/github-actions-workflow-status.tester.js
@@ -57,3 +57,29 @@ t.create('valid workflow (with event)')
     label: 'build',
     message: isWorkflowStatus,
   })
+
+t.create('workflow in progress')
+  .get('/actions/toolkit/unit-tests.yml.json?branch=main')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/actions/toolkit/actions/workflows/unit-tests.yml/runs')
+      .query({
+        branch: 'main',
+        page: '1',
+        per_page: '1',
+        exclude_pull_requests: 'true',
+      })
+      .reply(200, {
+        workflow_runs: [
+          {
+            status: 'in_progress',
+            conclusion: null,
+          },
+        ],
+      })
+  )
+  .expectBadge({
+    label: 'build',
+    message: 'in progress',
+    color: 'lightgrey',
+  })


### PR DESCRIPTION
Closes #8716

It was always too much to ask for this to go _completely_ to plan :laughing: 

When a build is not completed yet, it has a null value for `.conclusion` e.g:

```js
status: 'in_progress',
conclusion: null,
```

This PR allows `.conclusion` to be `null` and requires a non-null value for `status` which we can fall back to.
