### PR TITLE
add a bit of border to text boxes

### DIFF
--- a/frontend/src/css/custom.css
+++ b/frontend/src/css/custom.css
@@ -31,6 +31,12 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
   color-scheme: initial;
 }
 
+input[type="text"] {
+  border-color: var(--ifm-color-primary-lightest);
+  border-style: solid;
+  border-width: 1px;
+}
+
 /*
 TODO: remove these two styles when
 we can upgrade to docusaurus-theme-openapi@0.6.5


### PR DESCRIPTION
Refs https://github.com/badges/shields/discussions/9318

This just adds a little bit of border to text boxes when they're not focussed. Hopefully this makes it a bit clearer.

---

**Before:**

![Screenshot at 2023-06-26 21-03-08](https://github.com/badges/shields/assets/6025893/937b680e-d53c-46d7-aefa-cb0cc061ec3a)

---

**After:**

![Screenshot at 2023-06-26 21-03-41](https://github.com/badges/shields/assets/6025893/5dbd56c5-812d-485c-a6ac-e33d9e139446)
