### PR TITLE
Go back to default YouTube cache

### DIFF
--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -40,8 +40,6 @@ class YouTubeBase extends BaseJsonService {
     isRequired: true,
   }
 
-  static _cacheLength = 7200
-
   static defaultBadgeData = {
     label: 'youtube',
     color: 'red',


### PR DESCRIPTION
YouTube has finally granted the API quota increase.

I'm still trying to figure out what the new quota is, as the YouTube API team unhelpfully stated:
> We have increased your Quota by 200,000. The total quota for xxxx is now  200,000 units per day

The request form also insisted on how much _**additional**_ quota we wanted, our previous quota being 50,000, the new quota may actually be 250,000. Either way, we should have more than enough for many months to come. Let's set the cache back to its default value.