### PR TITLE
remove danger-plugin-no-test-shortcuts

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -11,7 +11,6 @@
 // DANGER_GITHUB_API_TOKEN=your-github-api-token npm run danger -- pr https://github.com/badges/shields/pull/2665
 
 const { danger, fail, message, warn } = require('danger')
-const { default: noTestShortcuts } = require('danger-plugin-no-test-shortcuts')
 const { fileMatch } = danger.git
 
 const documentation = fileMatch(
@@ -172,12 +171,4 @@ affectedServices.forEach(service => {
       ].join('')
     )
   }
-})
-
-// Prevent merging exclusive services tests.
-noTestShortcuts({
-  testFilePredicate: filePath => filePath.endsWith('.tester.js'),
-  patterns: {
-    only: ['only()'],
-  },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
         "cypress": "^12.3.0",
         "cypress-wait-for-stable-dom": "^0.1.0",
         "danger": "^11.2.1",
-        "danger-plugin-no-test-shortcuts": "^2.0.0",
         "deepmerge": "^4.2.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.6.0",
@@ -10539,15 +10538,6 @@
       },
       "engines": {
         "node": ">=14.13.1"
-      }
-    },
-    "node_modules/danger-plugin-no-test-shortcuts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/danger-plugin-no-test-shortcuts/-/danger-plugin-no-test-shortcuts-2.0.0.tgz",
-      "integrity": "sha1-Atu3JFWBlFTTbNWVLi/w9H34ENo=",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.4"
       }
     },
     "node_modules/danger/node_modules/ansi-styles": {
@@ -38046,15 +38036,6 @@
             "p-try": "^2.0.0"
           }
         }
-      }
-    },
-    "danger-plugin-no-test-shortcuts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/danger-plugin-no-test-shortcuts/-/danger-plugin-no-test-shortcuts-2.0.0.tgz",
-      "integrity": "sha1-Atu3JFWBlFTTbNWVLi/w9H34ENo=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
       }
     },
     "dashdash": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "cypress": "^12.3.0",
     "cypress-wait-for-stable-dom": "^0.1.0",
     "danger": "^11.2.1",
-    "danger-plugin-no-test-shortcuts": "^2.0.0",
     "deepmerge": "^4.2.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
Turns out this is the thing that was trying to read from the local checkout:
https://github.com/macklinu/danger-plugin-no-test-shortcuts/blob/ebd8c91e333d96a7c6d6e5e6fa1411d0fb460a40/src/index.ts#L49

I think the short term solution is to just ditch this check to get danger working again.

Longer term, I'll make an issue to find another solution to this. One option would be to re-implement the check in danger but based on the diff instead of the local files (like we do with some of the other checks). The other option would be to try and write it as a lint/pre-commit check (we're basically checking the same thing for mocha tests via eslint: https://github.com/badges/shields/blob/2fb98897429c9a5bfa2960a85461a2df66654222/.eslintrc.yml#L115 ).
