### PR TITLE
stop linking to twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@
     <a href="https://discord.gg/HjJCwm5">
         <img src="https://img.shields.io/discord/308323056592486420?logo=discord"
             alt="chat on Discord"></a>
-    <a href="https://twitter.com/intent/follow?screen_name=shields_io">
-        <img src="https://img.shields.io/twitter/follow/shields_io?style=social&logo=X"
-            alt="follow on Twitter"></a>
 </p>
 
 This is home to [Shields.io][shields.io], a service for concise, consistent,

--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -93,10 +93,6 @@ const config = {
                 href: 'https://discord.gg/HjJCwm5',
               },
               {
-                label: 'X',
-                href: 'https://twitter.com/shields_io',
-              },
-              {
                 label: 'Awesome Badges',
                 href: 'https://github.com/badges/awesome-badges',
               },


### PR DESCRIPTION
Follow on from https://github.com/badges/shields/pull/9678#issuecomment-1777898375

Given the one person with access to this is no longer actively checking it, I'm not convinced it is a useful thing to still be pointing people at.

So we could just.. stop.