### PR TITLE
remove pull_request:edited trigger from most workflows

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,7 +1,7 @@
 name: Danger
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 permissions:
   checks: write

--- a/.github/workflows/enforce-dependency-review.yml
+++ b/.github/workflows/enforce-dependency-review.yml
@@ -1,7 +1,7 @@
 name: 'Dependency Review'
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   enforce-dependency-review:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,7 +1,7 @@
 name: E2E
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -1,7 +1,7 @@
 name: Frontend
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-integration-17.yml
+++ b/.github/workflows/test-integration-17.yml
@@ -1,7 +1,7 @@
 name: Integration@node 17
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -1,7 +1,7 @@
 name: Integration
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-main-17.yml
+++ b/.github/workflows/test-main-17.yml
@@ -1,7 +1,7 @@
 name: Main@node 17
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -1,7 +1,7 @@
 name: Main
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-package-cli.yml
+++ b/.github/workflows/test-package-cli.yml
@@ -1,7 +1,7 @@
 name: Package CLI
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'

--- a/.github/workflows/test-package-lib.yml
+++ b/.github/workflows/test-package-lib.yml
@@ -1,7 +1,7 @@
 name: Package Library
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches-ignore:
       - 'gh-pages'


### PR DESCRIPTION
When we have a lot of dependabot PRs to review, sometimes we use all our rate limit up and stuff starts failing.

I think one of the issues causing this is that because we trigger a build on `pull_request:edited`, as soon as dependabot edits the top post of a PR to say "dependabot is rebasing this PR", all the builds unnecessarily re-trigger. Then they retrigger again on `pull_request:synchronize` when it force-pushes the branch.

This PR removes the `pull_request:edited` trigger from most of the workflows. I've left it on the service tests because its quite useful that editing the PR title re-runs those.

Hopefully this should reduce the number of builds we run a bit and make it a bit easier to stay under the rate limit.