### PR TITLE
migrate examples to openApi part 8; affects [ubuntu uptimerobot vaadin vcpkg visualstudiomarketplace wheelmap]

### DIFF
--- a/services/ubuntu/ubuntu.service.js
+++ b/services/ubuntu/ubuntu.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
-import { BaseJsonService, NotFound } from '../index.js'
+import { BaseJsonService, NotFound, pathParams } from '../index.js'
 
 const schema = Joi.object({
   entries: Joi.array()
@@ -20,13 +20,32 @@ export default class Ubuntu extends BaseJsonService {
     pattern: ':packageName/:series?',
   }
 
-  static examples = [
-    {
-      title: 'Ubuntu package',
-      namedParams: { series: 'bionic', packageName: 'ubuntu-wallpapers' },
-      staticPreview: renderVersionBadge({ version: '18.04.1-0ubuntu1' }),
+  static openApi = {
+    '/ubuntu/v/{packageName}/{series}': {
+      get: {
+        summary: 'Ubuntu package',
+        parameters: pathParams(
+          {
+            name: 'packageName',
+            example: 'ubuntu-wallpapers',
+          },
+          {
+            name: 'series',
+            example: 'bionic',
+          },
+        ),
+      },
     },
-  ]
+    '/ubuntu/v/{packageName}': {
+      get: {
+        summary: 'Ubuntu package',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'ubuntu-wallpapers',
+        }),
+      },
+    },
+  }
 
   static defaultBadgeData = {
     label: 'ubuntu',

--- a/services/ubuntu/ubuntu.service.js
+++ b/services/ubuntu/ubuntu.service.js
@@ -23,7 +23,7 @@ export default class Ubuntu extends BaseJsonService {
   static openApi = {
     '/ubuntu/v/{packageName}/{series}': {
       get: {
-        summary: 'Ubuntu package',
+        summary: 'Ubuntu Package Version (for series)',
         parameters: pathParams(
           {
             name: 'packageName',
@@ -38,7 +38,7 @@ export default class Ubuntu extends BaseJsonService {
     },
     '/ubuntu/v/{packageName}': {
       get: {
-        summary: 'Ubuntu package',
+        summary: 'Ubuntu Package Version',
         parameters: pathParams({
           name: 'packageName',
           example: 'ubuntu-wallpapers',

--- a/services/uptimerobot/uptimerobot-status.service.js
+++ b/services/uptimerobot/uptimerobot-status.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import UptimeRobotBase from './uptimerobot-base.js'
 
 export default class UptimeRobotStatus extends UptimeRobotBase {
@@ -6,15 +7,17 @@ export default class UptimeRobotStatus extends UptimeRobotBase {
     pattern: ':monitorSpecificKey',
   }
 
-  static examples = [
-    {
-      title: 'Uptime Robot status',
-      namedParams: {
-        monitorSpecificKey: 'm778918918-3e92c097147760ee39d02d36',
+  static openApi = {
+    '/uptimerobot/status/{monitorSpecificKey}': {
+      get: {
+        summary: 'Uptime Robot status',
+        parameters: pathParams({
+          name: 'monitorSpecificKey',
+          example: 'm778918918-3e92c097147760ee39d02d36',
+        }),
       },
-      staticPreview: this.render({ status: 2 }),
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'status',

--- a/services/vaadin-directory/vaadin-directory-rating-count.service.js
+++ b/services/vaadin-directory/vaadin-directory-rating-count.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { BaseVaadinDirectoryService } from './vaadin-directory-base.js'
@@ -10,15 +11,17 @@ export default class VaadinDirectoryRatingCount extends BaseVaadinDirectoryServi
     pattern: ':alias(rc|rating-count)/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'Vaadin Directory',
-      pattern: 'rating-count/:packageName',
-      namedParams: { packageName: 'vaadinvaadin-grid' },
-      staticPreview: this.render({ ratingCount: 6 }),
-      keywords: ['vaadin-directory', 'rating-count'],
+  static openApi = {
+    '/vaadin-directory/rating-count/{packageName}': {
+      get: {
+        summary: 'Vaadin Directory',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'vaadinvaadin-grid',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'rating count',

--- a/services/vaadin-directory/vaadin-directory-rating-count.service.js
+++ b/services/vaadin-directory/vaadin-directory-rating-count.service.js
@@ -14,7 +14,7 @@ export default class VaadinDirectoryRatingCount extends BaseVaadinDirectoryServi
   static openApi = {
     '/vaadin-directory/rating-count/{packageName}': {
       get: {
-        summary: 'Vaadin Directory',
+        summary: 'Vaadin Directory Rating Count',
         parameters: pathParams({
           name: 'packageName',
           example: 'vaadinvaadin-grid',

--- a/services/vaadin-directory/vaadin-directory-release-date.service.js
+++ b/services/vaadin-directory/vaadin-directory-release-date.service.js
@@ -14,7 +14,7 @@ export default class VaadinDirectoryReleaseDate extends BaseVaadinDirectoryServi
   static openApi = {
     '/vaadin-directory/release-date/{packageName}': {
       get: {
-        summary: 'Vaadin Directory',
+        summary: 'Vaadin Directory Release Date',
         parameters: pathParams({
           name: 'packageName',
           example: 'vaadinvaadin-grid',

--- a/services/vaadin-directory/vaadin-directory-release-date.service.js
+++ b/services/vaadin-directory/vaadin-directory-release-date.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { formatDate } from '../text-formatters.js'
 import { age as ageColor } from '../color-formatters.js'
 import { BaseVaadinDirectoryService } from './vaadin-directory-base.js'
@@ -10,15 +11,17 @@ export default class VaadinDirectoryReleaseDate extends BaseVaadinDirectoryServi
     pattern: ':alias(rd|release-date)/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'Vaadin Directory',
-      pattern: 'release-date/:packageName',
-      namedParams: { packageName: 'vaadinvaadin-grid' },
-      staticPreview: this.render({ date: '2018-12-12' }),
-      keywords: ['vaadin-directory', 'date', 'latest release date'],
+  static openApi = {
+    '/vaadin-directory/release-date/{packageName}': {
+      get: {
+        summary: 'Vaadin Directory',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'vaadinvaadin-grid',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'latest release date',

--- a/services/vaadin-directory/vaadin-directory-status.service.js
+++ b/services/vaadin-directory/vaadin-directory-status.service.js
@@ -12,7 +12,7 @@ export default class VaadinDirectoryStatus extends BaseVaadinDirectoryService {
   static openApi = {
     '/vaadin-directory/status/{packageName}': {
       get: {
-        summary: 'Vaadin Directory',
+        summary: 'Vaadin Directory Status',
         parameters: pathParams({
           name: 'packageName',
           example: 'vaadinvaadin-grid',

--- a/services/vaadin-directory/vaadin-directory-status.service.js
+++ b/services/vaadin-directory/vaadin-directory-status.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { BaseVaadinDirectoryService } from './vaadin-directory-base.js'
 
 export default class VaadinDirectoryStatus extends BaseVaadinDirectoryService {
@@ -8,14 +9,17 @@ export default class VaadinDirectoryStatus extends BaseVaadinDirectoryService {
     pattern: ':packageName',
   }
 
-  static examples = [
-    {
-      title: 'Vaadin Directory',
-      namedParams: { packageName: 'vaadinvaadin-grid' },
-      staticPreview: this.render({ status: 'published' }),
-      keywords: ['vaadin-directory', 'status'],
+  static openApi = {
+    '/vaadin-directory/status/{packageName}': {
+      get: {
+        summary: 'Vaadin Directory',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'vaadinvaadin-grid',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'vaadin directory',

--- a/services/vaadin-directory/vaadin-directory-version.service.js
+++ b/services/vaadin-directory/vaadin-directory-version.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
 import { BaseVaadinDirectoryService } from './vaadin-directory-base.js'
 
@@ -9,15 +10,17 @@ export default class VaadinDirectoryVersion extends BaseVaadinDirectoryService {
     pattern: ':alias(v|version)/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'Vaadin Directory',
-      pattern: 'v/:packageName',
-      namedParams: { packageName: 'vaadinvaadin-grid' },
-      staticPreview: renderVersionBadge({ version: 'v5.3.0-alpha4' }),
-      keywords: ['vaadin-directory', 'latest'],
+  static openApi = {
+    '/vaadin-directory/v/{packageName}': {
+      get: {
+        summary: 'Vaadin Directory',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'vaadinvaadin-grid',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'vaadin directory',

--- a/services/vaadin-directory/vaadin-directory-version.service.js
+++ b/services/vaadin-directory/vaadin-directory-version.service.js
@@ -13,7 +13,7 @@ export default class VaadinDirectoryVersion extends BaseVaadinDirectoryService {
   static openApi = {
     '/vaadin-directory/v/{packageName}': {
       get: {
-        summary: 'Vaadin Directory',
+        summary: 'Vaadin Directory Version',
         parameters: pathParams({
           name: 'packageName',
           example: 'vaadinvaadin-grid',

--- a/services/vcpkg/vcpkg-version.service.js
+++ b/services/vcpkg/vcpkg-version.service.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { ConditionalGithubAuthV3Service } from '../github/github-auth-service.js'
 import { fetchJsonFromRepo } from '../github/github-common-fetch.js'
 import { renderVersionBadge } from '../version.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { parseVersionFromVcpkgManifest } from './vcpkg-version-helpers.js'
 
 // Handle the different version fields available in Vcpkg manifests
@@ -29,13 +29,17 @@ export default class VcpkgVersion extends ConditionalGithubAuthV3Service {
 
   static route = { base: 'vcpkg/v', pattern: ':portName' }
 
-  static examples = [
-    {
-      title: 'Vcpkg',
-      namedParams: { portName: 'entt' },
-      staticPreview: this.render({ version: '3.11.1' }),
+  static openApi = {
+    '/vcpkg/v/{portName}': {
+      get: {
+        summary: 'Vcpkg',
+        parameters: pathParams({
+          name: 'portName',
+          example: 'entt',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'vcpkg' }
 

--- a/services/vcpkg/vcpkg-version.service.js
+++ b/services/vcpkg/vcpkg-version.service.js
@@ -32,7 +32,7 @@ export default class VcpkgVersion extends ConditionalGithubAuthV3Service {
   static openApi = {
     '/vcpkg/v/{portName}': {
       get: {
-        summary: 'Vcpkg',
+        summary: 'Vcpkg Version',
         parameters: pathParams({
           name: 'portName',
           example: 'entt',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-last-updated.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-last-updated.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { age } from '../color-formatters.js'
 import { formatDate } from '../text-formatters.js'
 import VisualStudioMarketplaceBase from './visual-studio-marketplace-base.js'
@@ -11,15 +12,17 @@ export default class VisualStudioMarketplaceLastUpdated extends VisualStudioMark
       '(visual-studio-marketplace|vscode-marketplace)/last-updated/:extensionId',
   }
 
-  static examples = [
-    {
-      title: 'Visual Studio Marketplace Last Updated',
-      pattern: 'visual-studio-marketplace/last-updated/:extensionId',
-      namedParams: { extensionId: 'yasht.terminal-all-in-one' },
-      staticPreview: this.render({ lastUpdated: '2019-04-13T07:50:27.000Z' }),
-      keywords: this.keywords,
+  static openApi = {
+    '/visual-studio-marketplace/last-updated/{extensionId}': {
+      get: {
+        summary: 'Visual Studio Marketplace Last Updated',
+        parameters: pathParams({
+          name: 'extensionId',
+          example: 'yasht.terminal-all-in-one',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'last updated',

--- a/services/visual-studio-marketplace/visual-studio-marketplace-release-date.service.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-release-date.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { age } from '../color-formatters.js'
 import { formatDate } from '../text-formatters.js'
 import VisualStudioMarketplaceBase from './visual-studio-marketplace-base.js'
@@ -11,15 +12,17 @@ export default class VisualStudioMarketplaceReleaseDate extends VisualStudioMark
       '(visual-studio-marketplace|vscode-marketplace)/release-date/:extensionId',
   }
 
-  static examples = [
-    {
-      title: 'Visual Studio Marketplace Release Date',
-      pattern: 'visual-studio-marketplace/release-date/:extensionId',
-      namedParams: { extensionId: 'yasht.terminal-all-in-one' },
-      staticPreview: this.render({ releaseDate: '2019-04-13T07:50:27.000Z' }),
-      keywords: this.keywords,
+  static openApi = {
+    '/visual-studio-marketplace/release-date/{extensionId}': {
+      get: {
+        summary: 'Visual Studio Marketplace Release Date',
+        parameters: pathParams({
+          name: 'extensionId',
+          example: 'yasht.terminal-all-in-one',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'release date',

--- a/services/wheelmap/wheelmap.service.js
+++ b/services/wheelmap/wheelmap.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   node: Joi.object({
@@ -21,13 +21,17 @@ export default class Wheelmap extends BaseJsonService {
     isRequired: true,
   }
 
-  static examples = [
-    {
-      title: 'Wheelmap',
-      namedParams: { nodeId: '26699541' },
-      staticPreview: this.render({ accessibility: 'yes' }),
+  static openApi = {
+    '/wheelmap/a/{nodeId}': {
+      get: {
+        summary: 'Wheelmap',
+        parameters: pathParams({
+          name: 'nodeId',
+          example: '26699541',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'accessibility' }
 


### PR DESCRIPTION
Refs #9285

..and so begins the long slow process of working through these. The first batch I am working on is classes with:

- currently passing service tests
- only path params
- either one example, or two examples due to optional path params (e.g: `branch*`)
- no documentation string

These are the most trivial services to convert, requiring the least manual work.
I am going to submit PRs touching batches of about 15-20 files at a time as I work through these.
Then I'll start moving onto slightly more complicated cases.