### PR TITLE
[CTAN] fallback to date if version is empty

### DIFF
--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -70,7 +70,7 @@ class CtanVersion extends BaseCtanService {
     const json = await this.fetch({ library })
     const version = json.version.number
     if (version.length > 0) {
-      return renderVersionBadge({ version: version })
+      return renderVersionBadge({ version })
     } else {
       const date = json.version.date
       if (date.length > 0) {

--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -1,8 +1,7 @@
 import Joi from 'joi'
 import { renderLicenseBadge } from '../licenses.js'
 import { renderVersionBadge } from '../version.js'
-import { BaseJsonService } from '../index.js'
-import { InvalidResponse } from '../error.js'
+import { BaseJsonService, InvalidResponse } from '../index.js'
 
 const schema = Joi.object({
   license: Joi.array().items(Joi.string()).single(),

--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -7,7 +7,7 @@ const schema = Joi.object({
   license: Joi.array().items(Joi.string()).single(),
   version: Joi.object({
     number: Joi.string().allow('').required(),
-    date: Joi.string().allow('')
+    date: Joi.string().allow(''),
   }).required(),
 }).required()
 
@@ -76,7 +76,7 @@ class CtanVersion extends BaseCtanService {
       if (date.length > 0) {
         return renderVersionBadge({
           version: date,
-          versionFormatter: (color) => 'blue'
+          versionFormatter: color => 'blue',
         })
       } else {
         return new InvalidResponse({

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -80,5 +80,5 @@ t.create('version')
 t.create('date as version').get('/v/l3kernel.json').expectBadge({
   label: 'ctan',
   message: isIsoDate,
-  color: 'blue'
+  color: 'blue',
 })

--- a/services/ctan/ctan.tester.js
+++ b/services/ctan/ctan.tester.js
@@ -8,6 +8,10 @@ const isVPlusDottedVersionAtLeastOneWithOptionalAlphabetLetter = withRegex(
   /^v\d+(\.\d+)?(\.\d+)?[a-z]?$/
 )
 
+// a loose pattern matches an ISO 8601 date
+// e.g.: 2023-01-01
+const isIsoDate = withRegex(/^\d{4}-\d{2}-\d{2}$/)
+
 export const t = new ServiceTester({
   id: 'ctan',
   title: 'Comprehensive TEX Archive Network',
@@ -72,3 +76,9 @@ t.create('version')
     message: 'v1.11',
     color: 'blue',
   })
+
+t.create('date as version').get('/v/l3kernel.json').expectBadge({
+  label: 'ctan',
+  message: isIsoDate,
+  color: 'blue'
+})


### PR DESCRIPTION
I'm new to node.js, hence this PR is more or less an imitation of existing code in the same repo.

Do you suggest to make `version.date` in `schema` also required?

Fixes #9017

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
