### PR TITLE
add meaningful descriptions including keywords; affects [amo bitcomponents coincap conan cpan]

### DIFF
--- a/services/amo/amo-base.js
+++ b/services/amo/amo-base.js
@@ -2,7 +2,8 @@ import Joi from 'joi'
 import { nonNegativeInteger } from '../validators.js'
 import { BaseJsonService } from '../index.js'
 
-const keywords = ['amo', 'firefox']
+const description =
+  '[addons.mozilla.org](https://addons.mozilla.org) (AMO) publishes extensions for Mozilla Firefox'
 
 const schema = Joi.object({
   average_daily_users: nonNegativeInteger,
@@ -26,4 +27,4 @@ class BaseAmoService extends BaseJsonService {
   }
 }
 
-export { BaseAmoService, keywords }
+export { BaseAmoService, description }

--- a/services/amo/amo-downloads.service.js
+++ b/services/amo/amo-downloads.service.js
@@ -1,8 +1,9 @@
 import { renderDownloadsBadge } from '../downloads.js'
 import { redirector, pathParams } from '../index.js'
-import { BaseAmoService } from './amo-base.js'
+import { BaseAmoService, description as baseDescription } from './amo-base.js'
 
-const description = `
+const description = `${baseDescription}
+
 Previously \`amo/d\` provided a &ldquo;total downloads&rdquo; badge. However,
 [updates to the v3 API](https://github.com/badges/shields/issues/3079)
 only give us weekly downloads. The route \`amo/d\` redirects to \`amo/dw\`.

--- a/services/amo/amo-rating.service.js
+++ b/services/amo/amo-rating.service.js
@@ -1,7 +1,7 @@
 import { starRating } from '../text-formatters.js'
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { pathParams } from '../index.js'
-import { BaseAmoService } from './amo-base.js'
+import { BaseAmoService, description } from './amo-base.js'
 
 export default class AmoRating extends BaseAmoService {
   static category = 'rating'
@@ -11,12 +11,14 @@ export default class AmoRating extends BaseAmoService {
     '/amo/rating/{addonId}': {
       get: {
         summary: 'Mozilla Add-on Rating',
+        description,
         parameters: pathParams({ name: 'addonId', example: 'dustman' }),
       },
     },
     '/amo/stars/{addonId}': {
       get: {
         summary: 'Mozilla Add-on Stars',
+        description,
         parameters: pathParams({ name: 'addonId', example: 'dustman' }),
       },
     },

--- a/services/amo/amo-users.service.js
+++ b/services/amo/amo-users.service.js
@@ -1,6 +1,6 @@
 import { renderDownloadsBadge } from '../downloads.js'
 import { pathParams } from '../index.js'
-import { BaseAmoService } from './amo-base.js'
+import { BaseAmoService, description } from './amo-base.js'
 
 export default class AmoUsers extends BaseAmoService {
   static category = 'downloads'
@@ -10,6 +10,7 @@ export default class AmoUsers extends BaseAmoService {
     '/amo/users/{addonId}': {
       get: {
         summary: 'Mozilla Add-on Users',
+        description,
         parameters: pathParams({ name: 'addonId', example: 'dustman' }),
       },
     },

--- a/services/amo/amo-version.service.js
+++ b/services/amo/amo-version.service.js
@@ -1,6 +1,6 @@
 import { renderVersionBadge } from '../version.js'
 import { pathParams } from '../index.js'
-import { BaseAmoService } from './amo-base.js'
+import { BaseAmoService, description } from './amo-base.js'
 
 export default class AmoVersion extends BaseAmoService {
   static category = 'version'
@@ -10,6 +10,7 @@ export default class AmoVersion extends BaseAmoService {
     '/amo/v/{addonId}': {
       get: {
         summary: 'Mozilla Add-on Version',
+        description,
         parameters: pathParams({ name: 'addonId', example: 'dustman' }),
       },
     },

--- a/services/bit/bit-components.service.js
+++ b/services/bit/bit-components.service.js
@@ -20,7 +20,7 @@ export default class BitComponents extends BaseJsonService {
   static openApi = {
     '/bit/collection/total-components/{owner}/{collection}': {
       get: {
-        summary: 'Bit',
+        summary: 'Bit Components',
         parameters: pathParams(
           {
             name: 'owner',

--- a/services/coincap/coincap-base.js
+++ b/services/coincap/coincap-base.js
@@ -1,5 +1,8 @@
 import { BaseJsonService } from '../index.js'
 
+const description =
+  '[Coincap](https://coincap.io/) is a cryptocurrency exchange'
+
 export default class BaseCoincapService extends BaseJsonService {
   static category = 'other'
 
@@ -19,4 +22,4 @@ export default class BaseCoincapService extends BaseJsonService {
   }
 }
 
-export { BaseCoincapService }
+export { BaseCoincapService, description }

--- a/services/coincap/coincap-changepercent24hr.service.js
+++ b/services/coincap/coincap-changepercent24hr.service.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { pathParams } from '../index.js'
 import { floorCount } from '../color-formatters.js'
-import BaseCoincapService from './coincap-base.js'
+import { BaseCoincapService, description } from './coincap-base.js'
 
 const schema = Joi.object({
   data: Joi.object({
@@ -19,6 +19,7 @@ export default class CoincapChangePercent24HrUsd extends BaseCoincapService {
     '/coincap/change-percent-24hr/{assetId}': {
       get: {
         summary: 'Coincap (Change Percent 24Hr)',
+        description,
         parameters: pathParams({
           name: 'assetId',
           example: 'bitcoin',

--- a/services/coincap/coincap-priceusd.service.js
+++ b/services/coincap/coincap-priceusd.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { pathParams } from '../index.js'
-import BaseCoincapService from './coincap-base.js'
+import { BaseCoincapService, description } from './coincap-base.js'
 
 const schema = Joi.object({
   data: Joi.object({
@@ -18,6 +18,7 @@ export default class CoincapPriceUsd extends BaseCoincapService {
     '/coincap/price-usd/{assetId}': {
       get: {
         summary: 'Coincap (Price USD)',
+        description,
         parameters: pathParams({
           name: 'assetId',
           example: 'bitcoin',

--- a/services/coincap/coincap-rank.service.js
+++ b/services/coincap/coincap-rank.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { pathParams } from '../index.js'
-import BaseCoincapService from './coincap-base.js'
+import { BaseCoincapService, description } from './coincap-base.js'
 
 const schema = Joi.object({
   data: Joi.object({
@@ -18,6 +18,7 @@ export default class CoincapRank extends BaseCoincapService {
     '/coincap/rank/{assetId}': {
       get: {
         summary: 'Coincap (Rank)',
+        description,
         parameters: pathParams({
           name: 'assetId',
           example: 'bitcoin',

--- a/services/conan/conan-version.service.js
+++ b/services/conan/conan-version.service.js
@@ -13,6 +13,7 @@ export default class ConanVersion extends ConditionalGithubAuthV3Service {
     '/conan/v/{packageName}': {
       get: {
         summary: 'Conan Center',
+        description: '[Conan](https://conan.io/) is a package manager for C++',
         parameters: pathParams({
           name: 'packageName',
           example: 'boost',

--- a/services/cpan/cpan-license.service.js
+++ b/services/cpan/cpan-license.service.js
@@ -1,5 +1,5 @@
 import { pathParams } from '../index.js'
-import BaseCpanService from './cpan.js'
+import { BaseCpanService, description } from './cpan.js'
 
 export default class CpanLicense extends BaseCpanService {
   static category = 'license'
@@ -9,6 +9,7 @@ export default class CpanLicense extends BaseCpanService {
     '/cpan/l/{packageName}': {
       get: {
         summary: 'CPAN License',
+        description,
         parameters: pathParams({
           name: 'packageName',
           example: 'Config-Augeas',

--- a/services/cpan/cpan-version.service.js
+++ b/services/cpan/cpan-version.service.js
@@ -1,6 +1,6 @@
 import { pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
-import BaseCpanService from './cpan.js'
+import { BaseCpanService, description } from './cpan.js'
 
 export default class CpanVersion extends BaseCpanService {
   static category = 'version'
@@ -10,6 +10,7 @@ export default class CpanVersion extends BaseCpanService {
     '/cpan/v/{packageName}': {
       get: {
         summary: 'CPAN Version',
+        description,
         parameters: pathParams({
           name: 'packageName',
           example: 'Config-Augeas',

--- a/services/cpan/cpan.js
+++ b/services/cpan/cpan.js
@@ -6,6 +6,9 @@ const schema = Joi.object({
   license: Joi.array().items(Joi.string()).min(1).required(),
 }).required()
 
+const description =
+  '[CPAN](https://www.cpan.org/) is a package registry for Perl'
+
 export default class BaseCpanService extends BaseJsonService {
   static defaultBadgeData = { label: 'cpan' }
 
@@ -14,3 +17,5 @@ export default class BaseCpanService extends BaseJsonService {
     return this._requestJson({ schema, url })
   }
 }
+
+export { BaseCpanService, description }


### PR DESCRIPTION
Refs #9285

This PR comes out of a comment in the PR #9500 review: https://github.com/badges/shields/pull/9500#discussion_r1378685603

I haven't tackled every single case, but I decided to start off by taking an initial subset of services where we removed keywords when I did earlier conversion PRs, just to think it through and get a feel for this task.

In order to make text available to our search plugin, it needs to be user-visible text on the page. We can't give it "hidden" tags or keywords. In general, I don't think that's a bad thing: One of the things we should be working towards is providing clearer user-facing documentation. If you land directly on https://shields.io/badges/clojars-downloads (for the sake of argument), I think we can do more to explain "what is this thing, and why do you care about it" than we do now.

I think having tried to do a few of these, this format of describing the upstream service e.g:

> [Conan](https://conan.io/) is a package manager for C++"

seems to lend itself reasonably well to achieving that objective and fitting all the right keywords in. It also means if we've got 10 badges for a service, we can rely on the "summary" field to describe the badge and share a more generic description across a bunch of badges if we want. We don't need to write a slightly different description for each one just to get the keywords in (although in some cases, the might be useful for some other reason). Interested to know if others think this "voice" works stylistically.

I've not really hit this situation so far, but another possible thing we could do if we're struggling to mash a word soup of keywords into a natural language sentence or two is literally write something like

> keywords: firefox, amo, extension

or

> tags: firefox, amo, extension

at the end of the description just to make those words searchable text on the page.

/cc @PyvesB 