### PR TITLE
cache some badges for longer

### DIFF
--- a/services/bundlephobia/bundlephobia.service.js
+++ b/services/bundlephobia/bundlephobia.service.js
@@ -65,6 +65,8 @@ export default class Bundlephobia extends BaseJsonService {
     },
   ]
 
+  static _cacheLength = 900
+
   static defaultBadgeData = { label: 'bundlephobia', color: 'informational' }
 
   static render({ format, size }) {

--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -49,7 +49,7 @@ export default class Discord extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 60
+  static _cacheLength = 300
 
   static defaultBadgeData = { label: 'chat' }
 

--- a/services/opencollective/opencollective-all.service.js
+++ b/services/opencollective/opencollective-all.service.js
@@ -16,7 +16,7 @@ export default class OpencollectiveAll extends OpencollectiveBase {
     },
   }
 
-  static _cacheLength = 1800
+  static _cacheLength = 3600
 
   static defaultBadgeData = {
     label: 'backers and sponsors',

--- a/services/opencollective/opencollective-backers.service.js
+++ b/services/opencollective/opencollective-backers.service.js
@@ -16,7 +16,7 @@ export default class OpencollectiveBackers extends OpencollectiveBase {
     },
   }
 
-  static _cacheLength = 1800
+  static _cacheLength = 3600
 
   static defaultBadgeData = {
     label: 'backers',

--- a/services/opencollective/opencollective-sponsors.service.js
+++ b/services/opencollective/opencollective-sponsors.service.js
@@ -16,7 +16,7 @@ export default class OpencollectiveSponsors extends OpencollectiveBase {
     },
   }
 
-  static _cacheLength = 1800
+  static _cacheLength = 3600
 
   static defaultBadgeData = {
     label: 'sponsors',

--- a/services/pypi/pypi-downloads.service.js
+++ b/services/pypi/pypi-downloads.service.js
@@ -53,7 +53,7 @@ export default class PypiDownloads extends BaseJsonService {
     },
   ]
 
-  static _cacheLength = 21600
+  static _cacheLength = 28800
 
   static defaultBadgeData = { label: 'downloads' }
 


### PR DESCRIPTION
Having merged and deployed https://github.com/badges/shields/pull/9546 there's still a bunch of services where we're regularly hitting rate limits. Upping the caches again.

I'm a bit worried I might have completely smashed our sentry allowance for the month, but I wasn't able to immediately do something about this yesterday.

There are some other rate limiting issues which I will track elsewhere.

I'm going to just merge and deploy this one today.