### PR TITLE
migrate examples to openApi part 16; affects [gitlabrelease swagger]

### DIFF
--- a/services/gitlab/gitlab-release.service.js
+++ b/services/gitlab/gitlab-release.service.js
@@ -52,17 +52,26 @@ export default class GitLabRelease extends GitLabBase {
           }),
           queryParam({
             name: 'sort',
-            schema: { type: 'string', enum: ['date', 'semver'] },
+            schema: {
+              type: 'string',
+              enum: queryParamSchema.describe().keys.sort.allow,
+            },
             example: 'semver',
           }),
           queryParam({
             name: 'display_name',
-            schema: { type: 'string', enum: ['tag', 'release'] },
+            schema: {
+              type: 'string',
+              enum: queryParamSchema.describe().keys.display_name.allow,
+            },
             example: 'release',
           }),
           queryParam({
             name: 'date_order_by',
-            schema: { type: 'string', enum: ['created_at', 'released_at'] },
+            schema: {
+              type: 'string',
+              enum: queryParamSchema.describe().keys.date_order_by.allow,
+            },
             example: 'created_at',
           }),
         ],

--- a/services/gitlab/gitlab-release.service.js
+++ b/services/gitlab/gitlab-release.service.js
@@ -48,7 +48,6 @@ export default class GitLabRelease extends GitLabBase {
           queryParam({
             name: 'include_prereleases',
             schema: { type: 'boolean' },
-            allowEmptyValue: true,
             example: null,
           }),
           queryParam({

--- a/services/gitlab/gitlab-release.service.js
+++ b/services/gitlab/gitlab-release.service.js
@@ -12,13 +12,21 @@ const schema = Joi.array().items(
   }),
 )
 
+const sortEnum = ['date', 'semver']
+const displayNameEnum = ['tag', 'release']
+const dateOrderByEnum = ['created_at', 'released_at']
+
 const queryParamSchema = Joi.object({
   gitlab_url: optionalUrl,
   include_prereleases: Joi.equal(''),
-  sort: Joi.string().valid('date', 'semver').default('date'),
-  display_name: Joi.string().valid('tag', 'release').default('tag'),
+  sort: Joi.string()
+    .valid(...sortEnum)
+    .default('date'),
+  display_name: Joi.string()
+    .valid(...displayNameEnum)
+    .default('tag'),
   date_order_by: Joi.string()
-    .valid('created_at', 'released_at')
+    .valid(...dateOrderByEnum)
     .default('created_at'),
 }).required()
 
@@ -52,26 +60,17 @@ export default class GitLabRelease extends GitLabBase {
           }),
           queryParam({
             name: 'sort',
-            schema: {
-              type: 'string',
-              enum: queryParamSchema.describe().keys.sort.allow,
-            },
+            schema: { type: 'string', enum: sortEnum },
             example: 'semver',
           }),
           queryParam({
             name: 'display_name',
-            schema: {
-              type: 'string',
-              enum: queryParamSchema.describe().keys.display_name.allow,
-            },
+            schema: { type: 'string', enum: displayNameEnum },
             example: 'release',
           }),
           queryParam({
             name: 'date_order_by',
-            schema: {
-              type: 'string',
-              enum: queryParamSchema.describe().keys.date_order_by.allow,
-            },
+            schema: { type: 'string', enum: dateOrderByEnum },
             example: 'created_at',
           }),
         ],

--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { optionalUrl } from '../validators.js'
-import { BaseJsonService, NotFound } from '../index.js'
+import { BaseJsonService, NotFound, queryParams } from '../index.js'
 
 const schema = Joi.object()
   .keys({
@@ -26,17 +26,19 @@ export default class SwaggerValidatorService extends BaseJsonService {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'Swagger Validator',
-      staticPreview: this.render({ status: 'valid' }),
-      namedParams: {},
-      queryParams: {
-        specUrl:
-          'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore-expanded.json',
+  static openApi = {
+    '/swagger/valid/3.0': {
+      get: {
+        summary: 'Swagger Validator',
+        parameters: queryParams({
+          name: 'specUrl',
+          required: true,
+          example:
+            'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore-expanded.json',
+        }),
       },
     },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'swagger',


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9285

In this PR, I've started tackling query params.
Instead of converting a lot of services, I've concentrated on picking a couple of services that I think cover all of the most common variations so we can see what that looks like and establish the patterns we're going to use going forwards.

Can anyone think of a case I have missed here?

