### PR TITLE
sort service path matches

### DIFF
--- a/core/base-service/loader.js
+++ b/core/base-service/loader.js
@@ -28,7 +28,7 @@ class InvalidService extends Error {
 }
 
 function getServicePaths(pattern) {
-  return globSync(toUnixPath(path.join(serviceDir, '**', pattern)))
+  return globSync(toUnixPath(path.join(serviceDir, '**', pattern))).sort()
 }
 
 async function loadServiceClasses(servicePaths) {


### PR DESCRIPTION
Went to run a deploy today.
When  I checked it on staging, I realised I _missed a spot_ when I merged https://github.com/badges/shields/pull/8952
Glob results no longer come sorted, so we have to do it ourselves.