### PR TITLE
[bundlejs] add badge for the npm package size

### DIFF
--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -126,7 +126,7 @@ export default class BundlejsPackage extends BaseJsonService {
         ETIMEDOUT: { prettyMessage: 'timeout', cacheSeconds: 10 },
       },
       httpErrors: {
-        404: 'timeout',
+        404: 'package or version not found',
       },
     })
   }

--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -1,0 +1,122 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+
+const schema = Joi.object({
+  size: Joi.object({
+    compressedSize: Joi.string(),
+  }).required(),
+}).required()
+
+const keywords = ['node', 'bundlejs']
+
+const esbuild =
+  '<a href="https://github.com/evanw/esbuild" target="_blank" rel="noopener">esbuild</a>'
+const denoflate =
+  '<a href="https://github.com/hazae41/denoflate" target="_blank" rel="noopener">denoflate</a>'
+const bundlejs =
+  '<a href="https://bundlejs.com/" target="_blank" rel="noopener">bundlejs</a>'
+
+const documentation = `
+<p>
+ View ${esbuild} minified and ${denoflate} gzipped size of a package or selected exports, via ${bundlejs}.
+</p>
+`
+
+export default class BundlejsPackage extends BaseJsonService {
+  static category = 'size'
+
+  static route = {
+    base: 'bundlejs/package',
+    pattern: ':scope(@[^/]+)?/:packageName/:exports?',
+  }
+
+  static examples = [
+    {
+      title: 'npm package minimized gzipped size',
+      pattern: ':packageName',
+      namedParams: {
+        packageName: 'react',
+      },
+      staticPreview: this.render({ size: '2.94 kB' }),
+      keywords,
+      documentation,
+    },
+    {
+      title: 'npm package minimized gzipped size (version)',
+      pattern: ':packageName',
+      namedParams: {
+        packageName: 'react@18.2.0',
+      },
+      staticPreview: this.render({ size: '2.94 kB' }),
+      keywords,
+      documentation,
+    },
+    {
+      title: 'npm package minimized gzipped size (scoped)',
+      pattern: ':scope/:packageName',
+      namedParams: {
+        scope: '@cycle',
+        packageName: 'rx-run',
+      },
+      staticPreview: this.render({ size: '32.3 kB' }),
+      keywords,
+      documentation,
+    },
+    {
+      title: 'npm package minimized gzipped size (select exports)',
+      pattern: ':packageName/:exports',
+      namedParams: {
+        packageName: 'value-enhancer',
+        exports: 'isVal,val',
+      },
+      staticPreview: this.render({ size: '823 B' }),
+      keywords,
+      documentation,
+    },
+    {
+      title:
+        'npm package minimized gzipped size (scoped version select exports)',
+      pattern: ':scope/:packageName/:exports',
+      namedParams: {
+        scope: '@ngneat',
+        packageName: 'falso@6.4.0',
+        exports: 'randEmail,randFullName',
+      },
+      staticPreview: this.render({ size: '17.8 kB' }),
+      keywords,
+      documentation,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'bundlejs', color: 'informational' }
+
+  static render({ size }) {
+    return {
+      label: 'minified size (gzip)',
+      message: size,
+    }
+  }
+
+  async fetch({ scope, packageName, exports }) {
+    const searchParams = {
+      q: `${scope ? `${scope}/` : ''}${packageName}`,
+    }
+    if (exports) {
+      searchParams.treeshake = `[{${exports}}]`
+    }
+    return this._requestJson({
+      schema,
+      url: 'https://deno.bundlejs.com',
+      options: { searchParams },
+      errorMessages: {
+        404: 'package or version not found',
+      },
+    })
+  }
+
+  async handle({ scope, packageName, exports }) {
+    const json = await this.fetch({ scope, packageName, exports })
+    const size = json.size.compressedSize
+    return this.constructor.render({ size })
+  }
+}

--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -107,7 +107,15 @@ export default class BundlejsPackage extends BaseJsonService {
     return this._requestJson({
       schema,
       url: 'https://deno.bundlejs.com',
-      options: { searchParams },
+      options: {
+        searchParams,
+        timeout: {
+          request: 3000,
+        },
+      },
+      systemErrors: {
+        ETIMEDOUT: { prettyMessage: 'bundling', cacheSeconds: 10 },
+      },
       errorMessages: {
         404: 'package or version not found',
       },

--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -123,10 +123,10 @@ export default class BundlejsPackage extends BaseJsonService {
         },
       },
       systemErrors: {
-        ETIMEDOUT: { prettyMessage: 'bundling', cacheSeconds: 10 },
+        ETIMEDOUT: { prettyMessage: 'timeout', cacheSeconds: 10 },
       },
       httpErrors: {
-        404: 'package or version not found',
+        404: 'timeout',
       },
     })
   }

--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -116,7 +116,7 @@ export default class BundlejsPackage extends BaseJsonService {
       systemErrors: {
         ETIMEDOUT: { prettyMessage: 'bundling', cacheSeconds: 10 },
       },
-      errorMessages: {
+      httpErrors: {
         404: 'package or version not found',
       },
     })

--- a/services/bundlejs/bundlejs-package.service.js
+++ b/services/bundlejs/bundlejs-package.service.js
@@ -3,8 +3,12 @@ import { BaseJsonService } from '../index.js'
 
 const schema = Joi.object({
   size: Joi.object({
-    compressedSize: Joi.string(),
+    compressedSize: Joi.string().required(),
   }).required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  exports: Joi.string(),
 }).required()
 
 const keywords = ['node', 'bundlejs']
@@ -26,8 +30,9 @@ export default class BundlejsPackage extends BaseJsonService {
   static category = 'size'
 
   static route = {
-    base: 'bundlejs/package',
-    pattern: ':scope(@[^/]+)?/:packageName/:exports?',
+    base: 'bundlejs/size',
+    pattern: ':scope(@[^/]+)?/:packageName',
+    queryParamSchema,
   }
 
   static examples = [
@@ -64,9 +69,11 @@ export default class BundlejsPackage extends BaseJsonService {
     },
     {
       title: 'npm package minimized gzipped size (select exports)',
-      pattern: ':packageName/:exports',
+      pattern: ':packageName',
       namedParams: {
         packageName: 'value-enhancer',
+      },
+      queryParams: {
         exports: 'isVal,val',
       },
       staticPreview: this.render({ size: '823 B' }),
@@ -76,10 +83,12 @@ export default class BundlejsPackage extends BaseJsonService {
     {
       title:
         'npm package minimized gzipped size (scoped version select exports)',
-      pattern: ':scope/:packageName/:exports',
+      pattern: ':scope/:packageName',
       namedParams: {
         scope: '@ngneat',
         packageName: 'falso@6.4.0',
+      },
+      queryParams: {
         exports: 'randEmail,randFullName',
       },
       staticPreview: this.render({ size: '17.8 kB' }),
@@ -110,7 +119,7 @@ export default class BundlejsPackage extends BaseJsonService {
       options: {
         searchParams,
         timeout: {
-          request: 3000,
+          request: 3500,
         },
       },
       systemErrors: {
@@ -122,7 +131,7 @@ export default class BundlejsPackage extends BaseJsonService {
     })
   }
 
-  async handle({ scope, packageName, exports }) {
+  async handle({ scope, packageName }, { exports }) {
     const json = await this.fetch({ scope, packageName, exports })
     const size = json.size.compressedSize
     return this.constructor.render({ size })

--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -15,11 +15,11 @@ t.create('bundlejs/package (scoped)')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (select exports)')
-  .get('/value-enhancer/isVal,val.json')
+  .get('/value-enhancer.json?exports=isVal,val')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (scoped version select exports)')
-  .get('/@ngneat/falso@6.4.0/randEmail,randFullName.json')
+  .get('/@ngneat/falso@6.4.0.json?exports=randEmail,randFullName')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (not found)')

--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -23,5 +23,21 @@ t.create('bundlejs/package (scoped version select exports)')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (not found)')
-  .get('/@some-no-exist/some-no-exist.json')
+  .get('/react@18.2.0.json')
+  .intercept(nock =>
+    nock('https://deno.bundlejs.com')
+      .get(/./)
+      .query({ q: 'react@18.2.0' })
+      .reply(404),
+  )
+  .expectBadge({ label: 'bundlejs', message: 'package or version not found' })
+
+t.create('bundlejs/package (timeout)')
+  .get('/react@18.2.0.json')
+  .intercept(nock =>
+    nock('https://deno.bundlejs.com')
+      .get(/./)
+      .query({ q: 'react@18.2.0' })
+      .replyWithError({ code: 'ETIMEDOUT' }),
+  )
   .expectBadge({ label: 'bundlejs', message: 'timeout' })

--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -24,4 +24,4 @@ t.create('bundlejs/package (scoped version select exports)')
 
 t.create('bundlejs/package (not found)')
   .get('/@some-no-exist/some-no-exist.json')
-  .expectBadge({ label: 'bundlejs', message: 'package or version not found' })
+  .expectBadge({ label: 'bundlejs', message: 'timeout' })

--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -1,0 +1,33 @@
+import { isFileSize } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('bundlejs/package (packageName)')
+  .timeout(20000)
+  .get('/jquery.json')
+  .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
+
+t.create('bundlejs/package (version)')
+  .timeout(20000)
+  .get('/react@18.2.0.json')
+  .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
+
+t.create('bundlejs/package (scoped)')
+  .timeout(20000)
+  .get('/@cycle/rx-run.json')
+  .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
+
+t.create('bundlejs/package (select exports)')
+  .timeout(20000)
+  .get('/value-enhancer/isVal,val.json')
+  .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
+
+t.create('bundlejs/package (scoped version select exports)')
+  .timeout(20000)
+  .get('/@ngneat/falso@6.4.0/randEmail,randFullName.json')
+  .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
+
+t.create('bundlejs/package (not found)')
+  .timeout(20000)
+  .get('/@some-no-exist/some-no-exist.json')
+  .expectBadge({ label: 'bundlejs', message: 'package or version not found' })

--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -3,31 +3,25 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('bundlejs/package (packageName)')
-  .timeout(20000)
   .get('/jquery.json')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (version)')
-  .timeout(20000)
   .get('/react@18.2.0.json')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (scoped)')
-  .timeout(20000)
   .get('/@cycle/rx-run.json')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (select exports)')
-  .timeout(20000)
   .get('/value-enhancer/isVal,val.json')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (scoped version select exports)')
-  .timeout(20000)
   .get('/@ngneat/falso@6.4.0/randEmail,randFullName.json')
   .expectBadge({ label: 'minified size (gzip)', message: isFileSize })
 
 t.create('bundlejs/package (not found)')
-  .timeout(20000)
   .get('/@some-no-exist/some-no-exist.json')
   .expectBadge({ label: 'bundlejs', message: 'package or version not found' })


### PR DESCRIPTION
View [esbuild](https://github.com/evanw/esbuild) minified and [denoflate](https://github.com/hazae41/denoflate) gzipped size of a package or selected exports, via [bundlejs](https://bundlejs.com/).

Comparing to the existing bundlephobia service, bundlejs is more accurate in terms of treeshaking. It also supports displaying only the size of the selected exports.

cc @okikio