### PR TITLE
push images to both GHCR and DockerHub

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           context: .
           push: false
-          tags: shieldsio/shields:pr-validation
+          tags: ghcr.io/badges/shields:pr-validation
           build-args: |
             version=${{ env.SHORT_SHA }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   create-release:
@@ -50,5 +51,20 @@ jobs:
           context: .
           push: true
           tags: shieldsio/shields:server-${{ steps.date.outputs.date }}
+          build-args: |
+            version=server-${{ steps.date.outputs.date }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push snapshot release to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/badges/shields:server-${{ steps.date.outputs.date }}
           build-args: |
             version=server-${{ steps.date.outputs.date }}

--- a/.github/workflows/publish-docker-next.yml
+++ b/.github/workflows/publish-docker-next.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  packages: write
+
 jobs:
   publish-docker-next:
     runs-on: ubuntu-latest
@@ -25,11 +28,26 @@ jobs:
       - name: Set Git Short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
-      - name: Build and push
+      - name: Build and push to DockerHub
         uses: docker/build-push-action@v4
         with:
           context: .
           push: true
           tags: shieldsio/shields:next
+          build-args: |
+            version=${{ env.SHORT_SHA }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to GHCR
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/badges/shields:next
           build-args: |
             version=${{ env.SHORT_SHA }}


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/8993

I've set up https://github.com/badges/shields/pkgs/container/shields but it is currently private because I don't have permission to make it public :upside_down_face: 

We should now be able to push to it from a GH action though. I totally haven't tested this yet. Think I'm just going to merge it and fix it if it doesn't work.
