### PR TITLE
switch to fixed OpenCollective images

### DIFF
--- a/frontend/src/pages/community.md
+++ b/frontend/src/pages/community.md
@@ -23,7 +23,7 @@ Shields.io is possible thanks to the people and companies who donate money, serv
 
 <p>
     <object
-        data="https://opencollective.com/shields/sponsors.svg?avatarHeight=80&width=600"
+        data="https://opencollective.com/shields/tiers/sponsor.svg?avatarHeight=80&width=600"
         class="opencollective-image"
     ></object>
 </p>
@@ -34,7 +34,7 @@ Shields.io is possible thanks to the people and companies who donate money, serv
 
 <p>
     <object
-        data="https://opencollective.com/shields/backers.svg?width=600"
+        data="https://opencollective.com/shields/tiers/backer.svg?width=600"
         class="opencollective-image">
     </object>
 </p>


### PR DESCRIPTION
Refs https://github.com/opencollective/opencollective/issues/6982 and https://github.com/opencollective/opencollective-images/pull/580

tl;dr:
- The OpenCollective images URLs we were using don't accurately show our current sponsors and backers
- These new ones do

I'd quite like to get this one merged so I can deploy and close the loop with the sponsor that contacted us about this.