### PR TITLE
Stop logging 429s to sentry (for now)

### DIFF
--- a/core/base-service/check-error-response.js
+++ b/core/base-service/check-error-response.js
@@ -1,4 +1,3 @@
-import log from '../server/log.js'
 import { NotFound, InvalidResponse, Inaccessible } from './errors.js'
 
 const defaultErrorMessages = {
@@ -26,13 +25,6 @@ export default function checkErrorResponse(httpErrors = {}) {
         error = new InvalidResponse(props)
       }
     }
-
-    if (res.statusCode === 429) {
-      log.error(
-        new Error(`429 Too Many Requests calling ${res.requestUrl.origin}`),
-      )
-    }
-
     if (error) {
       error.response = res
       error.buffer = buffer

--- a/core/base-service/check-error-response.spec.js
+++ b/core/base-service/check-error-response.spec.js
@@ -47,7 +47,7 @@ describe('async error handler', function () {
 
   context('when status is 429', function () {
     const buffer = Buffer.from('some stuff')
-    const res = { statusCode: 429, requestUrl: new URL('https://example.com/') }
+    const res = { statusCode: 429 }
 
     it('throws InvalidResponse', async function () {
       try {


### PR DESCRIPTION
Well.. that was exciting, wasn't it? :sweat_smile: 

Doing this has been useful. Just having this turned on for a couple of hours has revealed that there are:

1. Problems we need to solve
2. Categories of noise we need to silence in order for this to be useful

In its current form, I want to turn this off for now, otherwise we're just going to smash our sentry allowance for the month on ingesting events which are mostly duplicating things we now already know.

This will probably come back, but I'm going to go and do some work on the above points before we re-enable it it.