### PR TITLE
deprecate [redmine] plugin rating badges

### DIFF
--- a/services/redmine/redmine.service.js
+++ b/services/redmine/redmine.service.js
@@ -7,7 +7,7 @@ export const RedminePluginRating = deprecatedService({
     pattern: ':various*',
   },
   label: 'redmine',
-  dateAdded: new Date('2023-09-11'),
+  dateAdded: new Date('2023-09-14'),
 })
 
 export const RedminePluginStars = deprecatedService({

--- a/services/redmine/redmine.service.js
+++ b/services/redmine/redmine.service.js
@@ -1,79 +1,21 @@
-import Joi from 'joi'
-import { starRating } from '../text-formatters.js'
-import { floorCount as floorCountColor } from '../color-formatters.js'
-import { BaseXmlService } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const schema = Joi.object({
-  'redmine-plugin': Joi.object({
-    'ratings-average': Joi.number().min(0).required(),
-  }).required(),
+export const RedminePluginRating = deprecatedService({
+  category: 'rating',
+  route: {
+    base: 'redmine/plugin/rating',
+    pattern: ':various*',
+  },
+  label: 'redmine',
+  dateAdded: new Date('2023-09-11'),
 })
 
-class BaseRedminePluginRating extends BaseXmlService {
-  static category = 'rating'
-
-  static render({ rating }) {
-    throw new Error(`render() function not implemented for ${this.name}`)
-  }
-
-  async fetch({ plugin }) {
-    const url = `https://www.redmine.org/plugins/${plugin}.xml`
-    return this._requestXml({ schema, url })
-  }
-
-  async handle({ plugin }) {
-    const data = await this.fetch({ plugin })
-    const rating = data['redmine-plugin']['ratings-average']
-    return this.constructor.render({ rating })
-  }
-}
-
-class RedminePluginRating extends BaseRedminePluginRating {
-  static route = {
-    base: 'redmine/plugin/rating',
-    pattern: ':plugin',
-  }
-
-  static examples = [
-    {
-      title: 'Plugin on redmine.org',
-      namedParams: { plugin: 'redmine_xlsx_format_issue_exporter' },
-      staticPreview: this.render({ rating: 5 }),
-    },
-  ]
-
-  static defaultBadgeData = { label: 'redmine' }
-
-  static render({ rating }) {
-    return {
-      label: 'rating',
-      message: `${rating.toFixed(1)}/5.0`,
-      color: floorCountColor(rating, 2, 3, 4),
-    }
-  }
-}
-
-class RedminePluginStars extends BaseRedminePluginRating {
-  static route = {
+export const RedminePluginStars = deprecatedService({
+  category: 'rating',
+  route: {
     base: 'redmine/plugin/stars',
-    pattern: ':plugin',
-  }
-
-  static examples = [
-    {
-      title: 'Plugin on redmine.org',
-      namedParams: { plugin: 'redmine_xlsx_format_issue_exporter' },
-      staticPreview: this.render({ rating: 5 }),
-    },
-  ]
-
-  static render({ rating }) {
-    return {
-      label: 'stars',
-      message: starRating(Math.round(rating)),
-      color: floorCountColor(rating, 2, 3, 4),
-    }
-  }
-}
-
-export { RedminePluginRating, RedminePluginStars }
+    pattern: ':various*',
+  },
+  label: 'redmine',
+  dateAdded: new Date('2023-09-11'),
+})

--- a/services/redmine/redmine.service.js
+++ b/services/redmine/redmine.service.js
@@ -17,5 +17,5 @@ export const RedminePluginStars = deprecatedService({
     pattern: ':various*',
   },
   label: 'redmine',
-  dateAdded: new Date('2023-09-11'),
+  dateAdded: new Date('2023-09-14'),
 })

--- a/services/redmine/redmine.tester.js
+++ b/services/redmine/redmine.tester.js
@@ -1,6 +1,4 @@
-import Joi from 'joi'
 import { ServiceTester } from '../tester.js'
-import { isStarRating } from '../test-validators.js'
 
 export const t = new ServiceTester({
   id: 'redmine',
@@ -10,20 +8,13 @@ export const t = new ServiceTester({
 t.create('plugin rating')
   .get('/plugin/rating/redmine_xlsx_format_issue_exporter.json')
   .expectBadge({
-    label: 'rating',
-    message: Joi.string().regex(/^[0-9]+\.[0-9]+\/5\.0$/),
+    label: 'redmine',
+    message: 'no longer available',
   })
 
 t.create('plugin stars')
   .get('/plugin/stars/redmine_xlsx_format_issue_exporter.json')
   .expectBadge({
-    label: 'stars',
-    message: isStarRating,
-  })
-
-t.create('plugin not found')
-  .get('/plugin/rating/plugin_not_found.json')
-  .expectBadge({
     label: 'redmine',
-    message: 'not found',
+    message: 'no longer available',
   })


### PR DESCRIPTION
Redmine badges have been failing for some time due to a consistent 500 error from the upstream API.

- https://img.shields.io/redmine/plugin/stars/redmine_xlsx_format_issue_exporter
- https://www.redmine.org/plugins/redmine_xlsx_format_issue_exporter
- https://www.redmine.org/plugins/redmine_xlsx_format_issue_exporter.xml

The badge receives little traffic and despite being broken for months, nobody has complained. If we a look at a bunch of different redmine plugins, we see the same thing for all of them:

- https://www.redmine.org/plugins/redmine_issue_dynamic_edit.xml
- https://www.redmine.org/plugins/redmine-x-upgrade-plugin.xml
- https://www.redmine.org/plugins/redmine-x-gantt-chart-plugin.xml
- https://www.redmine.org/plugins/redmine_issue_to_email.xml
- etc

Suggest we deprecate this service.