### PR TITLE
migrate examples to openApi part 10

### DIFF
--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderBuildStatusBadge } from '../build-status.js'
-import { BaseJsonService, redirector } from '../index.js'
+import { BaseJsonService, redirector, pathParams } from '../index.js'
 
 const bitbucketPipelinesSchema = Joi.object({
   values: Joi.array()
@@ -30,17 +30,27 @@ class BitbucketPipelines extends BaseJsonService {
     pattern: ':user/:repo/:branch+',
   }
 
-  static examples = [
-    {
-      title: 'Bitbucket Pipelines',
-      namedParams: {
-        user: 'atlassian',
-        repo: 'adf-builder-javascript',
-        branch: 'task/SECO-2168',
+  static openApi = {
+    '/bitbucket/pipelines/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'Bitbucket Pipelines',
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'atlassian',
+          },
+          {
+            name: 'repo',
+            example: 'adf-builder-javascript',
+          },
+          {
+            name: 'branch',
+            example: 'task/SECO-2168',
+          },
+        ),
       },
-      staticPreview: this.render({ status: 'SUCCESSFUL' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'build' }
 


### PR DESCRIPTION
Refs #9285

This one doesn't have passing service tests and I don't have the examples to hand to fix them, so I'm going to push a commit that does nothing, let the tests fail, then push a commit that does stuff so we can at least see the failures aren't new.

In general, this whole process probably will require modifying more code that doesn't have (reliably) passing service tests.
