### PR TITLE
sync docusaurus plugin versions

### DIFF
--- a/.github/scripts/check-docusaurus-versions.sh
+++ b/.github/scripts/check-docusaurus-versions.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 
 if ( npm run build 2>&1 | grep '\[ERROR\]' )
 then
+    echo "You probably need to run: npm update @docusaurus/preset-classic"
     exit 1
 else
     exit 0

--- a/.github/scripts/check-docusaurus-versions.sh
+++ b/.github/scripts/check-docusaurus-versions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Docusaurus outputs some important errors as log messages
+# but doesn't actually fail
+# https://github.com/facebook/docusaurus/blob/v2.4.3/packages/docusaurus/src/server/siteMetadata.ts#L75-L92
+# this script runs `docusaurus build`. If it outputs any [ERROR]s, we exit with 1
+
+if ( npm run build 2>&1 | grep '\[ERROR\]' )
+then
+    exit 1
+else
+    exit 0
+fi

--- a/.github/workflows/check-docusaurus-versions.yml
+++ b/.github/workflows/check-docusaurus-versions.yml
@@ -1,0 +1,23 @@
+name: Check Docusaurus Plugin Versions
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches-ignore:
+      - 'gh-pages'
+      - 'dependabot/**'
+
+jobs:
+  check-docusaurus-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 18
+          cypress: true
+
+      - run: .github/scripts/check-docusaurus-versions.sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -154,34 +154,34 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.2.tgz",
-      "integrity": "sha512-hkG80c9kx9ClVAEcUJbTd2ziVC713x9Bji9Ty4XJfKXlxlsx3iXsoNhAwfeR4ulzIUg7OE5gez0UU1zVDdG7kg==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
       "dev": true,
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.9.2",
-        "@algolia/autocomplete-shared": "1.9.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.2.tgz",
-      "integrity": "sha512-2LVsf4W66hVHQ3Ua/8k15oPlxjELCztbAkQm/hP42Sw+GLkHAdY1vaVRYziaWq64+Oljfg6FKkZHCdgXH+CGIA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
       "dev": true,
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.2"
+        "@algolia/autocomplete-shared": "1.9.3"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.2.tgz",
-      "integrity": "sha512-pqgIm2GNqtCT59Y1ICctIPrYTi34+wNPiNWEclD/yDzp5uDUUsyGe5XrUjCNyQRTKonAlmYxoaEHOn8FWgmBHA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
       "dev": true,
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.9.2"
+        "@algolia/autocomplete-shared": "1.9.3"
       },
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.2.tgz",
-      "integrity": "sha512-XxX6YDn+7LG+SmdpXEOnj7fc3TjiVpQ0CbGhjLwrd2tYr6LVY2D4Iiu/iuYJ4shvVDWWnpwArSk0uIWC/8OPUA==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
       "dev": true,
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -199,82 +199,82 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.2.tgz",
-      "integrity": "sha512-ZkVN7K/JE+qMQbpR6h3gQOGR6yCJpmucSBCmH5YDxnrYbp2CbrVCu0Nr+FGVoWzMJNznj1waShkfQ9awERulLw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.20.0.tgz",
+      "integrity": "sha512-uujahcBt4DxduBTvYdwO3sBfHuJvJokiC3BP1+O70fglmE1ShkH8lpXqZBac1rrU3FnNYSUs4pL9lBdTKeRPOQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.17.2"
+        "@algolia/cache-common": "4.20.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.2.tgz",
-      "integrity": "sha512-fojbhYIS8ovfYs6hwZpy1O4mBfVRxNgAaZRqsdVQd54hU4MxYDYFCxagYX28lOBz7btcDHld6BMoWXvjzkx6iQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.20.0.tgz",
+      "integrity": "sha512-vCfxauaZutL3NImzB2G9LjLt36vKAckc6DhMp05An14kVo8F1Yofb6SIl6U3SaEz8pG2QOB9ptwM5c+zGevwIQ==",
       "dev": true
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.2.tgz",
-      "integrity": "sha512-UYQcMzPurNi+cPYkuPemTZkjKAjdgAS1hagC5irujKbrYnN4yscK4TkOI5tX+O8/KegtJt3kOK07OIrJ2QDAAw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.20.0.tgz",
+      "integrity": "sha512-Wm9ak/IaacAZXS4mB3+qF/KCoVSBV6aLgIGFEtQtJwjv64g4ePMapORGmCyulCFwfePaRAtcaTbMcJF+voc/bg==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.17.2"
+        "@algolia/cache-common": "4.20.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.2.tgz",
-      "integrity": "sha512-doSk89pBPDpDyKJSHFADIGa2XSGrBCj3QwPvqtRJXDADpN+OjW+eTR8r4hEs/7X4GGfjfAOAES8JgDx+fZntYw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.20.0.tgz",
+      "integrity": "sha512-GGToLQvrwo7am4zVkZTnKa72pheQeez/16sURDWm7Seyz+HUxKi3BM6fthVVPUEBhtJ0reyVtuK9ArmnaKl10Q==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.17.2",
-        "@algolia/client-search": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.2.tgz",
-      "integrity": "sha512-V+DcXbOtD/hKwAR3qGQrtlrJ3q2f9OKfx843q744o4m3xHv5ueCAvGXB1znPsdaUrVDNAImcgEgqwI9x7EJbDw==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.20.0.tgz",
+      "integrity": "sha512-EIr+PdFMOallRdBTHHdKI3CstslgLORQG7844Mq84ib5oVFRVASuuPmG4bXBgiDbcsMLUeOC6zRVJhv1KWI0ug==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.17.2",
-        "@algolia/client-search": "4.17.2",
-        "@algolia/requester-common": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.2.tgz",
-      "integrity": "sha512-gKBUnjxi0ukJYIJxVREYGt1Dmj1B3RBYbfGWi0dIPp1BC1VvQm+BOuNwsIwmq/x3MPO+sGuK978eKiP3tZDvag==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.20.0.tgz",
+      "integrity": "sha512-P3WgMdEss915p+knMMSd/fwiHRHKvDu4DYRrCRaBrsfFw7EQHon+EbRSm4QisS9NYdxbS04kcvNoavVGthyfqQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.2.tgz",
-      "integrity": "sha512-wc4UgOWxSYWz5wpuelNmlt895jA9twjZWM2ms17Ws8qCvBHF7OVGdMGgbysPB8790YnfvvDnSsWOv3CEj26Eow==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.20.0.tgz",
+      "integrity": "sha512-N9+zx0tWOQsLc3K4PVRDV8GUeOLAY0i445En79Pr3zWB+m67V+n/8w4Kw1C5LlbHDDJcyhMMIlqezh6BEk7xAQ==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.17.2",
-        "@algolia/requester-common": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/client-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.2.tgz",
-      "integrity": "sha512-FUjIs+gRe0upJC++uVs4sdxMw15JxfkT86Gr/kqVwi9kcqaZhXntSbW/Fw959bIYXczjmeVQsilYvBWW4YvSZA==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.20.0.tgz",
+      "integrity": "sha512-zgwqnMvhWLdpzKTpd3sGmMlr4c+iS7eyyLGiaO51zDZWGMkpgoNVmltkzdBwxOVXz0RsFMznIxB9zuarUv4TZg==",
       "dev": true,
       "dependencies": {
-        "@algolia/client-common": "4.17.2",
-        "@algolia/requester-common": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/client-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -284,53 +284,53 @@
       "dev": true
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.2.tgz",
-      "integrity": "sha512-EfXuweUE+1HiSMsQidaDWA5Lv4NnStYIlh7PO5pLkI+sdhbMX0e5AO5nUAMIFM1VkEANes70RA8fzhP6OqCqQQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.20.0.tgz",
+      "integrity": "sha512-xouigCMB5WJYEwvoWW5XDv7Z9f0A8VoXJc3VKwlHJw/je+3p2RcDXfksLI4G4lIVncFUYMZx30tP/rsdlvvzHQ==",
       "dev": true
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.2.tgz",
-      "integrity": "sha512-JuG8HGVlJ+l/UEDK4h2Y8q/IEmRjQz1J0aS9tf6GPNbGYiSvMr1DDdZ+hqV3bb1XE6wU8Ypex56HisWMSpnG0A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.20.0.tgz",
+      "integrity": "sha512-THlIGG1g/FS63z0StQqDhT6bprUczBI8wnLT3JWvfAQDZX5P6fCg7dG+pIrUBpDIHGszgkqYEqECaKKsdNKOUA==",
       "dev": true,
       "dependencies": {
-        "@algolia/logger-common": "4.17.2"
+        "@algolia/logger-common": "4.20.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.2.tgz",
-      "integrity": "sha512-FKI2lYWwksALfRt2OETFmGb5+P7WVc4py2Ai3H7k8FSfTLwVvs9WVVmtlx6oANQ8RFEK4B85h8DQJTJ29TDfmA==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.20.0.tgz",
+      "integrity": "sha512-HbzoSjcjuUmYOkcHECkVTwAelmvTlgs48N6Owt4FnTOQdwn0b8pdht9eMgishvk8+F8bal354nhx/xOoTfwiAw==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.17.2"
+        "@algolia/requester-common": "4.20.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.2.tgz",
-      "integrity": "sha512-Rfim23ztAhYpE9qm+KCfCRo+YLJCjiiTG+IpDdzUjMpYPhUtirQT0A35YEd/gKn86YNyydxS9w8iRSjwKh+L0A==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.20.0.tgz",
+      "integrity": "sha512-9h6ye6RY/BkfmeJp7Z8gyyeMrmmWsMOCRBXQDs4mZKKsyVlfIVICpcSibbeYcuUdurLhIlrOUkH3rQEgZzonng==",
       "dev": true
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.2.tgz",
-      "integrity": "sha512-E0b0kyCDMvUIhQmDNd/mH4fsKJdEEX6PkMKrYJjzm6moo+rP22tqpq4Rfe7DZD8OB6/LsDD3zs3Kvd+L+M5wwQ==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.20.0.tgz",
+      "integrity": "sha512-ocJ66L60ABSSTRFnCHIEZpNHv6qTxsBwJEPfYaSBsLQodm0F9ptvalFkHMpvj5DfE22oZrcrLbOYM2bdPJRHng==",
       "dev": true,
       "dependencies": {
-        "@algolia/requester-common": "4.17.2"
+        "@algolia/requester-common": "4.20.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.2.tgz",
-      "integrity": "sha512-m8pXlz5OnNzjD1rcw+duCN4jG4yEzkJBsvKYMoN22Oq6rQwy1AY5muZ+IQUs4dL+A364CYkRMLRWhvXpCZ1x+g==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.20.0.tgz",
+      "integrity": "sha512-Lsii1pGWOAISbzeyuf+r/GPhvHMPHSPrTDWNcIzOE1SG1inlJHICaVe2ikuoRjcpgxZNU54Jl+if15SUCsaTUg==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-common": "4.17.2",
-        "@algolia/logger-common": "4.17.2",
-        "@algolia/requester-common": "4.17.2"
+        "@algolia/cache-common": "4.20.0",
+        "@algolia/logger-common": "4.20.0",
+        "@algolia/requester-common": "4.20.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2467,26 +2467,27 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.0.tgz",
-      "integrity": "sha512-Ob5FQLubplcBNihAVtriR59FRBeP8u69F6mu4L4yIr60KfsPc10bOV0DoPErJw0zF9IBN2cNLW9qdmt8zWPxyg==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
+      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
       "dev": true
     },
     "node_modules/@docsearch/react": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.0.tgz",
-      "integrity": "sha512-3IG8mmSMzSHNGy2S1VuPyYU9tFCxFpj5Ov8SYwsSHM4yMvFsaO9oFxXocA5lSenliIELhuOuS5+BdxHa/Qlf2A==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
+      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
       "dev": true,
       "dependencies": {
-        "@algolia/autocomplete-core": "1.9.2",
-        "@algolia/autocomplete-preset-algolia": "1.9.2",
-        "@docsearch/css": "3.5.0",
-        "algoliasearch": "^4.0.0"
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.2",
+        "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 19.0.0",
         "react": ">= 16.8.0 < 19.0.0",
-        "react-dom": ">= 16.8.0 < 19.0.0"
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -2496,6 +2497,9 @@
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
           "optional": true
         }
       }
@@ -2589,122 +2593,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/logger": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.3.tgz",
-      "integrity": "sha512-Zxws7r3yLufk9xM1zq9ged0YHs65mlRmtsobnFkdZTxWXdTYlWWLWdKyNKAsVC+D7zg+pv2fGbyabdOnyZOM3w==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/mdx-loader": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.3.tgz",
-      "integrity": "sha512-b1+fDnWtl3GiqkL0BRjYtc94FZrcDDBV1j8446+4tptB9BAOlePwG2p/pK6vGvfL53lkOsszXMghr2g67M0vCw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/parser": "^7.18.8",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.4.3",
-        "@docusaurus/utils": "2.4.3",
-        "@mdx-js/mdx": "^1.6.22",
-        "escape-html": "^1.0.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "image-size": "^1.0.1",
-        "mdast-util-to-string": "^2.0.0",
-        "remark-emoji": "^2.2.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.4.0",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.3",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.3.tgz",
-      "integrity": "sha512-fKcXsjrD86Smxv8Pt0TBFqYieZZCPh4cbf9oszUq/AMhZn3ujwpKaVYZACPX8mmjtYx0JOgNx52CREBfiGQB4A==",
-      "dev": true,
-      "dependencies": {
-        "@docusaurus/logger": "2.4.3",
-        "@svgr/webpack": "^6.2.1",
-        "escape-string-regexp": "^4.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "github-slugger": "^1.4.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.4.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-common": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.3.tgz",
-      "integrity": "sha512-/jascp4GbLQCPVmcGkPzEQjNaAk3ADVfMtudk49Ggb+131B1WDD6HqlSmDf8MxGdy7Dja2gc+StHf01kiWoTDQ==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-validation": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.3.tgz",
-      "integrity": "sha512-G2+Vt3WR5E/9drAobP+hhZQMaswRwDlp6qOMi7o7ZypB+VO7N//DZWhZEwhcRGepMDJGQEwtPv7UxtYwPL9PBw==",
-      "dev": true,
-      "dependencies": {
-        "@docusaurus/logger": "2.4.3",
-        "@docusaurus/utils": "2.4.3",
-        "joi": "^17.6.0",
-        "js-yaml": "^4.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
     "node_modules/@docusaurus/core/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2782,9 +2670,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
-      "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.3.tgz",
+      "integrity": "sha512-Zxws7r3yLufk9xM1zq9ged0YHs65mlRmtsobnFkdZTxWXdTYlWWLWdKyNKAsVC+D7zg+pv2fGbyabdOnyZOM3w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -2856,15 +2744,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
-      "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.3.tgz",
+      "integrity": "sha512-b1+fDnWtl3GiqkL0BRjYtc94FZrcDDBV1j8446+4tptB9BAOlePwG2p/pK6vGvfL53lkOsszXMghr2g67M0vCw==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2888,13 +2776,13 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.1.tgz",
-      "integrity": "sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.3.tgz",
+      "integrity": "sha512-cwkBkt1UCiduuvEAo7XZY01dJfRn7UR/75mBgOdb1hKknhrabJZ8YH+7savd/y9kLExPyrhe0QwdS9GuzsRRIA==",
       "dev": true,
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.4.1",
+        "@docusaurus/types": "2.4.3",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2908,18 +2796,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.1.tgz",
-      "integrity": "sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.3.tgz",
+      "integrity": "sha512-PVhypqaA0t98zVDpOeTqWUTvRqCEjJubtfFUQ7zJNYdbYTbS/E/ytq6zbLVsN/dImvemtO/5JQgjLxsh8XLo8Q==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/mdx-loader": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2938,184 +2826,19 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.1.tgz",
-      "integrity": "sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.3.tgz",
+      "integrity": "sha512-N7Po2LSH6UejQhzTCsvuX5NOzlC+HiXOVvofnEPj0WhMu1etpLEXE6a4aTxrtg95lQ5kf0xUIdjX9sh3d3G76A==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/module-type-aliases": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/mdx-loader": "2.4.3",
+        "@docusaurus/module-type-aliases": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -3134,182 +2857,17 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.1.tgz",
-      "integrity": "sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.3.tgz",
+      "integrity": "sha512-txtDVz7y3zGk67q0HjG0gRttVPodkHqE0bpJ+7dOaTH40CQFLSh7+aBeGnPOTl+oCPG+hxkim4SndqPqXjQ8Bg==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/mdx-loader": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -3322,180 +2880,15 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.1.tgz",
-      "integrity": "sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.3.tgz",
+      "integrity": "sha512-LkUbuq3zCmINlFb+gAd4ZvYr+bPAzMC0hwND4F7V9bZ852dCX8YoWyovVUBKq4er1XsOwSQaHmNGtObtn8Av8Q==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -3508,180 +2901,15 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
-      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.3.tgz",
+      "integrity": "sha512-KzBV3k8lDkWOhg/oYGxlK5o9bOwX7KpPc/FTWoB+SfKhlHfhq7qcQdMi1elAaVEIop8tgK6gD1E58Q+XC6otSQ==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3690,182 +2918,17 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
-      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.3.tgz",
+      "integrity": "sha512-5FMg0rT7sDy4i9AGsvJC71MQrqQZwgLNdDetLEGDHLfSHLvJhQbTCUGbGXknUgWXQJckcV/AILYeJy+HhxeIFA==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3874,182 +2937,17 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.1.tgz",
-      "integrity": "sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.3.tgz",
+      "integrity": "sha512-1jTzp71yDGuQiX9Bi0pVp3alArV0LSnHXempvQTxwCGAEzUWWaBg4d8pocAlTpbP9aULQQqhgzrs8hgTRPOM0A==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -4058,185 +2956,20 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-google-tag-manager/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.1.tgz",
-      "integrity": "sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.3.tgz",
+      "integrity": "sha512-LRQYrK1oH1rNfr4YvWBmRzTL0LN9UAPxBbghgeFRBm5yloF6P+zv1tm2pe2hQTX/QP5bSKdnajCvfnScgKXMZQ==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -4249,190 +2982,25 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.1.tgz",
-      "integrity": "sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.3.tgz",
+      "integrity": "sha512-tRyMliepY11Ym6hB1rAFSNGwQDpmszvWYJvlK1E+md4SW8i6ylNHtpZjaYFff9Mdk3i/Pg8ItQq9P0daOJAvQw==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/plugin-content-blog": "2.4.1",
-        "@docusaurus/plugin-content-docs": "2.4.1",
-        "@docusaurus/plugin-content-pages": "2.4.1",
-        "@docusaurus/plugin-debug": "2.4.1",
-        "@docusaurus/plugin-google-analytics": "2.4.1",
-        "@docusaurus/plugin-google-gtag": "2.4.1",
-        "@docusaurus/plugin-google-tag-manager": "2.4.1",
-        "@docusaurus/plugin-sitemap": "2.4.1",
-        "@docusaurus/theme-classic": "2.4.1",
-        "@docusaurus/theme-common": "2.4.1",
-        "@docusaurus/theme-search-algolia": "2.4.1",
-        "@docusaurus/types": "2.4.1"
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/plugin-content-blog": "2.4.3",
+        "@docusaurus/plugin-content-docs": "2.4.3",
+        "@docusaurus/plugin-content-pages": "2.4.3",
+        "@docusaurus/plugin-debug": "2.4.3",
+        "@docusaurus/plugin-google-analytics": "2.4.3",
+        "@docusaurus/plugin-google-gtag": "2.4.3",
+        "@docusaurus/plugin-google-tag-manager": "2.4.3",
+        "@docusaurus/plugin-sitemap": "2.4.3",
+        "@docusaurus/theme-classic": "2.4.3",
+        "@docusaurus/theme-common": "2.4.3",
+        "@docusaurus/theme-search-algolia": "2.4.3",
+        "@docusaurus/types": "2.4.3"
       },
       "engines": {
         "node": ">=16.14"
@@ -4440,171 +3008,6 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@docusaurus/react-loadable": {
@@ -4621,23 +3024,23 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.1.tgz",
-      "integrity": "sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.3.tgz",
+      "integrity": "sha512-QKRAJPSGPfDY2yCiPMIVyr+MqwZCIV2lxNzqbyUW0YkrlmdzzP3WuQJPMGLCjWgQp/5c9kpWMvMxjhpZx1R32Q==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/module-type-aliases": "2.4.1",
-        "@docusaurus/plugin-content-blog": "2.4.1",
-        "@docusaurus/plugin-content-docs": "2.4.1",
-        "@docusaurus/plugin-content-pages": "2.4.1",
-        "@docusaurus/theme-common": "2.4.1",
-        "@docusaurus/theme-translations": "2.4.1",
-        "@docusaurus/types": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/mdx-loader": "2.4.3",
+        "@docusaurus/module-type-aliases": "2.4.3",
+        "@docusaurus/plugin-content-blog": "2.4.3",
+        "@docusaurus/plugin-content-docs": "2.4.3",
+        "@docusaurus/plugin-content-pages": "2.4.3",
+        "@docusaurus/theme-common": "2.4.3",
+        "@docusaurus/theme-translations": "2.4.3",
+        "@docusaurus/types": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -4660,141 +3063,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@docusaurus/theme-classic/node_modules/clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -4803,24 +3071,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/@docusaurus/theme-classic/node_modules/prism-react-renderer": {
       "version": "1.3.5",
@@ -4831,31 +3081,19 @@
         "react": ">=0.14.9"
       }
     },
-    "node_modules/@docusaurus/theme-classic/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
-      "integrity": "sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.3.tgz",
+      "integrity": "sha512-7KaDJBXKBVGXw5WOVt84FtN8czGWhM0lbyWEZXGp8AFfL6sZQfRTluFp4QriR97qwzSyOfQb+nzcDZZU4tezUw==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/module-type-aliases": "2.4.1",
-        "@docusaurus/plugin-content-blog": "2.4.1",
-        "@docusaurus/plugin-content-docs": "2.4.1",
-        "@docusaurus/plugin-content-pages": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.3",
+        "@docusaurus/module-type-aliases": "2.4.3",
+        "@docusaurus/plugin-content-blog": "2.4.3",
+        "@docusaurus/plugin-content-docs": "2.4.3",
+        "@docusaurus/plugin-content-pages": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-common": "2.4.3",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -4893,19 +3131,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.1.tgz",
-      "integrity": "sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.3.tgz",
+      "integrity": "sha512-jziq4f6YVUB5hZOB85ELATwnxBz/RmSLD3ksGQOLDPKVzat4pmI8tddNWtriPpxR04BNT+ZfpPUMFkNFetSW1Q==",
       "dev": true,
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/plugin-content-docs": "2.4.1",
-        "@docusaurus/theme-common": "2.4.1",
-        "@docusaurus/theme-translations": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
+        "@docusaurus/core": "2.4.3",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/plugin-content-docs": "2.4.3",
+        "@docusaurus/theme-common": "2.4.3",
+        "@docusaurus/theme-translations": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
+        "@docusaurus/utils-validation": "2.4.3",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
@@ -4923,141 +3161,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
-      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.4.1",
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/mdx-loader": "2.4.1",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.4.1",
-        "@docusaurus/utils-common": "2.4.1",
-        "@docusaurus/utils-validation": "2.4.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^2.0.0",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
-      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
-      "dev": true,
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/@docusaurus/theme-search-algolia/node_modules/clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -5067,40 +3170,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.1.tgz",
-      "integrity": "sha512-T1RAGP+f86CA1kfE8ejZ3T3pUU3XcyvrGMfC/zxCtc2BsnoexuNI9Vk2CmuKCb+Tacvhxjv5unhxXce0+NKyvA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.3.tgz",
+      "integrity": "sha512-H4D+lbZbjbKNS/Zw1Lel64PioUAIT3cLYYJLUf3KkuO/oc9e0QCVhIYVtUI2SfBCF2NNdlyhBDQEEMygsCedIg==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^10.1.0",
@@ -5111,9 +3184,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
-      "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.3.tgz",
+      "integrity": "sha512-W6zNLGQqfrp/EoPD0bhb9n7OobP+RHpmvVzpA+Z/IuU3Q63njJM24hmT0GYboovWcDtFmnIJC9wcyx4RVPQscw==",
       "dev": true,
       "dependencies": {
         "@types/history": "^4.7.11",
@@ -5131,12 +3204,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
-      "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.3.tgz",
+      "integrity": "sha512-fKcXsjrD86Smxv8Pt0TBFqYieZZCPh4cbf9oszUq/AMhZn3ujwpKaVYZACPX8mmjtYx0JOgNx52CREBfiGQB4A==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/logger": "2.4.3",
         "@svgr/webpack": "^6.2.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -5166,9 +3239,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
-      "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.3.tgz",
+      "integrity": "sha512-/jascp4GbLQCPVmcGkPzEQjNaAk3ADVfMtudk49Ggb+131B1WDD6HqlSmDf8MxGdy7Dja2gc+StHf01kiWoTDQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -5186,13 +3259,13 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
-      "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.3.tgz",
+      "integrity": "sha512-G2+Vt3WR5E/9drAobP+hhZQMaswRwDlp6qOMi7o7ZypB+VO7N//DZWhZEwhcRGepMDJGQEwtPv7UxtYwPL9PBw==",
       "dev": true,
       "dependencies": {
-        "@docusaurus/logger": "2.4.1",
-        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/logger": "2.4.3",
+        "@docusaurus/utils": "2.4.3",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -7959,31 +6032,31 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.2.tgz",
-      "integrity": "sha512-VFu43JJNYIW74awp7oeQcQsPcxOhd8psqBDTfyNO2Zt6L1NqnNMTVnaIdQ+8dtKqUDBqQZp0szPxECvX8CK2Fg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.20.0.tgz",
+      "integrity": "sha512-y+UHEjnOItoNy0bYO+WWmLWBlPwDjKHW6mNHrPi0NkuhpQOOEbrkwQH/wgKFDLh7qlKjzoKeiRtlpewDPDG23g==",
       "dev": true,
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.17.2",
-        "@algolia/cache-common": "4.17.2",
-        "@algolia/cache-in-memory": "4.17.2",
-        "@algolia/client-account": "4.17.2",
-        "@algolia/client-analytics": "4.17.2",
-        "@algolia/client-common": "4.17.2",
-        "@algolia/client-personalization": "4.17.2",
-        "@algolia/client-search": "4.17.2",
-        "@algolia/logger-common": "4.17.2",
-        "@algolia/logger-console": "4.17.2",
-        "@algolia/requester-browser-xhr": "4.17.2",
-        "@algolia/requester-common": "4.17.2",
-        "@algolia/requester-node-http": "4.17.2",
-        "@algolia/transporter": "4.17.2"
+        "@algolia/cache-browser-local-storage": "4.20.0",
+        "@algolia/cache-common": "4.20.0",
+        "@algolia/cache-in-memory": "4.20.0",
+        "@algolia/client-account": "4.20.0",
+        "@algolia/client-analytics": "4.20.0",
+        "@algolia/client-common": "4.20.0",
+        "@algolia/client-personalization": "4.20.0",
+        "@algolia/client-search": "4.20.0",
+        "@algolia/logger-common": "4.20.0",
+        "@algolia/logger-console": "4.20.0",
+        "@algolia/requester-browser-xhr": "4.20.0",
+        "@algolia/requester-common": "4.20.0",
+        "@algolia/requester-node-http": "4.20.0",
+        "@algolia/transporter": "4.20.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.13.0.tgz",
-      "integrity": "sha512-kV3c1jMQCvkARtGsSDvAwuht4PAMSsQILqPiH4WFiARoa3jXJ/r1TQoBWAjWyWF48rsNYCv7kzxgB4LTxrvvuw==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.14.2.tgz",
+      "integrity": "sha512-FjDSrjvQvJT/SKMW74nPgFpsoPUwZCzGbCqbp8HhBFfSk/OvNFxzCaCmuO0p7AWeLy1gD+muFwQEkBwcl5H4pg==",
       "dev": true,
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -10564,9 +8637,9 @@
       }
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
-      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
+      "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -10795,12 +8868,12 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dev": true,
       "dependencies": {
-        "node-fetch": "^2.6.11"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -20193,9 +18266,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -24133,9 +22206,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
-      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
+      "version": "8.5.3",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz",
+      "integrity": "sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -25801,14 +23874,11 @@
       }
     },
     "node_modules/search-insights": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.6.0.tgz",
-      "integrity": "sha512-vU2/fJ+h/Mkm/DJOe+EaM5cafJv/1rRTZpGJTuFPf/Q5LjzgMDsqPdSaZsAe+GAWHHsfsu+rQSAn6c8IGtBEVw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.8.2.tgz",
+      "integrity": "sha512-PxA9M5Q2bpBelVvJ3oDZR8nuY00Z6qwOxL53wNpgzV28M/D6u9WUbImDckjLSILBF8F1hn/mgyuUaOPtjow4Qw==",
       "dev": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8.16.0"
-      }
+      "peer": true
     },
     "node_modules/section-matter": {
       "version": "1.0.0",
@@ -28509,9 +26579,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "1.0.35",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.36.tgz",
+      "integrity": "sha512-znuyCIXzl8ciS3+y3fHJI/2OhQIXbXw9MWC/o3qwyR+RGppjZHrM27CGFSKCJXi2Kctiz537iOu2KnXs1lMQhw==",
       "dev": true,
       "funding": [
         {
@@ -28521,6 +26591,10 @@
         {
           "type": "paypal",
           "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
         }
       ],
       "engines": {


### PR DESCRIPTION
Yesterday I merged https://github.com/badges/shields/pull/9600

When I was working on shields today, I realised that docusaurus was outputting

```
[ERROR] Invalid docusaurus-plugin-content-docs version 2.4.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.3).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
[ERROR] Invalid docusaurus-plugin-content-blog version 2.4.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.3).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
[ERROR] Invalid docusaurus-plugin-content-pages version 2.4.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.3).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
[ERROR] Invalid docusaurus-plugin-sitemap version 2.4.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.3).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
[ERROR] Invalid docusaurus-theme-classic version 2.4.1.
All official @docusaurus/* packages should have the exact same version as @docusaurus/core (2.4.3).
Maybe you want to check, or regenerate your yarn.lock or package-lock.json file?
```

This didn't cause anything to fail in CI - it just logged the errors to the console, which is why I didn't notice it.

The place where this is checked is https://github.com/facebook/docusaurus/blob/v2.4.3/packages/docusaurus/src/server/siteMetadata.ts#L75-L92

There doesn't appear to be any command or switch that can make this a hard error but I would really like this mismatch to cause a CI fail so I don't forget this next time. I am going to raise an issue about this upstream, but in the meantime I have cobbled together a crude bash script we can use. It is not very efficient because we have to build the whole frontend, but it is better than a kick in the teeth.
If you follow the commit history, you can see the build fails on the commit where I've added the check and then passes on the commit where I have fixed it.

FWIW, this particular mismatch (2.4.1 / 2.4.3) doesn't appear to actually be causing any issues, but I'd like to get this one reviewed/merged sooner rather than later.
