### PR TITLE
migrate examples to openApi part 17; affects [buildkite cii codeship crates jsdelivr npms] and bundlephobia

### DIFF
--- a/services/buildkite/buildkite.service.js
+++ b/services/buildkite/buildkite.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 // unknown is a valid 'other' status for Buildkite
 const schema = Joi.object({
@@ -11,25 +11,32 @@ export default class Buildkite extends BaseJsonService {
   static category = 'build'
   static route = { base: 'buildkite', pattern: ':identifier/:branch*' }
 
-  static examples = [
-    {
-      title: 'Buildkite',
-      pattern: ':identifier',
-      namedParams: {
-        identifier: '3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489',
+  static openApi = {
+    '/buildkite/{identifier}': {
+      get: {
+        summary: 'Buildkite',
+        parameters: pathParams({
+          name: 'identifier',
+          example: '3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489',
+        }),
       },
-      staticPreview: renderBuildStatusBadge({ status: 'passing' }),
     },
-    {
-      title: 'Buildkite (branch)',
-      pattern: ':identifier/:branch',
-      namedParams: {
-        identifier: '3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489',
-        branch: 'master',
+    '/buildkite/{identifier}/{branch}': {
+      get: {
+        summary: 'Buildkite (branch)',
+        parameters: pathParams(
+          {
+            name: 'identifier',
+            example: '3826789cf8890b426057e6fe1c4e683bdf04fa24d498885489',
+          },
+          {
+            name: 'branch',
+            example: 'master',
+          },
+        ),
       },
-      staticPreview: renderBuildStatusBadge({ status: 'passing' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'build' }
 

--- a/services/bundlephobia/bundlephobia.service.js
+++ b/services/bundlephobia/bundlephobia.service.js
@@ -8,6 +8,9 @@ const schema = Joi.object({
   gzip: nonNegativeInteger,
 }).required()
 
+const description =
+  '[Bundlephobia](https://bundlephobia.com) lets you understand the size of a javascript package from NPM before it becomes a part of your bundle.'
+
 export default class Bundlephobia extends BaseJsonService {
   static category = 'size'
 
@@ -20,6 +23,7 @@ export default class Bundlephobia extends BaseJsonService {
     '/bundlephobia/{format}/{packageName}': {
       get: {
         summary: 'npm bundle size',
+        description,
         parameters: pathParams(
           {
             name: 'format',
@@ -36,6 +40,7 @@ export default class Bundlephobia extends BaseJsonService {
     '/bundlephobia/{format}/{scope}/{packageName}': {
       get: {
         summary: 'npm bundle size (scoped)',
+        description,
         parameters: pathParams(
           {
             name: 'format',
@@ -56,6 +61,7 @@ export default class Bundlephobia extends BaseJsonService {
     '/bundlephobia/{format}/{packageName}/{version}': {
       get: {
         summary: 'npm bundle size (version)',
+        description,
         parameters: pathParams(
           {
             name: 'format',
@@ -76,6 +82,7 @@ export default class Bundlephobia extends BaseJsonService {
     '/bundlephobia/{format}/{scope}/{packageName}/{version}': {
       get: {
         summary: 'npm bundle size (scoped version)',
+        description,
         parameters: pathParams(
           {
             name: 'format',

--- a/services/bundlephobia/bundlephobia.service.js
+++ b/services/bundlephobia/bundlephobia.service.js
@@ -1,14 +1,12 @@
 import Joi from 'joi'
 import prettyBytes from 'pretty-bytes'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   size: nonNegativeInteger,
   gzip: nonNegativeInteger,
 }).required()
-
-const keywords = ['node', 'bundlephobia']
 
 export default class Bundlephobia extends BaseJsonService {
   static category = 'size'
@@ -18,52 +16,88 @@ export default class Bundlephobia extends BaseJsonService {
     pattern: ':format(min|minzip)/:scope(@[^/]+)?/:packageName/:version?',
   }
 
-  static examples = [
-    {
-      title: 'npm bundle size',
-      pattern: ':format(min|minzip)/:packageName',
-      namedParams: {
-        format: 'min',
-        packageName: 'react',
+  static openApi = {
+    '/bundlephobia/{format}/{packageName}': {
+      get: {
+        summary: 'npm bundle size',
+        parameters: pathParams(
+          {
+            name: 'format',
+            schema: { type: 'string', enum: this.getEnum('format') },
+            example: 'min',
+          },
+          {
+            name: 'packageName',
+            example: 'react',
+          },
+        ),
       },
-      staticPreview: this.render({ format: 'min', size: 6652 }),
-      keywords,
     },
-    {
-      title: 'npm bundle size (scoped)',
-      pattern: ':format(min|minzip)/:scope/:packageName',
-      namedParams: {
-        format: 'min',
-        scope: '@cycle',
-        packageName: 'core',
+    '/bundlephobia/{format}/{scope}/{packageName}': {
+      get: {
+        summary: 'npm bundle size (scoped)',
+        parameters: pathParams(
+          {
+            name: 'format',
+            schema: { type: 'string', enum: this.getEnum('format') },
+            example: 'min',
+          },
+          {
+            name: 'scope',
+            example: '@cycle',
+          },
+          {
+            name: 'packageName',
+            example: 'core',
+          },
+        ),
       },
-      staticPreview: this.render({ format: 'min', size: 3562 }),
-      keywords,
     },
-    {
-      title: 'npm bundle size (version)',
-      pattern: ':format(min|minzip)/:packageName/:version',
-      namedParams: {
-        format: 'min',
-        packageName: 'react',
-        version: '15.0.0',
+    '/bundlephobia/{format}/{packageName}/{version}': {
+      get: {
+        summary: 'npm bundle size (version)',
+        parameters: pathParams(
+          {
+            name: 'format',
+            schema: { type: 'string', enum: this.getEnum('format') },
+            example: 'min',
+          },
+          {
+            name: 'packageName',
+            example: 'react',
+          },
+          {
+            name: 'version',
+            example: '15.0.0',
+          },
+        ),
       },
-      staticPreview: this.render({ format: 'min', size: 20535 }),
-      keywords,
     },
-    {
-      title: 'npm bundle size (scoped version)',
-      pattern: ':format(min|minzip)/:scope/:packageName/:version',
-      namedParams: {
-        format: 'min',
-        scope: '@cycle',
-        packageName: 'core',
-        version: '7.0.0',
+    '/bundlephobia/{format}/{scope}/{packageName}/{version}': {
+      get: {
+        summary: 'npm bundle size (scoped version)',
+        parameters: pathParams(
+          {
+            name: 'format',
+            schema: { type: 'string', enum: this.getEnum('format') },
+            example: 'min',
+          },
+          {
+            name: 'scope',
+            example: '@cycle',
+          },
+          {
+            name: 'packageName',
+            example: 'core',
+          },
+          {
+            name: 'version',
+            example: '7.0.0',
+          },
+        ),
       },
-      staticPreview: this.render({ format: 'min', size: 3562 }),
-      keywords,
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'bundlephobia', color: 'informational' }
 

--- a/services/cii-best-practices/cii-best-practices.service.js
+++ b/services/cii-best-practices/cii-best-practices.service.js
@@ -37,6 +37,8 @@ export default class CIIBestPracticesService extends BaseJsonService {
     '/cii/{metric}/{projectId}': {
       get: {
         summary: 'CII Best Practices',
+        description:
+          'The Core Infrastructure Initiative (CII) Best Practices badge is a way for Open Source projects to show that they follow best practices',
         parameters: pathParams(
           {
             name: 'metric',

--- a/services/cii-best-practices/cii-best-practices.service.js
+++ b/services/cii-best-practices/cii-best-practices.service.js
@@ -1,13 +1,11 @@
 import Joi from 'joi'
 import { colorScale, coveragePercentage } from '../color-formatters.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   badge_level: Joi.string().required(),
   tiered_percentage: Joi.number().required(),
 }).required()
-
-const keywords = ['core infrastructure initiative']
 
 const summaryColorScale = colorScale(
   [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 200, 300],
@@ -35,37 +33,24 @@ export default class CIIBestPracticesService extends BaseJsonService {
     pattern: ':metric(level|percentage|summary)/:projectId',
   }
 
-  static examples = [
-    {
-      title: 'CII Best Practices Level',
-      pattern: 'level/:projectId',
-      namedParams: {
-        projectId: '1',
+  static openApi = {
+    '/cii/{metric}/{projectId}': {
+      get: {
+        summary: 'CII Best Practices',
+        parameters: pathParams(
+          {
+            name: 'metric',
+            example: 'level',
+            schema: { type: 'string', enum: this.getEnum('metric') },
+          },
+          {
+            name: 'projectId',
+            example: '1',
+          },
+        ),
       },
-      staticPreview: this.renderLevelBadge({ level: 'gold' }),
-      keywords,
     },
-    {
-      title: 'CII Best Practices Tiered Percentage',
-      pattern: 'percentage/:projectId',
-      namedParams: {
-        projectId: '29',
-      },
-      staticPreview: this.renderTieredPercentageBadge({ percentage: 107 }),
-      keywords,
-    },
-    {
-      title: 'CII Best Practices Summary',
-      pattern: 'summary/:projectId',
-      namedParams: {
-        projectId: '33',
-      },
-      staticPreview: this.renderSummaryBadge({ percentage: 94 }),
-      keywords,
-      documentation:
-        'This badge uses the same message and color scale as the native CII one, but with all the configuration and goodness that Shields provides!',
-    },
-  ]
+  }
 
   static defaultBadgeData = { label: 'cii' }
 

--- a/services/codeship/codeship.service.js
+++ b/services/codeship/codeship.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseSvgScrapingService } from '../index.js'
+import { BaseSvgScrapingService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   message: Joi.alternatives()
@@ -28,25 +28,32 @@ export default class Codeship extends BaseSvgScrapingService {
   static category = 'build'
   static route = { base: 'codeship', pattern: ':projectId/:branch*' }
 
-  static examples = [
-    {
-      title: 'Codeship',
-      pattern: ':projectId',
-      namedParams: {
-        projectId: 'd6c1ddd0-16a3-0132-5f85-2e35c05e22b1',
+  static openApi = {
+    '/codeship/{projectId}': {
+      get: {
+        summary: 'Codeship',
+        parameters: pathParams({
+          name: 'projectId',
+          example: 'd6c1ddd0-16a3-0132-5f85-2e35c05e22b1',
+        }),
       },
-      staticPreview: renderBuildStatusBadge({ status: 'passing' }),
     },
-    {
-      title: 'Codeship (branch)',
-      pattern: ':projectId/:branch',
-      namedParams: {
-        projectId: '0bdb0440-3af5-0133-00ea-0ebda3a33bf6',
-        branch: 'master',
+    '/codeship/{projectId}/{branch}': {
+      get: {
+        summary: 'Codeship (branch)',
+        parameters: pathParams(
+          {
+            name: 'projectId',
+            example: '0bdb0440-3af5-0133-00ea-0ebda3a33bf6',
+          },
+          {
+            name: 'branch',
+            example: 'master',
+          },
+        ),
       },
-      staticPreview: renderBuildStatusBadge({ status: 'passing' }),
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'build' }
 

--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -47,4 +47,7 @@ class BaseCratesService extends BaseJsonService {
   }
 }
 
-export { BaseCratesService }
+const description =
+  '[Crates.io](https://crates.io/) is a package registry for Rust.'
+
+export { BaseCratesService, description }

--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -2,8 +2,6 @@ import Joi from 'joi'
 import { nonNegativeInteger } from '../validators.js'
 import { BaseJsonService } from '../index.js'
 
-const keywords = ['Rust']
-
 const crateSchema = Joi.object({
   crate: Joi.object({
     downloads: nonNegativeInteger,
@@ -49,4 +47,4 @@ class BaseCratesService extends BaseJsonService {
   }
 }
 
-export { BaseCratesService, keywords }
+export { BaseCratesService }

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -1,6 +1,6 @@
 import { renderDownloadsBadge } from '../downloads.js'
-import { InvalidParameter, NotFound } from '../index.js'
-import { BaseCratesService, keywords } from './crates-base.js'
+import { InvalidParameter, NotFound, pathParams } from '../index.js'
+import { BaseCratesService } from './crates-base.js'
 
 export default class CratesDownloads extends BaseCratesService {
   static category = 'downloads'
@@ -9,49 +9,50 @@ export default class CratesDownloads extends BaseCratesService {
     pattern: ':variant(d|dv|dr)/:crate/:version?',
   }
 
-  static examples = [
-    {
-      title: 'Crates.io',
-      pattern: 'd/:crate',
-      namedParams: {
-        crate: 'rustc-serialize',
+  static openApi = {
+    '/crates/d/{crate}': {
+      get: {
+        summary: 'Crates.io Total Downloads',
+        parameters: pathParams({
+          name: 'crate',
+          example: 'rustc-serialize',
+        }),
       },
-      staticPreview: this.render({ variant: 'd', downloads: 5000000 }),
-      keywords,
     },
-    {
-      title: 'Crates.io (latest)',
-      pattern: 'dv/:crate',
-      namedParams: {
-        crate: 'rustc-serialize',
+    '/crates/dv/{crate}': {
+      get: {
+        summary: 'Crates.io Downloads (latest version)',
+        parameters: pathParams({
+          name: 'crate',
+          example: 'rustc-serialize',
+        }),
       },
-      staticPreview: this.render({ variant: 'dv', downloads: 2000000 }),
-      keywords,
     },
-    {
-      title: 'Crates.io (version)',
-      pattern: 'dv/:crate/:version',
-      namedParams: {
-        crate: 'rustc-serialize',
-        version: '0.3.24',
+    '/crates/dv/{crate}/{version}': {
+      get: {
+        summary: 'Crates.io Downloads (version)',
+        parameters: pathParams(
+          {
+            name: 'crate',
+            example: 'rustc-serialize',
+          },
+          {
+            name: 'version',
+            example: '0.3.24',
+          },
+        ),
       },
-      staticPreview: this.render({
-        variant: 'dv',
-        downloads: 2000000,
-        version: '0.3.24',
-      }),
-      keywords,
     },
-    {
-      title: 'Crates.io (recent)',
-      pattern: 'dr/:crate',
-      namedParams: {
-        crate: 'rustc-serialize',
+    '/crates/dr/{crate}': {
+      get: {
+        summary: 'Crates.io Downloads (recent)',
+        parameters: pathParams({
+          name: 'crate',
+          example: 'rustc-serialize',
+        }),
       },
-      staticPreview: this.render({ variant: 'dr', downloads: 2000000 }),
-      keywords,
     },
-  ]
+  }
 
   static render({ variant, downloads, version }) {
     let labelOverride

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -1,6 +1,6 @@
 import { renderDownloadsBadge } from '../downloads.js'
 import { InvalidParameter, NotFound, pathParams } from '../index.js'
-import { BaseCratesService } from './crates-base.js'
+import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesDownloads extends BaseCratesService {
   static category = 'downloads'
@@ -13,6 +13,7 @@ export default class CratesDownloads extends BaseCratesService {
     '/crates/d/{crate}': {
       get: {
         summary: 'Crates.io Total Downloads',
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'rustc-serialize',
@@ -22,6 +23,7 @@ export default class CratesDownloads extends BaseCratesService {
     '/crates/dv/{crate}': {
       get: {
         summary: 'Crates.io Downloads (latest version)',
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'rustc-serialize',
@@ -31,6 +33,7 @@ export default class CratesDownloads extends BaseCratesService {
     '/crates/dv/{crate}/{version}': {
       get: {
         summary: 'Crates.io Downloads (version)',
+        description,
         parameters: pathParams(
           {
             name: 'crate',
@@ -46,6 +49,7 @@ export default class CratesDownloads extends BaseCratesService {
     '/crates/dr/{crate}': {
       get: {
         summary: 'Crates.io Downloads (recent)',
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'rustc-serialize',

--- a/services/crates/crates-license.service.js
+++ b/services/crates/crates-license.service.js
@@ -1,26 +1,36 @@
-import { InvalidResponse } from '../index.js'
-import { BaseCratesService, keywords } from './crates-base.js'
+import { InvalidResponse, pathParams } from '../index.js'
+import { BaseCratesService } from './crates-base.js'
 
 export default class CratesLicense extends BaseCratesService {
   static category = 'license'
   static route = { base: 'crates/l', pattern: ':crate/:version?' }
 
-  static examples = [
-    {
-      title: 'Crates.io',
-      pattern: ':crate',
-      namedParams: { crate: 'rustc-serialize' },
-      staticPreview: this.render({ license: 'MIT/Apache-2.0' }),
-      keywords,
+  static openApi = {
+    '/crates/l/{crate}': {
+      get: {
+        summary: 'Crates.io License',
+        parameters: pathParams({
+          name: 'crate',
+          example: 'rustc-serialize',
+        }),
+      },
     },
-    {
-      title: 'Crates.io',
-      pattern: ':crate/:version',
-      namedParams: { crate: 'rustc-serialize', version: '0.3.24' },
-      staticPreview: this.render({ license: 'MIT/Apache-2.0' }),
-      keywords,
+    '/crates/l/{crate}/{version}': {
+      get: {
+        summary: 'Crates.io License (version)',
+        parameters: pathParams(
+          {
+            name: 'crate',
+            example: 'rustc-serialize',
+          },
+          {
+            name: 'version',
+            example: '0.3.24',
+          },
+        ),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'license', color: 'blue' }
 

--- a/services/crates/crates-license.service.js
+++ b/services/crates/crates-license.service.js
@@ -1,5 +1,5 @@
 import { InvalidResponse, pathParams } from '../index.js'
-import { BaseCratesService } from './crates-base.js'
+import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesLicense extends BaseCratesService {
   static category = 'license'
@@ -9,6 +9,7 @@ export default class CratesLicense extends BaseCratesService {
     '/crates/l/{crate}': {
       get: {
         summary: 'Crates.io License',
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'rustc-serialize',
@@ -18,6 +19,7 @@ export default class CratesLicense extends BaseCratesService {
     '/crates/l/{crate}/{version}': {
       get: {
         summary: 'Crates.io License (version)',
+        description,
         parameters: pathParams(
           {
             name: 'crate',

--- a/services/crates/crates-license.tester.js
+++ b/services/crates/crates-license.tester.js
@@ -16,7 +16,7 @@ t.create('license (not found)')
 // https://github.com/badges/shields/issues/7073
 t.create('license (null licenses in history)')
   .get('/stun.json')
-  .expectBadge({ label: 'license', message: 'MIT/Apache-2.0' })
+  .expectBadge({ label: 'license', message: 'MIT OR Apache-2.0' })
 
 t.create('license (version with null license)')
   .get('/stun/0.0.1.json')

--- a/services/crates/crates-version.service.js
+++ b/services/crates/crates-version.service.js
@@ -1,19 +1,22 @@
 import { renderVersionBadge } from '../version.js'
-import { InvalidResponse } from '../index.js'
-import { BaseCratesService, keywords } from './crates-base.js'
+import { InvalidResponse, pathParams } from '../index.js'
+import { BaseCratesService } from './crates-base.js'
 
 export default class CratesVersion extends BaseCratesService {
   static category = 'version'
   static route = { base: 'crates/v', pattern: ':crate' }
 
-  static examples = [
-    {
-      title: 'Crates.io',
-      namedParams: { crate: 'rustc-serialize' },
-      staticPreview: renderVersionBadge({ version: '0.3.24' }),
-      keywords,
+  static openApi = {
+    '/crates/v/{crate}': {
+      get: {
+        summary: 'Crates.io Version',
+        parameters: pathParams({
+          name: 'crate',
+          example: 'rustc-serialize',
+        }),
+      },
     },
-  ]
+  }
 
   transform(json) {
     if (json.errors) {

--- a/services/crates/crates-version.service.js
+++ b/services/crates/crates-version.service.js
@@ -1,6 +1,6 @@
 import { renderVersionBadge } from '../version.js'
 import { InvalidResponse, pathParams } from '../index.js'
-import { BaseCratesService } from './crates-base.js'
+import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesVersion extends BaseCratesService {
   static category = 'version'
@@ -10,6 +10,7 @@ export default class CratesVersion extends BaseCratesService {
     '/crates/v/{crate}': {
       get: {
         summary: 'Crates.io Version',
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'rustc-serialize',

--- a/services/jsdelivr/jsdelivr-hits-github.service.js
+++ b/services/jsdelivr/jsdelivr-hits-github.service.js
@@ -16,6 +16,7 @@ export default class JsDelivrHitsGitHub extends BaseJsDelivrService {
             name: 'period',
             example: 'hm',
             schema: { type: 'string', enum: this.getEnum('period') },
+            description: 'Hits per day, week, month or year',
           },
           {
             name: 'user',

--- a/services/jsdelivr/jsdelivr-hits-npm.service.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.service.js
@@ -16,6 +16,7 @@ export default class JsDelivrHitsNPM extends BaseJsDelivrService {
             name: 'period',
             schema: { type: 'string', enum: this.getEnum('period') },
             example: 'hm',
+            description: 'Hits per day, week, month or year',
           },
           {
             name: 'packageName',
@@ -32,6 +33,7 @@ export default class JsDelivrHitsNPM extends BaseJsDelivrService {
             name: 'period',
             schema: { type: 'string', enum: this.getEnum('period') },
             example: 'hm',
+            description: 'Hits per day, week, month or year',
           },
           {
             name: 'scope',

--- a/services/jsdelivr/jsdelivr-hits-npm.service.js
+++ b/services/jsdelivr/jsdelivr-hits-npm.service.js
@@ -1,3 +1,4 @@
+import { pathParams } from '../index.js'
 import { schema, periodMap, BaseJsDelivrService } from './jsdelivr-base.js'
 
 export default class JsDelivrHitsNPM extends BaseJsDelivrService {
@@ -6,27 +7,44 @@ export default class JsDelivrHitsNPM extends BaseJsDelivrService {
     pattern: ':period(hd|hw|hm|hy)/:scope(@[^/]+)?/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'jsDelivr hits (npm)',
-      pattern: ':period(hd|hw|hm|hy)/:packageName',
-      namedParams: {
-        period: 'hm',
-        packageName: 'jquery',
+  static openApi = {
+    '/jsdelivr/npm/{period}/{packageName}': {
+      get: {
+        summary: 'jsDelivr hits (npm)',
+        parameters: pathParams(
+          {
+            name: 'period',
+            schema: { type: 'string', enum: this.getEnum('period') },
+            example: 'hm',
+          },
+          {
+            name: 'packageName',
+            example: 'fire',
+          },
+        ),
       },
-      staticPreview: this.render({ period: 'hm', hits: 920101789 }),
     },
-    {
-      title: 'jsDelivr hits (npm scoped)',
-      pattern: ':period(hd|hw|hm|hy)/:scope?/:packageName',
-      namedParams: {
-        period: 'hm',
-        scope: '@angular',
-        packageName: 'fire',
+    '/jsdelivr/npm/{period}/{scope}/{packageName}': {
+      get: {
+        summary: 'jsDelivr hits (npm scoped)',
+        parameters: pathParams(
+          {
+            name: 'period',
+            schema: { type: 'string', enum: this.getEnum('period') },
+            example: 'hm',
+          },
+          {
+            name: 'scope',
+            example: '@angular',
+          },
+          {
+            name: 'packageName',
+            example: 'fire',
+          },
+        ),
       },
-      staticPreview: this.render({ period: 'hm', hits: 94123 }),
     },
-  ]
+  }
 
   async fetch({ period, packageName }) {
     return this._requestJson({

--- a/services/npms-io/npms-io-score.service.js
+++ b/services/npms-io/npms-io-score.service.js
@@ -15,6 +15,9 @@ const responseSchema = Joi.object({
   }),
 }).required()
 
+const description =
+  '[npms.io](https://npms.io) holds statistics for javascript packages.'
+
 export default class NpmsIOScore extends BaseJsonService {
   static category = 'analysis'
 
@@ -28,6 +31,7 @@ export default class NpmsIOScore extends BaseJsonService {
     '/npms-io/{type}/{packageName}': {
       get: {
         summary: 'npms.io',
+        description,
         parameters: pathParams(
           {
             name: 'type',
@@ -44,6 +48,7 @@ export default class NpmsIOScore extends BaseJsonService {
     '/npms-io/{type}/{scope}/{packageName}': {
       get: {
         summary: 'npms.io (scoped package)',
+        description,
         parameters: pathParams(
           {
             name: 'type',

--- a/services/npms-io/npms-io-score.service.js
+++ b/services/npms-io/npms-io-score.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 import { coveragePercentage } from '../color-formatters.js'
 
 // https://api-docs.npms.io/#api-Package-GetPackageInfo
@@ -15,8 +15,6 @@ const responseSchema = Joi.object({
   }),
 }).required()
 
-const keywords = ['node', 'npm score']
-
 export default class NpmsIOScore extends BaseJsonService {
   static category = 'analysis'
 
@@ -26,37 +24,44 @@ export default class NpmsIOScore extends BaseJsonService {
       ':type(final-score|maintenance-score|popularity-score|quality-score)/:scope(@.+)?/:packageName',
   }
 
-  static examples = [
-    {
-      title: 'npms.io (final)',
-      namedParams: { type: 'final-score', packageName: 'egg' },
-      staticPreview: this.render({ score: 0.9711 }),
-      keywords,
-    },
-    {
-      title: 'npms.io (popularity)',
-      pattern: ':type/:scope/:packageName',
-      namedParams: {
-        type: 'popularity-score',
-        scope: '@vue',
-        packageName: 'cli',
+  static openApi = {
+    '/npms-io/{type}/{packageName}': {
+      get: {
+        summary: 'npms.io',
+        parameters: pathParams(
+          {
+            name: 'type',
+            schema: { type: 'string', enum: this.getEnum('type') },
+            example: 'maintenance-score',
+          },
+          {
+            name: 'packageName',
+            example: 'command',
+          },
+        ),
       },
-      staticPreview: this.render({ type: 'popularity', score: 0.89 }),
-      keywords,
     },
-    {
-      title: 'npms.io (quality)',
-      namedParams: { type: 'quality-score', packageName: 'egg' },
-      staticPreview: this.render({ type: 'quality', score: 0.98 }),
-      keywords,
+    '/npms-io/{type}/{scope}/{packageName}': {
+      get: {
+        summary: 'npms.io (scoped package)',
+        parameters: pathParams(
+          {
+            name: 'type',
+            schema: { type: 'string', enum: this.getEnum('type') },
+            example: 'maintenance-score',
+          },
+          {
+            name: 'scope',
+            example: '@vue',
+          },
+          {
+            name: 'packageName',
+            example: 'cli',
+          },
+        ),
+      },
     },
-    {
-      title: 'npms.io (maintenance)',
-      namedParams: { type: 'maintenance-score', packageName: 'command' },
-      staticPreview: this.render({ type: 'maintenance', score: 0.222 }),
-      keywords,
-    },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'score',


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9285

I have touched fewer files in this PR as I'm starting to get into some more slightly more involved services now.

I'll be honest. 17 PRs deep into this project and knowing how many more there are to do, my enthusiasm for this endeavour is starting to decrease a bit. Staying strong though.

I've skipped the bundlephobia tests on this PR. They seem to be having some kind of outage at the moment affecting some packages but not others e.g:

https://bundlephobia.com/api/size?package=react (works)
https://bundlephobia.com/api/size?package=preact (error)

lets keep an eye on that one..