### PR TITLE
migrate examples to openApi part 34; affects [github]

### DIFF
--- a/services/github/github-actions-workflow-status.service.js
+++ b/services/github/github-actions-workflow-status.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseSvgScrapingService } from '../index.js'
+import { BaseSvgScrapingService, pathParam, queryParam } from '../index.js'
 import { documentation } from './github-helpers.js'
 
 const schema = Joi.object({
@@ -14,8 +14,6 @@ const queryParamSchema = Joi.object({
   branch: Joi.alternatives().try(Joi.string(), Joi.number().cast('string')),
 }).required()
 
-const keywords = ['action', 'actions']
-
 export default class GithubActionsWorkflowStatus extends BaseSvgScrapingService {
   static category = 'build'
 
@@ -25,53 +23,26 @@ export default class GithubActionsWorkflowStatus extends BaseSvgScrapingService 
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'GitHub Workflow Status',
-      namedParams: {
-        user: 'actions',
-        repo: 'toolkit',
-        workflow: 'unit-tests.yml',
+  static openApi = {
+    '/github/actions/workflow/status/{user}/{repo}/{workflow}': {
+      get: {
+        summary: 'GitHub Actions Workflow Status',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'actions' }),
+          pathParam({ name: 'repo', example: 'toolkit' }),
+          pathParam({ name: 'workflow', example: 'unit-tests.yml' }),
+          queryParam({ name: 'branch', example: 'main' }),
+          queryParam({
+            name: 'event',
+            example: 'push',
+            description:
+              'See GitHub Actions [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) for allowed values.',
+          }),
+        ],
       },
-      staticPreview: renderBuildStatusBadge({
-        status: 'passing',
-      }),
-      documentation,
-      keywords,
     },
-    {
-      title: 'GitHub Workflow Status (with branch)',
-      namedParams: {
-        user: 'actions',
-        repo: 'toolkit',
-        workflow: 'unit-tests.yml',
-      },
-      queryParams: {
-        branch: 'main',
-      },
-      staticPreview: renderBuildStatusBadge({
-        status: 'passing',
-      }),
-      documentation,
-      keywords,
-    },
-    {
-      title: 'GitHub Workflow Status (with event)',
-      namedParams: {
-        user: 'actions',
-        repo: 'toolkit',
-        workflow: 'unit-tests.yml',
-      },
-      queryParams: {
-        event: 'push',
-      },
-      staticPreview: renderBuildStatusBadge({
-        status: 'passing',
-      }),
-      documentation,
-      keywords,
-    },
-  ]
+  }
 
   static _cacheLength = 60
 

--- a/services/github/github-commit-activity.service.js
+++ b/services/github/github-commit-activity.service.js
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag'
 import Joi from 'joi'
 import parseLinkHeader from 'parse-link-header'
-import { InvalidResponse } from '../index.js'
+import { InvalidResponse, pathParam, queryParam } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { GithubAuthV4Service } from './github-auth-service.js'
@@ -35,33 +35,51 @@ export default class GitHubCommitActivity extends GithubAuthV4Service {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'GitHub commit activity',
-      // Override the pattern to omit the deprecated interval "4w".
-      pattern: ':interval(t|y|m|w)/:user/:repo',
-      namedParams: { interval: 'm', user: 'eslint', repo: 'eslint' },
-      queryParams: { authorFilter: 'nzakas' },
-      staticPreview: this.render({ interval: 'm', commitCount: 457 }),
-      keywords: ['commits'],
-      documentation,
-    },
-    {
-      title: 'GitHub commit activity (branch)',
-      // Override the pattern to omit the deprecated interval "4w".
-      pattern: ':interval(t|y|m|w)/:user/:repo/:branch*',
-      namedParams: {
-        interval: 'm',
-        user: 'badges',
-        repo: 'squint',
-        branch: 'main',
+  static openApi = {
+    '/github/commit-activity/{interval}/{user}/{repo}': {
+      get: {
+        summary: 'GitHub commit activity',
+        description: documentation,
+        parameters: [
+          pathParam({
+            name: 'interval',
+            example: 'm',
+            description: 'Commits in the last Week, Month, Year, or Total',
+            schema: {
+              type: 'string',
+              // Override the enum to omit the deprecated interval "4w".
+              enum: ['w', 'm', 'y', 't'],
+            },
+          }),
+          pathParam({ name: 'user', example: 'badges' }),
+          pathParam({ name: 'repo', example: 'squint' }),
+          queryParam({ name: 'authorFilter', example: 'calebcartwright' }),
+        ],
       },
-      queryParams: { authorFilter: 'calebcartwright' },
-      staticPreview: this.render({ interval: 'm', commitCount: 5 }),
-      keywords: ['commits'],
-      documentation,
     },
-  ]
+    '/github/commit-activity/{interval}/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'GitHub commit activity (branch)',
+        description: documentation,
+        parameters: [
+          pathParam({
+            name: 'interval',
+            example: 'm',
+            description: 'Commits in the last Week, Month, Year, or Total',
+            schema: {
+              type: 'string',
+              // Override the enum to omit the deprecated interval "4w".
+              enum: ['w', 'm', 'y', 't'],
+            },
+          }),
+          pathParam({ name: 'user', example: 'badges' }),
+          pathParam({ name: 'repo', example: 'squint' }),
+          pathParam({ name: 'branch', example: 'main' }),
+          queryParam({ name: 'authorFilter', example: 'calebcartwright' }),
+        ],
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'commit activity', color: 'blue' }
 

--- a/services/github/github-commits-since.service.js
+++ b/services/github/github-commits-since.service.js
@@ -12,10 +12,8 @@ import { documentation, httpErrorsFor } from './github-helpers.js'
 
 const schema = Joi.object({ ahead_by: nonNegativeInteger }).required()
 
-const versionDescription = `
-<p><code>version</code> can either be a tag or the special value <code>latest</code></p>
-<p>If <code>version</code> is <code>latest</code>, the <code>include_prereleases</code> , <code>sort</code> and <code>filter</code> params can be used to configure how we determine the latest version. If <code>version</code> is a tag, these params are ignored.</p>
-`
+const latestDocs =
+  '<p>The <code>include_prereleases</code>, <code>sort</code> and <code>filter</code> params can be used to configure how we determine the latest version.</p>'
 
 export default class GithubCommitsSince extends GithubAuthV3Service {
   static category = 'activity'
@@ -28,7 +26,7 @@ export default class GithubCommitsSince extends GithubAuthV3Service {
   static openApi = {
     '/github/commits-since/{user}/{repo}/{version}': {
       get: {
-        summary: 'GitHub commits since version',
+        summary: 'GitHub commits since tagged version',
         description: documentation,
         parameters: [
           pathParam({ name: 'user', example: 'SubtitleEdit' }),
@@ -36,15 +34,13 @@ export default class GithubCommitsSince extends GithubAuthV3Service {
           pathParam({
             name: 'version',
             example: '3.4.7',
-            description: versionDescription,
           }),
-          ...openApiQueryParams,
         ],
       },
     },
     '/github/commits-since/{user}/{repo}/{version}/{branch}': {
       get: {
-        summary: 'GitHub commits since version (branch)',
+        summary: 'GitHub commits since tagged version (branch)',
         description: documentation,
         parameters: [
           pathParam({ name: 'user', example: 'SubtitleEdit' }),
@@ -52,8 +48,29 @@ export default class GithubCommitsSince extends GithubAuthV3Service {
           pathParam({
             name: 'version',
             example: '3.4.7',
-            description: versionDescription,
           }),
+          pathParam({ name: 'branch', example: 'main' }),
+        ],
+      },
+    },
+    '/github/commits-since/{user}/{repo}/latest': {
+      get: {
+        summary: 'GitHub commits since latest release',
+        description: documentation + latestDocs,
+        parameters: [
+          pathParam({ name: 'user', example: 'SubtitleEdit' }),
+          pathParam({ name: 'repo', example: 'subtitleedit' }),
+          ...openApiQueryParams,
+        ],
+      },
+    },
+    '/github/commits-since/{user}/{repo}/latest/{branch}': {
+      get: {
+        summary: 'GitHub commits since latest release (branch)',
+        description: documentation + latestDocs,
+        parameters: [
+          pathParam({ name: 'user', example: 'SubtitleEdit' }),
+          pathParam({ name: 'repo', example: 'subtitleedit' }),
           pathParam({ name: 'branch', example: 'main' }),
           ...openApiQueryParams,
         ],

--- a/services/github/github-commits-since.service.js
+++ b/services/github/github-commits-since.service.js
@@ -1,14 +1,21 @@
 import Joi from 'joi'
+import { pathParam } from '../index.js'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import {
   fetchLatestRelease,
   queryParamSchema,
+  openApiQueryParams,
 } from './github-common-release.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
 
 const schema = Joi.object({ ahead_by: nonNegativeInteger }).required()
+
+const versionDescription = `
+<p><code>version</code> can either be a tag or the special value <code>latest</code></p>
+<p>If <code>version</code> is <code>latest</code>, the <code>include_prereleases</code> , <code>sort</code> and <code>filter</code> params can be used to configure how we determine the latest version. If <code>version</code> is a tag, these params are ignored.</p>
+`
 
 export default class GithubCommitsSince extends GithubAuthV3Service {
   static category = 'activity'
@@ -18,110 +25,41 @@ export default class GithubCommitsSince extends GithubAuthV3Service {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'GitHub commits since tagged version',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: '3.4.7',
+  static openApi = {
+    '/github/commits-since/{user}/{repo}/{version}': {
+      get: {
+        summary: 'GitHub commits since version',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'SubtitleEdit' }),
+          pathParam({ name: 'repo', example: 'subtitleedit' }),
+          pathParam({
+            name: 'version',
+            example: '3.4.7',
+            description: versionDescription,
+          }),
+          ...openApiQueryParams,
+        ],
       },
-      staticPreview: this.render({
-        version: '3.4.7',
-        commitCount: 4225,
-      }),
-      documentation,
     },
-    {
-      title: 'GitHub commits since tagged version (branch)',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: '3.4.7',
-        branch: 'master',
+    '/github/commits-since/{user}/{repo}/{version}/{branch}': {
+      get: {
+        summary: 'GitHub commits since version (branch)',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'SubtitleEdit' }),
+          pathParam({ name: 'repo', example: 'subtitleedit' }),
+          pathParam({
+            name: 'version',
+            example: '3.4.7',
+            description: versionDescription,
+          }),
+          pathParam({ name: 'branch', example: 'main' }),
+          ...openApiQueryParams,
+        ],
       },
-      staticPreview: this.render({
-        version: '3.4.7',
-        commitCount: 4225,
-      }),
-      documentation,
     },
-    {
-      title: 'GitHub commits since latest release (by date)',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: 'latest',
-      },
-      staticPreview: this.render({
-        version: '3.5.7',
-        commitCount: 157,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub commits since latest release (by date) for a branch',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: 'latest',
-        branch: 'master',
-      },
-      staticPreview: this.render({
-        version: '3.5.7',
-        commitCount: 157,
-      }),
-      documentation,
-    },
-    {
-      title:
-        'GitHub commits since latest release (by date including pre-releases)',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: 'latest',
-      },
-      queryParams: { include_prereleases: null },
-      staticPreview: this.render({
-        version: 'v3.5.8-alpha.1',
-        isPrerelease: true,
-        commitCount: 158,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub commits since latest release (by SemVer)',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: 'latest',
-      },
-      queryParams: { sort: 'semver' },
-      staticPreview: this.render({
-        version: 'v4.0.1',
-        sort: 'semver',
-        commitCount: 200,
-      }),
-      documentation,
-    },
-    {
-      title:
-        'GitHub commits since latest release (by SemVer including pre-releases)',
-      namedParams: {
-        user: 'SubtitleEdit',
-        repo: 'subtitleedit',
-        version: 'latest',
-      },
-      queryParams: { sort: 'semver', include_prereleases: null },
-      staticPreview: this.render({
-        version: 'v4.0.2-alpha.1',
-        sort: 'semver',
-        isPrerelease: true,
-        commitCount: 201,
-      }),
-      documentation,
-    },
-  ]
+  }
 
   static defaultBadgeData = { label: 'github', namedLogo: 'github' }
 

--- a/services/github/github-common-release.js
+++ b/services/github/github-common-release.js
@@ -2,7 +2,7 @@ import Joi from 'joi'
 import { matcher } from 'matcher'
 import { nonNegativeInteger } from '../validators.js'
 import { latest } from '../version.js'
-import { NotFound } from '../index.js'
+import { NotFound, queryParams } from '../index.js'
 import { httpErrorsFor } from './github-helpers.js'
 
 const releaseInfoSchema = Joi.object({
@@ -67,21 +67,37 @@ function getLatestRelease({ releases, sort, includePrereleases }) {
   return releases[0]
 }
 
+const sortEnum = ['date', 'semver']
+
 const queryParamSchema = Joi.object({
   include_prereleases: Joi.equal(''),
-  sort: Joi.string().valid('date', 'semver').default('date'),
+  sort: Joi.string()
+    .valid(...sortEnum)
+    .default('date'),
   filter: Joi.string(),
 }).required()
 
-const filterDocs = `<div>
-  <p>
+const filterDocs = `<p>
   The <code>filter</code> param can be used to apply a filter to the
   project's tag or release names before selecting the latest from the list.
   Two constructs are available: <code>*</code> is a wildcard matching zero
   or more characters, and if the pattern starts with a <code>!</code>,
   the whole pattern is negated.
-  </p>
-</div>`
+</p>`
+
+const openApiQueryParams = queryParams(
+  {
+    name: 'include_prereleases',
+    example: null,
+    schema: { type: 'boolean' },
+  },
+  {
+    name: 'sort',
+    example: 'semver',
+    schema: { type: 'string', enum: sortEnum },
+  },
+  { name: 'filter', example: '*beta*', description: filterDocs },
+)
 
 function applyFilter({ releases, filter, displayName }) {
   if (!filter) {
@@ -137,7 +153,7 @@ async function fetchLatestRelease(
   return latestRelease
 }
 
-export { fetchLatestRelease, filterDocs, queryParamSchema }
+export { fetchLatestRelease, queryParamSchema, openApiQueryParams }
 
 // currently only used for tests
 export const _getLatestRelease = getLatestRelease

--- a/services/github/github-downloads.tester.js
+++ b/services/github/github-downloads.tester.js
@@ -10,7 +10,7 @@ const mockLatestRelease = release => nock =>
 
 const mockReleases = releases => nock =>
   nock('https://api.github.com')
-    .get('/repos/photonstorm/phaser/releases')
+    .get('/repos/photonstorm/phaser/releases?per_page=100')
     .reply(200, releases)
 
 t.create('Downloads all releases')

--- a/services/github/github-go-mod.service.js
+++ b/services/github/github-go-mod.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
-import { InvalidResponse } from '../index.js'
+import { InvalidResponse, pathParam, queryParam } from '../index.js'
 import { ConditionalGithubAuthV3Service } from './github-auth-service.js'
 import { fetchRepoContent } from './github-common-fetch.js'
 import { documentation } from './github-helpers.js'
@@ -11,7 +11,8 @@ const queryParamSchema = Joi.object({
 
 const goVersionRegExp = /^go (.+)$/m
 
-const keywords = ['golang']
+const filenameDescription =
+  'The `filename` param can be used to specify the path to `go.mod`. By default, we look for `go.mod` in the repo root'
 
 export default class GithubGoModGoVersion extends ConditionalGithubAuthV3Service {
   static category = 'version'
@@ -21,42 +22,39 @@ export default class GithubGoModGoVersion extends ConditionalGithubAuthV3Service
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'GitHub go.mod Go version',
-      pattern: ':user/:repo',
-      namedParams: { user: 'gohugoio', repo: 'hugo' },
-      staticPreview: this.render({ version: '1.12' }),
-      documentation,
-      keywords,
+  static openApi = {
+    '/github/go-mod/go-version/{user}/{repo}': {
+      get: {
+        summary: 'GitHub go.mod Go version',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'gohugoio' }),
+          pathParam({ name: 'repo', example: 'hugo' }),
+          queryParam({
+            name: 'filename',
+            example: 'src/go.mod',
+            description: filenameDescription,
+          }),
+        ],
+      },
     },
-    {
-      title: 'GitHub go.mod Go version (branch)',
-      pattern: ':user/:repo/:branch',
-      namedParams: { user: 'gohugoio', repo: 'hugo', branch: 'master' },
-      staticPreview: this.render({ version: '1.12', branch: 'master' }),
-      documentation,
-      keywords,
+    '/github/go-mod/go-version/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'GitHub go.mod Go version (branch)',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'gohugoio' }),
+          pathParam({ name: 'repo', example: 'hugo' }),
+          pathParam({ name: 'branch', example: 'master' }),
+          queryParam({
+            name: 'filename',
+            example: 'src/go.mod',
+            description: filenameDescription,
+          }),
+        ],
+      },
     },
-    {
-      title: 'GitHub go.mod Go version (subdirectory of monorepo)',
-      pattern: ':user/:repo',
-      namedParams: { user: 'golang', repo: 'go' },
-      queryParams: { filename: 'src/go.mod' },
-      staticPreview: this.render({ version: '1.14' }),
-      documentation,
-      keywords,
-    },
-    {
-      title: 'GitHub go.mod Go version (branch & subdirectory of monorepo)',
-      pattern: ':user/:repo/:branch',
-      namedParams: { user: 'golang', repo: 'go', branch: 'master' },
-      queryParams: { filename: 'src/go.mod' },
-      staticPreview: this.render({ version: '1.14' }),
-      documentation,
-      keywords,
-    },
-  ]
+  }
 
   static defaultBadgeData = { label: 'Go' }
 

--- a/services/github/github-pull-request-check-state.tester.js
+++ b/services/github/github-pull-request-check-state.tester.js
@@ -2,8 +2,8 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('github pull request check state')
-  .get('/s/pulls/badges/shields/8486.json')
-  .expectBadge({ label: 'checks', message: 'failure' })
+  .get('/s/pulls/badges/shields/9863.json')
+  .expectBadge({ label: 'checks', message: 'success' })
 
 t.create('github pull request check state (pull request not found)')
   .get('/s/pulls/badges/shields/5101.json')
@@ -26,5 +26,5 @@ t.create(
   })
 
 t.create('github pull request check contexts')
-  .get('/contexts/pulls/badges/shields/8486.json')
-  .expectBadge({ label: 'checks', message: '2 success, 4 failure' })
+  .get('/contexts/pulls/badges/shields/9863.json')
+  .expectBadge({ label: 'checks', message: '1 success' })

--- a/services/github/github-release.service.js
+++ b/services/github/github-release.service.js
@@ -1,17 +1,20 @@
 import Joi from 'joi'
 import { addv } from '../text-formatters.js'
 import { version as versionColor } from '../color-formatters.js'
-import { redirector } from '../index.js'
+import { redirector, pathParam, queryParam } from '../index.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import {
   fetchLatestRelease,
-  filterDocs,
   queryParamSchema,
+  openApiQueryParams,
 } from './github-common-release.js'
 import { documentation } from './github-helpers.js'
 
+const displayNameEnum = ['tag', 'release']
 const extendedQueryParamSchema = Joi.object({
-  display_name: Joi.string().valid('tag', 'release').default('tag'),
+  display_name: Joi.string()
+    .valid(...displayNameEnum)
+    .default('tag'),
 })
 
 class GithubRelease extends GithubAuthV3Service {
@@ -22,86 +25,24 @@ class GithubRelease extends GithubAuthV3Service {
     queryParamSchema: queryParamSchema.concat(extendedQueryParamSchema),
   }
 
-  static examples = [
-    {
-      title: 'GitHub release (latest by date)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: { display_name: 'tag' },
-      staticPreview: this.render({
-        version: 'v4.16.4',
-        sort: 'date',
-        isPrerelease: false,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub release (latest by date including pre-releases)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: { include_prereleases: null, display_name: 'tag' },
-      staticPreview: this.render({
-        version: 'v5.0.0-alpha.7',
-        sort: 'date',
-        isPrerelease: true,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub release (latest SemVer)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: { sort: 'semver', display_name: 'tag' },
-      staticPreview: this.render({
-        version: 'v4.16.4',
-        sort: 'semver',
-        isPrerelease: false,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub release (latest SemVer including pre-releases)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: {
-        sort: 'semver',
-        include_prereleases: null,
-        display_name: 'tag',
+  static openApi = {
+    '/github/v/release/{user}/{repo}': {
+      get: {
+        summary: 'GitHub Release',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'expressjs' }),
+          pathParam({ name: 'repo', example: 'express' }),
+          ...openApiQueryParams,
+          queryParam({
+            name: 'display_name',
+            example: 'tag',
+            schema: { type: 'string', enum: displayNameEnum },
+          }),
+        ],
       },
-      staticPreview: this.render({
-        version: 'v5.0.0-alpha.7',
-        sort: 'semver',
-        isPrerelease: true,
-      }),
-      documentation,
     },
-    {
-      title: 'GitHub release (release name instead of tag name)',
-      namedParams: { user: 'gooddata', repo: 'gooddata-java' },
-      queryParams: {
-        sort: 'date',
-        include_prereleases: null,
-        display_name: 'release',
-      },
-      staticPreview: this.render({
-        version: '3.7.0+api3',
-        sort: 'date',
-        isPrerelease: true,
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub release (with filter)',
-      namedParams: { user: 'RetroMusicPlayer', repo: 'RetroMusicPlayer' },
-      queryParams: {
-        sort: 'date',
-        display_name: 'release',
-        filter: '*Open Beta',
-      },
-      staticPreview: this.render({
-        version: 'Release v6.0.2 - Open Beta',
-        sort: 'date',
-        isPrerelease: false,
-      }),
-      documentation: documentation + filterDocs,
-    },
-  ]
+  }
 
   static defaultBadgeData = { label: 'release', namedLogo: 'github' }
 

--- a/services/github/github-tag.service.js
+++ b/services/github/github-tag.service.js
@@ -4,9 +4,12 @@ import { matcher } from 'matcher'
 import { addv } from '../text-formatters.js'
 import { version as versionColor } from '../color-formatters.js'
 import { latest } from '../version.js'
-import { NotFound, redirector } from '../index.js'
+import { NotFound, redirector, pathParam } from '../index.js'
 import { GithubAuthV4Service } from './github-auth-service.js'
-import { filterDocs, queryParamSchema } from './github-common-release.js'
+import {
+  queryParamSchema,
+  openApiQueryParams,
+} from './github-common-release.js'
 import { documentation, transformErrors } from './github-helpers.js'
 
 const schema = Joi.object({
@@ -34,44 +37,19 @@ class GithubTag extends GithubAuthV4Service {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'GitHub tag (latest by date)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      staticPreview: this.render({
-        version: 'v5.0.0-alpha.7',
-        sort: 'date',
-      }),
-      documentation,
+  static openApi = {
+    '/github/v/tag/{user}/{repo}': {
+      get: {
+        summary: 'GitHub Tag',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'expressjs' }),
+          pathParam({ name: 'repo', example: 'express' }),
+          ...openApiQueryParams,
+        ],
+      },
     },
-    {
-      title: 'GitHub tag (latest SemVer)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: { sort: 'semver' },
-      staticPreview: this.render({ version: 'v4.16.4', sort: 'semver' }),
-      documentation,
-    },
-    {
-      title: 'GitHub tag (latest SemVer pre-release)',
-      namedParams: { user: 'expressjs', repo: 'express' },
-      queryParams: { sort: 'semver', include_prereleases: null },
-      staticPreview: this.render({
-        version: 'v5.0.0-alpha.7',
-        sort: 'semver',
-      }),
-      documentation,
-    },
-    {
-      title: 'GitHub tag (with filter)',
-      namedParams: { user: 'badges', repo: 'shields' },
-      queryParams: { filter: '!server-*' },
-      staticPreview: this.render({
-        version: 'v3.3.1',
-        sort: 'date',
-      }),
-      documentation: documentation + filterDocs,
-    },
-  ]
+  }
 
   static defaultBadgeData = {
     label: 'tag',


### PR DESCRIPTION
Refs #9285

There were a couple of failing GitHub service tests so I started off by fixing them here, just so I could run `[github]` on the PR:

1. When I did #9818 I forgot to update the tests for GitHub downloads - it uses a helper function shared with releases/tags. I fixed the mock
2. When I updated the branch protection rules for #9799 it changed the status of older PRs to pending. I updated the example

so that gets the github tests passing

---

Then I started tackling some of the meatier GitHub badges that had a lot of variants or use shared helpers. I've only touched 6 services in this PR as there is quite a lot of diff to review just for these 6 services and I'm trying to keep each PRs relatively small/easy to review.