### PR TITLE
temp fix: wrap code examples tabs in narrow browser windows

### DIFF
--- a/frontend/src/css/custom.css
+++ b/frontend/src/css/custom.css
@@ -30,3 +30,17 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 .opencollective-image {
   color-scheme: initial;
 }
+
+/*
+TODO: remove these two styles when
+we can upgrade to docusaurus-theme-openapi@0.6.5
+*/
+
+div.api-code-tab-group {
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+div.api-code-tab-group button.api-code-tab  {
+  width: unset;
+}


### PR DESCRIPTION
closes https://github.com/badges/shields/issues/9278

I've contributed a fix for this upstream at https://github.com/cloud-annotations/docusaurus-openapi/pull/250

Its not in a package release yet though, so while we wait for that I'm going to apply the fix here (by winning the selector specificity war). We can roll it back when docusaurus-theme-openapi@0.6.5 is available.
