### PR TITLE
devops: automate bug report tests

### DIFF
--- a/.github/workflows/test-bug-run-badge.yml
+++ b/.github/workflows/test-bug-run-badge.yml
@@ -41,7 +41,7 @@ jobs:
           node-version: 16
           cypress: false
 
-      - name: Run tests
+      - name: Output debug info
         id: run_tests
         env:
           TEST_BADGE_LINK: '${{ needs.extract-bug-badge-url.outputs.link }}'

--- a/.github/workflows/test-bug-run-badge.yml
+++ b/.github/workflows/test-bug-run-badge.yml
@@ -42,7 +42,6 @@ jobs:
           cypress: false
 
       - name: Output debug info
-        id: run_tests
         env:
           TEST_BADGE_LINK: '${{ needs.extract-bug-badge-url.outputs.link }}'
         run: npm run badge $TEST_BADGE_LINK

--- a/.github/workflows/test-bug-run-badge.yml
+++ b/.github/workflows/test-bug-run-badge.yml
@@ -1,0 +1,78 @@
+name: Test new bug report badge
+run-name: Test bug report on issue ${{ github.event.issue.number }}
+on:
+  issues:
+    types: [opened]
+jobs:
+  extract-bug-badge-url:
+    if: ${{ contains(github.event.issue.labels.*.name, 'question') }}
+    runs-on: ubuntu-latest
+    outputs:
+      runBadgeTest: ${{ steps.testCondition.outputs.runNext }}
+      link: ${{ steps.testCondition.outputs.link }}
+    steps:
+      - name: Test badge test run conditions
+        id: testCondition
+        run: |
+          product=$(echo "${{ github.event.issue.body }}" | grep -A2 "Are you experiencing an issue with.*" | tail -n 1)
+          link=$(echo "${{ github.event.issue.body }}" | grep -A2 "Link to the badge.*" | tail -n 1)
+
+          if [[ "$product" == "shields.io" && "$link" == "https://img.shields.io"* ]]; then
+            echo "runNext=true" >> "$GITHUB_OUTPUT"
+            echo "link=$link" >> "$GITHUB_OUTPUT"
+          else
+            echo "Conditions not met. Skipping the workflow..."
+            echo "runNext=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  run-bug-badge-url-test:
+    needs: extract-bug-badge-url
+    if: needs.extract-bug-badge-url.outputs.runBadgeTest == 'true'
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 16
+          cypress: false
+
+      - name: Run tests
+        id: run_tests
+        env:
+          TEST_BADGE_LINK: '${{ needs.extract-bug-badge-url.outputs.link }}'
+          GH_TOKEN: '${{ secrets.GH_PAT }}'
+          LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
+          OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
+          OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'
+          SL_INSIGHT_USER_UUID: '${{ secrets.SERVICETESTS_SL_INSIGHT_USER_UUID }}'
+          SL_INSIGHT_API_TOKEN: '${{ secrets.SERVICETESTS_SL_INSIGHT_API_TOKEN }}'
+          TWITCH_CLIENT_ID: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_ID }}'
+          TWITCH_CLIENT_SECRET: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_SECRET }}'
+          WHEELMAP_TOKEN: '${{ secrets.SERVICETESTS_WHEELMAP_TOKEN }}'
+          YOUTUBE_API_KEY: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
+        run: npm run badge $TEST_BADGE_LINK
+
+      - name: Add Comment to Issue
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueNumber = context.issue.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runId = context.runId;
+            const jobUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`;
+            const issueComment = `
+              Badge tested using \`npm run badge ${{ needs.extract-bug-badge-url.outputs.link }}\`
+              Output is available [here](${jobUrl})
+            `;
+            github.rest.issues.createComment({
+              issue_number: issueNumber,
+              owner: owner,
+              repo: repo,
+              body: issueComment
+            });

--- a/.github/workflows/test-bug-run-badge.yml
+++ b/.github/workflows/test-bug-run-badge.yml
@@ -45,16 +45,6 @@ jobs:
         id: run_tests
         env:
           TEST_BADGE_LINK: '${{ needs.extract-bug-badge-url.outputs.link }}'
-          GH_TOKEN: '${{ secrets.GH_PAT }}'
-          LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
-          OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
-          OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'
-          SL_INSIGHT_USER_UUID: '${{ secrets.SERVICETESTS_SL_INSIGHT_USER_UUID }}'
-          SL_INSIGHT_API_TOKEN: '${{ secrets.SERVICETESTS_SL_INSIGHT_API_TOKEN }}'
-          TWITCH_CLIENT_ID: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_ID }}'
-          TWITCH_CLIENT_SECRET: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_SECRET }}'
-          WHEELMAP_TOKEN: '${{ secrets.SERVICETESTS_WHEELMAP_TOKEN }}'
-          YOUTUBE_API_KEY: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
         run: npm run badge $TEST_BADGE_LINK
 
       - name: Add Comment to Issue


### PR DESCRIPTION
Devs run `npm run badge` often when getting a bug report for shields.io service. This PR automates this tests so the maintainer can get test results automaticly when getting into a new ticket. Add test-bug-run-badge.yml workflow for github actions automation.

Will only run if bug has the 'qeustion' label added by bug reporting template. And will only setup enviorment and perform the test if the link provided in the issue is valid and the issue is related to shields.io. Link to job results is sent as a new comment on the issue.

Resolves #9351

Image of the bot in action
![image](https://github.com/badges/shields/assets/15849761/20d3f90f-f42b-4ac3-a496-f6f0f14bfabf)


<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
