### PR TITLE
allow calling [github] without auth

### DIFF
--- a/services/github/github-api-provider.integration.js
+++ b/services/github/github-api-provider.integration.js
@@ -17,11 +17,32 @@ describe('Github API provider', function () {
 
   let githubApiProvider
 
-  context('without token pool', function () {
+  context('with no auth', function () {
     before(function () {
       githubApiProvider = new GithubApiProvider({
         baseUrl,
-        withPooling: false,
+        authType: GithubApiProvider.AUTH_TYPES.NO_AUTH,
+      })
+    })
+
+    it('should be able to run 10 requests', async function () {
+      this.timeout('20s')
+      for (let i = 0; i < 10; ++i) {
+        const { res } = await githubApiProvider.fetch(
+          fetch,
+          '/repos/rust-lang/rust',
+          {},
+        )
+        expect(res.statusCode).to.equal(200)
+      }
+    })
+  })
+
+  context('with global token', function () {
+    before(function () {
+      githubApiProvider = new GithubApiProvider({
+        baseUrl,
+        authType: GithubApiProvider.AUTH_TYPES.GLOBAL_TOKEN,
         globalToken: token,
         reserveFraction,
       })
@@ -30,7 +51,12 @@ describe('Github API provider', function () {
     it('should be able to run 10 requests', async function () {
       this.timeout('20s')
       for (let i = 0; i < 10; ++i) {
-        await githubApiProvider.fetch(fetch, '/repos/rust-lang/rust', {})
+        const { res } = await githubApiProvider.fetch(
+          fetch,
+          '/repos/rust-lang/rust',
+          {},
+        )
+        expect(res.statusCode).to.equal(200)
       }
     })
   })
@@ -40,7 +66,7 @@ describe('Github API provider', function () {
     before(function () {
       githubApiProvider = new GithubApiProvider({
         baseUrl,
-        withPooling: true,
+        authType: GithubApiProvider.AUTH_TYPES.TOKEN_POOL,
         reserveFraction,
       })
       githubApiProvider.addToken(token)

--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -43,7 +43,7 @@ class GithubApiProvider {
   //   reserve it for the user.
   constructor({
     baseUrl,
-    authType,
+    authType = this.constructor.AUTH_TYPES.NO_AUTH,
     onTokenInvalidated = tokenString => {},
     globalToken,
     reserveFraction = 0.25,

--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -33,11 +33,17 @@ const bodySchema = Joi.object({
 
 // Provides an interface to the Github API. Manages the base URL.
 class GithubApiProvider {
+  static AUTH_TYPES = {
+    NO_AUTH: 'No Auth',
+    GLOBAL_TOKEN: 'Global Token',
+    TOKEN_POOL: 'Token Pool',
+  }
+
   // reserveFraction: The amount of much of a token's quota we avoid using, to
   //   reserve it for the user.
   constructor({
     baseUrl,
-    withPooling = true,
+    authType,
     onTokenInvalidated = tokenString => {},
     globalToken,
     reserveFraction = 0.25,
@@ -45,13 +51,13 @@ class GithubApiProvider {
   }) {
     Object.assign(this, {
       baseUrl,
-      withPooling,
+      authType,
       onTokenInvalidated,
       globalToken,
       reserveFraction,
     })
 
-    if (this.withPooling) {
+    if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       this.standardTokens = new TokenPool({ batchSize: 25 })
       this.searchTokens = new TokenPool({ batchSize: 5 })
       this.graphqlTokens = new TokenPool({ batchSize: 25 })
@@ -60,7 +66,7 @@ class GithubApiProvider {
   }
 
   addToken(tokenString) {
-    if (this.withPooling) {
+    if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       this.standardTokens.add(tokenString)
       this.searchTokens.add(tokenString)
       this.graphqlTokens.add(tokenString)
@@ -157,7 +163,7 @@ class GithubApiProvider {
 
     let token
     let tokenString
-    if (this.withPooling) {
+    if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       try {
         token = this.tokenForUrl(url)
       } catch (e) {
@@ -167,7 +173,7 @@ class GithubApiProvider {
         })
       }
       tokenString = token.id
-    } else {
+    } else if (this.authType === this.constructor.AUTH_TYPES.GLOBAL_TOKEN) {
       tokenString = this.globalToken
     }
 
@@ -176,14 +182,20 @@ class GithubApiProvider {
       ...{
         headers: {
           'User-Agent': userAgent,
-          Authorization: `token ${tokenString}`,
           'X-GitHub-Api-Version': this.restApiVersion,
           ...options.headers,
         },
       },
     }
+    if (
+      this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL ||
+      this.authType === this.constructor.AUTH_TYPES.GLOBAL_TOKEN
+    ) {
+      mergedOptions.headers.Authorization = `token ${tokenString}`
+    }
+
     const response = await requestFetcher(`${baseUrl}${url}`, mergedOptions)
-    if (this.withPooling) {
+    if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       if (response.res.statusCode === 401) {
         this.invalidateToken(token)
       } else if (response.res.statusCode < 500) {

--- a/services/github/github-api-provider.spec.js
+++ b/services/github/github-api-provider.spec.js
@@ -8,7 +8,11 @@ describe('Github API provider', function () {
 
   let mockStandardToken, mockSearchToken, mockGraphqlToken, provider
   beforeEach(function () {
-    provider = new GithubApiProvider({ baseUrl, reserveFraction })
+    provider = new GithubApiProvider({
+      baseUrl,
+      authType: GithubApiProvider.AUTH_TYPES.TOKEN_POOL,
+      reserveFraction,
+    })
 
     mockStandardToken = { update: sinon.spy(), invalidate: sinon.spy() }
     sinon.stub(provider.standardTokens, 'next').returns(mockStandardToken)

--- a/services/github/github-auth-service.js
+++ b/services/github/github-auth-service.js
@@ -63,7 +63,14 @@ class GithubAuthV4Service extends BaseGraphqlService {
       `,
     )
 
-    return super._requestGraphql({ ...attrs, ...{ url, query } })
+    return super._requestGraphql({
+      ...attrs,
+      ...{
+        url,
+        query,
+        httpErrorMessages: { 401: 'auth required for graphql api' },
+      },
+    })
   }
 }
 

--- a/services/github/github-auth-service.spec.js
+++ b/services/github/github-auth-service.spec.js
@@ -41,6 +41,7 @@ describe('GithubAuthV3Service', function () {
     )
     const githubApiProvider = new GithubApiProvider({
       baseUrl: 'https://github-api.example.com',
+      authType: GithubApiProvider.AUTH_TYPES.TOKEN_POOL,
       restApiVersion: '2022-11-28',
     })
     const mockToken = { update: sinon.mock(), invalidate: sinon.mock() }

--- a/services/github/github-search.service.js
+++ b/services/github/github-search.service.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
-import { httpErrorsFor, documentation } from './github-helpers.js'
+import { documentation } from './github-helpers.js'
 
 const schema = Joi.object({ total_count: nonNegativeInteger }).required()
 
@@ -49,7 +49,11 @@ export default class GithubSearch extends GithubAuthV3Service {
         },
       },
       schema,
-      httpErrors: httpErrorsFor('repo not found'),
+      httpErrors: {
+        401: 'auth required for search api',
+        404: 'repo not found',
+        422: 'repo not found',
+      },
     })
     return this.constructor.render({ query, totalCount })
   }


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/2754
Refs https://github.com/badges/shields/pull/9386#discussion_r1264705287

This PR resolves a long-standing issue that even though GitHub allows anonymous access to the v3 API with a reasonable rate limit, you have to set a key locally to do any development on any GitHub badges. The changes in https://github.com/badges/shields/pull/9386 make it extra desirable to be able to call the GH API without auth if possible.

I've set this PR to run the github test suite. Five of them will fail, but I submitted another PR to fix the tests at https://github.com/badges/shields/pull/9425 so we could merge that first then rebase this onto it, although I think the integration tests are actually the critical ones here.