### PR TITLE
migrate examples to openApi part 12; affects [GitHub Gist]

### DIFF
--- a/services/github/gist/github-gist-last-commit.service.js
+++ b/services/github/gist/github-gist-last-commit.service.js
@@ -16,7 +16,7 @@ export default class GistLastCommit extends GithubAuthV3Service {
     '/github/gist/last-commit/{gistId}': {
       get: {
         summary: 'GitHub Gist last commit',
-        description: documentation,
+        description: `Shows the latest commit to a GitHub Gist.\n${documentation}`,
         parameters: pathParams({
           name: 'gistId',
           example: '8710649',

--- a/services/github/gist/github-gist-last-commit.service.js
+++ b/services/github/gist/github-gist-last-commit.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../../index.js'
 import { formatDate } from '../../text-formatters.js'
 import { age as ageColor } from '../../color-formatters.js'
 import { GithubAuthV3Service } from '../github-auth-service.js'
@@ -11,17 +12,18 @@ const schema = Joi.object({
 export default class GistLastCommit extends GithubAuthV3Service {
   static category = 'activity'
   static route = { base: 'github/gist/last-commit', pattern: ':gistId' }
-  static examples = [
-    {
-      title: 'GitHub Gist last commit',
-      namedParams: {
-        gistId: '8710649',
+  static openApi = {
+    '/github/gist/last-commit/{gistId}': {
+      get: {
+        summary: 'GitHub Gist last commit',
+        description: documentation,
+        parameters: pathParams({
+          name: 'gistId',
+          example: '8710649',
+        }),
       },
-      staticPreview: this.render({ commitDate: '2022-07-29T20:01:41Z' }),
-      keywords: ['latest'],
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'last commit' }
 

--- a/services/github/gist/github-gist-stars.service.js
+++ b/services/github/gist/github-gist-stars.service.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 import Joi from 'joi'
 import { metric } from '../../text-formatters.js'
-import { NotFound } from '../../index.js'
+import { NotFound, pathParams } from '../../index.js'
 import { GithubAuthV4Service } from '../github-auth-service.js'
 import { documentation as commonDocumentation } from '../github-helpers.js'
 
@@ -20,7 +20,7 @@ const schema = Joi.object({
   }).required(),
 }).required()
 
-const documentation = `${commonDocumentation}
+const description = `${commonDocumentation}
 <p>This badge shows the number of stargazers for a gist. Gist id is accepted as input and 'gist not found' is returned if the gist is not found for the given gist id.
 </p>`
 
@@ -32,18 +32,18 @@ export default class GistStars extends GithubAuthV4Service {
     pattern: ':gistId',
   }
 
-  static examples = [
-    {
-      title: 'Github Gist stars',
-      namedParams: { gistId: '47a4d00457a92aa426dbd48a18776322' },
-      staticPreview: {
-        label: this.defaultBadgeData.label,
-        message: metric(29),
-        style: 'social',
+  static openApi = {
+    '/github/gist/stars/{gistId}': {
+      get: {
+        summary: 'Github Gist stars',
+        description,
+        parameters: pathParams({
+          name: 'gistId',
+          example: '47a4d00457a92aa426dbd48a18776322',
+        }),
       },
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'Stars',

--- a/services/github/github-all-contributors.service.js
+++ b/services/github/github-all-contributors.service.js
@@ -28,7 +28,7 @@ export default class GithubAllContributorsService extends ConditionalGithubAuthV
   static openApi = {
     '/github/all-contributors/{user}/{repo}/{branch}': {
       get: {
-        summary: 'GitHub contributors (via allcontributors.org)',
+        summary: 'GitHub contributors from allcontributors.org (with branch)',
         description,
         parameters: pathParams(
           {
@@ -48,7 +48,7 @@ export default class GithubAllContributorsService extends ConditionalGithubAuthV
     },
     '/github/all-contributors/{user}/{repo}': {
       get: {
-        summary: 'GitHub contributors (via allcontributors.org)',
+        summary: 'GitHub contributors from allcontributors.org',
         description,
         parameters: pathParams(
           {

--- a/services/github/github-all-contributors.service.js
+++ b/services/github/github-all-contributors.service.js
@@ -1,10 +1,11 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { renderContributorBadge } from '../contributor-count.js'
 import { ConditionalGithubAuthV3Service } from './github-auth-service.js'
 import { fetchJsonFromRepo } from './github-common-fetch.js'
 import { documentation as commonDocumentation } from './github-helpers.js'
 
-const documentation = `
+const description = `
 The All Contributors service allows you to recognize all your project
 contributors, including those that don't push code. See
 [https://allcontributors.org](https://allcontributors.org)
@@ -24,18 +25,44 @@ export default class GithubAllContributorsService extends ConditionalGithubAuthV
     pattern: ':user/:repo/:branch*',
   }
 
-  static examples = [
-    {
-      title: 'GitHub contributors (via allcontributors.org)',
-      namedParams: {
-        repo: 'all-contributors',
-        user: 'all-contributors',
-        branch: 'master',
+  static openApi = {
+    '/github/all-contributors/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'GitHub contributors (via allcontributors.org)',
+        description,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'all-contributors',
+          },
+          {
+            name: 'repo',
+            example: 'all-contributors',
+          },
+          {
+            name: 'branch',
+            example: 'master',
+          },
+        ),
       },
-      staticPreview: this.render({ contributorCount: 66 }),
-      documentation,
     },
-  ]
+    '/github/all-contributors/{user}/{repo}': {
+      get: {
+        summary: 'GitHub contributors (via allcontributors.org)',
+        description,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'all-contributors',
+          },
+          {
+            name: 'repo',
+            example: 'all-contributors',
+          },
+        ),
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'all contributors' }
 

--- a/services/github/github-code-size.service.js
+++ b/services/github/github-code-size.service.js
@@ -1,4 +1,5 @@
 import prettyBytes from 'pretty-bytes'
+import { pathParams } from '../index.js'
 import { BaseGithubLanguage } from './github-languages-base.js'
 import { documentation } from './github-helpers.js'
 
@@ -9,17 +10,24 @@ export default class GithubCodeSize extends BaseGithubLanguage {
     pattern: ':user/:repo',
   }
 
-  static examples = [
-    {
-      title: 'GitHub code size in bytes',
-      namedParams: {
-        user: 'badges',
-        repo: 'shields',
+  static openApi = {
+    '/github/languages/code-size/{user}/{repo}': {
+      get: {
+        summary: 'GitHub code size in bytes',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'badges',
+          },
+          {
+            name: 'repo',
+            example: 'shields',
+          },
+        ),
       },
-      staticPreview: this.render({ size: 1625000 }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'code size' }
 

--- a/services/github/github-commit-status.service.js
+++ b/services/github/github-commit-status.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { NotFound, InvalidParameter } from '../index.js'
+import { NotFound, InvalidParameter, pathParams } from '../index.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
 
@@ -15,23 +15,32 @@ export default class GithubCommitStatus extends GithubAuthV3Service {
     pattern: ':user/:repo/:branch/:commit',
   }
 
-  static examples = [
-    {
-      title: 'GitHub commit merge status',
-      namedParams: {
-        user: 'badges',
-        repo: 'shields',
-        branch: 'master',
-        commit: '5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c',
+  static openApi = {
+    '/github/commit-status/{user}/{repo}/{branch}/{commit}': {
+      get: {
+        summary: 'GitHub commit merge status',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'badges',
+          },
+          {
+            name: 'repo',
+            example: 'shields',
+          },
+          {
+            name: 'branch',
+            example: 'master',
+          },
+          {
+            name: 'commit',
+            example: '5d4ab86b1b5ddfb3c4a70a70bd19932c52603b8c',
+          },
+        ),
       },
-      staticPreview: this.render({
-        isInBranch: true,
-        branch: 'master',
-      }),
-      keywords: ['branch'],
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'commit status' }
 

--- a/services/github/github-deployments.service.js
+++ b/services/github/github-deployments.service.js
@@ -1,6 +1,6 @@
 import gql from 'graphql-tag'
 import Joi from 'joi'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { GithubAuthV4Service } from './github-auth-service.js'
 import { documentation, transformErrors } from './github-helpers.js'
 
@@ -49,20 +49,28 @@ export default class GithubDeployments extends GithubAuthV4Service {
     pattern: ':user/:repo/:environment',
   }
 
-  static examples = [
-    {
-      title: 'GitHub deployments',
-      namedParams: {
-        user: 'badges',
-        repo: 'shields',
-        environment: 'shields-staging',
+  static openApi = {
+    '/github/deployments/{user}/{repo}/{environment}': {
+      get: {
+        summary: 'GitHub deployments',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'badges',
+          },
+          {
+            name: 'repo',
+            example: 'shields',
+          },
+          {
+            name: 'environment',
+            example: 'shields-staging',
+          },
+        ),
       },
-      staticPreview: this.render({
-        state: 'SUCCESS',
-      }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'state' }
 

--- a/services/github/github-labels.service.js
+++ b/services/github/github-labels.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
 
@@ -9,18 +10,28 @@ const schema = Joi.object({
 export default class GithubLabels extends GithubAuthV3Service {
   static category = 'issue-tracking'
   static route = { base: 'github/labels', pattern: ':user/:repo/:name' }
-  static examples = [
-    {
-      title: 'GitHub labels',
-      namedParams: {
-        user: 'atom',
-        repo: 'atom',
-        name: 'help-wanted',
+  static openApi = {
+    '/github/labels/{user}/{repo}/{name}': {
+      get: {
+        summary: 'GitHub labels',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'atom',
+          },
+          {
+            name: 'repo',
+            example: 'atom',
+          },
+          {
+            name: 'name',
+            example: 'help-wanted',
+          },
+        ),
       },
-      staticPreview: this.render({ name: 'help-wanted', color: '#159818' }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: ' ' }
 

--- a/services/github/github-language-count.service.js
+++ b/services/github/github-language-count.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { BaseGithubLanguage } from './github-languages-base.js'
 import { documentation } from './github-helpers.js'
@@ -5,17 +6,24 @@ import { documentation } from './github-helpers.js'
 export default class GithubLanguageCount extends BaseGithubLanguage {
   static category = 'analysis'
   static route = { base: 'github/languages/count', pattern: ':user/:repo' }
-  static examples = [
-    {
-      title: 'GitHub language count',
-      namedParams: {
-        user: 'badges',
-        repo: 'shields',
+  static openApi = {
+    '/github/languages/count/{user}/{repo}': {
+      get: {
+        summary: 'GitHub language count',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'badges',
+          },
+          {
+            name: 'repo',
+            example: 'shields',
+          },
+        ),
       },
-      staticPreview: this.render({ count: 5 }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'languages' }
 

--- a/services/github/github-license.service.js
+++ b/services/github/github-license.service.js
@@ -15,7 +15,7 @@ export default class GithubLicense extends GithubAuthV3Service {
   static openApi = {
     '/github/license/{user}/{repo}': {
       get: {
-        summary: 'GitHub',
+        summary: 'GitHub License',
         description: documentation,
         parameters: pathParams(
           {

--- a/services/github/github-license.service.js
+++ b/services/github/github-license.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { renderLicenseBadge } from '../licenses.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
@@ -11,18 +12,24 @@ const schema = Joi.object({
 export default class GithubLicense extends GithubAuthV3Service {
   static category = 'license'
   static route = { base: 'github/license', pattern: ':user/:repo' }
-  static examples = [
-    {
-      title: 'GitHub',
-      namedParams: { user: 'mashape', repo: 'apistatus' },
-      staticPreview: {
-        label: 'license',
-        message: 'MIT',
-        color: 'green',
+  static openApi = {
+    '/github/license/{user}/{repo}': {
+      get: {
+        summary: 'GitHub',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'mashape',
+          },
+          {
+            name: 'repo',
+            example: 'apistatus',
+          },
+        ),
       },
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'license' }
 

--- a/services/github/github-repo-size.service.js
+++ b/services/github/github-repo-size.service.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import prettyBytes from 'pretty-bytes'
+import { pathParams } from '../index.js'
 import { nonNegativeInteger } from '../validators.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
@@ -11,17 +12,24 @@ const schema = Joi.object({
 export default class GithubRepoSize extends GithubAuthV3Service {
   static category = 'size'
   static route = { base: 'github/repo-size', pattern: ':user/:repo' }
-  static examples = [
-    {
-      title: 'GitHub repo size',
-      namedParams: {
-        user: 'atom',
-        repo: 'atom',
+  static openApi = {
+    '/github/repo-size/{user}/{repo}': {
+      get: {
+        summary: 'GitHub repo size',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'atom',
+          },
+          {
+            name: 'repo',
+            example: 'atom',
+          },
+        ),
       },
-      staticPreview: this.render({ size: 319488 }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'repo size' }
 

--- a/services/github/github-search.service.js
+++ b/services/github/github-search.service.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import { pathParams } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
@@ -14,19 +15,28 @@ export default class GithubSearch extends GithubAuthV3Service {
     pattern: ':user/:repo/:query+',
   }
 
-  static examples = [
-    {
-      title: 'GitHub search hit counter',
-      pattern: ':user/:repo/:query',
-      namedParams: {
-        user: 'torvalds',
-        repo: 'linux',
-        query: 'goto',
+  static openApi = {
+    '/github/search/{user}/{repo}/{query}': {
+      get: {
+        summary: 'GitHub search hit counter',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'torvalds',
+          },
+          {
+            name: 'repo',
+            example: 'linux',
+          },
+          {
+            name: 'query',
+            example: 'goto',
+          },
+        ),
       },
-      staticPreview: this.render({ query: 'goto', totalCount: 14000 }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'counter',

--- a/services/github/github-sponsors.service.js
+++ b/services/github/github-sponsors.service.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag'
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import { GithubAuthV4Service } from './github-auth-service.js'
 import { documentation, transformErrors } from './github-helpers.js'
 
@@ -19,14 +19,18 @@ const schema = Joi.object({
 export default class GithubSponsors extends GithubAuthV4Service {
   static category = 'funding'
   static route = { base: 'github/sponsors', pattern: ':user' }
-  static examples = [
-    {
-      title: 'GitHub Sponsors',
-      namedParams: { user: 'Homebrew' },
-      staticPreview: this.render({ count: 217 }),
-      documentation,
+  static openApi = {
+    '/github/sponsors/{user}': {
+      get: {
+        summary: 'GitHub Sponsors',
+        description: documentation,
+        parameters: pathParams({
+          name: 'user',
+          example: 'Homebrew',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'sponsors',

--- a/services/github/github-top-language.service.js
+++ b/services/github/github-top-language.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { BaseGithubLanguage } from './github-languages-base.js'
 import { documentation } from './github-helpers.js'
 
@@ -9,21 +10,24 @@ export default class GithubTopLanguage extends BaseGithubLanguage {
     pattern: ':user/:repo',
   }
 
-  static examples = [
-    {
-      title: 'GitHub top language',
-      namedParams: {
-        user: 'badges',
-        repo: 'shields',
+  static openApi = {
+    '/github/languages/top/{user}/{repo}': {
+      get: {
+        summary: 'GitHub top language',
+        description: documentation,
+        parameters: pathParams(
+          {
+            name: 'user',
+            example: 'badges',
+          },
+          {
+            name: 'repo',
+            example: 'shields',
+          },
+        ),
       },
-      staticPreview: this.render({
-        language: 'javascript',
-        languageSize: 99.5,
-        totalSize: 100,
-      }),
-      documentation,
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'language',


### PR DESCRIPTION
Refs #9285

I'm not going to repeat the same blurb. In this one I am still tackling easier cases (all path params) but I'm now moving on to the ones with a description/documentation string of some kind.