### PR TITLE
fix service tests on windows; run [crates] (to prove service tests still run)

### DIFF
--- a/core/base-service/loader.js
+++ b/core/base-service/loader.js
@@ -27,11 +27,13 @@ class InvalidService extends Error {
   }
 }
 
+function getServicePaths(pattern) {
+  return glob.sync(toUnixPath(path.join(serviceDir, '**', pattern)))
+}
+
 async function loadServiceClasses(servicePaths) {
   if (!servicePaths) {
-    servicePaths = glob.sync(
-      toUnixPath(path.join(serviceDir, '**', '*.service.js'))
-    )
+    servicePaths = getServicePaths('*.service.js')
   }
 
   const serviceClasses = []
@@ -102,15 +104,16 @@ async function collectDefinitions() {
 
 async function loadTesters() {
   return Promise.all(
-    glob
-      .sync(path.join(serviceDir, '**', '*.tester.js'))
-      .map(async path => await import(`file://${path}`))
+    getServicePaths('*.tester.js').map(
+      async path => await import(`file://${path}`)
+    )
   )
 }
 
 export {
   InvalidService,
   loadServiceClasses,
+  getServicePaths,
   checkNames,
   collectDefinitions,
   loadTesters,

--- a/core/base-service/loader.spec.js
+++ b/core/base-service/loader.spec.js
@@ -2,7 +2,11 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { loadServiceClasses, InvalidService } from './loader.js'
+import {
+  loadServiceClasses,
+  getServicePaths,
+  InvalidService,
+} from './loader.js'
 chai.use(chaiAsPromised)
 
 const { expect } = chai
@@ -63,5 +67,17 @@ describe('loadServiceClasses function', function () {
         path.join(fixturesDir, 'valid-class.fixture.js'),
       ])
     ).to.eventually.have.length(5)
+  })
+})
+
+describe('getServicePaths', function () {
+  // these tests just make sure we discover a
+  // plausibly large number of .service and .tester files
+  it('finds a non-zero number of services in the project', function () {
+    expect(getServicePaths('*.service.js')).to.have.length.above(400)
+  })
+
+  it('finds a non-zero number of testers in the project', function () {
+    expect(getServicePaths('*.tester.js')).to.have.length.above(400)
   })
 })


### PR DESCRIPTION
Refs #8437

This doesn't fix the `:trace` variant but it does fix being able to run `npm run test:services -- only="myservice"` on Windows.

The core fix here is actually:


```diff
diff --git a/core/base-service/loader.js b/core/base-service/loader.js
index 9bbf0c948..5fd87cd87 100644
--- a/core/base-service/loader.js
+++ b/core/base-service/loader.js
@@ -103,7 +103,7 @@ async function collectDefinitions() {
 async function loadTesters() {
   return Promise.all(
     glob
-      .sync(path.join(serviceDir, '**', '*.tester.js'))
+      .sync(toUnixPath(path.join(serviceDir, '**', '*.tester.js')))
       .map(async path => await import(`file://${path}`))
   )
 }
```

(basically in https://github.com/badges/shields/pull/8350 we missed the tests loader).

My original plan was to do that and directly write tests for `loadTesters()` and `loadServiceClasses()` but loading all the tester classes with ```.map(async path => await import(`file://${path}`))``` inside an `expect()` was causing some strange side effects with chai, so I decided to separate discovering all the files from loading them and write a test for just making sure we discover the files, which is why there is a bit more refactoring going on in this PR.

Side note: This doesn't have any bearing on anything, but I am unreasonably annoyed with myself, windows users, and the world as a whole that I had to install Windows in a VirtualBox in order to work this out when it basically amounted to applying a fix I had already worked out previously _without_ having to do that.