### PR TITLE
increase max age on [reddit] badges

### DIFF
--- a/services/reddit/subreddit-subscribers.service.js
+++ b/services/reddit/subreddit-subscribers.service.js
@@ -30,6 +30,8 @@ export default class RedditSubredditSubscribers extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 7200
+
   static defaultBadgeData = {
     label: 'reddit',
     namedLogo: 'reddit',

--- a/services/reddit/user-karma.service.js
+++ b/services/reddit/user-karma.service.js
@@ -31,6 +31,8 @@ export default class RedditUserKarma extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 7200
+
   static defaultBadgeData = {
     label: 'reddit karma',
     namedLogo: 'reddit',


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9256

New Reddit API policies will come into effect on 30th June.

Lets crank the max age up on the badges in anticipation of that.

It may also be necessary to implement auth on this service, but lets do this as a starting point.