### PR TITLE
Migrate from [DocsRs]' builds API to status API

### DIFF
--- a/services/docsrs/docsrs.service.js
+++ b/services/docsrs/docsrs.service.js
@@ -1,14 +1,9 @@
 import Joi from 'joi'
 import { BaseJsonService } from '../index.js'
 
-const schema = Joi.array()
-  .items(
-    Joi.object({
-      build_status: Joi.boolean().required(),
-    }),
-  )
-  .min(1)
-  .required()
+const schema = Joi.object({
+  doc_status: Joi.boolean().required(),
+}).required()
 
 export default class DocsRs extends BaseJsonService {
   static category = 'build'
@@ -17,19 +12,19 @@ export default class DocsRs extends BaseJsonService {
     {
       title: 'docs.rs',
       namedParams: { crate: 'regex', version: 'latest' },
-      staticPreview: this.render({ version: 'latest', buildStatus: true }),
+      staticPreview: this.render({ version: 'latest', docStatus: true }),
       keywords: ['rust'],
     },
   ]
 
   static defaultBadgeData = { label: 'docs' }
 
-  static render({ buildStatus, version }) {
+  static render({ docStatus, version }) {
     let label = `docs@${version}`
     if (version === 'latest') {
       label = 'docs'
     }
-    if (buildStatus) {
+    if (docStatus) {
       return {
         label,
         message: 'passing',
@@ -47,12 +42,12 @@ export default class DocsRs extends BaseJsonService {
   async fetch({ crate, version }) {
     return await this._requestJson({
       schema,
-      url: `https://docs.rs/crate/${crate}/${version}/builds.json`,
+      url: `https://docs.rs/crate/${crate}/${version}/status.json`,
     })
   }
 
   async handle({ crate, version = 'latest' }) {
-    const [{ build_status: buildStatus }] = await this.fetch({ crate, version })
-    return this.constructor.render({ version, buildStatus })
+    const { doc_status: docStatus } = await this.fetch({ crate, version })
+    return this.constructor.render({ version, docStatus })
   }
 }


### PR DESCRIPTION
To simplify refactoring how our builds are processed I want to remove the `/builds.json` endpoint on docs.rs. As a replacement [I added](https://github.com/rust-lang/docs.rs/pull/2147) a new endpoint simply giving the status that sites like shields.io wants: are there docs for this version available to link to. This also fixes some small issues with the old endpoint (some edgecases meant the first build was successful but there were no docs, or there were docs but the first build was marked unsuccessful).