### PR TITLE
Add dynamic TOML support via [DynamicToml] Service

### DIFF
--- a/core/base-service/index.js
+++ b/core/base-service/index.js
@@ -3,6 +3,7 @@ import BaseJsonService from './base-json.js'
 import BaseGraphqlService from './base-graphql.js'
 import BaseStaticService from './base-static.js'
 import BaseSvgScrapingService from './base-svg-scraping.js'
+import BaseTomlService from './base-toml.js'
 import BaseXmlService from './base-xml.js'
 import BaseYamlService from './base-yaml.js'
 import deprecatedService from './deprecated-service.js'
@@ -23,6 +24,7 @@ export {
   BaseGraphqlService,
   BaseStaticService,
   BaseSvgScrapingService,
+  BaseTomlService,
   BaseXmlService,
   BaseYamlService,
   deprecatedService,

--- a/services/dynamic/dynamic-toml.service.js
+++ b/services/dynamic/dynamic-toml.service.js
@@ -1,0 +1,54 @@
+import { MetricNames } from '../../core/base-service/metric-helper.js'
+import { BaseTomlService, queryParams } from '../index.js'
+import { createRoute } from './dynamic-helpers.js'
+import jsonPath from './json-path.js'
+
+export default class DynamicToml extends jsonPath(BaseTomlService) {
+  static enabledMetrics = [MetricNames.SERVICE_RESPONSE_SIZE]
+  static route = createRoute('toml')
+  static openApi = {
+    '/badge/dynamic/toml': {
+      get: {
+        summary: 'Dynamic TOML Badge',
+        description: `<p>
+          The Dynamic TOML Badge allows you to extract an arbitrary value from any
+          TOML Document using a JSONPath selector and show it on a badge.
+        </p>`,
+        parameters: queryParams(
+          {
+            name: 'url',
+            description: 'The URL to a TOML document',
+            required: true,
+            example:
+              'https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml',
+          },
+          {
+            name: 'query',
+            description:
+              'A <a href="https://jsonpath.com/">JSONPath</a> expression that will be used to query the document',
+            required: true,
+            example: '$.title',
+          },
+          {
+            name: 'prefix',
+            description: 'Optional prefix to append to the value',
+            example: '[',
+          },
+          {
+            name: 'suffix',
+            description: 'Optional suffix to append to the value',
+            example: ']',
+          },
+        ),
+      },
+    },
+  }
+
+  async fetch({ schema, url, httpErrors }) {
+    return this._requestToml({
+      schema,
+      url,
+      httpErrors,
+    })
+  }
+}

--- a/services/dynamic/dynamic-toml.tester.js
+++ b/services/dynamic/dynamic-toml.tester.js
@@ -39,11 +39,11 @@ t.create('TOML from url | caching with new query params')
   .get(
     '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.owner.name',
   )
-  .expectBadge({ label: 'Tom Preston-Werner', message: '0.8.0' })
+  .expectBadge({ label: 'custom badge', message: 'Tom Preston-Werner' })
 
 t.create('TOML from url | with prefix & suffix & label')
   .get(
-    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.database.temp_targets.cpu&prefix=+&suffix=°C&label=CPU Temp Target',
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.database.temp_targets.cpu&prefix=%2B&suffix=°C&label=CPU Temp Target',
   )
   .expectBadge({ label: 'CPU Temp Target', message: '+79.5°C' })
 
@@ -102,6 +102,6 @@ t.create('TOML contains a string')
   )
   .expectBadge({
     label: 'custom badge',
-    message: 'resource must contain an object or array',
+    message: 'unparseable toml response',
     color: 'lightgrey',
   })

--- a/services/dynamic/dynamic-toml.tester.js
+++ b/services/dynamic/dynamic-toml.tester.js
@@ -1,0 +1,107 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('No URL specified')
+  .get('.json?query=$.name&label=Package Name')
+  .expectBadge({
+    label: 'Package Name',
+    message: 'invalid query parameter: url',
+    color: 'red',
+  })
+
+t.create('No query specified')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&label=Package Name',
+  )
+  .expectBadge({
+    label: 'Package Name',
+    message: 'invalid query parameter: query',
+    color: 'red',
+  })
+
+t.create('TOML from url')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.title',
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'TOML Example',
+    color: 'blue',
+  })
+
+t.create('TOML from url | multiple results')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.database.data[0][*]',
+  )
+  .expectBadge({ label: 'custom badge', message: 'delta, phi' })
+
+t.create('TOML from url | caching with new query params')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.owner.name',
+  )
+  .expectBadge({ label: 'Tom Preston-Werner', message: '0.8.0' })
+
+t.create('TOML from url | with prefix & suffix & label')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.database.temp_targets.cpu&prefix=+&suffix=°C&label=CPU Temp Target',
+  )
+  .expectBadge({ label: 'CPU Temp Target', message: '+79.5°C' })
+
+t.create('TOML from url | object doesnt exist')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.does_not_exist',
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'no result',
+    color: 'lightgrey',
+  })
+
+t.create('TOML from url | invalid url')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/not-a-file.toml&query=$.version',
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'resource not found',
+    color: 'red',
+  })
+
+t.create('TOML from url | user color overrides default')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/toml-spec-example.toml&query=$.title&color=10ADED',
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'TOML Example',
+    color: '#10aded',
+  })
+
+t.create('TOML from url | error color overrides default')
+  .get(
+    '.json?url=https://raw.githubusercontent.com/squirrelchat/smol-toml/mistress/bench/testfiles/not-a-file.toml&query=$.version',
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'resource not found',
+    color: 'red',
+  })
+
+t.create('TOML from url | error color overrides user specified')
+  .get('.json?query=$.version&color=10ADED')
+  .expectBadge({
+    label: 'custom badge',
+    message: 'invalid query parameter: url',
+    color: 'red',
+  })
+
+t.create('TOML contains a string')
+  .get('.json?url=https://example.test/toml&query=$.foo,')
+  .intercept(nock =>
+    nock('https://example.test').get('/toml').reply(200, '"foo"'),
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'resource must contain an object or array',
+    color: 'lightgrey',
+  })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
This adds a dynamic service for TOML files.

I kept everything as close to the other dynamic services as possible. To be able to use the `BaseTomlService` from #9438, I exported in the core where the other base services are exported.
For the tests and default values I used the [`toml-spec-example.toml`](https://github.com/squirrelchat/smol-toml/blob/mistress/bench/testfiles/toml-spec-example.toml) from [`smol-toml`](https://github.com/squirrelchat/smol-toml) because `smol-toml` is used in here and it is the same example TOML file that [toml.io](https://toml.io) shows on their homepage, sadly they do not host this toml themselves.

I mostly ported over the test from the dynamic YAML service.