### PR TITLE
[GithubActionsWorkflowStatus] Support private repos

### DIFF
--- a/core/base-service/base-json.js
+++ b/core/base-service/base-json.js
@@ -34,10 +34,18 @@ class BaseJsonService extends BaseService {
    *    and custom error messages e.g: `{ 404: 'package not found' }`.
    *    This can be used to extend or override the
    *    [default](https://github.com/badges/shields/blob/master/core/base-service/check-error-response.js#L5)
+   * @param {object} [attrs.validateArgs={}] Arguments to pass to `_validate`.
+   *    For example to override the default `prettyErrorMessage`.
    * @returns {object} Parsed response
    * @see https://github.com/sindresorhus/got/blob/main/documentation/2-options.md
    */
-  async _requestJson({ schema, url, options = {}, errorMessages = {} }) {
+  async _requestJson({
+    schema,
+    url,
+    options = {},
+    errorMessages = {},
+    validateArgs = {},
+  }) {
     const mergedOptions = {
       ...{ headers: { Accept: 'application/json' } },
       ...options,
@@ -48,7 +56,7 @@ class BaseJsonService extends BaseService {
       errorMessages,
     })
     const json = this._parseJson(buffer)
-    return this.constructor._validate(json, schema)
+    return this.constructor._validate(json, schema, validateArgs)
   }
 }
 

--- a/services/build-status.js
+++ b/services/build-status.js
@@ -15,7 +15,14 @@ const greenStatuses = [
   'successful',
 ]
 
-const orangeStatuses = ['partially succeeded', 'unstable', 'timeout']
+const orangeStatuses = [
+  'partially succeeded',
+  'unstable',
+  'timeout',
+  'timed_out',
+  'action_required',
+  'action required',
+]
 
 const redStatuses = [
   'broken',
@@ -49,6 +56,9 @@ const otherStatuses = [
   'stopped',
   'testing',
   'waiting',
+  'in_progress',
+  'in progress',
+  'neutral',
 ]
 
 const allStatuses = greenStatuses
@@ -76,17 +86,18 @@ const isBuildStatus = Joi.equal(...allStatuses)
 function renderBuildStatusBadge({ label, status }) {
   let message
   let color
+  const readableStatus = status.replace('_', ' ')
   if (greenStatuses.includes(status)) {
     message = 'passing'
     color = 'brightgreen'
   } else if (orangeStatuses.includes(status)) {
-    message = status === 'partially succeeded' ? 'passing' : status
+    message = status === 'partially succeeded' ? 'passing' : readableStatus
     color = 'orange'
   } else if (redStatuses.includes(status)) {
-    message = status === 'failed' ? 'failing' : status
+    message = status === 'failed' ? 'failing' : readableStatus
     color = 'red'
   } else {
-    message = status
+    message = readableStatus
   }
   return {
     label,

--- a/services/github/github-actions-workflow-status.tester.js
+++ b/services/github/github-actions-workflow-status.tester.js
@@ -64,3 +64,22 @@ t.create('valid workflow (with event)')
     label: 'build',
     message: isWorkflowStatus,
   })
+
+t.create('omitted workflow').get('/actions/toolkit.json').expectBadge({
+  label: 'build',
+  message: isWorkflowStatus,
+})
+
+t.create('omitted workflow (with branch)')
+  .get('/actions/toolkit.json?branch=main')
+  .expectBadge({
+    label: 'build',
+    message: isWorkflowStatus,
+  })
+
+t.create('omitted workflow (with event)')
+  .get('/actions/toolkit.json?event=push')
+  .expectBadge({
+    label: 'build',
+    message: isWorkflowStatus,
+  })


### PR DESCRIPTION
Implements #9189 

The badge is fully backwards compatible with the tests of the current implementation, but instead of the `badge.svg` URL it fetches the workflow status using the GitHub API, allowing for access to private repos using a PAT.

As a bonus, the `:workflow` path parameter is now optional. If empty, it takes the status of the latest run of all workflows in a repository.
Depending on whether the workflow name is passed, it uses either the [List runs for a repo API](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-repository) or [List runs for a workflow API](https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#list-workflow-runs-for-a-workflow).

I made a few small changes outside of the service code. I may be able to implement this in other ways if it doesn't fit the overall design. Please let me know what you think:
- In `build-status.js` I added a `readableStatus`, replacing `_` with ` ` for readability. This will show a badge message `in progress` instead of `in_progress`, which I think is nicer to read.
- In `validate.js`, I added a way to pass options to the `_validate` method via `_requestJson` to be able to override the `prettyErrorMessage`. I did this to make sure the `no build` message is set if any validation error occurs (e.g. if there are no runs found). Another way would be to loosen the schema of the request and check the length somewhere else.

Please let me know any feedback you have. I'm not a first-time contributor to shields, but it's been a long time so I might be rusty :see_no_evil: 

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
