### PR TITLE
fix a load of spacing issues in frontend content

### DIFF
--- a/services/amo/amo-downloads.service.js
+++ b/services/amo/amo-downloads.service.js
@@ -3,11 +3,9 @@ import { redirector } from '../index.js'
 import { BaseAmoService, keywords } from './amo-base.js'
 
 const documentation = `
-<p>
-  Previously <code>amo/d</code> provided a &ldquo;total downloads&rdquo; badge. However,
-  <a href="https://github.com/badges/shields/issues/3079">updates to the v3 API</a> only
-  give us weekly downloads. The route <code>amo/d</code> redirects to <code>amo/dw</code>.
-</p>
+Previously \`amo/d\` provided a &ldquo;total downloads&rdquo; badge. However,
+[updates to the v3 API](https://github.com/badges/shields/issues/3079)
+only give us weekly downloads. The route \`amo/d\` redirects to \`amo/dw\`.
 `
 
 class AmoWeeklyDownloads extends BaseAmoService {

--- a/services/azure-devops/azure-devops-build.service.js
+++ b/services/azure-devops/azure-devops-build.service.js
@@ -9,23 +9,20 @@ const queryParamSchema = Joi.object({
 })
 
 const documentation = `
-<p>
-  A badge requires three pieces of information: <code>ORGANIZATION</code>,
-  <code>PROJECT_ID</code> and <code>DEFINITION_ID</code>.
-</p>
-<p>
-  To start, edit your build definition and look at the url:
-</p>
+A badge requires three pieces of information:
+\`ORGANIZATION\`, \`PROJECT_ID\` and \`DEFINITION_ID\`.
+
+To start, edit your build definition and look at the url:
+
 <img
   src="https://user-images.githubusercontent.com/3749820/47259976-e2d9ec80-d4b2-11e8-92cc-7c81089a7a2c.png"
   alt="ORGANIZATION is after the dev.azure.com part, PROJECT_NAME is right after that, DEFINITION_ID is at the end after the id= part." />
-<p>
-  Then use the Azure DevOps REST API to translate the
-  <code>PROJECT_NAME</code> to a <code>PROJECT_ID</code>.
-</p>
-<p>
-  Navigate to <code>https://dev.azure.com/ORGANIZATION/_apis/projects/PROJECT_NAME</code>
-</p>
+
+Then use the Azure DevOps REST API to translate the
+\`PROJECT_NAME\` to a \`PROJECT_ID\`.
+
+Navigate to \`https://dev.azure.com/ORGANIZATION/_apis/projects/PROJECT_NAME\`
+
 <img
   src="https://user-images.githubusercontent.com/3749820/47266325-1d846900-d535-11e8-9211-2ee72fb91877.png"
   alt="PROJECT_ID is in the id property of the API response." />

--- a/services/azure-devops/azure-devops-coverage.service.js
+++ b/services/azure-devops/azure-devops-coverage.service.js
@@ -4,25 +4,22 @@ import AzureDevOpsBase from './azure-devops-base.js'
 import { keywords } from './azure-devops-helpers.js'
 
 const documentation = `
-<p>
-  To obtain your own badge, you need to get 3 pieces of information:
-  <code>ORGANIZATION</code>, <code>PROJECT</code> and <code>DEFINITION_ID</code>.
-</p>
-<p>
-  First, you need to select your build definition and look at the url:
-</p>
+To obtain your own badge, you need to get 3 pieces of information:
+\`ORGANIZATION\`, \`PROJECT_ID\` and \`DEFINITION_ID\`.
+
+First, you need to select your build definition and look at the url:
+
 <img
   src="https://user-images.githubusercontent.com/3749820/47259976-e2d9ec80-d4b2-11e8-92cc-7c81089a7a2c.png"
   alt="ORGANIZATION is after the dev.azure.com part, PROJECT is right after that, DEFINITION_ID is at the end after the id= part." />
-<p>
-  Your badge will then have the form:
-  <code>https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID.svg</code>.
-</p>
-<p>
-  Optionally, you can specify a named branch:
-  <code>https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID/NAMED_BRANCH.svg</code>.
-</p>
+
+Your badge will then have the form:
+\`https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID.svg\`.
+
+Optionally, you can specify a named branch:
+\`https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID/NAMED_BRANCH.svg\`.
 `
+
 const buildCodeCoverageSchema = Joi.object({
   coverageData: Joi.array()
     .items(

--- a/services/azure-devops/azure-devops-release.service.js
+++ b/services/azure-devops/azure-devops-release.service.js
@@ -3,21 +3,18 @@ import { BaseSvgScrapingService } from '../index.js'
 import { keywords, fetch } from './azure-devops-helpers.js'
 
 const documentation = `
-<p>
-  To obtain your own badge, you need to get 4 pieces of information:
-  <code>ORGANIZATION</code>, <code>PROJECT_ID</code>, <code>DEFINITION_ID</code> and <code>ENVIRONMENT_ID</code>.
-</p>
-<p>
-  First, you need to enable badges for each required environments in the options of your release definition.
-  Once you have save the change, look at badge url:
-</p>
+To obtain your own badge, you need to get 4 pieces of information:
+\`ORGANIZATION\`, \`PROJECT_ID\`, \`DEFINITION_ID\` and \`ENVIRONMENT_ID\`.
+
+First, you need to enable badges for each required environments in the options of your release definition.
+Once you have save the change, look at badge url:
+
 <img
   src="https://user-images.githubusercontent.com/3749820/47266694-7f939d00-d53a-11e8-9224-c2371dd2d0c9.png"
   alt="ORGANIZATION is after the dev.azure.com part, PROJECT_ID is after the badge part, DEFINITION_ID and ENVIRONMENT_ID are right after that." />
-<p>
-  Your badge will then have the form:
-  <code>https://img.shields.io/vso/release/ORGANIZATION/PROJECT_ID/DEFINITION_ID/ENVIRONMENT_ID.svg</code>.
-</p>
+
+Your badge will then have the form:
+\`https://img.shields.io/vso/release/ORGANIZATION/PROJECT_ID/DEFINITION_ID/ENVIRONMENT_ID.svg\`.
 `
 
 export default class AzureDevOpsRelease extends BaseSvgScrapingService {

--- a/services/azure-devops/azure-devops-tests.service.js
+++ b/services/azure-devops/azure-devops-tests.service.js
@@ -21,24 +21,21 @@ const commonAttrs = {
     compact_message: null,
   },
   documentation: `
-<p>
-  To obtain your own badge, you need to get 3 pieces of information:
-  <code>ORGANIZATION</code>, <code>PROJECT</code> and <code>DEFINITION_ID</code>.
-</p>
-<p>
-  First, you need to select your build definition and look at the url:
-</p>
+To obtain your own badge, you need to get 3 pieces of information:
+\`ORGANIZATION\`, \`PROJECT_ID\`, \`DEFINITION_ID\`.
+
+First, you need to select your build definition and look at the url:
+
 <img
   src="https://user-images.githubusercontent.com/3749820/47259976-e2d9ec80-d4b2-11e8-92cc-7c81089a7a2c.png"
   alt="ORGANIZATION is after the dev.azure.com part, PROJECT is right after that, DEFINITION_ID is at the end after the id= part." />
-<p>
-  Your badge will then have the form:
-  <code>https://img.shields.io/azure-devops/tests/ORGANIZATION/PROJECT/DEFINITION_ID.svg</code>.
-</p>
-<p>
-  Optionally, you can specify a named branch:
-  <code>https://img.shields.io/azure-devops/tests/ORGANIZATION/PROJECT/DEFINITION_ID/NAMED_BRANCH.svg</code>.
-</p>
+
+Your badge will then have the form:
+\`https://img.shields.io/azure-devops/tests/ORGANIZATION/PROJECT/DEFINITION_ID.svg\`.
+
+Optionally, you can specify a named branch:
+\`https://img.shields.io/azure-devops/tests/ORGANIZATION/PROJECT/DEFINITION_ID/NAMED_BRANCH.svg\`.
+
 ${commonDocumentation}
 `,
 }

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -78,9 +78,9 @@ const description = `<p>
       <tr>
         <td><code>namedLogo</code></td>
         <td>
-          Default: none. One of the named logos supported by Shields or
-          <a href="https://simpleicons.org/">simple-icons</a>. Can be overridden
-          by the query string.
+          Default: none. One of the named logos supported by Shields
+          or <a href="https://simpleicons.org/">simple-icons</a>. Can be
+          overridden by the query string.
         </td>
       </tr>
       <tr>

--- a/services/github/github-all-contributors.service.js
+++ b/services/github/github-all-contributors.service.js
@@ -5,12 +5,11 @@ import { fetchJsonFromRepo } from './github-common-fetch.js'
 import { documentation as commonDocumentation } from './github-helpers.js'
 
 const documentation = `
-<p>
-  The All Contributors service allows you to recognize all your project
-  contributors, including those that don't push code. See
-  <a href="https://allcontributors.org">https://allcontributors.org</a>
-  for more information.
-</p>
+The All Contributors service allows you to recognize all your project
+contributors, including those that don't push code. See
+[https://allcontributors.org](https://allcontributors.org)
+for more information.
+
 ${commonDocumentation}
 `
 

--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -10,31 +10,24 @@ import {
 } from './github-helpers.js'
 
 const documentation = `
-  <p>
-    This badge is designed for projects hosted on GitHub which are
-    participating in
-    <a href="https://hacktoberfest.digitalocean.com">Hacktoberfest</a>,
-    an initiative to encourage participating in open-source projects. The
-    badge can be added to the project readme to encourage potential
-    contributors to review the suggested issues and to celebrate the
-    contributions that have already been made.
-    The badge displays three pieces of information:
-    <ul>
-      <li>
-        The number of suggested issues. By default this will count open
-        issues with the <strong>hacktoberfest</strong> label, however you
-        can pick a different label (e.g.
-        <code>?suggestion_label=good%20first%20issue</code>).
-      </li>
-      <li>
-        The number of pull requests opened in October. This excludes any
-        PR with the <strong>invalid</strong> label.
-      </li>
-      <li>The number of days left of October.</li>
-    </ul>
-  </p>
+This badge is designed for projects hosted on GitHub which are
+participating in
+[Hacktoberfest](https://hacktoberfest.digitalocean.com),
+an initiative to encourage participating in open-source projects. The
+badge can be added to the project readme to encourage potential
+contributors to review the suggested issues and to celebrate the
+contributions that have already been made.
+The badge displays three pieces of information:
 
-  ${githubDocumentation}
+- The number of suggested issues. By default this will count open
+  issues with the <strong>hacktoberfest</strong> label, however you
+  can pick a different label (e.g.
+  \`?suggestion_label=good%20first%20issue\`).
+- The number of pull requests opened in October. This excludes any
+  PR with the <strong>invalid</strong> label.
+- The number of days left of October.
+
+${githubDocumentation}
 `
 
 const schema = Joi.object({

--- a/services/github/github-helpers.js
+++ b/services/github/github-helpers.js
@@ -4,7 +4,7 @@ import { InvalidResponse, NotFound } from '../index.js'
 const documentation = `
 If your GitHub badge errors, it might be because you hit GitHub's rate limits.
 You can increase Shields.io's rate limit by
-[adding the Shields GitHub](https://img.shields.io/github-auth)
+[adding the Shields GitHub application](https://img.shields.io/github-auth)
 using your GitHub account.
 `
 

--- a/services/github/github-helpers.js
+++ b/services/github/github-helpers.js
@@ -2,12 +2,10 @@ import { colorScale } from '../color-formatters.js'
 import { InvalidResponse, NotFound } from '../index.js'
 
 const documentation = `
-<p>
-  If your GitHub badge errors, it might be because you hit GitHub's rate limits.
-  You can increase Shields.io's rate limit by
-  <a href="https://img.shields.io/github-auth">adding the Shields GitHub
-  application</a> using your GitHub account.
-</p>
+If your GitHub badge errors, it might be because you hit GitHub's rate limits.
+You can increase Shields.io's rate limit by
+[adding the Shields GitHub](https://img.shields.io/github-auth)
+using your GitHub account.
 `
 
 function issueStateColor(s) {

--- a/services/github/github-pipenv.service.js
+++ b/services/github/github-pipenv.service.js
@@ -10,33 +10,25 @@ import { documentation as githubDocumentation } from './github-helpers.js'
 const keywords = ['pipfile']
 
 const documentation = `
-<p>
-  <a href="https://github.com/pypa/pipenv">Pipenv</a> is a dependency
-  manager for Python which manages a
-  <a href="https://virtualenv.pypa.io/en/latest/">virtualenv</a> for
-  projects. It adds/removes packages from your <code>Pipfile</code> as
-  you install/uninstall packages and generates the ever-important
-  <code>Pipfile.lock</code>, which can be checked in to source control
-  in order to produce deterministic builds.
-</p>
+[Pipenv](https://github.com/pypa/pipenv) is a dependency
+manager for Python which manages a
+[virtualenv](https://virtualenv.pypa.io/en/latest/) for
+projects. It adds/removes packages from your \`Pipfile\` as
+you install/uninstall packages and generates the ever-important
+\`Pipfile.lock\`, which can be checked in to source control
+in order to produce deterministic builds.
 
-<p>
-  The GitHub Pipenv badges are intended for applications using Pipenv
-  which are hosted on GitHub.
-</p>
+The GitHub Pipenv badges are intended for applications using Pipenv
+which are hosted on GitHub.
 
-<p>
-  When <code>Pipfile.lock</code> is checked in, the <strong>GitHub Pipenv
-  locked dependency version</strong> badge displays the locked version of
-  a dependency listed in <code>[packages]</code> or
-  <code>[dev-packages]</code> (or any of their transitive dependencies).
-</p>
+When \`Pipfile.lock\` is checked in, the <strong>GitHub Pipenv
+locked dependency version</strong> badge displays the locked version of
+a dependency listed in \`[packages]\` or
+\`[dev-packages]\` (or any of their transitive dependencies).
 
-<p>
-  Usually a Python version is specified in the <code>Pipfile</code>, which
-  <code>pipenv lock</code> then places in <code>Pipfile.lock</code>. The
-  <strong>GitHub Pipenv Python version</strong> badge displays that version.
-</p>
+Usually a Python version is specified in the \`Pipfile\`, which
+\`pipenv lock\` then places in \`Pipfile.lock\`.
+The <strong>GitHub Pipenv Python version</strong> badge displays that version.
 
 ${githubDocumentation}
 `

--- a/services/gitlab/gitlab-forks.service.js
+++ b/services/gitlab/gitlab-forks.service.js
@@ -2,6 +2,7 @@ import Joi from 'joi'
 import { optionalUrl, nonNegativeInteger } from '../validators.js'
 import { metric } from '../text-formatters.js'
 import GitLabBase from './gitlab-base.js'
+import { documentation } from './gitlab-helper.js'
 
 const schema = Joi.object({
   forks_count: nonNegativeInteger,
@@ -10,13 +11,6 @@ const schema = Joi.object({
 const queryParamSchema = Joi.object({
   gitlab_url: optionalUrl,
 }).required()
-
-const documentation = `
-<p>
-  You may use your GitLab Project Id (e.g. 278964) or your Project Path (e.g. gitlab-org/gitlab ).
-  Note that only internet-accessible GitLab instances are supported, for example https://jihulab.com, https://gitlab.gnome.org, or https://gitlab.com/.
-</p>
-`
 
 export default class GitlabForks extends GitLabBase {
   static category = 'social'

--- a/services/gitlab/gitlab-helper.js
+++ b/services/gitlab/gitlab-helper.js
@@ -1,12 +1,10 @@
 const documentation = `
-<p>
-  You may use your GitLab Project Id (e.g. 278964) or your Project Path (e.g. 
-  <a href="https://gitlab.com/gitlab-org/gitlab" target="_blank" >gitlab-org/gitlab</a> ).
-  Note that only internet-accessible GitLab instances are supported, for example 
-  <a href="https://jihulab.com" target="_blank" >https://jihulab.com</a>, 
-  <a href="https://gitlab.gnome.org" target="_blank" >https://gitlab.gnome.org</a>, or 
-  <a href="https://gitlab.com" target="_blank" >https://gitlab.com</a>.
-</p>
+You may use your GitLab Project Id (e.g. 278964) or your Project Path (e.g.
+[gitlab-org/gitlab](https://gitlab.com/gitlab-org/gitlab) ).
+Note that only internet-accessible GitLab instances are supported, for example
+[https://jihulab.com](https://jihulab.com),
+[https://gitlab.gnome.org](https://gitlab.gnome.org), or
+[https://gitlab.com](https://gitlab.com).
 `
 
 function httpErrorsFor(notFoundMessage = 'project not found') {

--- a/services/gitlab/gitlab-stars.service.js
+++ b/services/gitlab/gitlab-stars.service.js
@@ -2,6 +2,7 @@ import Joi from 'joi'
 import { optionalUrl, nonNegativeInteger } from '../validators.js'
 import { metric } from '../text-formatters.js'
 import GitLabBase from './gitlab-base.js'
+import { documentation } from './gitlab-helper.js'
 
 const schema = Joi.object({
   star_count: nonNegativeInteger,
@@ -10,13 +11,6 @@ const schema = Joi.object({
 const queryParamSchema = Joi.object({
   gitlab_url: optionalUrl,
 }).required()
-
-const documentation = `
-<p>
-  You may use your GitLab Project Id (e.g. 278964) or your Project Path (e.g. gitlab-org/gitlab ).
-  Note that only internet-accessible GitLab instances are supported, for example https://jihulab.com, https://gitlab.gnome.org, or https://gitlab.com/.
-</p>
-`
 
 export default class GitlabStars extends GitLabBase {
   static category = 'social'

--- a/services/hsts/hsts.service.js
+++ b/services/hsts/hsts.service.js
@@ -6,17 +6,14 @@ const schema = Joi.object({
 }).required()
 
 const documentation = `
-<p>
-  <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security">
-  <code>Strict-Transport-Security</code> is an HTTP response header</a> that signals that browsers should
-  only access the site using HTTPS.
-</p>
-<p>
-  For a higher level of security, it's possible for a domain owner to
-  <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security">preload
-  this behavior into participating web browsers</a>. Chromium maintains the <a href="https://www.chromium.org/hsts">HSTS preload list</a>, which
-  is the de facto standard that has been adopted by several browsers. This service checks a domain's status in that list.
-</p>
+[\`Strict-Transport-Security\` is an HTTP response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
+that signals that browsers should only access the site using HTTPS.
+
+For a higher level of security, it's possible for a domain owner to
+[preload this behavior into participating web browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security).
+Chromium maintains the [HSTS preload list](https://www.chromium.org/hsts), which
+is the de facto standard that has been adopted by several browsers.
+This service checks a domain's status in that list.
 `
 
 export default class HSTS extends BaseJsonService {

--- a/services/jira/jira-sprint.service.js
+++ b/services/jira/jira-sprint.service.js
@@ -23,11 +23,9 @@ const schema = Joi.object({
 }).required()
 
 const documentation = `
-<p>
-  To get the <code>Sprint ID</code>, go to your Backlog view in your project,
-  right click on your sprint name and get the value of
-  <code>data-sprint-id</code>.
-</p>
+To get the \`Sprint ID\`, go to your Backlog view in your project,
+right click on your sprint name and get the value of
+\`data-sprint-id\`.
 `
 
 export default class JiraSprint extends BaseJsonService {

--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -13,9 +13,11 @@ const queryParamSchema = Joi.object({
 }).required()
 
 const documentation = `
-<p>To find your user id, you can use <a link target="_blank" href="https://prouser123.me/misc/mastodon-userid-lookup.html">this tool</a>.</p><br>
-<p>Alternatively you can make a request to <code>https://your.mastodon.server/.well-known/webfinger?resource=acct:{user}@{domain}</code></p>
-<p>Failing that, you can also visit your profile page, where your user ID will be in the header in a tag like this: <code>&lt;link href='https://your.mastodon.server/api/salmon/{your-user-id}' rel='salmon'></code></p>
+To find your user id, you can use [this tool](https://prouser123.me/misc/mastodon-userid-lookup.html).
+
+Alternatively you can make a request to \`https://your.mastodon.server/.well-known/webfinger?resource=acct:<user>@<domain>\`
+
+Failing that, you can also visit your profile page, where your user ID will be in the header in a tag like this: \`<link href='https://your.mastodon.server/api/salmon/<your-user-id>' rel='salmon'>\`
 `
 
 export default class MastodonFollow extends BaseJsonService {

--- a/services/mozilla-observatory/mozilla-observatory.service.js
+++ b/services/mozilla-observatory/mozilla-observatory.service.js
@@ -26,21 +26,17 @@ const queryParamSchema = Joi.object({
 }).required()
 
 const documentation = `
-<p>
-  The <a href="https://observatory.mozilla.org">Mozilla HTTP Observatory</a>
-  is a set of tools to analyze your website
-  and inform you if you are utilizing the many available methods to secure it.
-</p>
-<p>
-  By default the scan result is hidden from the public result list.
-  You can activate the publication of the scan result
-  by setting the <code>publish</code> parameter.
-</p>
-<p>
-  The badge returns a cached site result if the site has been scanned anytime in the previous 24 hours.
-  If you need to force invalidating the cache,
-  you can to do it manually through the <a href="https://observatory.mozilla.org">Mozilla Observatory Website</a>
-</p>
+The [Mozilla HTTP Observatory](https://observatory.mozilla.org)
+is a set of tools to analyze your website
+and inform you if you are utilizing the many available methods to secure it.
+
+By default the scan result is hidden from the public result list.
+You can activate the publication of the scan result
+by setting the \`publish\` parameter.
+
+The badge returns a cached site result if the site has been scanned anytime in the previous 24 hours.
+If you need to force invalidating the cache,
+you can to do it manually through the [Mozilla Observatory Website](https://observatory.mozilla.org)
 `
 
 export default class MozillaObservatory extends BaseJsonService {

--- a/services/nycrc/nycrc.service.js
+++ b/services/nycrc/nycrc.service.js
@@ -23,11 +23,11 @@ const pkgJSONSchema = Joi.object({
   }).optional(),
 }).required()
 
-const documentation = `<p>
-  Create a code coverage badge, based on thresholds stored in a
-  <a href="https://github.com/istanbuljs/nyc#common-configuration-options">.nycrc config file</a>
-  on GitHub.
-</p>`
+const documentation = `
+Create a code coverage badge, based on thresholds stored in a
+[.nycrc config file](https://github.com/istanbuljs/nyc#common-configuration-options)
+on GitHub.
+`
 
 const validThresholds = ['branches', 'lines', 'functions']
 

--- a/services/osslifecycle/osslifecycle.service.js
+++ b/services/osslifecycle/osslifecycle.service.js
@@ -1,14 +1,12 @@
 import { BaseService, InvalidResponse } from '../index.js'
 
 const documentation = `
-<p>
-  OSS Lifecycle is an initiative started by Netflix to classify open-source projects into lifecycles
-  and clearly identify which projects are active and which ones are retired. To enable this badge,
-  simply create an OSSMETADATA tagging file at the root of your GitHub repository containing a
-  single line similar to the following: <code>osslifecycle=active</code>. Other suggested values are
-  <code>osslifecycle=maintenance</code> and <code>osslifecycle=archived</code>. A working example
-  can be viewed on the <a href="https://github.com/Netflix/osstracker">OSS Tracker repository</a>.
-</p>
+OSS Lifecycle is an initiative started by Netflix to classify open-source projects into lifecycles
+and clearly identify which projects are active and which ones are retired. To enable this badge,
+simply create an OSSMETADATA tagging file at the root of your GitHub repository containing a
+single line similar to the following: \`osslifecycle=active\`. Other suggested values are
+\`osslifecycle=maintenance\` and \`osslifecycle=archived\`. A working example
+can be viewed on the [OSS Tracker repository](https://github.com/Netflix/osstracker).
 `
 
 export default class OssTracker extends BaseService {

--- a/services/pingpong/pingpong-status.service.js
+++ b/services/pingpong/pingpong-status.service.js
@@ -6,10 +6,8 @@ const schema = Joi.object({
 }).required()
 
 const pingpongDocumentation = `
-<p>
-  To see more details about this badge and obtain your api key, visit
-  <a href="https://my.pingpong.one/integrations/badge-status/" target="_blank">https://my.pingpong.one/integrations/badge-status/</a>
-</p>
+To see more details about this badge and obtain your api key, visit
+[https://my.pingpong.one/integrations/badge-status/](https://my.pingpong.one/integrations/badge-status/)
 `
 
 export default class PingPongStatus extends BaseJsonService {

--- a/services/pingpong/pingpong-uptime.service.js
+++ b/services/pingpong/pingpong-uptime.service.js
@@ -7,10 +7,8 @@ const schema = Joi.object({
 }).required()
 
 const pingpongDocumentation = `
-<p>
-  To see more details about this badge and obtain your api key, visit
-  <a href="https://my.pingpong.one/integrations/badge-uptime/" target="_blank">https://my.pingpong.one/integrations/badge-uptime/</a>
-</p>
+To see more details about this badge and obtain your api key, visit
+[https://my.pingpong.one/integrations/badge-status/](https://my.pingpong.one/integrations/badge-status/)
 `
 
 export default class PingPongUptime extends BaseJsonService {

--- a/services/poeditor/poeditor.service.js
+++ b/services/poeditor/poeditor.service.js
@@ -4,14 +4,13 @@ import { coveragePercentage } from '../color-formatters.js'
 import { BaseJsonService, InvalidResponse } from '../index.js'
 
 const documentation = `
-  <p>
-    You must specify the read-only API token from the POEditor account to which the project belongs.
-  </p>
-  <p>
-    As per <a href="https://poeditor.com/docs/api">the POEditor API documentation</a>,
-    <q>all requests to the API must contain the parameter api_token. You can get a read-only key from your POEditor account.
-    You'll find it in <a href="https://poeditor.com/account/api">My Account > API Access</a>.</q>
-  </p>
+You must specify the read-only API token from the POEditor account to which the project belongs.
+
+As per [the POEditor API documentation](https://poeditor.com/docs/api)
+
+> All requests to the API must contain the parameter api_token.
+> You can get a read-only key from your POEditor account.
+> You'll find it in [My Account > API Access](https://poeditor.com/account/api).
 `
 
 const schema = Joi.object({

--- a/services/pypi/pypi-framework-versions.service.js
+++ b/services/pypi/pypi-framework-versions.service.js
@@ -40,7 +40,7 @@ const frameworkNameMap = {
 const documentation = `
 <p>
   This service currently support the following Frameworks: <br/>
-  ${Object.values(frameworkNameMap).map(obj => `<strong>${obj.name}</strong>`)}
+  ${Object.values(frameworkNameMap).map(obj => ` <strong>${obj.name}</strong>`)}
 </p>
 `
 export default class PypiFrameworkVersion extends PypiBase {

--- a/services/security-headers/security-headers.service.js
+++ b/services/security-headers/security-headers.service.js
@@ -8,14 +8,11 @@ const queryParamSchema = Joi.object({
 }).required()
 
 const documentation = `
-<p>
-  The <a href="https://securityheaders.com/">Security Headers</a>
-  provide an easy mechanism to analyze HTTP response headers and
-  give information on how to deploy missing headers.
-</p>
-<p>
-  The scan result will be hidden from the public result list and follow redirects will be on too.
-</p>
+The [Security Headers](https://securityheaders.com/)
+provide an easy mechanism to analyze HTTP response headers and
+give information on how to deploy missing headers.
+
+The scan result will be hidden from the public result list and follow redirects will be on too.
 `
 
 export default class SecurityHeaders extends BaseService {

--- a/services/tokei/tokei.service.js
+++ b/services/tokei/tokei.service.js
@@ -8,20 +8,17 @@ const schema = Joi.object({
 }).required()
 
 const documentation = `
-<p>
-  The <code>provider</code> is the domain name of git host.
-  If no TLD is provided, <code>.com</code> will be added.
-  For example, setting <code>gitlab</code> or <code>bitbucket.org</code> as the
-  provider also works.
-  <br><br>
-  Tokei will automatically count all files with a recognized extension. It will
-  automatically ignore files and folders in <code>.ignore</code> files. If you
-  want to ignore files or folders specifically for tokei, add them to the
-  <code>.tokeignore</code> in the root of your repository.
-  See 
-    <a href="https://github.com/XAMPPRocky/tokei#excluding-folders">https://github.com/XAMPPRocky/tokei#excluding-folders</a>
-  for more info.
-</p>
+The \`provider\` is the domain name of git host.
+If no TLD is provided, \`.com\` will be added.
+For example, setting \`gitlab\` or \`bitbucket.org\` as the
+provider also works.
+
+Tokei will automatically count all files with a recognized extension. It will
+automatically ignore files and folders in \`.ignore\` files. If you
+want to ignore files or folders specifically for tokei, add them to the
+\`.tokeignore\` in the root of your repository. See
+[https://github.com/XAMPPRocky/tokei#excluding-folders](https://github.com/XAMPPRocky/tokei#excluding-folders)
+for more info.
 `
 
 export default class Tokei extends BaseJsonService {

--- a/services/website/website.service.js
+++ b/services/website/website.service.js
@@ -10,23 +10,18 @@ import { BaseService } from '../index.js'
 import trace from '../../core/base-service/trace.js'
 
 const documentation = `
-<p>
-  The badge is of the form
-  <code>https://img.shields.io/website/PROTOCOL/URLREST.svg</code>.
-</p>
-<p>
-  The whole URL is obtained by concatenating the <code>PROTOCOL</code>
-  (<code>http</code> or <code>https</code>, for example) with the
-  <code>URLREST</code> (separating them with <code>://</code>).
-</p>
-<p>
-  The existence of a specific path on the server can be checked by appending
-  a path after the domain name, e.g.
-  <code>https://img.shields.io/website/http/www.website.com/path/to/page.html.svg</code>.
-</p>
-<p>
-  The messages and colors for the up and down states can also be customized.
-</p>
+The badge is of the form
+\`https://img.shields.io/website/PROTOCOL/URLREST.svg\`.
+
+The whole URL is obtained by concatenating the \`PROTOCOL\`
+(\`http\` or \`https\`, for example) with the
+\`URLREST\` (separating them with \`://\`).
+
+The existence of a specific path on the server can be checked by appending
+a path after the domain name, e.g.
+\`https://img.shields.io/website/http/www.website.com/path/to/page.html.svg\`.
+
+The messages and colors for the up and down states can also be customized.
 `
 
 const urlQueryParamSchema = Joi.object({

--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -4,8 +4,8 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 
 const documentation = `
-<p>By using the YouTube badges provided by Shields.io, you are agreeing to be bound by the YouTube Terms of Service. These can be found here:
-<a target="_blank" href="https://www.youtube.com/t/terms">https://www.youtube.com/t/terms</a></p>`
+By using the YouTube badges provided by Shields.io, you are agreeing to be bound by the YouTube Terms of Service.
+These can be found here: [https://www.youtube.com/t/terms](https://www.youtube.com/t/terms)`
 
 const schema = Joi.object({
   pageInfo: Joi.object({


### PR DESCRIPTION
I'm not going to claim I have caught every single `documentation` string with a spacing issue, but I reckon I've got >90% of them. This also lays down a pattern for fixing them if we find any more I have missed.

I have mostly chosen to fix these by converting them to markdown (which we can now use instead of HTML, if we want). In one or two cases, I have moved ht HTML around a bit. In general, we might want to consider converting all of these to markdown, but that is a bigger job.

I won't go through every single page with a spacing issue, but here's a few before/after links

| before | after |
| ------ | ----- |
| https://shields.io/badges/git-hub-contributors-via-allcontributors-org | https://pr-9281-badges-shields.fly.dev/badges/git-hub-contributors-via-allcontributors-org |
| https://shields.io/badges/you-tube-channel-views | https://pr-9281-badges-shields.fly.dev/badges/you-tube-channel-views |
| https://shields.io/badges/ping-pong-status | https://pr-9281-badges-shields.fly.dev/badges/ping-pong-status |
| https://shields.io/badges/git-lab-all-merge-requests | https://pr-9281-badges-shields.fly.dev/badges/git-lab-all-merge-requests |

Refs https://github.com/badges/shields/pull/9280