### PR TITLE
increase default cache on youtube badges

### DIFF
--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -38,6 +38,8 @@ class YouTubeBase extends BaseJsonService {
     isRequired: true,
   }
 
+  static _cacheLength = 1800
+
   static defaultBadgeData = {
     label: 'youtube',
     color: 'red',


### PR DESCRIPTION
refs #9236
refs #9237

I've still not managed to catch this happening. If we think it is rate limit-related, lets bump the max age up on these.