### PR TITLE
switch from xmldom to @xmldom/xmldom; affects [DynamicXml]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@renovatebot/ruby-semver": "^2.1.10",
         "@sentry/node": "^7.48.0",
         "@shields_io/camp": "^18.1.2",
+        "@xmldom/xmldom": "0.8.7",
         "badge-maker": "file:badge-maker",
         "bytes": "^3.1.2",
         "camelcase": "^7.0.1",
@@ -53,7 +54,6 @@
         "semver": "~7.4.0",
         "simple-icons": "8.10.0",
         "webextension-store-meta": "^1.0.5",
-        "xmldom": "~0.6.0",
         "xpath": "~0.0.32"
       },
       "devDependencies": {
@@ -6419,6 +6419,14 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -30173,14 +30181,6 @@
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/xmlhttprequest-ssl": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
@@ -35266,6 +35266,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -53447,11 +53452,6 @@
       "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
       "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xmlhttprequest-ssl": {
       "version": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@renovatebot/ruby-semver": "^2.1.10",
     "@sentry/node": "^7.48.0",
     "@shields_io/camp": "^18.1.2",
+    "@xmldom/xmldom": "0.8.7",
     "badge-maker": "file:badge-maker",
     "bytes": "^3.1.2",
     "camelcase": "^7.0.1",
@@ -65,7 +66,6 @@
     "semver": "~7.4.0",
     "simple-icons": "8.10.0",
     "webextension-store-meta": "^1.0.5",
-    "xmldom": "~0.6.0",
     "xpath": "~0.0.32"
   },
   "scripts": {

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -1,4 +1,4 @@
-import { DOMParser } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
 import xpath from 'xpath'
 import { MetricNames } from '../../core/base-service/metric-helper.js'
 import { renderDynamicBadge, errorMessages } from '../dynamic-common.js'


### PR DESCRIPTION
See the note at the top of the README on https://github.com/xmldom/xmldom

> Since version 0.7.0 this package is published to npm as [@xmldom/xmldom](https://www.npmjs.com/package/@xmldom/xmldom) and no longer as [xmldom](https://www.npmjs.com/package/xmldom), because https://github.com/xmldom/xmldom/issues/271.