### PR TITLE
migrate examples to openApi part 13; affects [curseforge date fedora hsts modrinth ore]

### DIFF
--- a/services/curseforge/curseforge-base.js
+++ b/services/curseforge/curseforge-base.js
@@ -14,7 +14,7 @@ const schema = Joi.object({
   }).required(),
 }).required()
 
-const documentation = `
+const description = `
 <p>
   The CurseForge badge requires the <code>Project ID</code> in order access the
   <a href="https://docs.curseforge.com/#get-mod" target="_blank">CurseForge API</a>.
@@ -58,4 +58,4 @@ export default class BaseCurseForgeService extends BaseJsonService {
   }
 }
 
-export { BaseCurseForgeService, documentation }
+export { BaseCurseForgeService, description }

--- a/services/curseforge/curseforge-downloads.service.js
+++ b/services/curseforge/curseforge-downloads.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
-import BaseCurseForgeService, { documentation } from './curseforge-base.js'
+import BaseCurseForgeService, { description } from './curseforge-base.js'
 
 export default class CurseForgeDownloads extends BaseCurseForgeService {
   static category = 'downloads'
@@ -9,16 +10,18 @@ export default class CurseForgeDownloads extends BaseCurseForgeService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'CurseForge Downloads',
-      namedParams: {
-        projectId: '238222',
+  static openApi = {
+    '/curseforge/dt/{projectId}': {
+      get: {
+        summary: 'CurseForge Downloads',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: '238222',
+        }),
       },
-      staticPreview: renderDownloadsBadge({ downloads: 234000000 }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/curseforge/curseforge-game-versions.service.js
+++ b/services/curseforge/curseforge-game-versions.service.js
@@ -1,4 +1,5 @@
-import BaseCurseForgeService, { documentation } from './curseforge-base.js'
+import { pathParams } from '../index.js'
+import BaseCurseForgeService, { description } from './curseforge-base.js'
 
 export default class CurseForgeGameVersions extends BaseCurseForgeService {
   static category = 'platform-support'
@@ -8,16 +9,18 @@ export default class CurseForgeGameVersions extends BaseCurseForgeService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'CurseForge Game Versions',
-      namedParams: {
-        projectId: '238222',
+  static openApi = {
+    '/curseforge/game-versions/{projectId}': {
+      get: {
+        summary: 'CurseForge Game Versions',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: '238222',
+        }),
       },
-      staticPreview: this.render({ versions: ['1.20.0', '1.19.4'] }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'game versions' }
 

--- a/services/curseforge/curseforge-version.service.js
+++ b/services/curseforge/curseforge-version.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
-import BaseCurseForgeService, { documentation } from './curseforge-base.js'
+import BaseCurseForgeService, { description } from './curseforge-base.js'
 
 export default class CurseForgeVersion extends BaseCurseForgeService {
   static category = 'version'
@@ -9,18 +10,18 @@ export default class CurseForgeVersion extends BaseCurseForgeService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'CurseForge Version',
-      namedParams: {
-        projectId: '238222',
+  static openApi = {
+    '/curseforge/v/{projectId}': {
+      get: {
+        summary: 'CurseForge Version',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: '238222',
+        }),
       },
-      staticPreview: renderVersionBadge({
-        version: 'jei-1.20-forge-14.0.0.4.jar',
-      }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'version' }
 

--- a/services/date/date.service.js
+++ b/services/date/date.service.js
@@ -1,7 +1,7 @@
 import { formatRelativeDate } from '../text-formatters.js'
-import { BaseService } from '../index.js'
+import { BaseService, pathParams } from '../index.js'
 
-const documentation = `
+const description = `
 <p>
   Supply a unix timestamp in seconds to display the relative time from/to now
 </p>
@@ -11,16 +11,18 @@ export default class Date extends BaseService {
   static category = 'other'
   static route = { base: 'date', pattern: ':timestamp(-?[0-9]+)' }
 
-  static examples = [
-    {
-      title: 'Relative date',
-      pattern: ':timestamp',
-      namedParams: { timestamp: '1540814400' },
-      staticPreview: this.render({ relativeDateString: '2 days ago' }),
-      keywords: ['time', 'countdown', 'countup', 'moment'],
-      documentation,
+  static openApi = {
+    '/date/{timestamp}': {
+      get: {
+        summary: 'Relative date',
+        description,
+        parameters: pathParams({
+          name: 'timestamp',
+          example: '1540814400',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'date' }
 

--- a/services/fedora/fedora.service.js
+++ b/services/fedora/fedora.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   version: Joi.string().required(),
@@ -9,18 +9,40 @@ const schema = Joi.object({
 // No way to permalink to current "stable", https://pagure.io/mdapi/issue/69
 const defaultBranch = 'rawhide'
 
+const description =
+  'See <a href="https://apps.fedoraproject.org/mdapi/">mdapi docs</a> for information on valid branches.'
+
 export default class Fedora extends BaseJsonService {
   static category = 'version'
   static route = { base: 'fedora/v', pattern: ':packageName/:branch?' }
-  static examples = [
-    {
-      title: 'Fedora package',
-      namedParams: { packageName: 'rpm', branch: 'rawhide' },
-      staticPreview: renderVersionBadge({ version: '4.14.2.1' }),
-      documentation:
-        'See <a href="https://apps.fedoraproject.org/mdapi/">mdapi docs</a> for information on valid branches.',
+  static openApi = {
+    '/fedora/v/{packageName}/{branch}': {
+      get: {
+        summary: 'Fedora package',
+        description,
+        parameters: pathParams(
+          {
+            name: 'packageName',
+            example: 'rpm',
+          },
+          {
+            name: 'branch',
+            example: 'rawhide',
+          },
+        ),
+      },
     },
-  ]
+    '/fedora/v/{packageName}': {
+      get: {
+        summary: 'Fedora package',
+        description,
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'rpm',
+        }),
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'fedora' }
 

--- a/services/fedora/fedora.service.js
+++ b/services/fedora/fedora.service.js
@@ -18,7 +18,7 @@ export default class Fedora extends BaseJsonService {
   static openApi = {
     '/fedora/v/{packageName}/{branch}': {
       get: {
-        summary: 'Fedora package',
+        summary: 'Fedora package (with branch)',
         description,
         parameters: pathParams(
           {

--- a/services/hsts/hsts.service.js
+++ b/services/hsts/hsts.service.js
@@ -1,11 +1,12 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
+
 const label = 'hsts preloaded'
 const schema = Joi.object({
   status: Joi.string().required(),
 }).required()
 
-const documentation = `
+const description = `
 [\`Strict-Transport-Security\` is an HTTP response header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
 that signals that browsers should only access the site using HTTPS.
 
@@ -24,15 +25,18 @@ export default class HSTS extends BaseJsonService {
     pattern: ':domain',
   }
 
-  static examples = [
-    {
-      title: 'Chromium HSTS preload',
-      namedParams: { domain: 'github.com' },
-      staticPreview: this.render({ status: 'preloaded' }),
-      keywords: ['security'],
-      documentation,
+  static openApi = {
+    '/hsts/preload/{domain}': {
+      get: {
+        summary: 'Chromium HSTS preload',
+        description,
+        parameters: pathParams({
+          name: 'domain',
+          example: 'github.com',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ status }) {
     let color = 'red'

--- a/services/modrinth/modrinth-base.js
+++ b/services/modrinth/modrinth-base.js
@@ -16,7 +16,7 @@ const versionSchema = Joi.array()
   )
   .required()
 
-const documentation =
+const description =
   "<p>You can use your project slug, or the project ID. The ID can be found in the 'Technical information' section of your Modrinth page.</p>"
 
 class BaseModrinthService extends BaseJsonService {
@@ -36,4 +36,4 @@ class BaseModrinthService extends BaseJsonService {
   }
 }
 
-export { BaseModrinthService, documentation }
+export { BaseModrinthService, description }

--- a/services/modrinth/modrinth-downloads.service.js
+++ b/services/modrinth/modrinth-downloads.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
-import { BaseModrinthService, documentation } from './modrinth-base.js'
+import { BaseModrinthService, description } from './modrinth-base.js'
 
 export default class ModrinthDownloads extends BaseModrinthService {
   static category = 'downloads'
@@ -9,14 +10,18 @@ export default class ModrinthDownloads extends BaseModrinthService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'Modrinth Downloads',
-      namedParams: { projectId: 'AANobbMI' },
-      staticPreview: renderDownloadsBadge({ downloads: 120000 }),
-      documentation,
+  static openApi = {
+    '/modrinth/dt/{projectId}': {
+      get: {
+        summary: 'Modrinth Downloads',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: 'AANobbMI',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/modrinth/modrinth-followers.service.js
+++ b/services/modrinth/modrinth-followers.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
-import { BaseModrinthService, documentation } from './modrinth-base.js'
+import { BaseModrinthService, description } from './modrinth-base.js'
 
 export default class ModrinthFollowers extends BaseModrinthService {
   static category = 'social'
@@ -9,17 +10,18 @@ export default class ModrinthFollowers extends BaseModrinthService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'Modrinth Followers',
-      namedParams: { projectId: 'AANobbMI' },
-      staticPreview: Object.assign(this.render({ followers: 176 }), {
-        label: 'Followers',
-        style: 'social',
-      }),
-      documentation,
+  static openApi = {
+    '/modrinth/followers/{projectId}': {
+      get: {
+        summary: 'Modrinth Followers',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: 'AANobbMI',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'followers' }
 

--- a/services/modrinth/modrinth-game-versions.service.js
+++ b/services/modrinth/modrinth-game-versions.service.js
@@ -1,4 +1,5 @@
-import { BaseModrinthService, documentation } from './modrinth-base.js'
+import { pathParams } from '../index.js'
+import { BaseModrinthService, description } from './modrinth-base.js'
 
 export default class ModrinthGameVersions extends BaseModrinthService {
   static category = 'platform-support'
@@ -8,14 +9,18 @@ export default class ModrinthGameVersions extends BaseModrinthService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'Modrinth Game Versions',
-      namedParams: { projectId: 'AANobbMI' },
-      staticPreview: this.render({ versions: ['1.19.2', '1.19.1', '1.19'] }),
-      documentation,
+  static openApi = {
+    '/modrinth/game-versions/{projectId}': {
+      get: {
+        summary: 'Modrinth Game Versions',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: 'AANobbMI',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'game versions' }
 

--- a/services/modrinth/modrinth-version.service.js
+++ b/services/modrinth/modrinth-version.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
-import { BaseModrinthService, documentation } from './modrinth-base.js'
+import { BaseModrinthService, description } from './modrinth-base.js'
 
 export default class ModrinthVersion extends BaseModrinthService {
   static category = 'version'
@@ -9,14 +10,18 @@ export default class ModrinthVersion extends BaseModrinthService {
     pattern: ':projectId',
   }
 
-  static examples = [
-    {
-      title: 'Modrinth Version',
-      namedParams: { projectId: 'AANobbMI' },
-      staticPreview: renderVersionBadge({ version: '0.4.4' }),
-      documentation,
+  static openApi = {
+    '/modrinth/v/{projectId}': {
+      get: {
+        summary: 'Modrinth Version',
+        description,
+        parameters: pathParams({
+          name: 'projectId',
+          example: 'AANobbMI',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'version' }
 

--- a/services/ore/ore-base.js
+++ b/services/ore/ore-base.js
@@ -32,11 +32,9 @@ const resourceSchema = Joi.object({
   }).required(),
 }).required()
 
-const documentation = `
+const description = `
 <p>Your Plugin ID is the name of your plugin in lowercase, without any spaces or dashes.</p>
 <p>Example: <code>https://ore.spongepowered.org/Erigitic/Total-Economy</code> - Here the Plugin ID is <code>totaleconomy</code>.</p>`
-
-const keywords = ['sponge', 'spongemc', 'spongepowered']
 
 class BaseOreService extends BaseJsonService {
   async _refreshSessionToken() {
@@ -83,4 +81,4 @@ class BaseOreService extends BaseJsonService {
 
 BaseOreService.sessionToken = null
 
-export { keywords, documentation, BaseOreService }
+export { description, BaseOreService }

--- a/services/ore/ore-category.service.js
+++ b/services/ore/ore-category.service.js
@@ -1,4 +1,5 @@
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { pathParams } from '../index.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreCategory extends BaseOreService {
   static category = 'other'
@@ -8,17 +9,18 @@ export default class OreCategory extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Ore Category',
-      namedParams: {
-        pluginId: 'nucleus',
+  static openApi = {
+    '/ore/category/{pluginId}': {
+      get: {
+        summary: 'Ore Category',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
       },
-      staticPreview: this.render({ category: 'misc' }),
-      documentation,
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'category',

--- a/services/ore/ore-downloads.service.js
+++ b/services/ore/ore-downloads.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderDownloadsBadge } from '../downloads.js'
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreDownloads extends BaseOreService {
   static category = 'downloads'
@@ -9,15 +10,18 @@ export default class OreDownloads extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Ore Downloads',
-      namedParams: { pluginId: 'nucleus' },
-      staticPreview: renderDownloadsBadge({ downloads: 560891 }),
-      documentation,
-      keywords,
+  static openApi = {
+    '/ore/dt/{pluginId}': {
+      get: {
+        summary: 'Ore Downloads',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/ore/ore-license.service.js
+++ b/services/ore/ore-license.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderLicenseBadge } from '../licenses.js'
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreLicense extends BaseOreService {
   static category = 'license'
@@ -9,17 +10,18 @@ export default class OreLicense extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Ore License',
-      namedParams: {
-        pluginId: 'nucleus',
+  static openApi = {
+    '/ore/l/{pluginId}': {
+      get: {
+        summary: 'Ore License',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
       },
-      staticPreview: this.render({ license: 'MIT' }),
-      documentation,
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'license',

--- a/services/ore/ore-sponge-versions.service.js
+++ b/services/ore/ore-sponge-versions.service.js
@@ -1,4 +1,5 @@
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { pathParams } from '../index.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreSpongeVersions extends BaseOreService {
   static category = 'platform-support'
@@ -8,17 +9,18 @@ export default class OreSpongeVersions extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Compatible versions (plugins on Ore)',
-      namedParams: {
-        pluginId: 'nucleus',
+  static openApi = {
+    '/ore/sponge-versions/{pluginId}': {
+      get: {
+        summary: 'Compatible versions (plugins on Ore)',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
       },
-      staticPreview: this.render({ versions: ['7.3', '6.0'] }),
-      documentation,
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'sponge',

--- a/services/ore/ore-stars.service.js
+++ b/services/ore/ore-stars.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreStars extends BaseOreService {
   static category = 'rating'
@@ -9,17 +10,18 @@ export default class OreStars extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Ore Stars',
-      namedParams: {
-        pluginId: 'nucleus',
+  static openApi = {
+    '/ore/stars/{pluginId}': {
+      get: {
+        summary: 'Ore Stars',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
       },
-      staticPreview: this.render({ stars: 1000 }),
-      documentation,
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'stars',

--- a/services/ore/ore-version.service.js
+++ b/services/ore/ore-version.service.js
@@ -1,5 +1,6 @@
+import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
-import { BaseOreService, documentation, keywords } from './ore-base.js'
+import { BaseOreService, description } from './ore-base.js'
 
 export default class OreVersion extends BaseOreService {
   static category = 'version'
@@ -9,17 +10,18 @@ export default class OreVersion extends BaseOreService {
     pattern: ':pluginId',
   }
 
-  static examples = [
-    {
-      title: 'Ore Version',
-      namedParams: {
-        pluginId: 'nucleus',
+  static openApi = {
+    '/ore/v/{pluginId}': {
+      get: {
+        summary: 'Ore Version',
+        description,
+        parameters: pathParams({
+          name: 'pluginId',
+          example: 'nucleus',
+        }),
       },
-      staticPreview: renderVersionBadge({ version: '2.2.3' }),
-      documentation,
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'version',


### PR DESCRIPTION
Refs #9285

I'm not going to repeat the same blurb. In this one I am still tackling easier cases (all path params) but I'm now moving on to the ones with a description/documentation string of some kind.
