### PR TITLE
fix review apps

### DIFF
--- a/.github/scripts/deploy-review-app.sh
+++ b/.github/scripts/deploy-review-app.sh
@@ -24,6 +24,7 @@ fi
 
 # Deploy
 flyctl deploy --app "$app" --region "$region"
+flyctl scale count 1 --app "$app" --yes
 
 # Post a comment on the PR
 app_url=$(flyctl status --app "$app" --json | jq -r .Hostname)

--- a/.github/scripts/deploy-review-app.sh
+++ b/.github/scripts/deploy-review-app.sh
@@ -18,7 +18,7 @@ git checkout "pr-$PR_NUMBER"
 
 # If the app does not already exist, create it
 if ! flyctl status --app "$app"; then
-  flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org"
+  flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --dockerfile ./Dockerfile
   echo $SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
 


### PR DESCRIPTION
I was having some issues with review apps today. Looks like there have been some upstream changes to fly.io which we need to account for:

1. Fly now auto-detects a node js app and tries to use a sort of "buildpack" like deploy strategy. We have to manually tell it to use our dockerfile, rather than that being the default
2. When you start a new app, by default fly give you 2 machines. We need to manually tell it to scale down to 1 after deploying

Going to just go ahead and merge this one as review apps are currently broken
