### PR TITLE
[Discourse] Update schema keys to use plural form (`topic_count` -> `topics_count`)

### DIFF
--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -18,10 +18,7 @@ const schemaPlural = Joi.object({
   likes_count: nonNegativeInteger,
 })
 
-const schema = Joi.alternatives(
-  schemaSingular,
-  schemaPlural,
-)
+const schema = Joi.alternatives(schemaSingular, schemaPlural)
 
 const queryParamSchema = Joi.object({
   server: optionalUrl.required(),
@@ -79,11 +76,11 @@ function DiscourseMetricIntegrationFactory({ metricType }) {
     async handle(_routeParams, { server }) {
       const data = await this.fetch({ server })
       // e.g. metricType == 'topic' --> try 'topic_count' then 'topics_count'
-      let stat = data[`${metricType}_count`];
+      let stat = data[`${metricType}_count`]
       if (stat === undefined) {
-        stat = data[`${metricType}s_count`];
+        stat = data[`${metricType}s_count`]
       }
-      return this.constructor.render({ stat });
+      return this.constructor.render({ stat })
     }
   }
 }

--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -4,12 +4,24 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger, optionalUrl } from '../validators.js'
 import { BaseJsonService } from '../index.js'
 
-const schema = Joi.object({
+const schemaSingular = Joi.object({
   topic_count: nonNegativeInteger,
   user_count: nonNegativeInteger,
   post_count: nonNegativeInteger,
   like_count: nonNegativeInteger,
 }).required()
+
+const schemaPlural = Joi.object({
+  topics_count: nonNegativeInteger,
+  users_count: nonNegativeInteger,
+  posts_count: nonNegativeInteger,
+  likes_count: nonNegativeInteger,
+})
+
+const schema = Joi.alternatives(
+  schemaSingular,
+  schemaPlural,
+)
 
 const queryParamSchema = Joi.object({
   server: optionalUrl.required(),

--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -4,11 +4,15 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger, optionalUrl } from '../validators.js'
 import { BaseJsonService } from '../index.js'
 
+// Note: At some point, Discourse changed its metrics from e.g. 'topic_count'
+// to 'topics_count' (plural). Newer servers seem to use this plural form,
+// but older servers may exist that rely on the singular form. See also:
+// https://github.com/badges/shields/issues/9776
 const schema = Joi.object({
-  topic_count: nonNegativeInteger,
-  user_count: nonNegativeInteger,
-  post_count: nonNegativeInteger,
-  like_count: nonNegativeInteger,
+  topics_count: nonNegativeInteger,
+  users_count: nonNegativeInteger,
+  posts_count: nonNegativeInteger,
+  likes_count: nonNegativeInteger,
 }).required()
 
 const queryParamSchema = Joi.object({
@@ -97,10 +101,10 @@ class DiscourseStatus extends DiscourseBase {
 }
 
 const metricIntegrations = [
-  { metricName: 'topics', property: 'topic_count' },
-  { metricName: 'users', property: 'user_count' },
-  { metricName: 'posts', property: 'post_count' },
-  { metricName: 'likes', property: 'like_count' },
+  { metricName: 'topics', property: 'topics_count' },
+  { metricName: 'users', property: 'users_count' },
+  { metricName: 'posts', property: 'posts_count' },
+  { metricName: 'likes', property: 'likes_count' },
 ].map(DiscourseMetricIntegrationFactory)
 
 export default [...metricIntegrations, DiscourseStatus]

--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -4,15 +4,11 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger, optionalUrl } from '../validators.js'
 import { BaseJsonService } from '../index.js'
 
-// Note: At some point, Discourse changed its metrics from e.g. 'topic_count'
-// to 'topics_count' (plural). Newer servers seem to use this plural form,
-// but older servers may exist that rely on the singular form. See also:
-// https://github.com/badges/shields/issues/9776
 const schema = Joi.object({
-  topics_count: nonNegativeInteger,
-  users_count: nonNegativeInteger,
-  posts_count: nonNegativeInteger,
-  likes_count: nonNegativeInteger,
+  topic_count: nonNegativeInteger,
+  user_count: nonNegativeInteger,
+  post_count: nonNegativeInteger,
+  like_count: nonNegativeInteger,
 }).required()
 
 const queryParamSchema = Joi.object({
@@ -101,10 +97,10 @@ class DiscourseStatus extends DiscourseBase {
 }
 
 const metricIntegrations = [
-  { metricName: 'topics', property: 'topics_count' },
-  { metricName: 'users', property: 'users_count' },
-  { metricName: 'posts', property: 'posts_count' },
-  { metricName: 'likes', property: 'likes_count' },
+  { metricName: 'topics', property: 'topic_count' },
+  { metricName: 'users', property: 'user_count' },
+  { metricName: 'posts', property: 'post_count' },
+  { metricName: 'likes', property: 'like_count' },
 ].map(DiscourseMetricIntegrationFactory)
 
 export default [...metricIntegrations, DiscourseStatus]

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -7,9 +7,9 @@ export const t = new ServiceTester({
 })
 
 const data = {
-  topics_count: 22513,
-  posts_count: 337719,
-  users_count: 31220,
+  topic_count: 22513,
+  post_count: 337719,
+  user_count: 31220,
   topics_7_days: 143,
   topics_30_days: 551,
   posts_7_days: 2679,
@@ -18,7 +18,7 @@ const data = {
   users_30_days: 803,
   active_users_7_days: 762,
   active_users_30_days: 1495,
-  likes_count: 308833,
+  like_count: 308833,
   likes_7_days: 3633,
   likes_30_days: 13397,
 }

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -6,76 +6,98 @@ export const t = new ServiceTester({
   title: 'Discourse',
 })
 
-const data = {
-  topic_count: 22513,
-  post_count: 337719,
-  user_count: 31220,
-  topics_7_days: 143,
-  topics_30_days: 551,
-  posts_7_days: 2679,
-  posts_30_days: 10445,
-  users_7_days: 204,
-  users_30_days: 803,
-  active_users_7_days: 762,
-  active_users_30_days: 1495,
-  like_count: 308833,
-  likes_7_days: 3633,
-  likes_30_days: 13397,
-}
+const dataCases = [
+  {
+    // Singular form
+    topic_count: 22513,
+    post_count: 337719,
+    user_count: 31220,
+    topics_7_days: 143,
+    topics_30_days: 551,
+    posts_7_days: 2679,
+    posts_30_days: 10445,
+    users_7_days: 204,
+    users_30_days: 803,
+    active_users_7_days: 762,
+    active_users_30_days: 1495,
+    like_count: 308833,
+    likes_7_days: 3633,
+    likes_30_days: 13397,
+  },
+  {
+    // Plural form
+    topics_count: 22513,
+    posts_count: 337719,
+    users_count: 31220,
+    topics_7_days: 143,
+    topics_30_days: 551,
+    posts_7_days: 2679,
+    posts_30_days: 10445,
+    users_7_days: 204,
+    users_30_days: 803,
+    active_users_7_days: 762,
+    active_users_30_days: 1495,
+    likes_count: 308833,
+    likes_7_days: 3633,
+    likes_30_days: 13397,
+  },
+];
 
-t.create('Topics')
-  .get('/topics.json?server=https://meta.discourse.org')
-  .intercept(nock =>
-    nock('https://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: '23k topics' })
+dataCases.forEach((data) => {
+  t.create('Topics')
+    .get('/topics.json?server=https://meta.discourse.org')
+    .intercept(nock =>
+      nock('https://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: '23k topics' })
 
-t.create('Posts')
-  .get('/posts.json?server=https://meta.discourse.org')
-  .intercept(nock =>
-    nock('https://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: '338k posts' })
+  t.create('Posts')
+    .get('/posts.json?server=https://meta.discourse.org')
+    .intercept(nock =>
+      nock('https://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: '338k posts' })
 
-t.create('Users')
-  .get('/users.json?server=https://meta.discourse.org')
-  .intercept(nock =>
-    nock('https://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: '31k users' })
+  t.create('Users')
+    .get('/users.json?server=https://meta.discourse.org')
+    .intercept(nock =>
+      nock('https://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: '31k users' })
 
-t.create('Likes')
-  .get('/likes.json?server=https://meta.discourse.org')
-  .intercept(nock =>
-    nock('https://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: '309k likes' })
+  t.create('Likes')
+    .get('/likes.json?server=https://meta.discourse.org')
+    .intercept(nock =>
+      nock('https://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: '309k likes' })
 
-t.create('Status')
-  .get('/status.json?server=https://meta.discourse.org')
-  .intercept(nock =>
-    nock('https://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: 'online' })
+  t.create('Status')
+    .get('/status.json?server=https://meta.discourse.org')
+    .intercept(nock =>
+      nock('https://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: 'online' })
 
-t.create('Status with http (not https)')
-  .get('/status.json?server=http://meta.discourse.org')
-  .intercept(nock =>
-    nock('http://meta.discourse.org')
-      .get('/site/statistics.json')
-      .reply(200, data),
-  )
-  .expectBadge({ label: 'discourse', message: 'online' })
+  t.create('Status with http (not https)')
+    .get('/status.json?server=http://meta.discourse.org')
+    .intercept(nock =>
+      nock('http://meta.discourse.org')
+        .get('/site/statistics.json')
+        .reply(200, data),
+    )
+    .expectBadge({ label: 'discourse', message: 'online' })
+});
 
 t.create('Invalid Host')
   .get('/status.json?server=https://some.host')

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -41,9 +41,9 @@ const dataCases = [
     likes_7_days: 3633,
     likes_30_days: 13397,
   },
-];
+]
 
-dataCases.forEach((data) => {
+dataCases.forEach(data => {
   t.create('Topics')
     .get('/topics.json?server=https://meta.discourse.org')
     .intercept(nock =>
@@ -97,7 +97,7 @@ dataCases.forEach((data) => {
         .reply(200, data),
     )
     .expectBadge({ label: 'discourse', message: 'online' })
-});
+})
 
 t.create('Invalid Host')
   .get('/status.json?server=https://some.host')

--- a/services/discourse/discourse.tester.js
+++ b/services/discourse/discourse.tester.js
@@ -7,9 +7,9 @@ export const t = new ServiceTester({
 })
 
 const data = {
-  topic_count: 22513,
-  post_count: 337719,
-  user_count: 31220,
+  topics_count: 22513,
+  posts_count: 337719,
+  users_count: 31220,
   topics_7_days: 143,
   topics_30_days: 551,
   posts_7_days: 2679,
@@ -18,7 +18,7 @@ const data = {
   users_30_days: 803,
   active_users_7_days: 762,
   active_users_30_days: 1495,
-  like_count: 308833,
+  likes_count: 308833,
   likes_7_days: 3633,
   likes_30_days: 13397,
 }


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

This PR does a simple find and replace to update the Discourse schema to use the current keys found in https://meta.discourse.org/site/statistics.json, as the older keys now return "Invalid response".

> [!NOTE] 
> I was wondering, though, if the old keys should still be preserved, as to not break backwards compatibility with servers using the old names. 
>
> (I tried finding the source of the change in Discourse's release notes/changelog, but there's surprisingly little information when querying e.g. "statistics.json" or "topic_count"/"topics_count". So, I'm not sure when this change actually took place, and thus it's hard to estimate the likelihood of there being servers out there using the old keys.)
>
> If we do want to support both sets of keys, then I'm not 100% sure what to do, as I've never written JavaScript before. (I tried reading the Joi docs, and got as far as using `.or()` in the schema definition for each pair of keys + using a `try`/`catch` when creating the `metricIntegrations` object, but I wasn't confident enough to commit that solution before discussing it first.)

Fixes #9776.