### PR TITLE
[SourceForge] Add the old API back

### DIFF
--- a/services/sourceforge/sourceforge.service.js
+++ b/services/sourceforge/sourceforge.service.js
@@ -1,0 +1,104 @@
+import Joi from 'joi'
+import dayjs from 'dayjs'
+import { renderDownloadsBadge } from '../downloads.js'
+import { nonNegativeInteger } from '../validators.js'
+import { BaseJsonService } from '../index.js'
+
+const schema = Joi.object({
+  total: nonNegativeInteger,
+}).required()
+
+const intervalMap = {
+  dd: {
+    startDate: endDate => endDate,
+    interval: 'day',
+  },
+  dw: {
+    // 6 days, since date range is inclusive,
+    startDate: endDate => dayjs(endDate).subtract(6, 'days'),
+    interval: 'week',
+  },
+  dm: {
+    startDate: endDate => dayjs(endDate).subtract(30, 'days'),
+    interval: 'month',
+  },
+  dt: {
+    startDate: () => dayjs(0),
+  },
+}
+
+export default class Sourceforge extends BaseJsonService {
+  static category = 'downloads'
+
+  static route = {
+    base: 'sourceforge',
+    pattern: ':interval(dt|dm|dw|dd)/:project/:folder*',
+  }
+
+  static examples = [
+    {
+      title: 'SourceForge Downloads',
+      pattern: ':interval(dt|dm|dw|dd)/:project',
+      namedParams: {
+        interval: 'dm',
+        project: 'sevenzip',
+      },
+      staticPreview: this.render({
+        downloads: 215990,
+        interval: 'dm',
+      }),
+    },
+    {
+      title: 'SourceForge Downloads (folder)',
+      pattern: ':interval(dt|dm|dw|dd)/:project/:folder',
+      namedParams: {
+        interval: 'dm',
+        project: 'arianne',
+        folder: 'stendhal',
+      },
+      staticPreview: this.render({
+        downloads: 550,
+        interval: 'dm',
+      }),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'sourceforge' }
+
+  static render({ downloads, interval }) {
+    return renderDownloadsBadge({
+      downloads,
+      labelOverride: 'downloads',
+      interval: intervalMap[interval].interval,
+    })
+  }
+
+  async fetch({ interval, project, folder }) {
+    const url = `https://sourceforge.net/projects/${project}/files/${
+      folder ? `${folder}/` : ''
+    }stats/json`
+    // get yesterday since today is incomplete
+    const endDate = dayjs().subtract(24, 'hours')
+    const startDate = intervalMap[interval].startDate(endDate)
+    const options = {
+      searchParams: {
+        start_date: startDate.format('YYYY-MM-DD'),
+        end_date: endDate.format('YYYY-MM-DD'),
+      },
+    }
+
+    return this._requestJson({
+      schema,
+      url,
+      options,
+      errorMessages: {
+        404: 'project not found',
+      },
+    })
+  }
+
+  async handle({ interval, project, folder }) {
+    const { total: downloads } = await this.fetch({ interval, project, folder })
+    return this.constructor.render({ interval, downloads })
+  }
+}

--- a/services/sourceforge/sourceforge.tester.js
+++ b/services/sourceforge/sourceforge.tester.js
@@ -1,0 +1,40 @@
+import { isMetric, isMetricOverTimePeriod } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('total downloads').get('/dt/sevenzip.json').expectBadge({
+  label: 'downloads',
+  message: isMetric,
+})
+
+t.create('total downloads (with subdirs)')
+  .get('/dt/smartmontools/smartmontools/7.1.json')
+  .expectBadge({
+    label: 'downloads',
+    message: isMetric,
+  })
+
+t.create('monthly downloads').get('/dm/sevenzip.json').expectBadge({
+  label: 'downloads',
+  message: isMetricOverTimePeriod,
+})
+
+t.create('weekly downloads').get('/dw/sevenzip.json').expectBadge({
+  label: 'downloads',
+  message: isMetricOverTimePeriod,
+})
+
+t.create('daily downloads').get('/dd/sevenzip.json').expectBadge({
+  label: 'downloads',
+  message: isMetricOverTimePeriod,
+})
+
+t.create('downloads folder').get('/dm/arianne/stendhal.json').expectBadge({
+  label: 'downloads',
+  message: isMetricOverTimePeriod,
+})
+
+t.create('invalid project').get('/dd/invalid.json').expectBadge({
+  label: 'sourceforge',
+  message: 'project not found',
+})


### PR DESCRIPTION
PR #9078 breaks the existing URLs for downloads like this
`https://img.shields.io/sourceforge/dt/sevenzip.svg`
![broken img](https://img.shields.io/sourceforge/dt/sevenzip.svg)
The API is changed to something like this
`https://img.shields.io/sourceforge/downloads/dt/sevenzip.svg`
![current api](https://img.shields.io/sourceforge/downloads/dt/sevenzip.svg)

This commit add the support for the old URLs by adding `sourceforge.service.js` and `sourceforge.tester.js` back with some modifications to adapt the existing `sourceforge-downloads.service.js`.