### PR TITLE
remove obsolete entries from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,22 +17,9 @@ updates:
       - dependency-name: 'decamelize'
       - dependency-name: 'humanize-string'
 
-      # https://github.com/badges/shields/pull/7288#issuecomment-974699240
-      - dependency-name: '@types/node'
-
   # badge-maker package dependencies
   - package-ecosystem: npm
     directory: '/badge-maker'
-    schedule:
-      interval: weekly
-      day: friday
-      time: '12:00'
-    open-pull-requests-limit: 99
-    rebase-strategy: disabled
-
-  # close-bot package dependencies
-  - package-ecosystem: npm
-    directory: '/.github/actions/close-bot'
     schedule:
       interval: weekly
       day: friday


### PR DESCRIPTION
There are a few entries in `dependabot.yml` which relate to code or packages which we have now deleted.

The best time to remove these would have been in the original PRs removing the code or packages referenced. The second best time is now :)