### PR TITLE
migrate examples to openApi part 37; affects [bitbucket bitrise chromewebstore circleci]

### DIFF
--- a/services/bitbucket/bitbucket-issues.service.js
+++ b/services/bitbucket/bitbucket-issues.service.js
@@ -26,11 +26,11 @@ function issueClassGenerator(raw) {
           parameters: pathParams(
             {
               name: 'user',
-              example: 'atlassian',
+              example: 'shields-io',
             },
             {
               name: 'repo',
-              example: 'python-bitbucket',
+              example: 'test-repo',
             },
           ),
         },

--- a/services/bitbucket/bitbucket-issues.service.js
+++ b/services/bitbucket/bitbucket-issues.service.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const bitbucketIssuesSchema = Joi.object({
   size: nonNegativeInteger,
@@ -10,22 +10,33 @@ const bitbucketIssuesSchema = Joi.object({
 function issueClassGenerator(raw) {
   const routePrefix = raw ? 'issues-raw' : 'issues'
   const badgeSuffix = raw ? '' : ' open'
+  const titleSuffix = raw ? ' (raw)' : ''
 
   return class BitbucketIssues extends BaseJsonService {
     static name = `BitbucketIssues${raw ? 'Raw' : ''}`
     static category = 'issue-tracking'
     static route = { base: `bitbucket/${routePrefix}`, pattern: ':user/:repo' }
 
-    static examples = [
-      {
-        title: 'Bitbucket open issues',
-        namedParams: {
-          user: 'atlassian',
-          repo: 'python-bitbucket',
+    static get openApi() {
+      const key = `/bitbucket/${routePrefix}/{user}/{repo}`
+      const route = {}
+      route[key] = {
+        get: {
+          summary: `Bitbucket open issues ${titleSuffix}`,
+          parameters: pathParams(
+            {
+              name: 'user',
+              example: 'atlassian',
+            },
+            {
+              name: 'repo',
+              example: 'python-bitbucket',
+            },
+          ),
         },
-        staticPreview: this.render({ issues: 33 }),
-      },
-    ]
+      }
+      return route
+    }
 
     static defaultBadgeData = { label: 'issues' }
 

--- a/services/bitbucket/bitbucket-issues.tester.js
+++ b/services/bitbucket/bitbucket-issues.tester.js
@@ -8,14 +8,14 @@ export const t = new ServiceTester({
 })
 
 t.create('issues-raw (valid)')
-  .get('/issues-raw/atlassian/python-bitbucket.json')
+  .get('/issues-raw/shields-io/test-repo.json')
   .expectBadge({
     label: 'issues',
     message: isMetric,
   })
 
 t.create('issues-raw (not found)')
-  .get('/issues-raw/atlassian/not-a-repo.json')
+  .get('/issues-raw/shields-io/not-a-repo.json')
   .expectBadge({ label: 'issues', message: 'not found' })
 
 t.create('issues-raw (private repo)')
@@ -23,14 +23,14 @@ t.create('issues-raw (private repo)')
   .expectBadge({ label: 'issues', message: 'private repo' })
 
 t.create('issues (valid)')
-  .get('/issues/atlassian/python-bitbucket.json')
+  .get('/issues/shields-io/test-repo.json')
   .expectBadge({
     label: 'issues',
     message: isMetricOpenIssues,
   })
 
 t.create('issues (not found)')
-  .get('/issues/atlassian/not-a-repo.json')
+  .get('/issues/shields-io/not-a-repo.json')
   .expectBadge({ label: 'issues', message: 'not found' })
 
 t.create('issues (private repo)')

--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -37,15 +37,15 @@ class BitbucketPipelines extends BaseJsonService {
         parameters: pathParams(
           {
             name: 'user',
-            example: 'atlassian',
+            example: 'shields-io',
           },
           {
             name: 'repo',
-            example: 'adf-builder-javascript',
+            example: 'test-repo',
           },
           {
             name: 'branch',
-            example: 'task/SECO-2168',
+            example: 'main',
           },
         ),
       },

--- a/services/bitbucket/bitbucket-pipelines.tester.js
+++ b/services/bitbucket/bitbucket-pipelines.tester.js
@@ -23,27 +23,27 @@ function bitbucketApiResponse(status) {
   })
 }
 
-t.create('master build result (not found)')
-  .get('/atlassian/not-a-repo/master.json')
+t.create('main build result (not found)')
+  .get('/shields-io/not-a-repo/main.json')
   .expectBadge({ label: 'build', message: 'not found' })
 
 t.create('branch build result (valid)')
-  .get('/atlassian/adf-builder-javascript/shields-test-dont-remove.json')
+  .get('/shields-io/test-repo/main.json')
   .expectBadge({
     label: 'build',
     message: isBuildStatus,
   })
 
 t.create('branch build result (not found)')
-  .get('/atlassian/not-a-repo/some-branch.json')
+  .get('/shields-io/not-a-repo/some-branch.json')
   .expectBadge({ label: 'build', message: 'not found' })
 
 t.create('branch build result (never built)')
-  .get('/atlassian/adf-builder-javascript/some/new/branch.json')
+  .get('/shields-io/test-repo/P-Y/update-readme-1704629121998.json')
   .expectBadge({ label: 'build', message: 'never built' })
 
 t.create('build result (passing)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -52,7 +52,7 @@ t.create('build result (passing)')
   .expectBadge({ label: 'build', message: 'passing' })
 
 t.create('build result (failing)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -61,7 +61,7 @@ t.create('build result (failing)')
   .expectBadge({ label: 'build', message: 'failing' })
 
 t.create('build result (error)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -70,7 +70,7 @@ t.create('build result (error)')
   .expectBadge({ label: 'build', message: 'error' })
 
 t.create('build result (stopped)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -79,7 +79,7 @@ t.create('build result (stopped)')
   .expectBadge({ label: 'build', message: 'stopped' })
 
 t.create('build result (expired)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -88,7 +88,7 @@ t.create('build result (expired)')
   .expectBadge({ label: 'build', message: 'expired' })
 
 t.create('build result (unexpected status)')
-  .get('/atlassian/adf-builder-javascript/master.json')
+  .get('/shields-io/test-repo/main.json')
   .intercept(nock =>
     nock('https://api.bitbucket.org')
       .get(/^\/2.0\/.*/)
@@ -97,7 +97,5 @@ t.create('build result (unexpected status)')
   .expectBadge({ label: 'build', message: 'invalid response data' })
 
 t.create('build result no branch redirect')
-  .get('/atlassian/adf-builder-javascript.svg')
-  .expectRedirect(
-    '/bitbucket/pipelines/atlassian/adf-builder-javascript/master.svg',
-  )
+  .get('/shields-io/test-repo.svg')
+  .expectRedirect('/bitbucket/pipelines/shields-io/test-repo/master.svg')

--- a/services/bitbucket/bitbucket-pull-request.service.js
+++ b/services/bitbucket/bitbucket-pull-request.service.js
@@ -41,11 +41,11 @@ function pullRequestClassGenerator(raw) {
           parameters: [
             pathParam({
               name: 'user',
-              example: 'atlassian',
+              example: 'shields-io',
             }),
             pathParam({
               name: 'repo',
-              example: 'python-bitbucket',
+              example: 'test-repo',
             }),
             queryParam({
               name: 'server',

--- a/services/bitbucket/bitbucket-pull-request.spec.js
+++ b/services/bitbucket/bitbucket-pull-request.spec.js
@@ -28,7 +28,7 @@ describe('BitbucketPullRequest', function () {
           },
           private: { bitbucket_username: user, bitbucket_password: pass },
         },
-        { user: 'atlassian', repo: 'python-bitbucket' },
+        { user: 'shields-io', repo: 'test-repo' },
       ),
     ).to.deep.equal({
       message: '42',

--- a/services/bitbucket/bitbucket-pull-request.tester.js
+++ b/services/bitbucket/bitbucket-pull-request.tester.js
@@ -8,27 +8,27 @@ export const t = new ServiceTester({
 })
 
 t.create('pr-raw (valid)')
-  .get('/pr-raw/atlassian/python-bitbucket.json')
+  .get('/pr-raw/shields-io/test-repo.json')
   .expectBadge({
     label: 'pull requests',
     message: isMetric,
   })
 
 t.create('pr-raw (not found)')
-  .get('/pr-raw/atlassian/not-a-repo.json')
+  .get('/pr-raw/shields-io/not-a-repo.json')
   .expectBadge({ label: 'pull requests', message: 'not found' })
 
 t.create('pr-raw (private repo)')
   .get('/pr-raw/chris48s/example-private-repo.json')
   .expectBadge({ label: 'pull requests', message: 'not found' })
 
-t.create('pr (valid)').get('/pr/atlassian/python-bitbucket.json').expectBadge({
+t.create('pr (valid)').get('/pr/shields-io/test-repo.json').expectBadge({
   label: 'pull requests',
   message: isMetricOpenIssues,
 })
 
 t.create('pr (not found)')
-  .get('/pr/atlassian/not-a-repo.json')
+  .get('/pr/shields-io/not-a-repo.json')
   .expectBadge({ label: 'pull requests', message: 'not found' })
 
 t.create('pr (private repo)')

--- a/services/bitrise/bitrise.service.js
+++ b/services/bitrise/bitrise.service.js
@@ -41,7 +41,7 @@ export default class Bitrise extends BaseJsonService {
         parameters: [
           pathParam({
             name: 'appId',
-            example: '4a2b10a819d12b67',
+            example: 'e736852157296019',
           }),
           pathParam({
             name: 'branch',

--- a/services/bitrise/bitrise.service.js
+++ b/services/bitrise/bitrise.service.js
@@ -29,7 +29,7 @@ export default class Bitrise extends BaseJsonService {
           }),
           queryParam({
             name: 'token',
-            example: '859FMDR8QHwabCzwvZK6vQ',
+            example: 'abc123def456',
             required: true,
           }),
         ],
@@ -49,7 +49,7 @@ export default class Bitrise extends BaseJsonService {
           }),
           queryParam({
             name: 'token',
-            example: '859FMDR8QHwabCzwvZK6vQ',
+            example: 'abc123def456',
             required: true,
           }),
         ],

--- a/services/bitrise/bitrise.service.js
+++ b/services/bitrise/bitrise.service.js
@@ -25,11 +25,12 @@ export default class Bitrise extends BaseJsonService {
         parameters: [
           pathParam({
             name: 'appId',
-            example: '3ff11fe8457bd304',
+            example: '4a2b10a819d12b67',
           }),
           queryParam({
             name: 'token',
-            example: 'lESRN9rEFFfDq92JtXs_jw',
+            example: '859FMDR8QHwabCzwvZK6vQ',
+            required: true,
           }),
         ],
       },
@@ -40,7 +41,7 @@ export default class Bitrise extends BaseJsonService {
         parameters: [
           pathParam({
             name: 'appId',
-            example: '3ff11fe8457bd304',
+            example: '4a2b10a819d12b67',
           }),
           pathParam({
             name: 'branch',
@@ -48,7 +49,7 @@ export default class Bitrise extends BaseJsonService {
           }),
           queryParam({
             name: 'token',
-            example: 'lESRN9rEFFfDq92JtXs_jw',
+            example: '859FMDR8QHwabCzwvZK6vQ',
             required: true,
           }),
         ],

--- a/services/bitrise/bitrise.service.js
+++ b/services/bitrise/bitrise.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParam, queryParam } from '../index.js'
 
 // https://devcenter.bitrise.io/api/app-status-badge/
 const schema = Joi.object({
@@ -18,14 +18,43 @@ export default class Bitrise extends BaseJsonService {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'Bitrise',
-      namedParams: { appId: '3ff11fe8457bd304', branch: 'master' },
-      queryParams: { token: 'lESRN9rEFFfDq92JtXs_jw' },
-      staticPreview: this.render({ status: 'success' }),
+  static openApi = {
+    '/bitrise/{appId}': {
+      get: {
+        summary: 'Bitrise',
+        parameters: [
+          pathParam({
+            name: 'appId',
+            example: '3ff11fe8457bd304',
+          }),
+          queryParam({
+            name: 'token',
+            example: 'lESRN9rEFFfDq92JtXs_jw',
+          }),
+        ],
+      },
     },
-  ]
+    '/bitrise/{appId}/{branch}': {
+      get: {
+        summary: 'Bitrise (branch)',
+        parameters: [
+          pathParam({
+            name: 'appId',
+            example: '3ff11fe8457bd304',
+          }),
+          pathParam({
+            name: 'branch',
+            example: 'master',
+          }),
+          queryParam({
+            name: 'token',
+            example: 'lESRN9rEFFfDq92JtXs_jw',
+            required: true,
+          }),
+        ],
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'bitrise' }
 

--- a/services/bitrise/bitrise.tester.js
+++ b/services/bitrise/bitrise.tester.js
@@ -3,27 +3,27 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('deploy status')
-  .get('/4a2b10a819d12b67.json?token=859FMDR8QHwabCzwvZK6vQ')
+  .get('/e736852157296019.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({
     label: 'bitrise',
     message: isBuildStatus,
   })
 
 t.create('deploy status with branch')
-  .get('/4a2b10a819d12b67/master.json?token=859FMDR8QHwabCzwvZK6vQ')
+  .get('/e736852157296019/master.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({
     label: 'bitrise',
     message: isBuildStatus,
   })
 
 t.create('unknown branch')
-  .get('/cde737473028420d/unknown.json?token=GCIdEzacE4GW32jLVrZb7A')
+  .get('/e736852157296019/unknown.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({ label: 'bitrise', message: 'branch not found' })
 
 t.create('invalid token')
-  .get('/cde737473028420d/unknown.json?token=token')
+  .get('/e736852157296019/unknown.json?token=token')
   .expectBadge({ label: 'bitrise', message: 'app not found or invalid token' })
 
 t.create('invalid App ID')
-  .get('/invalid/master.json?token=GCIdEzacE4GW32jLVrZb7A')
+  .get('/invalid/master.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({ label: 'bitrise', message: 'app not found or invalid token' })

--- a/services/bitrise/bitrise.tester.js
+++ b/services/bitrise/bitrise.tester.js
@@ -3,14 +3,14 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('deploy status')
-  .get('/3ff11fe8457bd304.json?token=lESRN9rEFFfDq92JtXs_jw')
+  .get('/4a2b10a819d12b67.json?token=859FMDR8QHwabCzwvZK6vQ')
   .expectBadge({
     label: 'bitrise',
     message: isBuildStatus,
   })
 
 t.create('deploy status with branch')
-  .get('/3ff11fe8457bd304/master.json?token=lESRN9rEFFfDq92JtXs_jw')
+  .get('/4a2b10a819d12b67/master.json?token=859FMDR8QHwabCzwvZK6vQ')
   .expectBadge({
     label: 'bitrise',
     message: isBuildStatus,

--- a/services/chrome-web-store/chrome-web-store-rating.service.js
+++ b/services/chrome-web-store/chrome-web-store-rating.service.js
@@ -1,6 +1,6 @@
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { metric, starRating } from '../text-formatters.js'
-import { NotFound } from '../index.js'
+import { NotFound, pathParams } from '../index.js'
 import BaseChromeWebStoreService from './chrome-web-store-base.js'
 
 class BaseChromeWebStoreRating extends BaseChromeWebStoreService {
@@ -15,13 +15,17 @@ class ChromeWebStoreRating extends BaseChromeWebStoreRating {
     pattern: ':storeId',
   }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: this.render({ rating: '3.67' }),
+  static openApi = {
+    '/chrome-web-store/rating/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store Rating',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ rating }) {
     rating = Math.round(rating * 100) / 100
@@ -47,13 +51,17 @@ class ChromeWebStoreRatingCount extends BaseChromeWebStoreRating {
     pattern: ':storeId',
   }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: this.render({ ratingCount: 12 }),
+  static openApi = {
+    '/chrome-web-store/rating-count/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store Rating Count',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ ratingCount }) {
     return {
@@ -81,13 +89,17 @@ class ChromeWebStoreRatingStars extends BaseChromeWebStoreRating {
     pattern: ':storeId',
   }
 
-  static examples = [
-    {
-      title: 'Chrome Web Store',
-      namedParams: { storeId: 'ogffaloegjglncjfehdfplabnoondfjo' },
-      staticPreview: this.render({ rating: '3.75' }),
+  static openApi = {
+    '/chrome-web-store/stars/{storeId}': {
+      get: {
+        summary: 'Chrome Web Store Stars',
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+        }),
+      },
     },
-  ]
+  }
 
   static render({ rating }) {
     return {

--- a/services/circleci/circleci.service.js
+++ b/services/circleci/circleci.service.js
@@ -1,11 +1,16 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseSvgScrapingService, redirector } from '../index.js'
+import {
+  BaseSvgScrapingService,
+  redirector,
+  pathParam,
+  queryParam,
+} from '../index.js'
 
 const circleSchema = Joi.object({ message: isBuildStatus }).required()
 const queryParamSchema = Joi.object({ token: Joi.string() }).required()
 
-const documentation = `
+const tokenDescription = `
   <p>
     You may specify an optional token to get the status for a private repository.
     <br />
@@ -25,22 +30,62 @@ class CircleCi extends BaseSvgScrapingService {
     queryParamSchema,
   }
 
-  static examples = [
-    {
-      title: 'CircleCI',
-      namedParams: {
-        vcsType: 'github',
-        user: 'RedSparr0w',
-        repo: 'node-csgo-parser',
-        branch: 'master',
+  static openApi = {
+    '/circleci/build/{vcsType}/{user}/{repo}': {
+      get: {
+        summary: 'CircleCI',
+        parameters: [
+          pathParam({
+            name: 'vcsType',
+            schema: { type: 'string', enum: this.getEnum('vcsType') },
+            example: 'github',
+          }),
+          pathParam({
+            name: 'user',
+            example: 'RedSparr0w',
+          }),
+          pathParam({
+            name: 'repo',
+            example: 'node-csgo-parser',
+          }),
+          queryParam({
+            name: 'token',
+            example: 'abc123def456',
+            description: tokenDescription,
+          }),
+        ],
       },
-      queryParams: {
-        token: 'abc123def456',
-      },
-      staticPreview: this.render({ status: 'success' }),
-      documentation,
     },
-  ]
+    '/circleci/build/{vcsType}/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'CircleCI (branch)',
+        parameters: [
+          pathParam({
+            name: 'vcsType',
+            schema: { type: 'string', enum: this.getEnum('vcsType') },
+            example: 'github',
+          }),
+          pathParam({
+            name: 'user',
+            example: 'RedSparr0w',
+          }),
+          pathParam({
+            name: 'repo',
+            example: 'node-csgo-parser',
+          }),
+          pathParam({
+            name: 'branch',
+            example: 'master',
+          }),
+          queryParam({
+            name: 'token',
+            example: 'abc123def456',
+            description: tokenDescription,
+          }),
+        ],
+      },
+    },
+  }
 
   static defaultBadgeData = { label: 'build' }
 

--- a/services/circleci/circleci.tester.js
+++ b/services/circleci/circleci.tester.js
@@ -33,7 +33,7 @@ t.create('circle ci (not found)')
 
 t.create('circle ci (valid, with token)')
   .get(
-    '/build/gh/RedSparr0w/node-csgo-parser/master.json?token=b90b5c49e59a4c67ba3a92f7992587ac7a0408c2',
+    '/build/gh/justkd/uidmanager/main.json?token=2edcfec5c13eaf6d951a8f2939b220cdca74644c',
   )
   .expectBadge({
     label: 'build',


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/9285.

~Leaving as draft for now, gonna see if I can find some good updated Bitbucket examples.~ All tests and examples fixed.