### PR TITLE
increase max-age on [docker] badges, again

### DIFF
--- a/services/docker/docker-pulls.service.js
+++ b/services/docker/docker-pulls.service.js
@@ -26,7 +26,7 @@ export default class DockerPulls extends BaseJsonService {
     },
   ]
 
-  static _cacheLength = 3600
+  static _cacheLength = 7200
 
   static defaultBadgeData = { label: 'docker pulls' }
 

--- a/services/docker/docker-stars.service.js
+++ b/services/docker/docker-stars.service.js
@@ -26,6 +26,8 @@ export default class DockerStars extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 7200
+
   static defaultBadgeData = { label: 'docker stars' }
 
   static render({ stars }) {


### PR DESCRIPTION
Follows on from
https://github.com/badges/shields/pull/9343
https://github.com/badges/shields/issues/9342


We're still hitting the rate limits :sob: 

This PR increases the max age on the pulls badges again. Also the stars badge, which is not as popular but is also an indicative popularity measurement and usually presents a rounded number and hence a good candidate for a longer max-age.