### PR TITLE
increase page size for [githubrelease] badge by semver

### DIFF
--- a/services/github/github-common-release.js
+++ b/services/github/github-common-release.js
@@ -43,6 +43,7 @@ async function fetchReleases(serviceInstance, { user, repo }) {
     url: `/repos/${user}/${repo}/releases`,
     schema: releaseInfoArraySchema,
     ...commonAttrs,
+    options: { searchParams: { per_page: 100 } },
   })
   return releases
 }


### PR DESCRIPTION
This was something I spotted when I was thinking about the review for https://github.com/badges/shields/pull/9781

If we are requesting the latest version by semver (rather than date) we request the first page of releases and search it for the latest release. The default page size is 30 releases and the max is 100.

I'm not really sure what happened here. I don't know if GitHub changed the default page size from 100 to 30 at some point or we messed this up in a refactor somewhere, but currently we only search the most recent 30 releases not the most recent 100.

The tags badge already does this correctly https://github.com/badges/shields/blob/2814de2ecd3dffcd5206c1398a28191211cf63b5/services/github/github-tag.service.js#L87-L92
