### PR TITLE
set a sensible meta description

### DIFF
--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -27,7 +27,7 @@ export default function Home() {
   const { siteConfig } = useDocusaurusContext()
   return (
     <Layout
-      description="Description will go into a meta tag in <head />"
+      description="Concise, consistent, and legible badges"
       title={`${siteConfig.title}`}
     >
       <HomepageHeader />


### PR DESCRIPTION
This is shown when a link to shields.io is "unfurled"