### PR TITLE
don't try to call .entries on null or undefined

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -221,7 +221,7 @@ class BaseService {
     const logTrace = (...args) => trace.logTrace('fetch', ...args)
     let logUrl = url
     const logOptions = Object.assign({}, options)
-    if ('searchParams' in options) {
+    if ('searchParams' in options && options.searchParams != null) {
       const params = new URLSearchParams(
         Object.fromEntries(
           Object.entries(options.searchParams).filter(


### PR DESCRIPTION
This PR fixes an issue introduced in PR #8540 . @calebcartwright 's suggestion we deploy this in isolation came good :smile:  This was causing us to throw a `TypeError: Cannot convert undefined or null to object` in some situations.

This PR closes #8756 but it is probably a wider issue
