### PR TITLE
deprecate [travis].org badges

### DIFF
--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -5,30 +5,19 @@ export const t = await createServiceTester()
 
 // Travis (.org) CI
 
-t.create('build status on default branch')
+t.create('build status without branch, deprecated')
   .get('/rust-lang/rust.json')
   .expectBadge({
     label: 'build',
-    message: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
+    message: 'no longer available',
   })
 
-t.create('build status on named branch')
+t.create('build status on named branch, deprecated')
   .get('/rust-lang/rust/stable.json')
   .expectBadge({
     label: 'build',
-    message: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
+    message: 'no longer available',
   })
-
-t.create('unknown repo')
-  .get('/this-repo/does-not-exist.json')
-  .expectBadge({ label: 'build', message: 'unknown' })
-
-t.create('invalid svg response')
-  .get('/foo/bar.json')
-  .intercept(nock =>
-    nock('https://api.travis-ci.org').get('/foo/bar.svg').reply(200)
-  )
-  .expectBadge({ label: 'build', message: 'unparseable svg response' })
 
 // Travis (.com) CI
 

--- a/services/travis/travis-php-version.service.js
+++ b/services/travis/travis-php-version.service.js
@@ -1,100 +1,13 @@
-import Joi from 'joi'
-import {
-  minorVersion,
-  versionReduction,
-  getPhpReleases,
-} from '../php-version.js'
-import { BaseJsonService } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const optionalNumberOrString = Joi.alternatives(Joi.string(), Joi.number())
-const schema = Joi.object({
-  branch: Joi.object({
-    config: Joi.object({
-      php: Joi.array().items(optionalNumberOrString),
-      matrix: Joi.object({
-        include: Joi.array().items(Joi.object({ php: optionalNumberOrString })),
-      }),
-      jobs: Joi.object({
-        include: Joi.array().items(Joi.object({ php: optionalNumberOrString })),
-      }),
-    }).required(),
-  }).required(),
-}).required()
-
-export default class TravisPhpVersion extends BaseJsonService {
-  static category = 'platform-support'
-
-  static route = {
+const TravisPhpVersion = deprecatedService({
+  category: 'platform-support',
+  route: {
     base: 'travis/php-v',
-    pattern: ':user/:repo/:branch+',
-  }
+    pattern: ':params+',
+  },
+  label: 'php',
+  dateAdded: new Date('2023-05-13'),
+})
 
-  static examples = [
-    {
-      title: 'PHP version from Travis config',
-      namedParams: { user: 'yiisoft', repo: 'yii', branch: 'master' },
-      staticPreview: this.render({ reduction: ['5.3 - 7.4'] }),
-    },
-  ]
-
-  static defaultBadgeData = {
-    label: 'php',
-  }
-
-  static render({ reduction, hasHhvm }) {
-    return {
-      message: reduction.concat(hasHhvm ? ['HHVM'] : []).join(', '),
-      color: 'blue',
-    }
-  }
-
-  constructor(context, config) {
-    super(context, config)
-    this._githubApiProvider = context.githubApiProvider
-  }
-
-  async transform({ branch: { config } }) {
-    let travisVersions = []
-
-    // from php
-    if (config.php) {
-      travisVersions = travisVersions.concat(config.php.map(v => v.toString()))
-    }
-    // from matrix
-    if (config.matrix && config.matrix.include) {
-      travisVersions = travisVersions.concat(
-        config.matrix.include.filter(v => 'php' in v).map(v => v.php.toString())
-      )
-    }
-    // from jobs
-    if (config.jobs && config.jobs.include) {
-      travisVersions = travisVersions.concat(
-        config.jobs.include.filter(v => 'php' in v).map(v => v.php.toString())
-      )
-    }
-
-    const versions = travisVersions
-      .map(v => minorVersion(v))
-      .filter(v => v.includes('.'))
-
-    return {
-      reduction: versionReduction(
-        versions,
-        await getPhpReleases(this._githubApiProvider)
-      ),
-      hasHhvm: travisVersions.find(v => v.startsWith('hhvm')),
-    }
-  }
-
-  async handle({ user, repo, branch }) {
-    const travisConfig = await this._requestJson({
-      schema,
-      url: `https://api.travis-ci.org/repos/${user}/${repo}/branches/${branch}`,
-      errorMessages: {
-        404: 'repo not found',
-      },
-    })
-    const { reduction, hasHhvm } = await this.transform(travisConfig)
-    return this.constructor.render({ reduction, hasHhvm })
-  }
-}
+export default TravisPhpVersion

--- a/services/travis/travis-php-version.tester.js
+++ b/services/travis/travis-php-version.tester.js
@@ -1,19 +1,10 @@
-import { isPhpVersionReduction } from '../test-validators.js'
-import { createServiceTester } from '../tester.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
+export const t = new ServiceTester({
+  id: 'TravisPhpVersion',
+  title: 'TravisPhpVersion',
+  pathPrefix: '/travis/php-v',
+})
 
-t.create('gets the package version of symfony 5.1')
+t.create('travis php version, deprecated')
   .get('/symfony/symfony/5.1.json')
-  .expectBadge({ label: 'php', message: isPhpVersionReduction })
-
-t.create('gets the package version of yii')
-  .get('/yiisoft/yii/master.json')
-  .expectBadge({ label: 'php', message: isPhpVersionReduction })
-
-t.create('gets the package version of pagination-bundle')
-  .get('/gpslab/pagination-bundle/master.json')
-  .expectBadge({ label: 'php', message: isPhpVersionReduction })
-
-t.create('invalid package name')
-  .get('/frodo/is-not-a-package/master.json')
-  .expectBadge({ label: 'php', message: 'repo not found' })
+  .expectBadge({ label: 'php', message: 'no longer available' })


### PR DESCRIPTION
closes https://github.com/badges/shields/issues/9071

This PR deprecates the travis .org build badges and travis PHP version but keeps the .com build badges
