### PR TITLE
migrate `examples` to `openApi` part 2; affects [archlinux bitcomponents bountysource cdnjs chrome clearlydefined clojars cocoapods coincap]

### DIFF
--- a/services/archlinux/archlinux.service.js
+++ b/services/archlinux/archlinux.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   pkgver: Joi.string().required(),
@@ -13,17 +13,27 @@ export default class ArchLinux extends BaseJsonService {
     pattern: ':repository/:architecture/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'Arch Linux package',
-      namedParams: {
-        architecture: 'x86_64',
-        repository: 'core',
-        packageName: 'pacman',
+  static openApi = {
+    '/archlinux/v/{repository}/{architecture}/{packageName}': {
+      get: {
+        summary: 'Arch Linux package',
+        parameters: pathParams(
+          {
+            name: 'repository',
+            example: 'core',
+          },
+          {
+            name: 'architecture',
+            example: 'x86_64',
+          },
+          {
+            name: 'packageName',
+            example: 'pacman',
+          },
+        ),
       },
-      staticPreview: renderVersionBadge({ version: '5.1.3' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'arch linux' }
 

--- a/services/bit/bit-components.service.js
+++ b/services/bit/bit-components.service.js
@@ -20,7 +20,7 @@ export default class BitComponents extends BaseJsonService {
   static openApi = {
     '/bit/collection/total-components/{owner}/{collection}': {
       get: {
-        summary: 'bit',
+        summary: 'Bit',
         parameters: pathParams(
           {
             name: 'owner',

--- a/services/bit/bit-components.service.js
+++ b/services/bit/bit-components.service.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { downloadCount } from '../color-formatters.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const collectionSchema = Joi.object({
   payload: Joi.object({
@@ -17,14 +17,23 @@ export default class BitComponents extends BaseJsonService {
     pattern: ':owner/:collection',
   }
 
-  static examples = [
-    {
-      title: 'bit',
-      namedParams: { owner: 'ramda', collection: 'ramda' },
-      staticPreview: this.render({ count: 330 }),
-      keywords: ['components'],
+  static openApi = {
+    '/bit/collection/total-components/{owner}/{collection}': {
+      get: {
+        summary: 'bit',
+        parameters: pathParams(
+          {
+            name: 'owner',
+            example: 'ramda',
+          },
+          {
+            name: 'collection',
+            example: 'ramda',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'components' }
 

--- a/services/bountysource/bountysource.service.js
+++ b/services/bountysource/bountysource.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({ activity_total: Joi.number().required() })
 
@@ -8,13 +8,17 @@ export default class Bountysource extends BaseJsonService {
   static category = 'funding'
   static route = { base: 'bountysource/team', pattern: ':team/activity' }
 
-  static examples = [
-    {
-      title: 'Bountysource',
-      namedParams: { team: 'mozilla-core' },
-      staticPreview: this.render({ total: 53000 }),
+  static openApi = {
+    '/bountysource/team/{team}/activity': {
+      get: {
+        summary: 'Bountysource',
+        parameters: pathParams({
+          name: 'team',
+          example: 'mozilla-core',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'bounties' }
 

--- a/services/cdnjs/cdnjs.service.js
+++ b/services/cdnjs/cdnjs.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
-import { BaseJsonService, NotFound } from '../index.js'
+import { BaseJsonService, NotFound, pathParams } from '../index.js'
 
 const cdnjsSchema = Joi.object({
   // optional due to non-standard 'not found' condition
@@ -11,12 +11,17 @@ export default class Cdnjs extends BaseJsonService {
   static category = 'version'
   static route = { base: 'cdnjs/v', pattern: ':library' }
 
-  static examples = [
-    {
-      namedParams: { library: 'jquery' },
-      staticPreview: this.render({ version: '1.5.2' }),
+  static openApi = {
+    '/cdnjs/v/{library}': {
+      get: {
+        summary: 'Cdnjs',
+        parameters: pathParams({
+          name: 'library',
+          example: 'jquery',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'cdnjs' }
 

--- a/services/chrome-web-store/chrome-web-store-price.service.js
+++ b/services/chrome-web-store/chrome-web-store-price.service.js
@@ -1,18 +1,22 @@
 import { currencyFromCode } from '../text-formatters.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import BaseChromeWebStoreService from './chrome-web-store-base.js'
 
 export default class ChromeWebStorePrice extends BaseChromeWebStoreService {
   static category = 'funding'
   static route = { base: 'chrome-web-store/price', pattern: ':storeId' }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: this.render({ priceCurrency: 'USD', price: 0 }),
+  static openApi = {
+    '/chrome-web-store/price/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'price' }
 

--- a/services/chrome-web-store/chrome-web-store-price.service.js
+++ b/services/chrome-web-store/chrome-web-store-price.service.js
@@ -9,7 +9,7 @@ export default class ChromeWebStorePrice extends BaseChromeWebStoreService {
   static openApi = {
     '/chrome-web-store/price/{storeId}': {
       get: {
-        summary: 'Chrome Web Store',
+        summary: 'Chrome Web Store Price',
         parameters: pathParams({
           name: 'storeId',
           example: 'ogffaloegjglncjfehdfplabnoondfjo',

--- a/services/chrome-web-store/chrome-web-store-users.service.js
+++ b/services/chrome-web-store/chrome-web-store-users.service.js
@@ -9,7 +9,7 @@ class ChromeWebStoreUsers extends BaseChromeWebStoreService {
   static openApi = {
     '/chrome-web-store/users/{storeId}': {
       get: {
-        summary: 'Chrome Web Store',
+        summary: 'Chrome Web Store Users',
         parameters: pathParams({
           name: 'storeId',
           example: 'ogffaloegjglncjfehdfplabnoondfjo',

--- a/services/chrome-web-store/chrome-web-store-users.service.js
+++ b/services/chrome-web-store/chrome-web-store-users.service.js
@@ -1,18 +1,22 @@
 import { renderDownloadsBadge } from '../downloads.js'
-import { redirector, NotFound } from '../index.js'
+import { redirector, NotFound, pathParams } from '../index.js'
 import BaseChromeWebStoreService from './chrome-web-store-base.js'
 
 class ChromeWebStoreUsers extends BaseChromeWebStoreService {
   static category = 'downloads'
   static route = { base: 'chrome-web-store/users', pattern: ':storeId' }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: renderDownloadsBadge({ downloads: 573 }),
+  static openApi = {
+    '/chrome-web-store/users/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'users' }
 

--- a/services/chrome-web-store/chrome-web-store-version.service.js
+++ b/services/chrome-web-store/chrome-web-store-version.service.js
@@ -9,7 +9,7 @@ export default class ChromeWebStoreVersion extends BaseChromeWebStoreService {
   static openApi = {
     '/chrome-web-store/v/{storeId}': {
       get: {
-        summary: 'Chrome Web Store',
+        summary: 'Chrome Web Store Version',
         parameters: pathParams({
           name: 'storeId',
           example: 'ogffaloegjglncjfehdfplabnoondfjo',

--- a/services/chrome-web-store/chrome-web-store-version.service.js
+++ b/services/chrome-web-store/chrome-web-store-version.service.js
@@ -1,18 +1,22 @@
 import { renderVersionBadge } from '../version.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import BaseChromeWebStoreService from './chrome-web-store-base.js'
 
 export default class ChromeWebStoreVersion extends BaseChromeWebStoreService {
   static category = 'version'
   static route = { base: 'chrome-web-store/v', pattern: ':storeId' }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: renderVersionBadge({ version: 'v1.1.0' }),
+  static openApi = {
+    '/chrome-web-store/v/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'chrome web store' }
 

--- a/services/clearlydefined/clearlydefined-score.service.js
+++ b/services/clearlydefined/clearlydefined-score.service.js
@@ -4,7 +4,7 @@ import {
   optionalNonNegativeInteger,
 } from '../validators.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
-import { BaseJsonService, NotFound } from '../index.js'
+import { BaseJsonService, NotFound, pathParams } from '../index.js'
 
 const schema = Joi.object({
   scores: Joi.object({
@@ -24,19 +24,35 @@ export default class ClearlyDefinedService extends BaseJsonService {
     pattern: 'score/:type/:provider/:namespace/:name/:revision',
   }
 
-  static examples = [
-    {
-      title: 'ClearlyDefined Score',
-      namedParams: {
-        type: 'npm',
-        provider: 'npmjs',
-        namespace: '-',
-        name: 'jquery',
-        revision: '3.4.1',
+  static openApi = {
+    '/clearlydefined/score/{type}/{provider}/{namespace}/{name}/{revision}': {
+      get: {
+        summary: 'ClearlyDefined Score',
+        parameters: pathParams(
+          {
+            name: 'type',
+            example: 'npm',
+          },
+          {
+            name: 'provider',
+            example: 'npmjs',
+          },
+          {
+            name: 'namespace',
+            example: '-',
+          },
+          {
+            name: 'name',
+            example: 'jquery',
+          },
+          {
+            name: 'revision',
+            example: '3.4.1',
+          },
+        ),
       },
-      staticPreview: this.render({ score: 88 }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'score' }
 

--- a/services/clojars/clojars-downloads.service.js
+++ b/services/clojars/clojars-downloads.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
 import { BaseClojarsService } from './clojars-base.js'
 
@@ -5,12 +6,17 @@ export default class ClojarsDownloads extends BaseClojarsService {
   static category = 'downloads'
   static route = { base: 'clojars/dt', pattern: ':clojar+' }
 
-  static examples = [
-    {
-      namedParams: { clojar: 'prismic' },
-      staticPreview: renderDownloadsBadge({ downloads: 117 }),
+  static openApi = {
+    '/clojars/dt/{clojar}': {
+      get: {
+        summary: 'ClojarsDownloads',
+        parameters: pathParams({
+          name: 'clojar',
+          example: 'prismic',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/clojars/clojars-downloads.service.js
+++ b/services/clojars/clojars-downloads.service.js
@@ -9,7 +9,7 @@ export default class ClojarsDownloads extends BaseClojarsService {
   static openApi = {
     '/clojars/dt/{clojar}': {
       get: {
-        summary: 'ClojarsDownloads',
+        summary: 'Clojars Downloads',
         parameters: pathParams({
           name: 'clojar',
           example: 'prismic',

--- a/services/cocoapods/cocoapods-docs.service.js
+++ b/services/cocoapods/cocoapods-docs.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { coveragePercentage as coveragePercentageColor } from '../color-formatters.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   cocoadocs: Joi.object({
@@ -12,13 +12,17 @@ export default class CocoapodsDocs extends BaseJsonService {
   static category = 'analysis'
   static route = { base: 'cocoapods/metrics/doc-percent', pattern: ':spec' }
 
-  static examples = [
-    {
-      title: 'Cocoapods doc percentage',
-      namedParams: { spec: 'AFNetworking' },
-      staticPreview: this.render({ percentage: 94 }),
+  static openApi = {
+    '/cocoapods/metrics/doc-percent/{spec}': {
+      get: {
+        summary: 'Cocoapods doc percentage',
+        parameters: pathParams({
+          name: 'spec',
+          example: 'AFNetworking',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'docs' }
 

--- a/services/cocoapods/cocoapods-license.service.js
+++ b/services/cocoapods/cocoapods-license.service.js
@@ -8,7 +8,7 @@ export default class CocoapodsLicense extends BaseCocoaPodsService {
   static openApi = {
     '/cocoapods/l/{spec}': {
       get: {
-        summary: 'Cocoapods',
+        summary: 'Cocoapods License',
         parameters: pathParams({
           name: 'spec',
           example: 'AFNetworking',

--- a/services/cocoapods/cocoapods-license.service.js
+++ b/services/cocoapods/cocoapods-license.service.js
@@ -1,16 +1,21 @@
+import { pathParams } from '../index.js'
 import BaseCocoaPodsService from './cocoapods-base.js'
 
 export default class CocoapodsLicense extends BaseCocoaPodsService {
   static category = 'license'
   static route = { base: 'cocoapods/l', pattern: ':spec' }
 
-  static examples = [
-    {
-      title: 'Cocoapods',
-      namedParams: { spec: 'AFNetworking' },
-      staticPreview: this.render({ license: 'MIT' }),
+  static openApi = {
+    '/cocoapods/l/{spec}': {
+      get: {
+        summary: 'Cocoapods',
+        parameters: pathParams({
+          name: 'spec',
+          example: 'AFNetworking',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'license' }
 

--- a/services/cocoapods/cocoapods-platform.service.js
+++ b/services/cocoapods/cocoapods-platform.service.js
@@ -1,18 +1,21 @@
+import { pathParams } from '../index.js'
 import BaseCocoaPodsService from './cocoapods-base.js'
 
 export default class CocoapodsPlatform extends BaseCocoaPodsService {
   static category = 'platform-support'
   static route = { base: 'cocoapods/p', pattern: ':spec' }
 
-  static examples = [
-    {
-      title: 'Cocoapods platforms',
-      namedParams: { spec: 'AFNetworking' },
-      staticPreview: this.render({
-        platforms: ['ios', 'osx', 'watchos', 'tvos'],
-      }),
+  static openApi = {
+    '/cocoapods/p/{spec}': {
+      get: {
+        summary: 'Cocoapods platforms',
+        parameters: pathParams({
+          name: 'spec',
+          example: 'AFNetworking',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'platform' }
 

--- a/services/cocoapods/cocoapods-version.service.js
+++ b/services/cocoapods/cocoapods-version.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
 import BaseCocoaPodsService from './cocoapods-base.js'
 
@@ -5,13 +6,17 @@ export default class CocoapodsVersion extends BaseCocoaPodsService {
   static category = 'version'
   static route = { base: 'cocoapods/v', pattern: ':spec' }
 
-  static examples = [
-    {
-      title: 'Cocoapods',
-      namedParams: { spec: 'AFNetworking' },
-      staticPreview: renderVersionBadge({ version: 'v3.2.1' }),
+  static openApi = {
+    '/cocoapods/v/{spec}': {
+      get: {
+        summary: 'Cocoapods',
+        parameters: pathParams({
+          name: 'spec',
+          example: 'AFNetworking',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'pod' }
 

--- a/services/cocoapods/cocoapods-version.service.js
+++ b/services/cocoapods/cocoapods-version.service.js
@@ -9,7 +9,7 @@ export default class CocoapodsVersion extends BaseCocoaPodsService {
   static openApi = {
     '/cocoapods/v/{spec}': {
       get: {
-        summary: 'Cocoapods',
+        summary: 'Cocoapods Version',
         parameters: pathParams({
           name: 'spec',
           example: 'AFNetworking',

--- a/services/codefactor/codefactor-grade.service.js
+++ b/services/codefactor/codefactor-grade.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseSvgScrapingService } from '../index.js'
+import { BaseSvgScrapingService, pathParams } from '../index.js'
 import { isValidGrade, gradeColor } from './codefactor-helpers.js'
 
 const schema = Joi.object({
@@ -13,18 +13,50 @@ export default class CodeFactorGrade extends BaseSvgScrapingService {
     pattern: ':vcsType(github|bitbucket)/:user/:repo/:branch*',
   }
 
-  static examples = [
-    {
-      title: 'CodeFactor Grade',
-      namedParams: {
-        vcsType: 'github',
-        user: 'microsoft',
-        repo: 'powertoys',
-        branch: 'main',
+  static openApi = {
+    '/codefactor/grade/{vcsType}/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'CodeFactor Grade',
+        parameters: pathParams(
+          {
+            name: 'vcsType',
+            example: 'github',
+          },
+          {
+            name: 'user',
+            example: 'microsoft',
+          },
+          {
+            name: 'repo',
+            example: 'powertoys',
+          },
+          {
+            name: 'branch',
+            example: 'main',
+          },
+        ),
       },
-      staticPreview: this.render({ grade: 'B+' }),
     },
-  ]
+    '/codefactor/grade/{vcsType}/{user}/{repo}': {
+      get: {
+        summary: 'CodeFactor Grade',
+        parameters: pathParams(
+          {
+            name: 'vcsType',
+            example: 'github',
+          },
+          {
+            name: 'user',
+            example: 'microsoft',
+          },
+          {
+            name: 'repo',
+            example: 'powertoys',
+          },
+        ),
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'code quality' }
 

--- a/services/codefactor/codefactor-grade.service.js
+++ b/services/codefactor/codefactor-grade.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseSvgScrapingService, pathParams } from '../index.js'
+import { BaseSvgScrapingService } from '../index.js'
 import { isValidGrade, gradeColor } from './codefactor-helpers.js'
 
 const schema = Joi.object({
@@ -13,50 +13,18 @@ export default class CodeFactorGrade extends BaseSvgScrapingService {
     pattern: ':vcsType(github|bitbucket)/:user/:repo/:branch*',
   }
 
-  static openApi = {
-    '/codefactor/grade/{vcsType}/{user}/{repo}/{branch}': {
-      get: {
-        summary: 'CodeFactor Grade (with branch)',
-        parameters: pathParams(
-          {
-            name: 'vcsType',
-            example: 'github',
-          },
-          {
-            name: 'user',
-            example: 'microsoft',
-          },
-          {
-            name: 'repo',
-            example: 'powertoys',
-          },
-          {
-            name: 'branch',
-            example: 'main',
-          },
-        ),
+  static examples = [
+    {
+      title: 'CodeFactor Grade',
+      namedParams: {
+        vcsType: 'github',
+        user: 'microsoft',
+        repo: 'powertoys',
+        branch: 'main',
       },
+      staticPreview: this.render({ grade: 'B+' }),
     },
-    '/codefactor/grade/{vcsType}/{user}/{repo}': {
-      get: {
-        summary: 'CodeFactor Grade',
-        parameters: pathParams(
-          {
-            name: 'vcsType',
-            example: 'github',
-          },
-          {
-            name: 'user',
-            example: 'microsoft',
-          },
-          {
-            name: 'repo',
-            example: 'powertoys',
-          },
-        ),
-      },
-    },
-  }
+  ]
 
   static defaultBadgeData = { label: 'code quality' }
 

--- a/services/codefactor/codefactor-grade.service.js
+++ b/services/codefactor/codefactor-grade.service.js
@@ -16,7 +16,7 @@ export default class CodeFactorGrade extends BaseSvgScrapingService {
   static openApi = {
     '/codefactor/grade/{vcsType}/{user}/{repo}/{branch}': {
       get: {
-        summary: 'CodeFactor Grade',
+        summary: 'CodeFactor Grade (with branch)',
         parameters: pathParams(
           {
             name: 'vcsType',

--- a/services/coincap/coincap-changepercent24hr.service.js
+++ b/services/coincap/coincap-changepercent24hr.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { floorCount } from '../color-formatters.js'
 import BaseCoincapService from './coincap-base.js'
 
@@ -14,16 +15,17 @@ const schema = Joi.object({
 export default class CoincapChangePercent24HrUsd extends BaseCoincapService {
   static route = { base: 'coincap/change-percent-24hr', pattern: ':assetId' }
 
-  static examples = [
-    {
-      title: 'Coincap (Change Percent 24Hr)',
-      namedParams: { assetId: 'bitcoin' },
-      staticPreview: this.render({
-        asset: { name: 'bitcoin', changePercent24Hr: '2.0670573674501840"' },
-      }),
-      keywords: ['bitcoin', 'crypto', 'cryptocurrency'],
+  static openApi = {
+    '/coincap/change-percent-24hr/{assetId}': {
+      get: {
+        summary: 'Coincap (Change Percent 24Hr)',
+        parameters: pathParams({
+          name: 'assetId',
+          example: 'bitcoin',
+        }),
+      },
     },
-  ]
+  }
 
   static percentFormat(changePercent24Hr) {
     return `${parseInt(changePercent24Hr).toFixed(2)}%`

--- a/services/coincap/coincap-priceusd.service.js
+++ b/services/coincap/coincap-priceusd.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import BaseCoincapService from './coincap-base.js'
 
 const schema = Joi.object({
@@ -13,16 +14,17 @@ const schema = Joi.object({
 export default class CoincapPriceUsd extends BaseCoincapService {
   static route = { base: 'coincap/price-usd', pattern: ':assetId' }
 
-  static examples = [
-    {
-      title: 'Coincap (Price USD)',
-      namedParams: { assetId: 'bitcoin' },
-      staticPreview: this.render({
-        asset: { name: 'bitcoin', priceUsd: '19116.0479117336250772' },
-      }),
-      keywords: ['bitcoin', 'crypto', 'cryptocurrency'],
+  static openApi = {
+    '/coincap/price-usd/{assetId}': {
+      get: {
+        summary: 'Coincap (Price USD)',
+        parameters: pathParams({
+          name: 'assetId',
+          example: 'bitcoin',
+        }),
+      },
     },
-  ]
+  }
 
   static priceFormat(price) {
     return `$${parseFloat(price)

--- a/services/coincap/coincap-rank.service.js
+++ b/services/coincap/coincap-rank.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import BaseCoincapService from './coincap-base.js'
 
 const schema = Joi.object({
@@ -13,14 +14,17 @@ const schema = Joi.object({
 export default class CoincapRank extends BaseCoincapService {
   static route = { base: 'coincap/rank', pattern: ':assetId' }
 
-  static examples = [
-    {
-      title: 'Coincap (Rank)',
-      namedParams: { assetId: 'bitcoin' },
-      staticPreview: this.render({ asset: { name: 'bitcoin', rank: '1' } }),
-      keywords: ['bitcoin', 'crypto', 'cryptocurrency'],
+  static openApi = {
+    '/coincap/rank/{assetId}': {
+      get: {
+        summary: 'Coincap (Rank)',
+        parameters: pathParams({
+          name: 'assetId',
+          example: 'bitcoin',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ asset }) {
     return {

--- a/services/github/github-workflow-status.service.js
+++ b/services/github/github-workflow-status.service.js
@@ -8,7 +8,7 @@ export default class DeprecatedGithubWorkflowStatus extends BaseService {
     pattern: ':various+',
   }
 
-  static examples = []
+  static openApi = {}
 
   static defaultBadgeData = { label: 'build' }
 


### PR DESCRIPTION
Refs #9285

..and so begins the long slow process of working through these. The first batch I am working on is classes with:

- currently passing service tests
- only path params
- either one example, or two examples due to optional path params (e.g: `branch*`)
- no documentation string

These are the most trivial services to convert, requiring the least manual work.
I am going to submit PRs touching batches of about 15-20 files at a time as I work through these.
Then I'll start moving onto slightly more complicated cases.