### PR TITLE
[crates] Use `?include=` to reduce crates.io backend load

### DIFF
--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -44,7 +44,7 @@ class BaseCratesService extends BaseJsonService {
   async fetch({ crate, version }) {
     const url = version
       ? `https://crates.io/api/v1/crates/${crate}/${version}`
-      : `https://crates.io/api/v1/crates/${crate}`
+      : `https://crates.io/api/v1/crates/${crate}?include=versions,downloads`
     return this._requestJson({ schema, url })
   }
 }

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -34,7 +34,7 @@ t.create('recent downloads (null)')
   .get('/dr/libc.json')
   .intercept(nock =>
     nock('https://crates.io')
-      .get('/api/v1/crates/libc')
+      .get('/api/v1/crates/libc?include=versions,downloads')
       .reply(200, {
         crate: {
           downloads: 42,


### PR DESCRIPTION
By default the `/crates/:crate_name` API endpoint returns the categories and keywords related to the crates. Unfortunately this causes two additional database queries on the crates.io backend.

This commit change the request URL to use `?include=` to only include the additional metadata that is needed for the requested badges.