### PR TITLE
exclude assets dir from raster redirects

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -362,20 +362,23 @@ class Server {
     })
 
     if (!rasterUrl) {
-      camp.route(/^\/((?!img\/)).*\.png$/, (query, match, end, request) => {
-        makeSend(
-          'svg',
-          request.res,
-          end,
-        )(
-          makeBadge({
-            label: '404',
-            message: 'raster badges not available',
-            color: 'lightgray',
-            format: 'svg',
-          }),
-        )
-      })
+      camp.route(
+        /^\/((?!img|assets\/)).*\.png$/,
+        (query, match, end, request) => {
+          makeSend(
+            'svg',
+            request.res,
+            end,
+          )(
+            makeBadge({
+              label: '404',
+              message: 'raster badges not available',
+              color: 'lightgray',
+              format: 'svg',
+            }),
+          )
+        },
+      )
     }
 
     camp.notfound(/(\.svg|\.json|)$/, (query, match, end, request) => {
@@ -412,18 +415,21 @@ class Server {
 
     if (rasterUrl) {
       // Redirect to the raster server for raster versions of modern badges.
-      camp.route(/^\/((?!img\/)).*\.png$/, (queryParams, match, end, ask) => {
-        ask.res.statusCode = 301
-        ask.res.setHeader(
-          'Location',
-          rasterRedirectUrl({ rasterUrl }, ask.req.url),
-        )
+      camp.route(
+        /^\/((?!img|assets\/)).*\.png$/,
+        (queryParams, match, end, ask) => {
+          ask.res.statusCode = 301
+          ask.res.setHeader(
+            'Location',
+            rasterRedirectUrl({ rasterUrl }, ask.req.url),
+          )
 
-        const cacheDuration = (30 * 24 * 3600) | 0 // 30 days.
-        ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
+          const cacheDuration = (30 * 24 * 3600) | 0 // 30 days.
+          ask.res.setHeader('Cache-Control', `max-age=${cacheDuration}`)
 
-        ask.res.end()
-      })
+          ask.res.end()
+        },
+      )
     }
 
     if (redirectUrl) {


### PR DESCRIPTION
Checked https://github.com/badges/shields/pull/9347 on staging

![Screenshot at 2023-07-24 13-04-33](https://github.com/badges/shields/assets/6025893/6224c704-531c-4804-80bf-cc8bd3bd6601)

Looks like sometimes get written to /assets/images as part of the build step