### PR TITLE
run service/docker builds on merge queue builds

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,6 +1,9 @@
 name: Build Docker Image
 on:
   pull_request:
+  push:
+    branches:
+      - 'gh-readonly-queue/**'
 
 jobs:
   build-docker-image:

--- a/.github/workflows/test-services-18.yml
+++ b/.github/workflows/test-services-18.yml
@@ -2,6 +2,9 @@ name: Services@node 18
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+  push:
+    branches:
+      - 'gh-readonly-queue/**'
 
 jobs:
   test-services-18:

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -2,6 +2,9 @@ name: Services
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
+  push:
+    branches:
+      - 'gh-readonly-queue/**'
 
 jobs:
   test-services:


### PR DESCRIPTION
refs #8892

I gave merge queues a quick spin. First problem I hit was that these builds are set to only trigger on pull requests so the queue doesn't try to run them, but then it never merges the thing at the head of the queue because its waiting for these builds (which haven't triggered) to run, so it just waits forever :upside_down_face: 

I suspect this won't be the only thing we need to change, but doing this should unblock finding out what the next one is..