### PR TITLE
[SourceForge] Added more badges for SourceForge 

### DIFF
--- a/services/sourceforge/sourceforge-language.service.js
+++ b/services/sourceforge/sourceforge-language.service.js
@@ -1,0 +1,45 @@
+import Joi from 'joi'
+import BaseSourceForgeService from './sourceforge-base.js'
+
+const schema = Joi.object({
+  categories: Joi.object({
+    language: Joi.array().required(),
+  }).required(),
+}).required()
+
+export default class SourceforgeLanguage extends BaseSourceForgeService {
+  static category = 'analysis'
+
+  static route = {
+    base: 'sourceforge/language',
+    pattern: ':index/:project',
+  }
+
+  static examples = [
+    {
+      title: 'SourceForge language',
+      namedParams: {
+        project: 'mingw',
+        index: '0',
+      },
+      staticPreview: this.render('Fortran'),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'language' }
+
+  static render(language) {
+    return {
+      message: language,
+      color: 'blue',
+    }
+  }
+
+  async handle({ project, index }) {
+    const body = await this.fetch({ project, schema })
+    return this.constructor.render(
+      body.categories.language[parseInt(index)]?.fullname ||
+        body.categories.language[0]?.fullname
+    )
+  }
+}

--- a/services/sourceforge/sourceforge-language.tester.js
+++ b/services/sourceforge/sourceforge-language.tester.js
@@ -1,0 +1,14 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('language (with existing index)')
+  .get('/1/mingw.json')
+  .expectBadge({ label: 'language', message: 'Pascal' })
+
+t.create('language with inexistent index')
+  .get('/8/mingw.json')
+  .expectBadge({ label: 'language', message: 'Fortran' })
+
+t.create('language (project not found)')
+  .get('/5/that-doesnt-exist.json')
+  .expectBadge({ label: 'language', message: 'project not found' })

--- a/services/sourceforge/sourceforge-license.service.js
+++ b/services/sourceforge/sourceforge-license.service.js
@@ -1,0 +1,43 @@
+import Joi from 'joi'
+import { renderLicenseBadge } from '../licenses.js'
+import BaseSourceForgeService from './sourceforge-base.js'
+
+const schema = Joi.object({
+  categories: Joi.object({
+    license: Joi.array().required(),
+  }).required(),
+}).required()
+
+export default class SourceforgeLicense extends BaseSourceForgeService {
+  static category = 'license'
+
+  static route = {
+    base: 'sourceforge/license',
+    pattern: ':index/:project',
+  }
+
+  static examples = [
+    {
+      title: 'SourceForge license',
+      namedParams: {
+        project: 'mingw',
+        index: '0',
+      },
+      staticPreview: this.render('BSD'),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'license' }
+
+  static render(license) {
+    return renderLicenseBadge({ license })
+  }
+
+  async handle({ project, index }) {
+    const body = await this.fetch({ project, schema })
+    return this.constructor.render(
+      body.categories.license[parseInt(index)]?.fullname ||
+        body.categories.license[0]?.fullname
+    )
+  }
+}

--- a/services/sourceforge/sourceforge-license.tester.js
+++ b/services/sourceforge/sourceforge-license.tester.js
@@ -1,0 +1,14 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('license (with existing index)')
+  .get('/1/mingw.json')
+  .expectBadge({ label: 'license', message: 'Public Domain' })
+
+t.create('license with inexistent index')
+  .get('/8/mingw.json')
+  .expectBadge({ label: 'license', message: 'BSD License' })
+
+t.create('license (project not found)')
+  .get('/5/that-doesnt-exist.json')
+  .expectBadge({ label: 'license', message: 'project not found' })

--- a/services/sourceforge/sourceforge-status.service.js
+++ b/services/sourceforge/sourceforge-status.service.js
@@ -1,0 +1,39 @@
+import Joi from 'joi'
+import BaseSourceForgeService from './sourceforge-base.js'
+
+const schema = Joi.object({
+  status: Joi.string().required(),
+}).required()
+
+export default class SourceforgeStatus extends BaseSourceForgeService {
+  static category = 'monitoring'
+
+  static route = {
+    base: 'sourceforge/status',
+    pattern: ':project',
+  }
+
+  static examples = [
+    {
+      title: 'SourceForge Status',
+      namedParams: {
+        project: 'mingw',
+      },
+      staticPreview: this.render('active'),
+    },
+  ]
+
+  static defaultBadgeData = { label: 'status' }
+
+  static render(status) {
+    return {
+      message: status,
+      color: status === 'active' ? 'green' : 'red',
+    }
+  }
+
+  async handle({ project }) {
+    const body = await this.fetch({ project, schema })
+    return this.constructor.render(body.status)
+  }
+}

--- a/services/sourceforge/sourceforge-status.tester.js
+++ b/services/sourceforge/sourceforge-status.tester.js
@@ -1,0 +1,10 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('status (active)')
+  .get('/mingw.json')
+  .expectBadge({ label: 'status', message: 'active', color: 'green' })
+
+t.create('status (project not found)')
+  .get('/that-doesnt-exist.json')
+  .expectBadge({ label: 'status', message: 'project not found', color: 'red' })


### PR DESCRIPTION
Hi !

In order to answer issue #9301 I added more badges for the SourceForge service:

| Data Field 	| Build URL                                       	| Badge 	|
|------------	|-------------------------------------------------	|-------	|
| License (index)   	| /sourceforge/license/0/mingw?style=flat-square  	| ![license](https://github.com/badges/shields/assets/59660601/3e6889d3-7a27-40dc-a83f-3d73e46a44ca) |
| Language (index)   	| /sourceforge/language/2/mingw?style=flat-square 	| ![language](https://github.com/badges/shields/assets/59660601/0232e587-9586-44cb-8e19-f3c9684f6c79)  	|
| Status     	| /sourceforge/status/mingw?style=flat-square     	| ![status](https://github.com/badges/shields/assets/59660601/f13df3e3-5d25-43ae-8257-5933abbe9397) |

New license and language badges allow you to choose the item to be displayed on the badge according to its index in the array (because sourceforge lists all languages and licenses for each project).
  
Close #9301 
