### PR TITLE
[pub] Use official version endpoint for pub-service

### DIFF
--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -5,7 +5,7 @@ import { baseDescription } from './pub-common.js'
 
 const schema = Joi.object({
   versions: Joi.array()
-    .items(Joi.object({ version: Joi.string() }))
+    .items(Joi.object({ version: Joi.string().required() }))
     .required(),
 }).required()
 

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -45,14 +45,14 @@ class PubVersion extends BaseJsonService {
   async fetch({ packageName }) {
     return this._requestJson({
       schema,
-      url: `https://pub.dartlang.org/packages/${packageName}.json`,
+      url: `https://pub.dev/api/packages/${packageName}`,
     })
   }
 
   async handle({ packageName }, queryParams) {
     const data = await this.fetch({ packageName })
     const includePre = queryParams.include_prereleases !== undefined
-    const versions = data.versions
+    const versions = data.versions.map((x) => x.version)
     const version = latest(versions, { pre: includePre })
     return renderVersionBadge({ version })
   }

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -4,7 +4,9 @@ import { BaseJsonService, redirector, pathParam, queryParam } from '../index.js'
 import { baseDescription } from './pub-common.js'
 
 const schema = Joi.object({
-  versions: Joi.array().items(Joi.string()).required(),
+  versions: Joi.array()
+    .items(Joi.object({ version: Joi.string() }))
+    .required(),
 }).required()
 
 const queryParamSchema = Joi.object({

--- a/services/pub/pub.service.js
+++ b/services/pub/pub.service.js
@@ -52,7 +52,7 @@ class PubVersion extends BaseJsonService {
   async handle({ packageName }, queryParams) {
     const data = await this.fetch({ packageName })
     const includePre = queryParams.include_prereleases !== undefined
-    const versions = data.versions.map((x) => x.version)
+    const versions = data.versions.map(x => x.version)
     const version = latest(versions, { pre: includePre })
     return renderVersionBadge({ version })
   }


### PR DESCRIPTION
* pub.dartlang.org is replaced by pub.dev as the official pub site.
* `api/packages/<packageName>` is the official endpoint for retrieving a version listing.
  see https://pub.dev/help/api#hosted-pub-repository-api -> https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md#list-all-versions-of-a-package

The `packages/<packageName>.json` endpoint is obsolete and might go away.

