### PR TITLE
Mention YouTube API services and link to Google Privacy Policy

### DIFF
--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -4,8 +4,10 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 
 const documentation = `
-By using the YouTube badges provided by Shields.io, you are agreeing to be bound by the YouTube Terms of Service.
-These can be found here: [https://www.youtube.com/t/terms](https://www.youtube.com/t/terms)`
+The YouTube badges provided by Shields.io leverage the YouTube API Services. By using this badge, you are:
+* agreeing to be bound by the YouTube Terms of Service, which can be found here: [https://www.youtube.com/t/terms](https://www.youtube.com/t/terms)
+* acknowledging and accepting the Google Privacy Policy, which can be found here: [https://policies.google.com/privacy](https://policies.google.com/privacy)
+`
 
 const schema = Joi.object({
   pageInfo: Joi.object({


### PR DESCRIPTION
I've been in discussions with the YouTube API Services team in order to get an API quota increase (see #8605). Unfortunately, there has been some push back, and the changes I made in #6304 are no longer deemed sufficient, even though the YouTube Developer API policy has not changed since then.

The latest response I got from the YouTube API Services team states the following:
> we appreciate you for adding the YouTube link in your website however as the YouTube API features are there in website kindly add the link of the[ http://www.google.com/policies/privacy](https://policies.google.com/privacy) in the same page by mentioning the website users are using the YouTube API services so that we can proceed further with your quota increase request

To that effect:
* I added a mention to the fact that our badges use the YouTube API Services.
* I added a link to the Google Privacy Policy.

The YouTube API Services have imposed a deadline for making these changes before July 7th, let's get this reviewed and deployed sooner rather than later.