### PR TITLE
Fix: [GithubCommitActivity] invalid branch error handling

### DIFF
--- a/services/github/github-commit-activity.service.js
+++ b/services/github/github-commit-activity.service.js
@@ -13,7 +13,7 @@ const schema = Joi.object({
         history: Joi.object({
           totalCount: nonNegativeInteger,
         }).required(),
-      }),
+      }).allow(null),
     }).required(),
   }).required(),
 }).required()

--- a/services/github/github-commit-activity.tester.js
+++ b/services/github/github-commit-activity.tester.js
@@ -52,3 +52,10 @@ t.create('commit activity (repo not found)')
     label: 'commit activity',
     message: 'repo not found',
   })
+
+t.create('commit activity (invalid branch)')
+  .get('/w/badges/shields/invalidBranchName.json')
+  .expectBadge({
+    label: 'commit activity',
+    message: 'invalid branch',
+  })


### PR DESCRIPTION
Current code to handle invalid branch in Github Commit Activity (branch) never runs.

When GraphQL response with a bad repo it returns an error indicating the bad repo.
When GraphQL has the correct repo with a bad branch it will return null inside the repo object without an error object.
The existing code seems to try and use that but due to the current Joi schema not allowing null it did not work and an error due to bad schema would show instead.

This PR fixes this issue and adds a test for this case

Photo from production showing invalid response data due to response differ from schema:
![image](https://github.com/badges/shields/assets/15849761/bf88ef15-cd51-4416-a5ee-7b5bb8af426a)
Photo of PR changes on my local debug instance, handling invalid branch:
![image](https://github.com/badges/shields/assets/15849761/2acac01b-c353-4761-86b8-42bf87d1c160)
 

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
