### PR TITLE
log an error to sentry if an upstream service responds with `429 Too Many Requests`

### DIFF
--- a/core/base-service/check-error-response.js
+++ b/core/base-service/check-error-response.js
@@ -1,3 +1,4 @@
+import log from '../server/log.js'
 import { NotFound, InvalidResponse, Inaccessible } from './errors.js'
 
 const defaultErrorMessages = {
@@ -25,6 +26,13 @@ export default function checkErrorResponse(httpErrors = {}) {
         error = new InvalidResponse(props)
       }
     }
+
+    if (res.statusCode === 429) {
+      log.error(
+        new Error(`429 Too Many Requests calling ${res.requestUrl.origin}`),
+      )
+    }
+
     if (error) {
       error.response = res
       error.buffer = buffer

--- a/core/base-service/check-error-response.spec.js
+++ b/core/base-service/check-error-response.spec.js
@@ -47,7 +47,7 @@ describe('async error handler', function () {
 
   context('when status is 429', function () {
     const buffer = Buffer.from('some stuff')
-    const res = { statusCode: 429 }
+    const res = { statusCode: 429, requestUrl: new URL('https://example.com/') }
 
     it('throws InvalidResponse', async function () {
       try {


### PR DESCRIPTION
I would quite like to get a notification in Sentry when an upstream service gives us a 429. Seems like hitting rate limits is something we would like to know about proactively rather than waiting for users to hit errors and let us know. This might turn out to be too noisy, but lets give it a try.