### PR TITLE
[Hangar] Add badges for Hangar plugin repository

### DIFF
--- a/services/hangar/hangar-base.js
+++ b/services/hangar/hangar-base.js
@@ -1,0 +1,53 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../../core/base-service/index.js'
+
+const projectSchema = Joi.object({
+  stats: Joi.object({
+    stars: Joi.number().required(),
+    downloads: Joi.number().required(),
+  }).required(),
+
+  settings: Joi.object({
+    license: Joi.object({
+      name: Joi.string().allow(null).allow(''),
+      url: Joi.string().allow(null).allow(''),
+    }),
+  }).required(),
+})
+
+const documentation = `
+<p>The author is the name of the user or organization that owns the plugin. Slug is the name of the plugin.</p>`
+
+const keywords = ['paper', 'papermc', 'paperspigot']
+
+class BaseHangarService extends BaseJsonService {
+  async fetch({
+    author,
+    slug,
+    schema = projectSchema,
+    url = `https://hangar.papermc.io/api/v1/projects/${author}/${slug}`,
+  }) {
+    return this._requestJson({
+      schema,
+      url,
+    })
+  }
+
+  async fetchPlain({
+    author,
+    slug,
+    searchParams = [],
+    url = `https://hangar.papermc.io/api/v1/projects/${author}/${slug}/latestrelease`,
+  }) {
+    const { buffer } = await this._request({
+      url,
+      options: {
+        searchParams,
+      },
+    })
+
+    return buffer
+  }
+}
+
+export { keywords, documentation, BaseHangarService }

--- a/services/hangar/hangar-downloads.service.js
+++ b/services/hangar/hangar-downloads.service.js
@@ -1,0 +1,32 @@
+import { renderDownloadsBadge } from '../downloads.js'
+import { BaseHangarService, documentation, keywords } from './hangar-base.js'
+
+export default class HangarDownloads extends BaseHangarService {
+  static category = 'downloads'
+
+  static route = {
+    base: 'hangar/downloads',
+    pattern: ':author/:slug',
+  }
+
+  static examples = [
+    {
+      title: 'Hangar Downloads',
+      namedParams: {
+        author: 'EssentialsX',
+        slug: 'Essentials',
+      },
+      staticPreview: renderDownloadsBadge({ downloads: 560891 }),
+      documentation,
+      keywords,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'downloads' }
+
+  async handle({ author, slug }) {
+    const { stats } = await this.fetch({ author, slug })
+    const { downloads } = stats
+    return renderDownloadsBadge({ downloads })
+  }
+}

--- a/services/hangar/hangar-downloads.tester.js
+++ b/services/hangar/hangar-downloads.tester.js
@@ -1,0 +1,17 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Essentials (project EssentialsX/Essentials)')
+  .get('/EssentialsX/Essentials.json')
+  .expectBadge({
+    label: 'downloads',
+    message: isMetric,
+  })
+
+t.create('Invalid Project (project md5lukas/invalid)')
+  .get('/md5lukas/invalid.json')
+  .expectBadge({
+    label: 'downloads',
+    message: 'not found',
+  })

--- a/services/hangar/hangar-license.service.js
+++ b/services/hangar/hangar-license.service.js
@@ -1,0 +1,49 @@
+import { renderLicenseBadge } from '../licenses.js'
+import { BaseHangarService, documentation, keywords } from './hangar-base.js'
+
+export default class HangarLicense extends BaseHangarService {
+  static category = 'license'
+
+  static route = {
+    base: 'hangar/l',
+    pattern: ':author/:slug',
+  }
+
+  static examples = [
+    {
+      title: 'Hangar License',
+      namedParams: {
+        author: 'EssentialsX',
+        slug: 'Essentials',
+      },
+      staticPreview: this.render({ license: 'GPL' }),
+      documentation,
+      keywords,
+    },
+  ]
+
+  static defaultBadgeData = {
+    label: 'license',
+  }
+
+  static render({ license }) {
+    return renderLicenseBadge({ license })
+  }
+
+  transform({ data }) {
+    const {
+      settings: {
+        license: { name, url },
+      },
+    } = data
+    /* license: { name: '', url: 'https://donationstore.net/legal/eula' }
+    encountered in the wild */
+    return { license: name || (url ? 'custom' : null) || undefined }
+  }
+
+  async handle({ author, slug }) {
+    const data = await this.fetch({ author, slug })
+    const { license } = this.transform({ data })
+    return this.constructor.render({ license })
+  }
+}

--- a/services/hangar/hangar-license.spec.js
+++ b/services/hangar/hangar-license.spec.js
@@ -1,0 +1,28 @@
+import { test, given } from 'sazerac'
+import HangarLicense from './hangar-license.service.js'
+
+describe('HangarLicense', function () {
+  test(HangarLicense.prototype.transform, () => {
+    given({
+      data: {
+        settings: { license: { name: 'MIT', url: 'http://sample.url' } },
+      },
+    }).expect({ license: 'MIT' })
+  })
+
+  test(HangarLicense.prototype.transform, () => {
+    given({
+      data: {
+        settings: { license: { name: null, url: 'http://sample.url' } },
+      },
+    }).expect({ license: 'custom' })
+  })
+
+  test(HangarLicense.prototype.transform, () => {
+    given({
+      data: {
+        settings: { license: { name: null, url: null } },
+      },
+    }).expect({ license: undefined })
+  })
+})

--- a/services/hangar/hangar-license.tester.js
+++ b/services/hangar/hangar-license.tester.js
@@ -1,0 +1,16 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Essentials (project EssentialsX/Essentials)')
+  .get('/EssentialsX/Essentials.json')
+  .expectBadge({
+    label: 'license',
+    message: 'GPL',
+  })
+
+t.create('Invalid Project (project md5lukas/invalid)')
+  .get('/md5lukas/invalid.json')
+  .expectBadge({
+    label: 'license',
+    message: 'not found',
+  })

--- a/services/hangar/hangar-stars.service.js
+++ b/services/hangar/hangar-stars.service.js
@@ -13,8 +13,8 @@ export default class HangarStars extends BaseHangarService {
     {
       title: 'Hangar Stars',
       namedParams: {
-        author: 'GeyserMC',
-        slug: 'Geyser',
+        author: 'EssentialsX',
+        slug: 'Essentials',
       },
       staticPreview: this.render({
         stars: 1000,

--- a/services/hangar/hangar-stars.service.js
+++ b/services/hangar/hangar-stars.service.js
@@ -1,0 +1,43 @@
+import { metric } from '../text-formatters.js'
+import { BaseHangarService, documentation, keywords } from './hangar-base.js'
+
+export default class HangarStars extends BaseHangarService {
+  static category = 'social'
+
+  static route = {
+    base: 'hangar/stars',
+    pattern: ':author/:slug',
+  }
+
+  static examples = [
+    {
+      title: 'Hangar Stars',
+      namedParams: {
+        author: 'GeyserMC',
+        slug: 'Geyser',
+      },
+      staticPreview: this.render({
+        stars: 1000,
+      }),
+      documentation,
+      keywords,
+    },
+  ]
+
+  static defaultBadgeData = {
+    label: 'stars',
+    color: 'blue',
+  }
+
+  static render({ stars }) {
+    return {
+      message: metric(stars),
+    }
+  }
+
+  async handle({ author, slug }) {
+    const { stats } = await this.fetch({ author, slug })
+    const { stars } = stats
+    return this.constructor.render({ stars })
+  }
+}

--- a/services/hangar/hangar-stars.tester.js
+++ b/services/hangar/hangar-stars.tester.js
@@ -1,0 +1,17 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Essentials (project EssentialsX/Essentials)')
+  .get('/EssentialsX/Essentials.json')
+  .expectBadge({
+    label: 'stars',
+    message: isMetric,
+  })
+
+t.create('Invalid Project (project md5lukas/invalid)')
+  .get('/md5lukas/invalid.json')
+  .expectBadge({
+    label: 'stars',
+    message: 'not found',
+  })

--- a/services/hangar/hangar-version.service.js
+++ b/services/hangar/hangar-version.service.js
@@ -1,0 +1,66 @@
+import { renderVersionBadge } from '../version.js'
+import {
+  BaseHangarService,
+  documentation as originalDocumentation,
+  keywords,
+} from './hangar-base.js'
+
+const documentation = `${originalDocumentation}
+<p>The channel is case-sensitive.</p>`
+
+export default class HangarVersion extends BaseHangarService {
+  static category = 'version'
+
+  static route = {
+    base: 'hangar/v',
+    pattern: ':author/:slug/:channel?',
+  }
+
+  static examples = [
+    {
+      title: 'Hangar Version',
+      namedParams: {
+        author: 'William278',
+        slug: 'HuskHomes',
+      },
+      staticPreview: renderVersionBadge({
+        version: '4.2',
+      }),
+      documentation,
+      keywords,
+    },
+    {
+      title: 'Hangar Version with custom release channel',
+      namedParams: {
+        author: 'William278',
+        slug: 'HuskHomes',
+        channel: 'Alpha',
+      },
+      staticPreview: renderVersionBadge({
+        version: '4.2-ebfe84c',
+      }),
+      documentation,
+      keywords,
+    },
+  ]
+
+  async handle({ author, slug, channel }) {
+    let version
+    if (channel === undefined) {
+      version = await this.fetchPlain({
+        author,
+        slug,
+      })
+    } else {
+      version = await this.fetchPlain({
+        searchParams: {
+          channel,
+        },
+        url: `https://hangar.papermc.io/api/v1/projects/${author}/${slug}/latest`,
+      })
+    }
+    return renderVersionBadge({
+      version,
+    })
+  }
+}

--- a/services/hangar/hangar-version.tester.js
+++ b/services/hangar/hangar-version.tester.js
@@ -1,0 +1,31 @@
+import { isVPlusDottedVersionNClausesWithOptionalSuffix } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Essentials (project EssentialsX/Essentials)')
+  .get('/EssentialsX/Essentials.json')
+  .expectBadge({
+    label: 'version',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+  })
+
+t.create('HuskHomes (project William278/HuskHomes)')
+  .get('/William278/HuskHomes.json')
+  .expectBadge({
+    label: 'version',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+  })
+
+t.create('HuskHomes Alpha Releases (project William278/HuskHomes)')
+  .get('/William278/HuskHomes/Alpha.json')
+  .expectBadge({
+    label: 'version',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+  })
+
+t.create('Invalid Project (project md5lukas/invalid)')
+  .get('/md5lukas/invalid.json')
+  .expectBadge({
+    label: 'version',
+    message: 'not found',
+  })


### PR DESCRIPTION
This PR adds badges for https://hangar.papermc.io
API-docs: https://hangar.papermc.io/api-docs

Hangar itself is based on Ore, for which also badges exist, but aren't entirely a 1to1 match
 
Multiple things I am not really sure about:
- For the version badge, Hangar provides a default release channel, but other ones can have custom names. Should it be a url pattern parameter like it is done at the moment or with query parameters similar to `include_prereleases`
- The way I added the notice to the documentation in hangar-version, is that something that is doable, because it only applies to that one service
- Can I use others public projects to test against or should I create some specifically for testing? (I already did for the invalid test, md5lukas is also a name I use)?
- Should I use :slug as the parameter name, because that is the way it is named in the API-docs or should I prefer the more user-friendly :name?
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
