### PR TITLE
cache [pypi] downloads for longer

### DIFF
--- a/services/pypi/pypi-downloads.service.js
+++ b/services/pypi/pypi-downloads.service.js
@@ -53,6 +53,8 @@ export default class PypiDownloads extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 21600
+
   static defaultBadgeData = { label: 'downloads' }
 
   async fetch({ packageName }) {


### PR DESCRIPTION
PyPIStats only update their data once per day but we're using the default max-age on these badges. We can set a much longer max-age on these to reduce the amount of requests that both us and the upstream service need to serve.