### PR TITLE
deprecate/fix [ansible] galaxy services

### DIFF
--- a/services/ansible/ansible-collection.service.js
+++ b/services/ansible/ansible-collection.service.js
@@ -1,45 +1,11 @@
-import Joi from 'joi'
-import { BaseJsonService, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const ansibleCollectionSchema = Joi.object({
-  name: Joi.string().required(),
-  namespace: Joi.object({
-    name: Joi.string().required(),
-  }),
-}).required()
-
-class AnsibleGalaxyCollectionName extends BaseJsonService {
-  static category = 'other'
-  static route = { base: 'ansible/collection', pattern: ':collectionId' }
-
-  static openApi = {
-    '/ansible/collection/{collectionId}': {
-      get: {
-        summary: 'Ansible Collection',
-        parameters: pathParams({ name: 'collectionId', example: '278' }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'collection' }
-
-  static render({ name }) {
-    return { message: name, color: 'blue' }
-  }
-
-  async fetch({ collectionId }) {
-    const url = `https://galaxy.ansible.com/api/v2/collections/${collectionId}/`
-    return this._requestJson({
-      url,
-      schema: ansibleCollectionSchema,
-    })
-  }
-
-  async handle({ collectionId }) {
-    const json = await this.fetch({ collectionId })
-    const name = `${json.namespace.name}.${json.name}`
-    return this.constructor.render({ name })
-  }
-}
-
-export { AnsibleGalaxyCollectionName }
+export const AnsibleGalaxyCollectionName = deprecatedService({
+  category: 'other',
+  route: {
+    base: 'ansible/collection',
+    pattern: ':collectionId',
+  },
+  label: 'collection',
+  dateAdded: new Date('2023-10-10'),
+})

--- a/services/ansible/ansible-collection.tester.js
+++ b/services/ansible/ansible-collection.tester.js
@@ -1,14 +1,10 @@
 import { ServiceTester } from '../tester.js'
 export const t = new ServiceTester({
-  id: 'AnsibleCollection',
-  title: 'AnsibleCollection',
+  id: 'AnsibleGalaxyCollectionName',
+  title: 'AnsibleGalaxyCollectionName',
   pathPrefix: '/ansible/collection',
 })
 
-t.create('collection name (valid)')
+t.create('collection name')
   .get('/278.json')
-  .expectBadge({ label: 'collection', message: 'community.general' })
-
-t.create('collection name (not found)')
-  .get('/000.json')
-  .expectBadge({ label: 'collection', message: 'not found' })
+  .expectBadge({ label: 'collection', message: 'no longer available' })

--- a/services/ansible/ansible-quality.service.js
+++ b/services/ansible/ansible-quality.service.js
@@ -1,52 +1,11 @@
-import Joi from 'joi'
-import { floorCount } from '../color-formatters.js'
-import { BaseJsonService, InvalidResponse, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const ansibleContentSchema = Joi.object({
-  quality_score: Joi.number().allow(null).required(),
-}).required()
-
-class AnsibleGalaxyContent extends BaseJsonService {
-  async fetch({ projectId }) {
-    const url = `https://galaxy.ansible.com/api/v1/content/${projectId}/`
-    return this._requestJson({
-      url,
-      schema: ansibleContentSchema,
-    })
-  }
-}
-
-export default class AnsibleGalaxyContentQualityScore extends AnsibleGalaxyContent {
-  static category = 'analysis'
-  static route = { base: 'ansible/quality', pattern: ':projectId' }
-
-  static openApi = {
-    '/ansible/quality/{projectId}': {
-      get: {
-        summary: 'Ansible Quality Score',
-        parameters: pathParams({ name: 'projectId', example: '432' }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'quality' }
-
-  static render({ qualityScore }) {
-    return {
-      message: qualityScore,
-      color: floorCount(qualityScore, 2, 3, 4),
-    }
-  }
-
-  async handle({ projectId }) {
-    const { quality_score: qualityScore } = await this.fetch({ projectId })
-
-    if (qualityScore === null) {
-      throw new InvalidResponse({
-        prettyMessage: 'no score available',
-      })
-    }
-
-    return this.constructor.render({ qualityScore })
-  }
-}
+export const AnsibleGalaxyContentQualityScore = deprecatedService({
+  category: 'analysis',
+  route: {
+    base: 'ansible/quality',
+    pattern: ':projectId',
+  },
+  label: 'quality',
+  dateAdded: new Date('2023-10-10'),
+})

--- a/services/ansible/ansible-quality.tester.js
+++ b/services/ansible/ansible-quality.tester.js
@@ -1,15 +1,10 @@
-import { nonNegativeInteger } from '../validators.js'
-import { createServiceTester } from '../tester.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
+export const t = new ServiceTester({
+  id: 'AnsibleGalaxyContentQualityScore',
+  title: 'AnsibleGalaxyContentQualityScore',
+  pathPrefix: '/ansible/quality',
+})
 
-t.create('quality score (valid)')
+t.create('quality score')
   .get('/432.json')
-  .expectBadge({ label: 'quality', message: nonNegativeInteger })
-
-t.create('quality score (project not found)')
-  .get('/0101.json')
-  .expectBadge({ label: 'quality', message: 'not found' })
-
-t.create('quality score (no score available)')
-  .get('/2504.json')
-  .expectBadge({ label: 'quality', message: 'no score available' })
+  .expectBadge({ label: 'quality', message: 'no longer available' })

--- a/services/ansible/ansible-role.service.js
+++ b/services/ansible/ansible-role.service.js
@@ -1,73 +1,83 @@
 import Joi from 'joi'
 import { renderDownloadsBadge } from '../downloads.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService, pathParams } from '../index.js'
+import {
+  BaseJsonService,
+  deprecatedService,
+  NotFound,
+  pathParams,
+} from '../index.js'
 
 const ansibleRoleSchema = Joi.object({
-  download_count: nonNegativeInteger,
-  name: Joi.string().required(),
-  summary_fields: Joi.object({
-    namespace: Joi.object({
-      name: Joi.string().required(),
-    }),
-  }),
+  results: Joi.array()
+    .items(
+      Joi.object({
+        download_count: nonNegativeInteger,
+      }),
+    )
+    .required(),
 }).required()
 
-class AnsibleGalaxyRole extends BaseJsonService {
-  async fetch({ roleId }) {
-    const url = `https://galaxy.ansible.com/api/v1/roles/${roleId}/`
-    return this._requestJson({
-      url,
-      schema: ansibleRoleSchema,
-    })
-  }
-}
+const AnsibleGalaxyRoleName = deprecatedService({
+  name: 'DeprecatedAnsibleGalaxyRoleName',
+  category: 'other',
+  route: {
+    base: 'ansible/role',
+    pattern: ':roleId',
+  },
+  label: 'role',
+  dateAdded: new Date('2023-10-10'),
+})
 
-class AnsibleGalaxyRoleDownloads extends AnsibleGalaxyRole {
+const AnsibleGalaxyRoleLegacyDownloads = deprecatedService({
+  name: 'DeprecatedAnsibleGalaxyRoleDownloads',
+  category: 'downloads',
+  route: {
+    base: 'ansible/role/d',
+    pattern: ':roleId',
+  },
+  label: 'role downloads',
+  dateAdded: new Date('2023-10-10'),
+})
+
+class AnsibleGalaxyRoleDownloads extends BaseJsonService {
   static category = 'downloads'
-  static route = { base: 'ansible/role/d', pattern: ':roleId' }
+  static route = { base: 'ansible/role/d', pattern: ':namespace/:name' }
 
   static openApi = {
-    '/ansible/role/d/{roleId}': {
+    '/ansible/role/d/{namespace}/{name}': {
       get: {
         summary: 'Ansible Role',
-        parameters: pathParams({ name: 'roleId', example: '3078' }),
+        parameters: pathParams(
+          { name: 'namespace', example: 'openwisp' },
+          { name: 'name', example: 'openwisp2' },
+        ),
       },
     },
   }
 
   static defaultBadgeData = { label: 'role downloads' }
 
-  async handle({ roleId }) {
-    const json = await this.fetch({ roleId })
-    return renderDownloadsBadge({ downloads: json.download_count })
+  async fetch({ namespace, name }) {
+    const url = 'https://galaxy.ansible.com/api/v1/roles/'
+    return this._requestJson({
+      url,
+      schema: ansibleRoleSchema,
+      options: { searchParams: { namespace, name, limit: 1 } },
+    })
+  }
+
+  async handle({ namespace, name }) {
+    const json = await this.fetch({ namespace, name })
+    if (json.results.length === 0) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return renderDownloadsBadge({ downloads: json.results[0].download_count })
   }
 }
 
-class AnsibleGalaxyRoleName extends AnsibleGalaxyRole {
-  static category = 'other'
-  static route = { base: 'ansible/role', pattern: ':roleId' }
-
-  static openApi = {
-    '/ansible/role/{roleId}': {
-      get: {
-        summary: 'Ansible Galaxy Role Name',
-        parameters: pathParams({ name: 'roleId', example: '3078' }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'role' }
-
-  static render({ name }) {
-    return { message: name, color: 'blue' }
-  }
-
-  async handle({ roleId }) {
-    const json = await this.fetch({ roleId })
-    const name = `${json.summary_fields.namespace.name}.${json.name}`
-    return this.constructor.render({ name })
-  }
+export {
+  AnsibleGalaxyRoleDownloads,
+  AnsibleGalaxyRoleName,
+  AnsibleGalaxyRoleLegacyDownloads,
 }
-
-export { AnsibleGalaxyRoleDownloads, AnsibleGalaxyRoleName }

--- a/services/ansible/ansible-role.tester.js
+++ b/services/ansible/ansible-role.tester.js
@@ -1,23 +1,23 @@
 import { isMetric } from '../test-validators.js'
 import { ServiceTester } from '../tester.js'
 export const t = new ServiceTester({
-  id: 'AnsibleRole',
-  title: 'AnsibleRole',
+  id: 'AnsibleGalaxyRole',
+  title: 'AnsibleGalaxyRole',
   pathPrefix: '/ansible/role',
 })
 
-t.create('role name (valid)')
+t.create('role name')
   .get('/14542.json')
-  .expectBadge({ label: 'role', message: 'openwisp.openwisp2' })
+  .expectBadge({ label: 'role', message: 'no longer available' })
 
-t.create('role name (not found)')
-  .get('/000.json')
-  .expectBadge({ label: 'role', message: 'not found' })
+t.create('role downloads (deprecated)')
+  .get('/d/14542.json')
+  .expectBadge({ label: 'role downloads', message: 'no longer available' })
 
 t.create('role downloads (valid)')
-  .get('/d/14542.json')
+  .get('/d/openwisp/openwisp2.json')
   .expectBadge({ label: 'role downloads', message: isMetric })
 
 t.create('role downloads (not found)')
-  .get('/d/does-not-exist.json')
+  .get('/d/does-not/exist.json')
   .expectBadge({ label: 'role downloads', message: 'not found' })


### PR DESCRIPTION
This PR implements the proposals from https://github.com/badges/shields/issues/9631#issuecomment-1753494195

- deprecate ansible galaxy collection name
- deprecate ansible galaxy quality score
- deprecate ansible role name
- deprecate ansible role downloads and replace with a new (but non-backwards-compatible) ansible role downloads badge