### PR TITLE
cache docker badges for longer (take 3)

### DIFF
--- a/services/docker/docker-automated.service.js
+++ b/services/docker/docker-automated.service.js
@@ -24,6 +24,8 @@ export default class DockerAutomatedBuild extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 14400
+
   static defaultBadgeData = { label: 'docker build' }
 
   static render({ isAutomated }) {

--- a/services/docker/docker-cloud-automated.service.js
+++ b/services/docker/docker-cloud-automated.service.js
@@ -17,6 +17,8 @@ export default class DockerCloudAutomatedBuild extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 14400
+
   static defaultBadgeData = { label: 'docker build' }
 
   static render({ buildSettings }) {

--- a/services/docker/docker-pulls.service.js
+++ b/services/docker/docker-pulls.service.js
@@ -26,7 +26,7 @@ export default class DockerPulls extends BaseJsonService {
     },
   ]
 
-  static _cacheLength = 7200
+  static _cacheLength = 14400
 
   static defaultBadgeData = { label: 'docker pulls' }
 

--- a/services/docker/docker-size.service.js
+++ b/services/docker/docker-size.service.js
@@ -92,6 +92,8 @@ export default class DockerSize extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 600
+
   static defaultBadgeData = { label: 'image size', color: 'blue' }
 
   static render({ size }) {

--- a/services/docker/docker-stars.service.js
+++ b/services/docker/docker-stars.service.js
@@ -26,7 +26,7 @@ export default class DockerStars extends BaseJsonService {
     },
   ]
 
-  static _cacheLength = 7200
+  static _cacheLength = 14400
 
   static defaultBadgeData = { label: 'docker stars' }
 


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9342

It looks like the magic number we need to stay under is 180 reqs/minute.

We're still going over that at peak times, so I am going to hit it again with the only hammer we've got.

I'm going to leave build status and version badges on the default max-ages for those categories though.