### PR TITLE
fix [bower] version badge

### DIFF
--- a/services/bower/bower-version.service.js
+++ b/services/bower/bower-version.service.js
@@ -1,15 +1,10 @@
-import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
 import { InvalidResponse } from '../index.js'
 import BaseBowerService from './bower-base.js'
 
-const queryParamSchema = Joi.object({
-  include_prereleases: Joi.equal(''),
-}).required()
-
 export default class BowerVersion extends BaseBowerService {
   static category = 'version'
-  static route = { base: 'bower/v', pattern: ':packageName', queryParamSchema }
+  static route = { base: 'bower/v', pattern: ':packageName' }
 
   static examples = [
     {
@@ -17,20 +12,12 @@ export default class BowerVersion extends BaseBowerService {
       namedParams: { packageName: 'bootstrap' },
       staticPreview: renderVersionBadge({ version: '4.2.1' }),
     },
-    {
-      title: 'Bower Version (including pre-releases)',
-      namedParams: { packageName: 'bootstrap' },
-      queryParams: { include_prereleases: null },
-      staticPreview: renderVersionBadge({ version: '4.2.1' }),
-    },
   ]
 
   static defaultBadgeData = { label: 'bower' }
 
-  static transform(data, includePrereleases) {
-    const version = includePrereleases
-      ? data.latest_release_number
-      : data.latest_stable_release_number
+  static transform(data) {
+    const version = data.latest_release_number
 
     if (!version) {
       throw new InvalidResponse({ prettyMessage: 'no releases' })
@@ -39,10 +26,9 @@ export default class BowerVersion extends BaseBowerService {
     return version
   }
 
-  async handle({ packageName }, queryParams) {
+  async handle({ packageName }) {
     const data = await this.fetch({ packageName })
-    const includePrereleases = queryParams.include_prereleases !== undefined
-    const version = this.constructor.transform(data, includePrereleases)
+    const version = this.constructor.transform(data)
 
     return renderVersionBadge({ version })
   }

--- a/services/bower/bower-version.spec.js
+++ b/services/bower/bower-version.spec.js
@@ -8,34 +8,14 @@ import BowerVersion from './bower-version.service.js'
 
 describe('BowerVersion', function () {
   test(BowerVersion.transform, () => {
-    given(
-      {
-        latest_release_number: '2.0.0-beta',
-        latest_stable_release_number: '1.8.3',
-      },
-      false,
-    ).expect('1.8.3')
-    given(
-      {
-        latest_release_number: '2.0.0-beta',
-        latest_stable_release_number: '1.8.3',
-      },
-      true,
-    ).expect('2.0.0-beta')
+    given({
+      latest_release_number: '2.0.0-beta',
+      latest_stable_release_number: '1.8.3',
+    }).expect('2.0.0-beta')
   })
 
   it('throws `no releases` InvalidResponse if no stable version', function () {
-    expect(() =>
-      BowerVersion.transform({ latest_release_number: 'panda' }, false),
-    )
-      .to.throw(InvalidResponse)
-      .with.property('prettyMessage', 'no releases')
-  })
-
-  it('throws `no releases` InvalidResponse if no prereleases', function () {
-    expect(() =>
-      BowerVersion.transform({ latest_stable_release_number: 'penguin' }, true),
-    )
+    expect(() => BowerVersion.transform({}))
       .to.throw(InvalidResponse)
       .with.property('prettyMessage', 'no releases')
   })

--- a/services/bower/bower-version.tester.js
+++ b/services/bower/bower-version.tester.js
@@ -9,7 +9,7 @@ export const t = new ServiceTester({
   pathPrefix: '/bower',
 })
 
-t.create('version').timeout(10000).get('/v/angular.json').expectBadge({
+t.create('version').timeout(10000).get('/v/backbone.json').expectBadge({
   label: 'bower',
   message: isVPlusDottedVersionAtLeastOne,
 })


### PR DESCRIPTION
Our bower badges use the libraries.io API. Also bower is a low traffic badge/mostly abandoned service.

The version badge (which should be latest stable version) consistently returns "no releases" for pretty much any package.

This is because if you look at the API response for a bunch of packages e.g:

- https://libraries.io/api/bower/bootstrap
- https://libraries.io/api/bower/angular
- https://libraries.io/api/bower/backbone
- https://libraries.io/api/bower/Font-Awesome
- https://libraries.io/api/bower/grunt
- https://libraries.io/api/bower/gulp
- https://libraries.io/api/bower/jQuery

they all return `latest_stable_release_number: null`, although it is worth noting that all of them do have a proper version number against `latest_release_number`, so the `include_prereleases` variant works in all those cases.

Given the `latest_release_number` number doesn't seem to be populated for any package (or at least I can't find an example where it works), I suggest we just switch this so that the version badge returns `latest_release_number` whether you call it with `include_prereleases` or not.