### PR TITLE
migrate examples to openApi part 9; affects [bowerlicense conda freecodecamp galaxytoolshed jenkins-plugin npmtypedefinitions puppetforge]

### DIFF
--- a/services/bower/bower-license.service.js
+++ b/services/bower/bower-license.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderLicenseBadge } from '../licenses.js'
 import BaseBowerService from './bower-base.js'
 
@@ -5,13 +6,17 @@ export default class BowerLicense extends BaseBowerService {
   static category = 'license'
   static route = { base: 'bower/l', pattern: ':packageName' }
 
-  static examples = [
-    {
-      title: 'Bower',
-      namedParams: { packageName: 'bootstrap' },
-      staticPreview: renderLicenseBadge({ licenses: ['MIT'] }),
+  static openApi = {
+    '/bower/l/{packageName}': {
+      get: {
+        summary: 'Bower',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'bootstrap',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'license' }
 

--- a/services/bower/bower-license.service.js
+++ b/services/bower/bower-license.service.js
@@ -9,7 +9,7 @@ export default class BowerLicense extends BaseBowerService {
   static openApi = {
     '/bower/l/{packageName}': {
       get: {
-        summary: 'Bower',
+        summary: 'Bower License',
         parameters: pathParams({
           name: 'packageName',
           example: 'bootstrap',

--- a/services/conda/conda-license.service.js
+++ b/services/conda/conda-license.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { renderLicenseBadge } from '../licenses.js'
 import toArray from '../../core/base-service/to-array.js'
 import BaseCondaService from './conda-base.js'
@@ -11,21 +12,23 @@ export default class CondaLicense extends BaseCondaService {
   static category = 'license'
   static route = { base: 'conda', pattern: 'l/:channel/:pkg' }
 
-  static examples = [
-    {
-      title: 'Conda - License',
-      pattern: 'l/:channel/:package',
-      namedParams: {
-        channel: 'conda-forge',
-        package: 'setuptools',
+  static openApi = {
+    '/conda/l/{channel}/{package}': {
+      get: {
+        summary: 'Conda - License',
+        parameters: pathParams(
+          {
+            name: 'channel',
+            example: 'conda-forge',
+          },
+          {
+            name: 'package',
+            example: 'setuptools',
+          },
+        ),
       },
-      staticPreview: this.render({
-        variant: 'l',
-        channel: 'conda-forge',
-        licenses: ['MIT'],
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'license' }
 

--- a/services/freecodecamp/freecodecamp-points.service.js
+++ b/services/freecodecamp/freecodecamp-points.service.js
@@ -1,6 +1,11 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
-import { BaseJsonService, InvalidResponse, NotFound } from '../index.js'
+import {
+  BaseJsonService,
+  InvalidResponse,
+  NotFound,
+  pathParams,
+} from '../index.js'
 
 /**
  * Validates that the schema response is what we're expecting.
@@ -30,13 +35,17 @@ export default class FreeCodeCampPoints extends BaseJsonService {
     pattern: ':username',
   }
 
-  static examples = [
-    {
-      title: 'freeCodeCamp points',
-      namedParams: { username: 'sethi' },
-      staticPreview: this.render({ points: 934 }),
+  static openApi = {
+    '/freecodecamp/points/{username}': {
+      get: {
+        summary: 'freeCodeCamp points',
+        parameters: pathParams({
+          name: 'username',
+          example: 'sethi',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'points', color: 'info' }
 

--- a/services/freecodecamp/freecodecamp-points.service.js
+++ b/services/freecodecamp/freecodecamp-points.service.js
@@ -41,7 +41,7 @@ export default class FreeCodeCampPoints extends BaseJsonService {
         summary: 'freeCodeCamp points',
         parameters: pathParams({
           name: 'username',
-          example: 'sethi',
+          example: 'raisedadead',
         }),
       },
     },

--- a/services/freecodecamp/freecodecamp-points.tester.js
+++ b/services/freecodecamp/freecodecamp-points.tester.js
@@ -3,7 +3,7 @@ import { isMetric } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('Total Points Valid')
-  .get('/sethi.json')
+  .get('/raisedadead.json')
   .expectBadge({ label: 'points', message: isMetric })
 
 t.create('Total Points Private')

--- a/services/galaxytoolshed/galaxytoolshed-activity.service.js
+++ b/services/galaxytoolshed/galaxytoolshed-activity.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { formatDate } from '../text-formatters.js'
 import BaseGalaxyToolshedService from './galaxytoolshed-base.js'
 
@@ -8,18 +9,23 @@ export default class GalaxyToolshedCreatedDate extends BaseGalaxyToolshedService
     pattern: ':repository/:owner',
   }
 
-  static examples = [
-    {
-      title: 'Galaxy Toolshed (created date)',
-      namedParams: {
-        repository: 'sra_tools',
-        owner: 'iuc',
+  static openApi = {
+    '/galaxytoolshed/created-date/{repository}/{owner}': {
+      get: {
+        summary: 'Galaxy Toolshed (created date)',
+        parameters: pathParams(
+          {
+            name: 'repository',
+            example: 'sra_tools',
+          },
+          {
+            name: 'owner',
+            example: 'iuc',
+          },
+        ),
       },
-      staticPreview: this.render({
-        date: this.render({ date: '2022-01-01' }),
-      }),
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'created date',

--- a/services/galaxytoolshed/galaxytoolshed-activity.service.js
+++ b/services/galaxytoolshed/galaxytoolshed-activity.service.js
@@ -12,7 +12,7 @@ export default class GalaxyToolshedCreatedDate extends BaseGalaxyToolshedService
   static openApi = {
     '/galaxytoolshed/created-date/{repository}/{owner}': {
       get: {
-        summary: 'Galaxy Toolshed (created date)',
+        summary: 'Galaxy Toolshed - Created Date',
         parameters: pathParams(
           {
             name: 'repository',

--- a/services/galaxytoolshed/galaxytoolshed-downloads.service.js
+++ b/services/galaxytoolshed/galaxytoolshed-downloads.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
 import BaseGalaxyToolshedService from './galaxytoolshed-base.js'
 
@@ -8,16 +9,23 @@ export default class GalaxyToolshedDownloads extends BaseGalaxyToolshedService {
     pattern: ':repository/:owner',
   }
 
-  static examples = [
-    {
-      title: 'Galaxy Toolshed - Downloads',
-      namedParams: {
-        repository: 'sra_tools',
-        owner: 'iuc',
+  static openApi = {
+    '/galaxytoolshed/downloads/{repository}/{owner}': {
+      get: {
+        summary: 'Galaxy Toolshed - Downloads',
+        parameters: pathParams(
+          {
+            name: 'repository',
+            example: 'sra_tools',
+          },
+          {
+            name: 'owner',
+            example: 'iuc',
+          },
+        ),
       },
-      staticPreview: renderDownloadsBadge({ downloads: 10000 }),
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'downloads',

--- a/services/jenkins/jenkins-plugin-version.service.js
+++ b/services/jenkins/jenkins-plugin-version.service.js
@@ -1,6 +1,6 @@
 import { getCachedResource } from '../../core/base-service/resource-cache.js'
 import { renderVersionBadge } from '../version.js'
-import { BaseService, NotFound } from '../index.js'
+import { BaseService, NotFound, pathParams } from '../index.js'
 
 export default class JenkinsPluginVersion extends BaseService {
   static category = 'version'
@@ -10,19 +10,17 @@ export default class JenkinsPluginVersion extends BaseService {
     pattern: ':plugin',
   }
 
-  static examples = [
-    {
-      title: 'Jenkins Plugins',
-      namedParams: {
-        plugin: 'blueocean',
-      },
-      staticPreview: {
-        label: 'plugin',
-        message: 'v1.10.1',
-        color: 'blue',
+  static openApi = {
+    '/jenkins/plugin/v/{plugin}': {
+      get: {
+        summary: 'Jenkins Plugins',
+        parameters: pathParams({
+          name: 'plugin',
+          example: 'blueocean',
+        }),
       },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'plugin' }
 

--- a/services/jenkins/jenkins-plugin-version.service.js
+++ b/services/jenkins/jenkins-plugin-version.service.js
@@ -13,7 +13,7 @@ export default class JenkinsPluginVersion extends BaseService {
   static openApi = {
     '/jenkins/plugin/v/{plugin}': {
       get: {
-        summary: 'Jenkins Plugins',
+        summary: 'Jenkins Plugin Version',
         parameters: pathParams({
           name: 'plugin',
           example: 'blueocean',

--- a/services/npm/npm-type-definitions.service.js
+++ b/services/npm/npm-type-definitions.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import NpmBase from './npm-base.js'
 
 // For this badge to correctly detect type definitions, either the relevant
@@ -8,17 +9,17 @@ export default class NpmTypeDefinitions extends NpmBase {
 
   static route = this.buildRoute('npm/types', { withTag: false })
 
-  static examples = [
-    {
-      title: 'npm type definitions',
-      pattern: ':packageName',
-      namedParams: { packageName: 'chalk' },
-      staticPreview: this.render({
-        supportedLanguages: ['TypeScript', 'Flow'],
-      }),
-      keywords: ['node', 'typescript', 'flow'],
+  static openApi = {
+    '/npm/types/{packageName}': {
+      get: {
+        summary: 'npm type definitions',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'chalk',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'types',

--- a/services/puppetforge/puppetforge-module-downloads.service.js
+++ b/services/puppetforge/puppetforge-module-downloads.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
 import { BasePuppetForgeModulesService } from './puppetforge-base.js'
 
@@ -9,16 +10,23 @@ export default class PuppetforgeModuleDownloads extends BasePuppetForgeModulesSe
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge downloads',
-      namedParams: {
-        user: 'camptocamp',
-        moduleName: 'openldap',
+  static openApi = {
+    '/puppetforge/dt/{user}/{moduleName}': {
+      get: {
+        summary: 'Puppet Forge downloads',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'camptocamp',
+          },
+          {
+            name: 'moduleName',
+            example: 'openldap',
+          },
+        ),
       },
-      staticPreview: renderDownloadsBadge({ downloads: 720000 }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/puppetforge/puppetforge-module-endorsement.service.js
+++ b/services/puppetforge/puppetforge-module-endorsement.service.js
@@ -1,4 +1,4 @@
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { BasePuppetForgeModulesService } from './puppetforge-base.js'
 
 export default class PuppetforgeModuleEndorsement extends BasePuppetForgeModulesService {
@@ -9,16 +9,23 @@ export default class PuppetforgeModuleEndorsement extends BasePuppetForgeModules
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge endorsement',
-      namedParams: {
-        user: 'camptocamp',
-        moduleName: 'openssl',
+  static openApi = {
+    '/puppetforge/e/{user}/{moduleName}': {
+      get: {
+        summary: 'Puppet Forge endorsement',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'camptocamp',
+          },
+          {
+            name: 'moduleName',
+            example: 'openssl',
+          },
+        ),
       },
-      staticPreview: this.render({ endorsement: 'approved' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'endorsement' }
 

--- a/services/puppetforge/puppetforge-module-feedback.service.js
+++ b/services/puppetforge/puppetforge-module-feedback.service.js
@@ -1,5 +1,5 @@
 import { coveragePercentage as coveragePercentageColor } from '../color-formatters.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { BasePuppetForgeModulesService } from './puppetforge-base.js'
 
 export default class PuppetforgeModuleFeedback extends BasePuppetForgeModulesService {
@@ -10,16 +10,23 @@ export default class PuppetforgeModuleFeedback extends BasePuppetForgeModulesSer
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge feedback score',
-      namedParams: {
-        user: 'camptocamp',
-        moduleName: 'openssl',
+  static openApi = {
+    '/puppetforge/f/{user}/{moduleName}': {
+      get: {
+        summary: 'Puppet Forge feedback score',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'camptocamp',
+          },
+          {
+            name: 'moduleName',
+            example: 'openssl',
+          },
+        ),
       },
-      staticPreview: this.render({ score: 61 }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'score' }
 

--- a/services/puppetforge/puppetforge-module-pdk-version.service.js
+++ b/services/puppetforge/puppetforge-module-pdk-version.service.js
@@ -1,5 +1,5 @@
 import { renderVersionBadge } from '../version.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { BasePuppetForgeModulesService } from './puppetforge-base.js'
 
 export default class PuppetforgeModulePdkVersion extends BasePuppetForgeModulesService {
@@ -10,16 +10,23 @@ export default class PuppetforgeModulePdkVersion extends BasePuppetForgeModulesS
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge – PDK version',
-      namedParams: {
-        user: 'tragiccode',
-        moduleName: 'azure_key_vault',
+  static openApi = {
+    '/puppetforge/pdk-version/{user}/{moduleName}': {
+      get: {
+        summary: 'Puppet Forge – PDK version',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'tragiccode',
+          },
+          {
+            name: 'moduleName',
+            example: 'azure_key_vault',
+          },
+        ),
       },
-      staticPreview: renderVersionBadge({ version: '1.7.1' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'pdk version' }
 

--- a/services/puppetforge/puppetforge-module-pdk-version.service.js
+++ b/services/puppetforge/puppetforge-module-pdk-version.service.js
@@ -13,7 +13,7 @@ export default class PuppetforgeModulePdkVersion extends BasePuppetForgeModulesS
   static openApi = {
     '/puppetforge/pdk-version/{user}/{moduleName}': {
       get: {
-        summary: 'Puppet Forge – PDK version',
+        summary: 'Puppet Forge - PDK version',
         parameters: pathParams(
           {
             name: 'user',

--- a/services/puppetforge/puppetforge-module-version.service.js
+++ b/services/puppetforge/puppetforge-module-version.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
 import { BasePuppetForgeModulesService } from './puppetforge-base.js'
 
@@ -9,16 +10,23 @@ export default class PuppetforgeModuleVersion extends BasePuppetForgeModulesServ
     pattern: ':user/:moduleName',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge version',
-      namedParams: {
-        user: 'vStone',
-        moduleName: 'percona',
+  static openApi = {
+    '/puppetforge/v/{user}/{moduleName}': {
+      get: {
+        summary: 'Puppet Forge version',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'vStone',
+          },
+          {
+            name: 'moduleName',
+            example: 'percona',
+          },
+        ),
       },
-      staticPreview: renderVersionBadge({ version: '1.3.3' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'puppetforge' }
 

--- a/services/puppetforge/puppetforge-user-module-count.service.js
+++ b/services/puppetforge/puppetforge-user-module-count.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { BasePuppetForgeUsersService } from './puppetforge-base.js'
@@ -10,15 +11,17 @@ export default class PuppetForgeModuleCountService extends BasePuppetForgeUsersS
     pattern: ':user',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge modules by user',
-      namedParams: {
-        user: 'camptocamp',
+  static openApi = {
+    '/puppetforge/mc/{user}': {
+      get: {
+        summary: 'Puppet Forge modules by user',
+        parameters: pathParams({
+          name: 'user',
+          example: 'camptocamp',
+        }),
       },
-      staticPreview: this.render({ modules: 60 }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'modules' }
 

--- a/services/puppetforge/puppetforge-user-release-count.service.js
+++ b/services/puppetforge/puppetforge-user-release-count.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { BasePuppetForgeUsersService } from './puppetforge-base.js'
@@ -10,15 +11,17 @@ export default class PuppetForgeReleaseCountService extends BasePuppetForgeUsers
     pattern: ':user',
   }
 
-  static examples = [
-    {
-      title: 'Puppet Forge releases by user',
-      namedParams: {
-        user: 'camptocamp',
+  static openApi = {
+    '/puppetforge/rc/{user}': {
+      get: {
+        summary: 'Puppet Forge releases by user',
+        parameters: pathParams({
+          name: 'user',
+          example: 'camptocamp',
+        }),
       },
-      staticPreview: this.render({ releases: 1000 }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'releases' }
 


### PR DESCRIPTION
Refs #9285

..and so begins the long slow process of working through these. The first batch I am working on is classes with:

- currently passing service tests
- only path params
- either one example, or two examples due to optional path params (e.g: `branch*`)
- no documentation string

These are the most trivial services to convert, requiring the least manual work.
I am going to submit PRs touching batches of about 15-20 files at a time as I work through these.
Then I'll start moving onto slightly more complicated cases.