### PR TITLE
output DockerHub digest in publish-docker-next workflow

### DIFF
--- a/.github/workflows/publish-docker-next.yml
+++ b/.github/workflows/publish-docker-next.yml
@@ -29,6 +29,7 @@ jobs:
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
 
       - name: Build and push to DockerHub
+        id: docker_build_push
         uses: docker/build-push-action@v4
         with:
           context: .
@@ -36,6 +37,9 @@ jobs:
           tags: shieldsio/shields:next
           build-args: |
             version=${{ env.SHORT_SHA }}
+
+      - name: Output Image Digest
+        run: echo ${{ steps.docker_build_push.outputs.digest }} >> $GITHUB_STEP_SUMMARY
 
       - name: Login to GHCR
         uses: docker/login-action@v2


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9391 and https://github.com/badges/shields-ops/issues/34

We now need to deploy based on a DockerHub digest. We can't use a rolling tag. Finding the digest in the build log is possible, but it could be easier.

This PR outputs the DockerHub digest to a job summary, which will reduce the friction here.