### PR TITLE
allow all numeric branch names in [githubactionsworkflowstatus]

### DIFF
--- a/services/github/github-actions-workflow-status.service.js
+++ b/services/github/github-actions-workflow-status.service.js
@@ -11,7 +11,7 @@ const schema = Joi.object({
 
 const queryParamSchema = Joi.object({
   event: Joi.string(),
-  branch: Joi.string(),
+  branch: Joi.alternatives().try(Joi.string(), Joi.number().cast('string')),
 }).required()
 
 const keywords = ['action', 'actions']

--- a/services/github/github-actions-workflow-status.tester.js
+++ b/services/github/github-actions-workflow-status.tester.js
@@ -35,6 +35,15 @@ t.create('nonexistent event')
     message: 'no status',
   })
 
+t.create('numeric branch name')
+  .get('/actions/toolkit/unit-tests.yml.json?branch=9999')
+  .expectBadge({
+    label: 'build',
+    // the key thing we're testing here is that this doesn't fail with
+    // "invalid query parameter: branch"
+    message: 'no status',
+  })
+
 t.create('valid workflow')
   .get('/actions/toolkit/unit-tests.yml.json')
   .expectBadge({


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/8720

Lets get a nice easy one out of the way first.

Tbh, I suspect this might be an issue that exists in other places, but I'm not going to shave that yak right this second. Squeaky wheel gets the grease today.