### PR TITLE
remove obsolete [travis] .org examples

### DIFF
--- a/services/travis/travis-build.service.js
+++ b/services/travis/travis-build.service.js
@@ -19,24 +19,6 @@ export class TravisComBuild extends BaseSvgScrapingService {
 
   static examples = [
     {
-      title: 'Travis (.org)',
-      pattern: ':user/:repo',
-      namedParams: { user: 'rust-lang', repo: 'rust' },
-      staticPreview: {
-        message: 'passing',
-        color: 'brightgreen',
-      },
-    },
-    {
-      title: 'Travis (.org) branch',
-      pattern: ':user/:repo/:branch',
-      namedParams: { user: 'rust-lang', repo: 'rust', branch: 'master' },
-      staticPreview: {
-        message: 'passing',
-        color: 'brightgreen',
-      },
-    },
-    {
       title: 'Travis (.com)',
       pattern: 'com/:user/:repo',
       namedParams: { user: 'ivandelabeldad', repo: 'rackian-gateway' },


### PR DESCRIPTION
We deprecated these in https://github.com/badges/shields/pull/9171 but I forgot to remove the .org examples (the class uses to cover both the .com and .org cases) so they are still (wrongly) shown in the frontend.