### PR TITLE
fix [GitHubCommitActivity] service tests

### DIFF
--- a/services/github/github-commit-activity.tester.js
+++ b/services/github/github-commit-activity.tester.js
@@ -35,7 +35,7 @@ t.create('commit activity (1 year) by author')
   .get(`/y/badges/shields.json?authorFilter=${authorFilterUser}`)
   .expectBadge({
     label: `commit activity by ${authorFilterUser}`,
-    message: isMetricOverTimePeriod,
+    message: isCommitActivity,
   })
 
 t.create('commit activity (1 month)').get('/m/eslint/eslint.json').expectBadge({
@@ -47,7 +47,7 @@ t.create('commit activity (1 month) by author')
   .get(`/m/badges/shields.json?authorFilter=${authorFilterUser}`)
   .expectBadge({
     label: `commit activity by ${authorFilterUser}`,
-    message: isMetricOverTimePeriod,
+    message: isCommitActivity,
   })
 
 t.create('commit activity (4 weeks)')
@@ -61,7 +61,7 @@ t.create('commit activity (4 weeks) by author')
   .get(`/4w/badges/shields.json?authorFilter=${authorFilterUser}`)
   .expectBadge({
     label: `commit activity by ${authorFilterUser}`,
-    message: isMetricOverTimePeriod,
+    message: isCommitActivity,
   })
 
 t.create('commit activity (1 week)').get('/w/eslint/eslint.json').expectBadge({


### PR DESCRIPTION
Hit failures on this in a couple of PRs lately.
This is going to be hard to write in a way that doesn't just keep breaking, so I've changed these test cases to allow `isZeroOverTimePeriod`