### PR TITLE
migrate examples to openApi part 6; affects [opencollective opm ossf powershell pub pypi reddit repology]

### DIFF
--- a/services/opencollective/opencollective-all.service.js
+++ b/services/opencollective/opencollective-all.service.js
@@ -1,16 +1,20 @@
+import { pathParams } from '../index.js'
 import OpencollectiveBase from './opencollective-base.js'
 
 export default class OpencollectiveAll extends OpencollectiveBase {
   static route = this.buildRoute('all')
 
-  static examples = [
-    {
-      title: 'Open Collective backers and sponsors',
-      namedParams: { collective: 'shields' },
-      staticPreview: this.render(35),
-      keywords: ['opencollective'],
+  static openApi = {
+    '/opencollective/all/{collective}': {
+      get: {
+        summary: 'Open Collective backers and sponsors',
+        parameters: pathParams({
+          name: 'collective',
+          example: 'shields',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'backers and sponsors',

--- a/services/opencollective/opencollective-backers.service.js
+++ b/services/opencollective/opencollective-backers.service.js
@@ -1,16 +1,20 @@
+import { pathParams } from '../index.js'
 import OpencollectiveBase from './opencollective-base.js'
 
 export default class OpencollectiveBackers extends OpencollectiveBase {
   static route = this.buildRoute('backers')
 
-  static examples = [
-    {
-      title: 'Open Collective backers',
-      namedParams: { collective: 'shields' },
-      staticPreview: this.render(25),
-      keywords: ['opencollective'],
+  static openApi = {
+    '/opencollective/backers/{collective}': {
+      get: {
+        summary: 'Open Collective backers',
+        parameters: pathParams({
+          name: 'collective',
+          example: 'shields',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'backers',

--- a/services/opencollective/opencollective-sponsors.service.js
+++ b/services/opencollective/opencollective-sponsors.service.js
@@ -1,16 +1,20 @@
+import { pathParams } from '../index.js'
 import OpencollectiveBase from './opencollective-base.js'
 
 export default class OpencollectiveSponsors extends OpencollectiveBase {
   static route = this.buildRoute('sponsors')
 
-  static examples = [
-    {
-      title: 'Open Collective sponsors',
-      namedParams: { collective: 'shields' },
-      staticPreview: this.render(10),
-      keywords: ['opencollective'],
+  static openApi = {
+    '/opencollective/sponsors/{collective}': {
+      get: {
+        summary: 'Open Collective sponsors',
+        parameters: pathParams({
+          name: 'collective',
+          example: 'shields',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'sponsors',

--- a/services/opm/opm-version.service.js
+++ b/services/opm/opm-version.service.js
@@ -1,5 +1,5 @@
 import { renderVersionBadge } from '../version.js'
-import { BaseService, NotFound, InvalidResponse } from '../index.js'
+import { BaseService, NotFound, InvalidResponse, pathParams } from '../index.js'
 
 export default class OpmVersion extends BaseService {
   static category = 'version'
@@ -9,16 +9,23 @@ export default class OpmVersion extends BaseService {
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'OPM',
-      namedParams: {
-        user: 'openresty',
-        moduleName: 'lua-resty-lrucache',
+  static openApi = {
+    '/opm/v/{user}/{moduleName}': {
+      get: {
+        summary: 'OPM',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'openresty',
+          },
+          {
+            name: 'moduleName',
+            example: 'lua-resty-lrucache',
+          },
+        ),
       },
-      staticPreview: renderVersionBadge({ version: 'v0.08' }),
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'opm',

--- a/services/opm/opm-version.service.js
+++ b/services/opm/opm-version.service.js
@@ -12,7 +12,7 @@ export default class OpmVersion extends BaseService {
   static openApi = {
     '/opm/v/{user}/{moduleName}': {
       get: {
-        summary: 'OPM',
+        summary: 'OPM Version',
         parameters: pathParams(
           {
             name: 'user',

--- a/services/ossf-scorecard/ossf-scorecard.service.js
+++ b/services/ossf-scorecard/ossf-scorecard.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 import { colorScale } from '../color-formatters.js'
 
 const schema = Joi.object({
@@ -16,17 +16,27 @@ export default class OSSFScorecard extends BaseJsonService {
 
   static route = { base: 'ossf-scorecard', pattern: ':host/:orgName/:repoName' }
 
-  static examples = [
-    {
-      title: 'OSSF-Scorecard Score',
-      namedParams: {
-        host: 'github.com',
-        orgName: 'rohankh532',
-        repoName: 'org-workflow-add',
+  static openApi = {
+    '/ossf-scorecard/{host}/{orgName}/{repoName}': {
+      get: {
+        summary: 'OSSF-Scorecard Score',
+        parameters: pathParams(
+          {
+            name: 'host',
+            example: 'github.com',
+          },
+          {
+            name: 'orgName',
+            example: 'rohankh532',
+          },
+          {
+            name: 'repoName',
+            example: 'org-workflow-add',
+          },
+        ),
       },
-      staticPreview: this.render({ score: '7.5' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'score' }
 

--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -1,5 +1,5 @@
 import { fetch, createServiceFamily } from '../nuget/nuget-v2-service-family.js'
-import { BaseXmlService } from '../index.js'
+import { BaseXmlService, pathParams } from '../index.js'
 
 const WINDOWS_TAG_NAME = 'windows'
 const MACOS_TAG_NAME = 'macos'
@@ -32,15 +32,17 @@ class PowershellGalleryPlatformSupport extends BaseXmlService {
     pattern: ':packageName',
   }
 
-  static examples = [
-    {
-      title: 'PowerShell Gallery',
-      namedParams: { packageName: 'PackageManagement' },
-      staticPreview: this.render({
-        platforms: ['windows', 'macos', 'linux'],
-      }),
+  static openApi = {
+    '/powershellgallery/p/{packageName}': {
+      get: {
+        summary: 'PowerShell Gallery',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'PackageManagement',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'platform',

--- a/services/powershellgallery/powershellgallery.service.js
+++ b/services/powershellgallery/powershellgallery.service.js
@@ -35,7 +35,7 @@ class PowershellGalleryPlatformSupport extends BaseXmlService {
   static openApi = {
     '/powershellgallery/p/{packageName}': {
       get: {
-        summary: 'PowerShell Gallery',
+        summary: 'PowerShell Gallery Platform Support',
         parameters: pathParams({
           name: 'packageName',
           example: 'PackageManagement',

--- a/services/pub/pub-publisher.service.js
+++ b/services/pub/pub-publisher.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   publisherId: Joi.string().allow(null).required(),
@@ -13,14 +13,17 @@ export class PubPublisher extends BaseJsonService {
     pattern: ':packageName',
   }
 
-  static examples = [
-    {
-      title: 'Pub Publisher',
-      namedParams: { packageName: 'path' },
-      staticPreview: this.render({ publisher: 'dart.dev' }),
-      keywords: ['dart', 'dartlang'],
+  static openApi = {
+    '/pub/publisher/{packageName}': {
+      get: {
+        summary: 'Pub Publisher',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'path',
+        }),
+      },
     },
-  ]
+  }
 
   static _cacheLength = 3600
 

--- a/services/pypi/pypi-format.service.js
+++ b/services/pypi/pypi-format.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import PypiBase from './pypi-base.js'
 import { getPackageFormats } from './pypi-helpers.js'
 
@@ -6,15 +7,17 @@ export default class PypiFormat extends PypiBase {
 
   static route = this.buildRoute('pypi/format')
 
-  static examples = [
-    {
-      title: 'PyPI - Format',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ hasWheel: true }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/format/{packageName}': {
+      get: {
+        summary: 'PyPI - Format',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'format' }
 

--- a/services/pypi/pypi-implementation.service.js
+++ b/services/pypi/pypi-implementation.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import PypiBase from './pypi-base.js'
 import { parseClassifiers } from './pypi-helpers.js'
 
@@ -6,15 +7,17 @@ export default class PypiImplementation extends PypiBase {
 
   static route = this.buildRoute('pypi/implementation')
 
-  static examples = [
-    {
-      title: 'PyPI - Implementation',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ implementations: ['cpython'] }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/implementation/{packageName}': {
+      get: {
+        summary: 'PyPI - Implementation',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'implementation' }
 

--- a/services/pypi/pypi-license.service.js
+++ b/services/pypi/pypi-license.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderLicenseBadge } from '../licenses.js'
 import PypiBase from './pypi-base.js'
 import { getLicenses } from './pypi-helpers.js'
@@ -7,15 +8,17 @@ export default class PypiLicense extends PypiBase {
 
   static route = this.buildRoute('pypi/l')
 
-  static examples = [
-    {
-      title: 'PyPI - License',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ licenses: ['BSD'] }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/l/{packageName}': {
+      get: {
+        summary: 'PyPI - License',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ licenses }) {
     return renderLicenseBadge({ licenses })

--- a/services/pypi/pypi-python-versions.service.js
+++ b/services/pypi/pypi-python-versions.service.js
@@ -1,4 +1,5 @@
 import semver from 'semver'
+import { pathParams } from '../index.js'
 import PypiBase from './pypi-base.js'
 import { parseClassifiers } from './pypi-helpers.js'
 
@@ -7,14 +8,17 @@ export default class PypiPythonVersions extends PypiBase {
 
   static route = this.buildRoute('pypi/pyversions')
 
-  static examples = [
-    {
-      title: 'PyPI - Python Version',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ versions: ['3.5', '3.6', '3.7'] }),
+  static openApi = {
+    '/pypi/pyversions/{packageName}': {
+      get: {
+        summary: 'PyPI - Python Version',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'python' }
 

--- a/services/pypi/pypi-status.service.js
+++ b/services/pypi/pypi-status.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import PypiBase from './pypi-base.js'
 import { parseClassifiers } from './pypi-helpers.js'
 
@@ -6,15 +7,17 @@ export default class PypiStatus extends PypiBase {
 
   static route = this.buildRoute('pypi/status')
 
-  static examples = [
-    {
-      title: 'PyPI - Status',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ status: 'stable' }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/status/{packageName}': {
+      get: {
+        summary: 'PyPI - Status',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'status' }
 

--- a/services/pypi/pypi-version.service.js
+++ b/services/pypi/pypi-version.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { pep440VersionColor } from '../color-formatters.js'
 import { renderVersionBadge } from '../version.js'
 import PypiBase from './pypi-base.js'
@@ -7,15 +8,17 @@ export default class PypiVersion extends PypiBase {
 
   static route = this.buildRoute('pypi/v')
 
-  static examples = [
-    {
-      title: 'PyPI',
-      pattern: ':packageName',
-      namedParams: { packageName: 'nine' },
-      staticPreview: this.render({ version: '1.0.0' }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/v/{packageName}': {
+      get: {
+        summary: 'PyPI',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'nine',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'pypi' }
 

--- a/services/pypi/pypi-version.service.js
+++ b/services/pypi/pypi-version.service.js
@@ -11,7 +11,7 @@ export default class PypiVersion extends PypiBase {
   static openApi = {
     '/pypi/v/{packageName}': {
       get: {
-        summary: 'PyPI',
+        summary: 'PyPI - Version',
         parameters: pathParams({
           name: 'packageName',
           example: 'nine',

--- a/services/pypi/pypi-wheel.service.js
+++ b/services/pypi/pypi-wheel.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import PypiBase from './pypi-base.js'
 import { getPackageFormats } from './pypi-helpers.js'
 
@@ -6,15 +7,17 @@ export default class PypiWheel extends PypiBase {
 
   static route = this.buildRoute('pypi/wheel')
 
-  static examples = [
-    {
-      title: 'PyPI - Wheel',
-      pattern: ':packageName',
-      namedParams: { packageName: 'Django' },
-      staticPreview: this.render({ hasWheel: true }),
-      keywords: ['python'],
+  static openApi = {
+    '/pypi/wheel/{packageName}': {
+      get: {
+        summary: 'PyPI - Wheel',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'Django',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'wheel' }
 

--- a/services/reddit/subreddit-subscribers.service.js
+++ b/services/reddit/subreddit-subscribers.service.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { optionalNonNegativeInteger } from '../validators.js'
 import { metric } from '../text-formatters.js'
-import { BaseJsonService, NotFound } from '../index.js'
+import { BaseJsonService, NotFound, pathParams } from '../index.js'
 
 const schema = Joi.object({
   data: Joi.object({
@@ -17,18 +17,17 @@ export default class RedditSubredditSubscribers extends BaseJsonService {
     pattern: ':subreddit',
   }
 
-  static examples = [
-    {
-      title: 'Subreddit subscribers',
-      namedParams: { subreddit: 'drums' },
-      staticPreview: {
-        label: 'follow r/drums',
-        message: '77k',
-        color: 'red',
-        style: 'social',
+  static openApi = {
+    '/reddit/subreddit-subscribers/{subreddit}': {
+      get: {
+        summary: 'Subreddit subscribers',
+        parameters: pathParams({
+          name: 'subreddit',
+          example: 'drums',
+        }),
       },
     },
-  ]
+  }
 
   static _cacheLength = 7200
 

--- a/services/repology/repology-repositories.service.js
+++ b/services/repology/repology-repositories.service.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseSvgScrapingService } from '../index.js'
+import { BaseSvgScrapingService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   message: nonNegativeInteger,
@@ -15,13 +15,17 @@ export default class RepologyRepositories extends BaseSvgScrapingService {
     pattern: ':projectName',
   }
 
-  static examples = [
-    {
-      title: 'Repology - Repositories',
-      namedParams: { projectName: 'starship' },
-      staticPreview: this.render({ repositoryCount: '18' }),
+  static openApi = {
+    '/repology/repositories/{projectName}': {
+      get: {
+        summary: 'Repology - Repositories',
+        parameters: pathParams({
+          name: 'projectName',
+          example: 'starship',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'repositories',


### PR DESCRIPTION
Refs #9285

..and so begins the long slow process of working through these. The first batch I am working on is classes with:

- currently passing service tests
- only path params
- either one example, or two examples due to optional path params (e.g: `branch*`)
- no documentation string

These are the most trivial services to convert, requiring the least manual work.
I am going to submit PRs touching batches of about 15-20 files at a time as I work through these.
Then I'll start moving onto slightly more complicated cases.