### PR TITLE
migrate examples to openApi part 7; affects [reuse sourceforge sourcegraph spack stackexchange testspace treeware twitch]

### DIFF
--- a/services/reuse/reuse-compliance.service.js
+++ b/services/reuse/reuse-compliance.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 import { isReuseCompliance, COLOR_MAP } from './reuse-compliance-helper.js'
 
 const responseSchema = Joi.object({
@@ -14,16 +14,17 @@ export default class Reuse extends BaseJsonService {
     pattern: ':remote+',
   }
 
-  static examples = [
-    {
-      title: 'REUSE Compliance',
-      namedParams: {
-        remote: 'github.com/fsfe/reuse-tool',
+  static openApi = {
+    '/reuse/compliance/{remote}': {
+      get: {
+        summary: 'REUSE Compliance',
+        parameters: pathParams({
+          name: 'remote',
+          example: 'github.com/fsfe/reuse-tool',
+        }),
       },
-      staticPreview: this.render({ status: 'compliant' }),
-      keywords: ['license'],
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'reuse',

--- a/services/sourceforge/sourceforge-commit-count.service.js
+++ b/services/sourceforge/sourceforge-commit-count.service.js
@@ -17,7 +17,7 @@ export default class SourceforgeCommitCount extends BaseJsonService {
   static openApi = {
     '/sourceforge/commit-count/{project}': {
       get: {
-        summary: 'SourceForge commit count',
+        summary: 'SourceForge Commit Count',
         parameters: pathParams({
           name: 'project',
           example: 'guitarix',

--- a/services/sourceforge/sourceforge-commit-count.service.js
+++ b/services/sourceforge/sourceforge-commit-count.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 
 const schema = Joi.object({
@@ -14,17 +14,17 @@ export default class SourceforgeCommitCount extends BaseJsonService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge commit count',
-      namedParams: {
-        project: 'guitarix',
+  static openApi = {
+    '/sourceforge/commit-count/{project}': {
+      get: {
+        summary: 'SourceForge commit count',
+        parameters: pathParams({
+          name: 'project',
+          example: 'guitarix',
+        }),
       },
-      staticPreview: this.render({
-        commitCount: 1365,
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'commit count' }
 

--- a/services/sourceforge/sourceforge-contributors.service.js
+++ b/services/sourceforge/sourceforge-contributors.service.js
@@ -18,7 +18,7 @@ export default class SourceforgeContributors extends BaseSourceForgeService {
   static openApi = {
     '/sourceforge/contributors/{project}': {
       get: {
-        summary: 'SourceForge contributors',
+        summary: 'SourceForge Contributors',
         parameters: pathParams({
           name: 'project',
           example: 'guitarix',

--- a/services/sourceforge/sourceforge-contributors.service.js
+++ b/services/sourceforge/sourceforge-contributors.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { renderContributorBadge } from '../contributor-count.js'
 import BaseSourceForgeService from './sourceforge-base.js'
 
@@ -14,17 +15,17 @@ export default class SourceforgeContributors extends BaseSourceForgeService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge contributors',
-      namedParams: {
-        project: 'guitarix',
+  static openApi = {
+    '/sourceforge/contributors/{project}': {
+      get: {
+        summary: 'SourceForge contributors',
+        parameters: pathParams({
+          name: 'project',
+          example: 'guitarix',
+        }),
       },
-      staticPreview: this.render({
-        contributorCount: 9,
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'contributors' }
 

--- a/services/sourceforge/sourceforge-languages.service.js
+++ b/services/sourceforge/sourceforge-languages.service.js
@@ -20,7 +20,7 @@ export default class SourceforgeLanguages extends BaseSourceForgeService {
   static openApi = {
     '/sourceforge/languages/{project}': {
       get: {
-        summary: 'SourceForge languages',
+        summary: 'SourceForge Languages',
         parameters: pathParams({
           name: 'project',
           example: 'mingw',

--- a/services/sourceforge/sourceforge-languages.service.js
+++ b/services/sourceforge/sourceforge-languages.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import BaseSourceForgeService from './sourceforge-base.js'
 
@@ -16,15 +17,17 @@ export default class SourceforgeLanguages extends BaseSourceForgeService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge languages',
-      namedParams: {
-        project: 'mingw',
+  static openApi = {
+    '/sourceforge/languages/{project}': {
+      get: {
+        summary: 'SourceForge languages',
+        parameters: pathParams({
+          name: 'project',
+          example: 'mingw',
+        }),
       },
-      staticPreview: this.render(6),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'languages' }
 

--- a/services/sourceforge/sourceforge-last-commit.service.js
+++ b/services/sourceforge/sourceforge-last-commit.service.js
@@ -24,7 +24,7 @@ export default class SourceforgeLastCommit extends BaseJsonService {
   static openApi = {
     '/sourceforge/last-commit/{project}': {
       get: {
-        summary: 'SourceForge last commit',
+        summary: 'SourceForge Last Commit',
         parameters: pathParams({
           name: 'project',
           example: 'guitarix',

--- a/services/sourceforge/sourceforge-last-commit.service.js
+++ b/services/sourceforge/sourceforge-last-commit.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 import { formatDate } from '../text-formatters.js'
 import { age as ageColor } from '../color-formatters.js'
 
@@ -21,17 +21,17 @@ export default class SourceforgeLastCommit extends BaseJsonService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge last commit',
-      namedParams: {
-        project: 'guitarix',
+  static openApi = {
+    '/sourceforge/last-commit/{project}': {
+      get: {
+        summary: 'SourceForge last commit',
+        parameters: pathParams({
+          name: 'project',
+          example: 'guitarix',
+        }),
       },
-      staticPreview: this.render({
-        commitDate: 1653556285,
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'last commit' }
 

--- a/services/sourceforge/sourceforge-platform.service.js
+++ b/services/sourceforge/sourceforge-platform.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import BaseSourceForgeService from './sourceforge-base.js'
 
 const schema = Joi.object({
@@ -19,17 +20,17 @@ export default class SourceforgePlatform extends BaseSourceForgeService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge Platform',
-      namedParams: {
-        project: 'guitarix',
+  static openApi = {
+    '/sourceforge/platform/{project}': {
+      get: {
+        summary: 'SourceForge Platform',
+        parameters: pathParams({
+          name: 'project',
+          example: 'guitarix',
+        }),
       },
-      staticPreview: this.render({
-        platforms: ['linux', 'bsd'],
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'platform' }
 

--- a/services/sourceforge/sourceforge-translations.service.js
+++ b/services/sourceforge/sourceforge-translations.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import BaseSourceForgeService from './sourceforge-base.js'
 
@@ -16,17 +17,17 @@ export default class SourceforgeTranslations extends BaseSourceForgeService {
     pattern: ':project',
   }
 
-  static examples = [
-    {
-      title: 'SourceForge Translations',
-      namedParams: {
-        project: 'guitarix',
+  static openApi = {
+    '/sourceforge/translations/{project}': {
+      get: {
+        summary: 'SourceForge Translations',
+        parameters: pathParams({
+          name: 'project',
+          example: 'guitarix',
+        }),
       },
-      staticPreview: this.render({
-        translationCount: 4,
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'translations' }
 

--- a/services/sourcegraph/sourcegraph.service.js
+++ b/services/sourcegraph/sourcegraph.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const projectsCountRegex = /^\s[0-9]*(\.[0-9]k)?\sprojects$/
 const schema = Joi.object({
@@ -14,16 +14,17 @@ export default class Sourcegraph extends BaseJsonService {
     pattern: ':repo(.*?)',
   }
 
-  static examples = [
-    {
-      title: 'Sourcegraph for Repo Reference Count',
-      pattern: ':repo',
-      namedParams: {
-        repo: 'github.com/gorilla/mux',
+  static openApi = {
+    '/sourcegraph/rrc/{repo}': {
+      get: {
+        summary: 'Sourcegraph for Repo Reference Count',
+        parameters: pathParams({
+          name: 'repo',
+          example: 'github.com/gorilla/mux',
+        }),
       },
-      staticPreview: this.render({ projectsCount: '9.9k projects' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { color: 'brightgreen', label: 'used by' }
 

--- a/services/spack/spack.service.js
+++ b/services/spack/spack.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '..//version.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 const schema = Joi.object({
   latest_version: Joi.string().required(),
 }).required()
@@ -13,14 +13,17 @@ export default class SpackVersion extends BaseJsonService {
     pattern: ':packageName',
   }
 
-  static examples = [
-    {
-      title: 'Spack',
-      namedParams: { packageName: 'adios2' },
-      staticPreview: this.render({ version: '2.8.0' }),
-      keywords: ['hpc'],
+  static openApi = {
+    '/spack/v/{packageName}': {
+      get: {
+        summary: 'Spack',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'adios2',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'spack' }
 

--- a/services/stackexchange/stackexchange-monthlyquestions.service.js
+++ b/services/stackexchange/stackexchange-monthlyquestions.service.js
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs'
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { nonNegativeInteger } from '../validators.js'
 import {
   renderQuestionsBadge,
@@ -16,18 +17,23 @@ export default class StackExchangeMonthlyQuestions extends StackExchangeBase {
     pattern: ':stackexchangesite/qm/:query',
   }
 
-  static examples = [
-    {
-      title: 'Stack Exchange monthly questions',
-      namedParams: { stackexchangesite: 'stackoverflow', query: 'dayjs' },
-      staticPreview: this.render({
-        stackexchangesite: 'stackoverflow',
-        query: 'dayjs',
-        numValue: 2000,
-      }),
-      keywords: ['stackexchange', 'stackoverflow'],
+  static openApi = {
+    '/stackexchange/{stackexchangesite}/qm/{query}': {
+      get: {
+        summary: 'Stack Exchange monthly questions',
+        parameters: pathParams(
+          {
+            name: 'stackexchangesite',
+            example: 'stackoverflow',
+          },
+          {
+            name: 'query',
+            example: 'dayjs',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static render(props) {
     return renderQuestionsBadge({

--- a/services/stackexchange/stackexchange-reputation.service.js
+++ b/services/stackexchange/stackexchange-reputation.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { StackExchangeBase } from './stackexchange-base.js'
@@ -20,17 +21,23 @@ export default class StackExchangeReputation extends StackExchangeBase {
     pattern: ':stackexchangesite/r/:query',
   }
 
-  static examples = [
-    {
-      title: 'Stack Exchange reputation',
-      namedParams: { stackexchangesite: 'stackoverflow', query: '123' },
-      staticPreview: this.render({
-        stackexchangesite: 'stackoverflow',
-        numValue: 10,
-      }),
-      keywords: ['stackexchange', 'stackoverflow'],
+  static openApi = {
+    '/stackexchange/{stackexchangesite}/r/{query}': {
+      get: {
+        summary: 'Stack Exchange reputation',
+        parameters: pathParams(
+          {
+            name: 'stackexchangesite',
+            example: 'stackoverflow',
+          },
+          {
+            name: 'query',
+            example: '123',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static render({ stackexchangesite, numValue }) {
     const label = `${stackexchangesite} reputation`

--- a/services/stackexchange/stackexchange-taginfo.service.js
+++ b/services/stackexchange/stackexchange-taginfo.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import {
   renderQuestionsBadge,
   StackExchangeBase,
@@ -21,18 +22,23 @@ export default class StackExchangeQuestions extends StackExchangeBase {
     pattern: ':stackexchangesite/t/:query',
   }
 
-  static examples = [
-    {
-      title: 'Stack Exchange questions',
-      namedParams: { stackexchangesite: 'stackoverflow', query: 'gson' },
-      staticPreview: this.render({
-        stackexchangesite: 'stackoverflow',
-        query: 'gson',
-        numValue: 10,
-      }),
-      keywords: ['stackexchange', 'stackoverflow'],
+  static openApi = {
+    '/stackexchange/{stackexchangesite}/t/{query}': {
+      get: {
+        summary: 'Stack Exchange questions',
+        parameters: pathParams(
+          {
+            name: 'stackexchangesite',
+            example: 'stackoverflow',
+          },
+          {
+            name: 'query',
+            example: 'gson',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static render(props) {
     return renderQuestionsBadge({

--- a/services/testspace/testspace-test-pass-ratio.service.js
+++ b/services/testspace/testspace-test-pass-ratio.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import TestspaceBase from './testspace-base.js'
 
 export default class TestspacePassRatio extends TestspaceBase {
@@ -6,20 +7,27 @@ export default class TestspacePassRatio extends TestspaceBase {
     pattern: ':org/:project/:space+',
   }
 
-  static examples = [
-    {
-      title: 'Testspace pass ratio',
-      namedParams: {
-        org: 'swellaby',
-        project: 'swellaby:testspace-sample',
-        space: 'main',
+  static openApi = {
+    '/testspace/pass-ratio/{org}/{project}/{space}': {
+      get: {
+        summary: 'Testspace pass ratio',
+        parameters: pathParams(
+          {
+            name: 'org',
+            example: 'swellaby',
+          },
+          {
+            name: 'project',
+            example: 'swellaby:testspace-sample',
+          },
+          {
+            name: 'space',
+            example: 'main',
+          },
+        ),
       },
-      staticPreview: this.render({
-        passed: 2,
-        total: 3,
-      }),
     },
-  ]
+  }
 
   static render({ passed, total }) {
     const ratio = ((passed / total) * 100).toFixed(0)

--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -2,7 +2,7 @@ import crypto from 'crypto'
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { floorCount } from '../color-formatters.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const apiSchema = Joi.object({
   total: Joi.number().required(),
@@ -16,13 +16,23 @@ export default class TreewareTrees extends BaseJsonService {
     pattern: ':owner/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'Treeware (Trees)',
-      namedParams: { owner: 'stoplightio', packageName: 'spectral' },
-      staticPreview: this.render({ count: 250 }),
+  static openApi = {
+    '/treeware/trees/{owner}/{packageName}': {
+      get: {
+        summary: 'Treeware (Trees)',
+        parameters: pathParams(
+          {
+            name: 'owner',
+            example: 'stoplightio',
+          },
+          {
+            name: 'packageName',
+            example: 'spectral',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'trees',

--- a/services/twitch/twitch-extension-version.service.js
+++ b/services/twitch/twitch-extension-version.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
 import TwitchBase from './twitch-base.js'
 
@@ -17,15 +18,17 @@ export default class TwitchExtensionVersion extends TwitchBase {
     pattern: ':extensionId',
   }
 
-  static examples = [
-    {
-      title: 'Twitch Extension Version',
-      namedParams: {
-        extensionId: '2nq5cu1nc9f4p75b791w8d3yo9d195',
+  static openApi = {
+    '/twitch/extension/v/{extensionId}': {
+      get: {
+        summary: 'Twitch Extension Version',
+        parameters: pathParams({
+          name: 'extensionId',
+          example: '2nq5cu1nc9f4p75b791w8d3yo9d195',
+        }),
       },
-      staticPreview: renderVersionBadge({ version: '1.0.0' }),
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'twitch extension',


### PR DESCRIPTION
Refs #9285

..and so begins the long slow process of working through these. The first batch I am working on is classes with:

- currently passing service tests
- only path params
- either one example, or two examples due to optional path params (e.g: `branch*`)
- no documentation string

These are the most trivial services to convert, requiring the least manual work.
I am going to submit PRs touching batches of about 15-20 files at a time as I work through these.
Then I'll start moving onto slightly more complicated cases.