### PR TITLE
add some tests for [docsrs]

### DIFF
--- a/services/docsrs/docsrs.tester.js
+++ b/services/docsrs/docsrs.tester.js
@@ -20,3 +20,11 @@ t.create('Getting latest version works')
     label: 'docs',
     message: Joi.allow('passing', 'failing'),
   })
+
+t.create('Crate not found')
+  .get('/not-a-crate/latest.json')
+  .expectBadge({ label: 'docs', message: 'not found' })
+
+t.create('Version not found')
+  .get('/tokio/not-a-version.json')
+  .expectBadge({ label: 'docs', message: 'not found' })


### PR DESCRIPTION
While reviewing https://github.com/badges/shields/pull/9422 I noticed we are missing a couple of tests for the not found cases on this service.