### PR TITLE
[Discord] Edit badge defaults.

### DIFF
--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -47,12 +47,12 @@ export default class Discord extends BaseJsonService {
 
   static _cacheLength = 30
 
-  static defaultBadgeData = { label: 'chat' }
+  static defaultBadgeData = { label: 'Discord' }
 
   static render({ members }) {
     return {
       message: `${members} online`,
-      color: 'brightgreen',
+      color: '#5865F2',
     }
   }
 

--- a/services/discord/discord.spec.js
+++ b/services/discord/discord.spec.js
@@ -30,7 +30,7 @@ describe('Discord', function () {
       }),
     ).to.deep.equal({
       message: '125 online',
-      color: 'brightgreen',
+      color: '#5865F2',
     })
 
     scope.done()

--- a/services/discord/discord.tester.js
+++ b/services/discord/discord.tester.js
@@ -5,14 +5,14 @@ export const t = await createServiceTester()
 t.create('gets status for Reactiflux')
   .get('/102860784329052160.json')
   .expectBadge({
-    label: 'chat',
+    label: 'Discord',
     message: Joi.string().regex(/^[0-9]+ online$/),
-    color: 'brightgreen',
+    color: '#5865F2',
   })
 
 t.create('invalid server ID')
   .get('/12345.json')
-  .expectBadge({ label: 'chat', message: 'invalid server' })
+  .expectBadge({ label: 'Discord', message: 'invalid server' })
 
 t.create('widget disabled')
   .get('/12345.json')
@@ -24,7 +24,7 @@ t.create('widget disabled')
         message: 'Widget Disabled',
       }),
   )
-  .expectBadge({ label: 'chat', message: 'widget disabled' })
+  .expectBadge({ label: 'Discord', message: 'widget disabled' })
 
 t.create('server error')
   .get('/12345.json')
@@ -33,4 +33,4 @@ t.create('server error')
       .get('/api/v6/guilds/12345/widget.json')
       .reply(500, 'Something broke'),
   )
-  .expectBadge({ label: 'chat', message: 'inaccessible' })
+  .expectBadge({ label: 'Discord', message: 'inaccessible' })


### PR DESCRIPTION
Label the badge as "Discord" instead of "chat". Use the official Discord logo's color value of 5865F2.