### PR TITLE
[NuGet BaGet]: Added new BaGet service (Self hosted NuGet server)

### DIFF
--- a/services/baget/baget.service.js
+++ b/services/baget/baget.service.js
@@ -1,0 +1,41 @@
+import { createServiceFamily } from '../nuget/nuget-v3-service-family.js'
+
+const { NugetVersionService: Version, NugetDownloadService: Downloads } =
+  createServiceFamily({
+    defaultLabel: 'baget',
+    serviceBaseUrl: 'baget',
+    withTenant: false,
+    withFeed: false,
+    withQueryNamedParams: false,
+    packageDataIncludesVersion: true,
+  })
+
+class BagetVersionService extends Version {
+  static examples = [
+    {
+      title: 'Baget',
+      pattern: 'v/:packageName',
+      namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+      staticPreview: this.render({ version: '5.2.4' }),
+    },
+    {
+      title: 'Baget (with prereleases)',
+      pattern: 'vpre/:packageName',
+      namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+      staticPreview: this.render({ version: '5.2.5-preview1' }),
+    },
+  ]
+}
+
+class BagetDownloadService extends Downloads {
+  static examples = [
+    {
+      title: 'Baget',
+      pattern: 'dt/:packageName',
+      namedParams: { packageName: 'Microsoft.AspNet.Mvc' },
+      staticPreview: this.render({ downloads: 49e6 }),
+    },
+  ]
+}
+
+export { BagetVersionService, BagetDownloadService }


### PR DESCRIPTION
This PR adds support for version & download badges from a [BaGet](https://github.com/loic-sharma/BaGet) server.

I'm not sure how to add examples / tests for this new service due to it's self hosted nature and no public instance being available (that I'm aware of)

I've tested badge generation against our local (private) BaGet instance with the following commands:

```sh
npm run badge -- /baget/v/<PackageName?source=<Instance url>
npm run badge -- /baget/vpre/<PackageName>?source=<Instance url>
npm run badge -- /baget/dt/<PackageName?source=<Instance url>
```

I've extended the logic from `nuget-v3-service-family` to support the small differences in API in the BaGet server api implementation, mainly searching without the `packageid` parameter and the package version being available in the response, without need for lookup in the `versions` array (which is also sorted in DESC, not ASC)
