### PR TITLE
Fix puppetforge module feedback badges

### DIFF
--- a/services/puppetforge/puppetforge-base.js
+++ b/services/puppetforge/puppetforge-base.js
@@ -24,6 +24,8 @@ const modulesSchema = Joi.object({
   ),
 }).required()
 
+const moduleValidationsSchema = Joi.array().required()
+
 class BasePuppetForgeUsersService extends BaseJsonService {
   async fetch({ user }) {
     return this._requestJson({
@@ -42,4 +44,17 @@ class BasePuppetForgeModulesService extends BaseJsonService {
   }
 }
 
-export { BasePuppetForgeModulesService, BasePuppetForgeUsersService }
+class BasePuppetForgeModulesValidationsService extends BaseJsonService {
+  async fetch({ user, moduleName }) {
+    return this._requestJson({
+      schema: moduleValidationsSchema,
+      url: `https://forgeapi.puppetlabs.com/private/validations/${user}-${moduleName}`,
+    })
+  }
+}
+
+export {
+  BasePuppetForgeModulesService,
+  BasePuppetForgeModulesValidationsService,
+  BasePuppetForgeUsersService,
+}

--- a/services/puppetforge/puppetforge-module-feedback.service.js
+++ b/services/puppetforge/puppetforge-module-feedback.service.js
@@ -1,8 +1,8 @@
 import { coveragePercentage as coveragePercentageColor } from '../color-formatters.js'
 import { NotFound } from '../index.js'
-import { BasePuppetForgeModulesService } from './puppetforge-base.js'
+import { BasePuppetForgeModulesValidationsService } from './puppetforge-base.js'
 
-export default class PuppetforgeModuleFeedback extends BasePuppetForgeModulesService {
+export default class PuppetforgeModuleFeedback extends BasePuppetForgeModulesValidationsService {
   static category = 'rating'
 
   static route = {
@@ -32,9 +32,9 @@ export default class PuppetforgeModuleFeedback extends BasePuppetForgeModulesSer
 
   async handle({ user, moduleName }) {
     const data = await this.fetch({ user, moduleName })
-    if (data.feedback_score == null) {
+    if (data.at(-1) == null || data.at(-1).score == null) {
       throw new NotFound({ prettyMessage: 'unknown' })
     }
-    return this.constructor.render({ score: data.feedback_score })
+    return this.constructor.render({ score: data.at(-1).score })
   }
 }


### PR DESCRIPTION
The forge has stopped to collect user feedback a long time ago. However, it gained the capability to now run static analysis on modules and give it a score.  This score has been work in progress for some time will probably change again in the future, and might include back user feedback in the future, but as this is moving quite slow, rather than waiting to unbreak this badge, we can switch to the current API endpoint that provide this scoring as a drop-in replacement for user feedback.

Since the badge is already labelled "score", this seems a reasonable move.
