### PR TITLE
Fix several typos

### DIFF
--- a/badge-maker/lib/xml.js
+++ b/badge-maker/lib/xml.js
@@ -35,7 +35,7 @@ class XmlElement {
    *    Name of the XML tag
    * @param {Array.<string|module:badge-maker/lib/xml~XmlElement>} [attrs.content=[]]
    *    Array of objects to render inside the tag. content may contain a mix of
-   *    string and XmlElement objects. If content is `[]` or ommitted the
+   *    string and XmlElement objects. If content is `[]` or omitted the
    *    element will be rendered as a self-closing element.
    * @param {object} [attrs.attrs={}]
    *    Object representing the tag's attributes as name/value pairs

--- a/core/base-service/base-graphql.js
+++ b/core/base-service/base-graphql.js
@@ -20,7 +20,7 @@ class BaseGraphqlService extends BaseService {
   /**
    * Parse data from JSON endpoint
    *
-   * @param {string} buffer JSON repsonse from upstream API
+   * @param {string} buffer JSON response from upstream API
    * @returns {object} Parsed response
    */
   _parseJson(buffer) {
@@ -51,7 +51,7 @@ class BaseGraphqlService extends BaseService {
    *    for allowed keys
    *    and {@link module:core/base-service/errors~RuntimeErrorProps} for allowed values
    * @param {Function} [attrs.transformJson=data => data] Function which takes the raw json and transforms it before
-   * further procesing. In case of multiple query in a single graphql call and few of them
+   * further processing. In case of multiple query in a single graphql call and few of them
    * throw error, partial data might be used ignoring the error.
    * @param {Function} [attrs.transformErrors=defaultTransformErrors]
    *    Function which takes an errors object from a GraphQL

--- a/core/base-service/base-json.js
+++ b/core/base-service/base-json.js
@@ -14,7 +14,7 @@ class BaseJsonService extends BaseService {
   /**
    * Parse data from JSON endpoint
    *
-   * @param {string} buffer JSON repsonse from upstream API
+   * @param {string} buffer JSON response from upstream API
    * @returns {object} Parsed response
    */
   _parseJson(buffer) {

--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -322,7 +322,7 @@ describe('BaseService', function () {
   })
 
   describe('ScoutCamp integration', function () {
-    // TODO Strangly, without the useless escape the regexes do not match in Node 12.
+    // TODO Strangely, without the useless escape the regexes do not match in Node 12.
     // eslint-disable-next-line no-useless-escape
     const expectedRouteRegex = /^\/foo(?:\/([^\/#\?]+?))(|\.svg|\.json)$/
 

--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -363,7 +363,7 @@ function pathParam({
  *   { name: 'name2', example: 'example2' },
  * )
  * ```
- * is equivilent to
+ * is equivalent to
  * ```
  * const params = [
  *   pathParam({ name: 'name1', example: 'example1' }),
@@ -409,7 +409,7 @@ function queryParam({
  *   { name: 'name2', example: 'example2' },
  * )
  * ```
- * is equivilent to
+ * is equivalent to
  * ```
  * const params = [
  *   queryParam({ name: 'name1', example: 'example1' }),

--- a/services/github/github-directory-file-count.spec.js
+++ b/services/github/github-directory-file-count.spec.js
@@ -32,13 +32,13 @@ describe('GithubDirectoryFileCount', function () {
     })
   })
 
-  it('throws InvalidParameter on receving an object as contents instead of an array', function () {
+  it('throws InvalidParameter on receiving an object as contents instead of an array', function () {
     expect(() => GithubDirectoryFileCount.transform({}, {}))
       .to.throw(InvalidParameter)
       .with.property('prettyMessage', 'not a directory')
   })
 
-  it('throws InvalidParameter on receving type dir and extension', function () {
+  it('throws InvalidParameter on receiving type dir and extension', function () {
     expect(() =>
       GithubDirectoryFileCount.transform(contents, {
         type: 'dir',
@@ -52,7 +52,7 @@ describe('GithubDirectoryFileCount', function () {
       )
   })
 
-  it('throws InvalidParameter on receving no type and extension', function () {
+  it('throws InvalidParameter on receiving no type and extension', function () {
     expect(() =>
       GithubDirectoryFileCount.transform(contents, { extension: 'js' }),
     )

--- a/services/packagist/packagist-license.tester.js
+++ b/services/packagist/packagist-license.tester.js
@@ -6,7 +6,7 @@ t.create('license (valid)')
   .expectBadge({ label: 'license', message: 'MIT' })
 
 // note: packagist does serve up license at the version level
-// but our endpoint only supports fetching license for the lastest version
+// but our endpoint only supports fetching license for the latest version
 t.create('license (invalid, package version in request)')
   .get('/symfony/symfony/v2.8.0.json')
   .expectBadge({ label: '404', message: 'badge not found' })

--- a/services/pypi/pypi-version.tester.js
+++ b/services/pypi/pypi-version.tester.js
@@ -22,7 +22,7 @@ t.create('version (semver)').get('/requests.json').expectBadge({
   message: isSemver,
 })
 
-// ..whereas this project does not folow SemVer
+// ..whereas this project does not follow SemVer
 t.create('version (not semver)').get('/psycopg2.json').expectBadge({
   label: 'pypi',
   message: isPsycopg2Version,

--- a/services/static-badge/static-badge.service.js
+++ b/services/static-badge/static-badge.service.js
@@ -6,12 +6,12 @@ const description = `<p>
 </p>
 <ul>
   <li>
-    Label, message and color seperated by a dash <code>-</code>. For example:<br />
+    Label, message and color separated by a dash <code>-</code>. For example:<br />
     <img alt="any text: you like" src="https://img.shields.io/badge/any_text-you_like-blue" /> -
     <a href="https://img.shields.io/badge/any_text-you_like-blue">https://img.shields.io/badge/any_text-you_like-blue</a>
   </li>
   <li>
-    Message and color only, seperated by a dash <code>-</code>. For example:<br />
+    Message and color only, separated by a dash <code>-</code>. For example:<br />
     <img alt="just the message" src="https://img.shields.io/badge/just%20the%20message-8A2BE2" /> -
     <a href="https://img.shields.io/badge/just%20the%20message-8A2BE2">https://img.shields.io/badge/just%20the%20message-8A2BE2</a>
   </li>
@@ -57,7 +57,7 @@ export default class StaticBadge extends BaseStaticService {
           {
             name: 'badgeContent',
             description:
-              'Label, (optional) message, and color. Seperated by dashes',
+              'Label, (optional) message, and color. Separated by dashes',
             in: 'path',
             required: true,
             schema: { type: 'string' },

--- a/services/website-status.js
+++ b/services/website-status.js
@@ -8,7 +8,7 @@ import Joi from 'joi'
 
 /**
  * Joi schema for validating query params.
- * Checks if the query params obect has valid up_message, down_message, up_color and down_color properties.
+ * Checks if the query params object has valid up_message, down_message, up_color and down_color properties.
  *
  * @type {Joi}
  */


### PR DESCRIPTION
I observed that "separated" was misspelled at the top of https://shields.io/badges so this PR addresses those typos.

I then ran the codespell tool, which identified some additional typos (some of which might not be user-facing). Those are included in this PR, too.