### PR TITLE
Docs: update TUTORIAL.md add BaseTomlService

### DIFF
--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -96,6 +96,8 @@ Other classes implement useful behavior on top of [BaseService].
   implements methods for performing requests to an XML API and schema validation.
 - [BaseYamlService](https://contributing.shields.io/module-core_base-service_base-yaml-BaseYamlService.html)
   implements methods for performing requests to a YAML API and schema validation.
+- [BaseTomlService](https://contributing.shields.io/module-core_base-service_base-toml-BaseTomlService.html)
+  implements methods for performing requests to a TOML API and schema validation.
 - [BaseSvgScrapingService](https://contributing.shields.io/module-core_base-service_base-svg-scraping-BaseSvgScrapingService.html)
   implements methods for retrieving information from existing third-party badges.
 - [BaseGraphqlService](https://contributing.shields.io/module-core_base-service_base-graphql-BaseGraphqlService.html)


### PR DESCRIPTION
In the docs at TUTORIAL.md the new base service BaseTomlService was missing in the list of base services.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
