### PR TITLE
adjust route for [npmsio] badges

### DIFF
--- a/services/npms-io/npms-io-score.service.js
+++ b/services/npms-io/npms-io-score.service.js
@@ -23,32 +23,36 @@ export default class NpmsIOScore extends BaseJsonService {
   static route = {
     base: 'npms-io',
     pattern:
-      ':type(final|maintenance|popularity|quality)-score/:scope(@.+)?/:packageName',
+      ':type(final-score|maintenance-score|popularity-score|quality-score)/:scope(@.+)?/:packageName',
   }
 
   static examples = [
     {
       title: 'npms.io (final)',
-      namedParams: { type: 'final', packageName: 'egg' },
+      namedParams: { type: 'final-score', packageName: 'egg' },
       staticPreview: this.render({ score: 0.9711 }),
       keywords,
     },
     {
       title: 'npms.io (popularity)',
       pattern: ':type/:scope/:packageName',
-      namedParams: { type: 'popularity', scope: '@vue', packageName: 'cli' },
+      namedParams: {
+        type: 'popularity-score',
+        scope: '@vue',
+        packageName: 'cli',
+      },
       staticPreview: this.render({ type: 'popularity', score: 0.89 }),
       keywords,
     },
     {
       title: 'npms.io (quality)',
-      namedParams: { type: 'quality', packageName: 'egg' },
+      namedParams: { type: 'quality-score', packageName: 'egg' },
       staticPreview: this.render({ type: 'quality', score: 0.98 }),
       keywords,
     },
     {
       title: 'npms.io (maintenance)',
-      namedParams: { type: 'maintenance', packageName: 'command' },
+      namedParams: { type: 'maintenance-score', packageName: 'command' },
       staticPreview: this.render({ type: 'maintenance', score: 0.222 }),
       keywords,
     },
@@ -76,8 +80,10 @@ export default class NpmsIOScore extends BaseJsonService {
       errorMessages: { 404: 'package not found or too new' },
     })
 
-    const score = type === 'final' ? json.score.final : json.score.detail[type]
+    const scoreType = type.slice(0, -6)
+    const score =
+      scoreType === 'final' ? json.score.final : json.score.detail[scoreType]
 
-    return this.constructor.render({ type, score })
+    return this.constructor.render({ type: scoreType, score })
   }
 }


### PR DESCRIPTION
This is another "get everything to play nice with openapi" PR.
In openapi, a route "segment" (the bit in-between 2 slashes basically) can either be a constant value or a variable parameter, but not a mix of both.
Shields almost universally sticks to this (its a fairly sensible rule), except for this one badge. Path-to-regexp lets us do this, but it doesn't translate well. This PR adjusts the npms-io route and adds a redirect for compatibility.
