### PR TITLE
Fix tests for [dynamic endpoint] services

### DIFF
--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -27,7 +27,7 @@ t.create('Malformed url')
   )
   .expectBadge({
     label: 'Package Name',
-    message: 'inaccessible',
+    message: 'invalid',
     color: 'lightgrey',
   })
 

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -1,6 +1,6 @@
 import zlib from 'zlib'
 import { expect } from 'chai'
-import { getShieldsIcon } from '../../lib/logos.js'
+import { getShieldsIcon, getSimpleIcon } from '../../lib/logos.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
@@ -73,13 +73,13 @@ t.create('named logo with color')
       schemaVersion: 1,
       label: 'hey',
       message: 'yo',
-      namedLogo: 'npm',
+      namedLogo: 'github',
       logoColor: 'blue',
     })
   )
   .after((err, res, body) => {
     expect(err).not.to.be.ok
-    expect(body).to.include(getShieldsIcon({ name: 'npm', color: 'blue' }))
+    expect(body).to.include(getSimpleIcon({ name: 'github', color: 'blue' }))
   })
 
 const logoSvg = Buffer.from(


### PR DESCRIPTION
As noted in https://github.com/badges/shields/pull/8966#issue-1611093392 there are a couple of failing service tests that were not related to the changes in #8966

The endpoint one, I think we broke in https://github.com/badges/shields/pull/8263 Custom logo with a colour never made any sense as a test case anyway.

For the dynamic one, I'm not sure where we broke this. Based on the commit history for the file https://github.com/badges/shields/commits/master/services/dynamic/dynamic-json.tester.js I suspect we upgraded got and the error message changed.