### PR TITLE
[bitbucketpipelines] resolve "invalid response data" for halted pipelines

### DIFF
--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -78,7 +78,7 @@ class BitbucketPipelines extends BaseJsonService {
       value =>
         value.state &&
         (value.state.name === 'COMPLETED' ||
-         value.state.name === 'IN_PROGRESS'),
+          value.state.name === 'IN_PROGRESS'),
     )
     if (values.length > 0) {
       if (Object.prototype.hasOwnProperty.call(values[0].state, 'result')) {

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -21,7 +21,9 @@ const bitbucketPipelinesSchema = Joi.object({
             name: Joi.string().required(),
             type: Joi.string().optional(),
           }),
-        }).required().or('result','stage'),
+        })
+          .required()
+          .or('result','stage'),
       }),
     )
     .required(),
@@ -73,10 +75,13 @@ class BitbucketPipelines extends BaseJsonService {
 
   static transform(data) {
     const values = data.values.filter(
-      value => value.state && (value.state.name === 'COMPLETED' || value.state.name === 'IN_PROGRESS'),
+      value =>
+        value.state &&
+        (value.state.name === 'COMPLETED' ||
+         value.state.name === 'IN_PROGRESS'),
     )
     if (values.length > 0) {
-      if(Object.prototype.hasOwnProperty.call(values[0].state, 'result')) {
+      if (Object.prototype.hasOwnProperty.call(values[0].state, 'result')) {
         return values[0].state.result.name
       }
       return values[0].state.stage.name

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -23,7 +23,7 @@ const bitbucketPipelinesSchema = Joi.object({
           }),
         })
           .required()
-          .or('result','stage'),
+          .or('result', 'stage'),
       }),
     )
     .required(),

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -76,7 +76,7 @@ class BitbucketPipelines extends BaseJsonService {
       value => value.state && (value.state.name === 'COMPLETED' || value.state.name === 'IN_PROGRESS'),
     )
     if (values.length > 0) {
-      if (values[0].state.hasOwnProperty('result')) {
+      if(Object.prototype.hasOwnProperty.call(values[0].state, 'result')) {
         return values[0].state.result.name
       }
       return values[0].state.stage.name

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -16,7 +16,7 @@ const bitbucketPipelinesSchema = Joi.object({
               'STOPPED',
               'EXPIRED',
             ),
-          }).required(),
+          }).optional(),
         }).required(),
       }),
     )

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -72,6 +72,9 @@ class BitbucketPipelines extends BaseJsonService {
       value => value.state && value.state.name === 'COMPLETED',
     )
     if (values.length > 0) {
+      if !values[0].state.hasOwnProperty('result') { // DID THIS ------------------------------------------------------------------
+        return 'HALTED'
+      }
       return values[0].state.result.name
     }
     return 'never built'

--- a/services/bitbucket/bitbucket-pipelines.tester.js
+++ b/services/bitbucket/bitbucket-pipelines.tester.js
@@ -32,8 +32,8 @@ function bitbucketNoResultResponse(stageName) {
           name: 'IN_PROGRESS',
           stage: {
             name: stageName,
-            type: 'pipeline_state_in_progress_halted'
-          }
+            type: 'pipeline_state_in_progress_halted',
+          },
         },
       },
     ],
@@ -60,7 +60,7 @@ t.create('branch build result (never built)')
   .expectBadge({ label: 'build', message: 'never built' })
 
 t.create('build result (stage only)')
-.get('/atlassian/adf-builder-javascript/master.json')
+  .get('/atlassian/adf-builder-javascript/master.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)

--- a/services/bitbucket/bitbucket-pipelines.tester.js
+++ b/services/bitbucket/bitbucket-pipelines.tester.js
@@ -30,7 +30,10 @@ function bitbucketNoResultResponse(stageName) {
         state: {
           type: 'pipeline_state_in_progress',
           name: 'IN_PROGRESS',
-          stage: { name: stageName, type: 'pipeline_state_in_progress_halted' }
+          stage: {
+            name: stageName,
+            type: 'pipeline_state_in_progress_halted'
+          }
         },
       },
     ],


### PR DESCRIPTION
Should resolve issue #9096 
Bitbucket responses for pipelines in progress will now fall back to utilizing the stage name instead of being invalid.
