### PR TITLE
adjust route for [npmsio] badges

### DIFF
--- a/services/npms-io/npms-io-score-redirect.service.js
+++ b/services/npms-io/npms-io-score-redirect.service.js
@@ -1,0 +1,27 @@
+import { redirector } from '../index.js'
+
+export default [
+  redirector({
+    name: 'NpmsIOScoreRedirectWithScope',
+    category: 'analysis',
+    route: {
+      base: 'npms-io',
+      pattern:
+        ':type(final|maintenance|popularity|quality)-score/:scope(@.+)/:packageName',
+    },
+    transformPath: ({ type, scope, packageName }) =>
+      `/npms-io/score/${type}/${scope}/${packageName}`,
+    dateAdded: new Date('2023-02-27'),
+  }),
+  redirector({
+    name: 'NpmsIOScoreRedirectWithoutScope',
+    category: 'analysis',
+    route: {
+      base: 'npms-io',
+      pattern: ':type(final|maintenance|popularity|quality)-score/:packageName',
+    },
+    transformPath: ({ type, packageName }) =>
+      `/npms-io/score/${type}/${packageName}`,
+    dateAdded: new Date('2023-02-27'),
+  }),
+]

--- a/services/npms-io/npms-io-score.service.js
+++ b/services/npms-io/npms-io-score.service.js
@@ -23,7 +23,7 @@ export default class NpmsIOScore extends BaseJsonService {
   static route = {
     base: 'npms-io',
     pattern:
-      ':type(final|maintenance|popularity|quality)-score/:scope(@.+)?/:packageName',
+      'score/:type(final|maintenance|popularity|quality)/:scope(@.+)?/:packageName',
   }
 
   static examples = [

--- a/services/npms-io/npms-io-score.tester.js
+++ b/services/npms-io/npms-io-score.tester.js
@@ -2,13 +2,13 @@ import { createServiceTester } from '../tester.js'
 import { isPercentage } from '../test-validators.js'
 export const t = await createServiceTester()
 
-t.create('should show final score').get('/final-score/vue.json').expectBadge({
+t.create('should show final score').get('/score/final/vue.json').expectBadge({
   label: 'score',
   message: isPercentage,
 })
 
 t.create('should show color')
-  .get('/final-score/mock-for-package-score.json')
+  .get('/score/final/mock-for-package-score.json')
   .intercept(nock => {
     nock.enableNetConnect()
 
@@ -27,35 +27,43 @@ t.create('should show color')
   })
 
 t.create('should show final score with scope')
-  .get('/final-score/@vue/cli.json')
+  .get('/score/final/@vue/cli.json')
   .expectBadge({
     label: 'score',
     message: isPercentage,
   })
 
 t.create('should show maintenance')
-  .get('/maintenance-score/vue.json')
+  .get('/score/maintenance/vue.json')
   .expectBadge({
     label: 'maintenance',
     message: isPercentage,
   })
 
 t.create('should show popularity')
-  .get('/popularity-score/vue.json')
+  .get('/score/popularity/vue.json')
   .expectBadge({
     label: 'popularity',
     message: isPercentage,
   })
 
-t.create('should show quality').get('/quality-score/vue.json').expectBadge({
+t.create('should show quality').get('/score/quality/vue.json').expectBadge({
   label: 'quality',
   message: isPercentage,
 })
 
 t.create('unknown package')
-  .get('/final-score/npm-api-does-not-have-this-package.json')
+  .get('/score/final/npm-api-does-not-have-this-package.json')
   .expectBadge({
     label: 'score',
     message: 'package not found or too new',
     color: 'red',
   })
+
+t.create('Redirect with scope')
+  .get('/final-score/@cycle/core')
+  .expectRedirect('/npms-io/score/final/@cycle/core.svg')
+
+t.create('Redirect without scope')
+  .get('/final-score/got')
+  .expectRedirect('/npms-io/score/final/got.svg')


### PR DESCRIPTION
This is another "get everything to play nice with openapi" PR.
In openapi, a route "segment" (the bit in-between 2 slashes basically) can either be a constant value or a variable parameter, but not a mix of both.
Shields almost universally sticks to this (its a fairly sensible rule), except for this one badge. Path-to-regexp lets us do this, but it doesn't translate well. This PR adjusts the npms-io route and adds a redirect for compatibility.