### PR TITLE
disable dependabot auto rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
+    rebase-strategy: disabled
     ignore:
       # https://github.com/badges/shields/issues/7324
       # https://github.com/badges/shields/issues/7447
@@ -27,6 +28,7 @@ updates:
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
+    rebase-strategy: disabled
 
   # close-bot package dependencies
   - package-ecosystem: npm
@@ -36,8 +38,12 @@ updates:
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
+    rebase-strategy: disabled
+
+  # GH actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99
+    rebase-strategy: disabled


### PR DESCRIPTION
Dependabot made a change a while back which means every time we merge a dependabot PR, dependabot automatically rebases any other open dependabot PRs.

This means that when we're working through the weekly updates, we consume a lot of github rate limit points on re-triggering the same builds. Often I have to merge the updates in batches due to exhausting our rate limit.

This PR turns that off. It does increase the need for us to manually use `@dependabot rebase` when we actually do want a rebase but in the grand schema of things, I think this should make things smoother because we won't exhaust our rate limit so quickly.

Relevant docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy
