### PR TITLE
expose port 443 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ COPY --from=Builder /usr/src/app /usr/src/app
 
 CMD node server
 
-EXPOSE 80
+EXPOSE 80 443


### PR DESCRIPTION
If we don't explicitly specify a port, running `node server` will serve on port 80 if https://github.com/badges/shields/blob/a7368b86707e4953e63d4e83ab3719e077fa724a/config/custom-environment-variables.yml#L20 is false and 443 if it is true, but we don't expose 443 so if that var is true, the port we open in the dockerfile isn't the one the server is listening on.

We could explicitly tell the server to serve TLS on port 80, but I think it makes more sense to expose 443 to cover this case.

This related to https://github.com/badges/shields/issues/8424
The other thing we need to do on this repo is a PR bumping scoutcamp once we've done a release with https://github.com/badges/sc/pull/6 in it
Then once we've got a docker image with that in it, we're on to PRs in the super secret devops repo 🤫