### PR TITLE
[twitter] --> x

### DIFF
--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -17,7 +17,7 @@ class TwitterUrl extends BaseService {
 
   static examples = [
     {
-      title: 'Twitter URL',
+      title: 'X (formerly Twitter) URL',
       namedParams: {},
       queryParams: {
         url: 'https://shields.io',
@@ -35,7 +35,7 @@ class TwitterUrl extends BaseService {
   static _cacheLength = 86400
 
   static defaultBadgeData = {
-    namedLogo: 'twitter',
+    namedLogo: 'x',
   }
 
   async handle(_routeParams, { url }) {
@@ -75,7 +75,7 @@ class TwitterFollow extends BaseJsonService {
 
   static examples = [
     {
-      title: 'Twitter Follow',
+      title: 'X (formerly Twitter) Follow',
       namedParams: {
         user: 'shields_io',
       },
@@ -93,7 +93,7 @@ class TwitterFollow extends BaseJsonService {
   static _cacheLength = 86400
 
   static defaultBadgeData = {
-    namedLogo: 'twitter',
+    namedLogo: 'x',
   }
 
   static render({ user }) {


### PR DESCRIPTION
Closes #9479

I'm not going to get too bogged down in moving routes and files around as this is really just a pretty deprecation message, but this PR updates the name of the services in the docs and the default logo.

If you're explicitly using `logo=twitter`, then you'll continue to get the twitter logo. If simple-icons decide to make that slug an alias for the x logo in future, we'll inherit that decision.
