### PR TITLE
move from @renovate/pep440 to @renovatebot/pep440; affects [pypi piwheels python]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@renovate/pep440": "^1.0.0",
+        "@renovatebot/pep440": "^3.0.11",
         "@renovatebot/ruby-semver": "^3.0.18",
         "@sentry/node": "^7.80.1",
         "@shields_io/camp": "^18.1.2",
@@ -4659,12 +4659,13 @@
         }
       }
     },
-    "node_modules/@renovate/pep440": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@renovate/pep440/-/pep440-1.0.0.tgz",
-      "integrity": "sha512-k3pZVxGEGpU7rpH507/9vxfFjuxX7qx4MSj9Fk+6zBsf/uZmAy8x97dNtZacbge7gP9TazbW1d7SEb5vsOmKlw==",
-      "dependencies": {
-        "xregexp": "4.4.1"
+    "node_modules/@renovatebot/pep440": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@renovatebot/pep440/-/pep440-3.0.11.tgz",
+      "integrity": "sha512-7mbXJ8ywpOFbETuim9wx2Xg4QULFN4aZQGxOfbXoXWWJbvyQ+5/47bq9fR09cChta56pheucXd4aVbGeEkwQwA==",
+      "engines": {
+        "node": "^18.12.0 || >= 20.0.0",
+        "pnpm": "^8.6.11"
       }
     },
     "node_modules/@renovatebot/ruby-semver": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/badges/shields"
   },
   "dependencies": {
-    "@renovate/pep440": "^1.0.0",
+    "@renovatebot/pep440": "^3.0.11",
     "@renovatebot/ruby-semver": "^3.0.18",
     "@sentry/node": "^7.80.1",
     "@shields_io/camp": "^18.1.2",

--- a/services/color-formatters.js
+++ b/services/color-formatters.js
@@ -6,7 +6,7 @@
  */
 
 import dayjs from 'dayjs'
-import pep440 from '@renovate/pep440'
+import pep440 from '@renovatebot/pep440'
 
 /**
  * Determines the color used for a badge based on version.

--- a/services/python/python-version-from-toml.tester.js
+++ b/services/python/python-version-from-toml.tester.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import pep440 from '@renovate/pep440'
+import pep440 from '@renovatebot/pep440'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 


### PR DESCRIPTION
At some point this package moved namespace and we didn't notice.
We're already using the right copy of `@renovatebot/ruby-semver`
