### PR TITLE
Fix typo in OpenAPI service documentation

### DIFF
--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -241,7 +241,7 @@ function category2openapi(category, services) {
           name: 'style',
           in: 'query',
           required: false,
-          description: 'If not specified, the defautl style is "flat".',
+          description: 'If not specified, the default style is "flat".',
           schema: {
             type: 'string',
             enum: ['flat', 'flat-square', 'plastic', 'for-the-badge', 'social'],

--- a/core/base-service/openapi.spec.js
+++ b/core/base-service/openapi.spec.js
@@ -88,7 +88,7 @@ const expected = {
         name: 'style',
         in: 'query',
         required: false,
-        description: 'If not specified, the defautl style is "flat".',
+        description: 'If not specified, the default style is "flat".',
         schema: {
           enum: ['flat', 'flat-square', 'plastic', 'for-the-badge', 'social'],
           type: 'string',


### PR DESCRIPTION
Fixes the following typo:

`defauTL -> defauLT`