### PR TITLE
[crates] tidyup

### DIFF
--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -29,14 +29,7 @@ const versionSchema = Joi.object({
   }).required(),
 }).required()
 
-const errorSchema = Joi.object({
-  errors: Joi.array()
-    .items(Joi.object({ detail: Joi.string().required() }))
-    .min(1)
-    .required(),
-}).required()
-
-const schema = Joi.alternatives(crateSchema, versionSchema, errorSchema)
+const schema = Joi.alternatives(crateSchema, versionSchema)
 
 class BaseCratesService extends BaseJsonService {
   static defaultBadgeData = { label: 'crates.io' }

--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -1,5 +1,5 @@
 import { renderDownloadsBadge } from '../downloads.js'
-import { InvalidParameter, NotFound, pathParams } from '../index.js'
+import { InvalidParameter, pathParams } from '../index.js'
 import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesDownloads extends BaseCratesService {
@@ -92,15 +92,6 @@ export default class CratesDownloads extends BaseCratesService {
     }
 
     const json = await this.fetch({ crate, version })
-
-    if (json.errors) {
-      /* a call like
-         https://crates.io/api/v1/crates/libc/0.1
-         or
-         https://crates.io/api/v1/crates/libc/0.1.76
-         returns a 200 OK with an errors object */
-      throw new NotFound({ prettyMessage: json.errors[0].detail })
-    }
 
     const downloads = this.transform({ variant, json })
 

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -55,7 +55,7 @@ t.create('recent downloads (with version)')
 
 t.create('downloads (invalid version)')
   .get('/d/libc/7.json')
-  .expectBadge({ label: 'crates.io', message: 'invalid semver: 7' })
+  .expectBadge({ label: 'crates.io', message: 'not found' })
 
 t.create('downloads (not found)')
   .get('/d/not-a-real-package.json')

--- a/services/crates/crates-license.service.js
+++ b/services/crates/crates-license.service.js
@@ -36,17 +36,7 @@ export default class CratesLicense extends BaseCratesService {
 
   static defaultBadgeData = { label: 'license', color: 'blue' }
 
-  static render({ license: message }) {
-    return { message }
-  }
-
-  static transform({ errors, version, versions }) {
-    // crates.io returns a 200 response with an errors object in
-    // error scenarios, e.g. https://crates.io/api/v1/crates/libc/0.1
-    if (errors) {
-      throw new InvalidResponse({ prettyMessage: errors[0].detail })
-    }
-
+  static transform({ version, versions }) {
     const license = version ? version.license : versions[0].license
     if (!license) {
       throw new InvalidResponse({ prettyMessage: 'invalid null license' })
@@ -58,6 +48,6 @@ export default class CratesLicense extends BaseCratesService {
   async handle({ crate, version }) {
     const json = await this.fetch({ crate, version })
     const { license } = this.constructor.transform(json)
-    return this.constructor.render({ license })
+    return { message: license }
   }
 }

--- a/services/crates/crates-license.spec.js
+++ b/services/crates/crates-license.spec.js
@@ -14,14 +14,6 @@ describe('CratesLicense', function () {
     }).expect({ license: 'MIT/Apache 2.0' })
   })
 
-  it('throws InvalidResponse on error response', function () {
-    expect(() =>
-      CratesLicense.transform({ errors: [{ detail: 'invalid semver' }] }),
-    )
-      .to.throw(InvalidResponse)
-      .with.property('prettyMessage', 'invalid semver')
-  })
-
   it('throws InvalidResponse on null license with specific version', function () {
     expect(() =>
       CratesLicense.transform({ version: { num: '1.2.3', license: null } }),

--- a/services/crates/crates-msrv.service.js
+++ b/services/crates/crates-msrv.service.js
@@ -51,13 +51,7 @@ export default class CratesMSRV extends BaseCratesService {
 
   static defaultBadgeData = { label: 'msrv', color: 'blue' }
 
-  static transform({ errors, version, versions }) {
-    // crates.io returns a 200 response with an errors object in
-    // error scenarios, e.g. https://crates.io/api/v1/crates/libc/0.1
-    if (errors) {
-      throw new NotFound({ prettyMessage: errors[0].detail })
-    }
-
+  static transform({ version, versions }) {
     const msrv = version ? version.rust_version : versions[0].rust_version
     if (!msrv) {
       throw new NotFound({ prettyMessage: 'unknown' })

--- a/services/crates/crates-version.service.js
+++ b/services/crates/crates-version.service.js
@@ -1,5 +1,5 @@
 import { renderVersionBadge } from '../version.js'
-import { InvalidResponse, pathParams } from '../index.js'
+import { pathParams } from '../index.js'
 import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesVersion extends BaseCratesService {
@@ -20,9 +20,6 @@ export default class CratesVersion extends BaseCratesService {
   }
 
   transform(json) {
-    if (json.errors) {
-      throw new InvalidResponse({ prettyMessage: json.errors[0].detail })
-    }
     return json.crate.max_stable_version
       ? json.crate.max_stable_version
       : json.crate.max_version

--- a/services/crates/crates-version.spec.js
+++ b/services/crates/crates-version.spec.js
@@ -1,6 +1,4 @@
 import { test, given } from 'sazerac'
-import { expect } from 'chai'
-import { InvalidResponse } from '../index.js'
 import CratesVersion from './crates-version.service.js'
 
 describe('CratesVersion', function () {
@@ -9,11 +7,5 @@ describe('CratesVersion', function () {
     given({
       crate: { max_stable_version: '1.1.0', max_version: '1.9.0-alpha' },
     }).expect('1.1.0')
-  })
-
-  it('throws InvalidResponse on error response', function () {
-    expect(() =>
-      CratesVersion.prototype.transform({ errors: [{ detail: 'idk how...' }] }),
-    ).to.throw(InvalidResponse)
   })
 })


### PR DESCRIPTION
There's a few small things here that came out of the review of https://github.com/badges/shields/pull/9871

1. Fix a failing service test. This is a change in the upstream API behaviour. That case now returns a `404 Not Found` with the body `{"errors":[{"detail":"crate `libc` does not have a version `7`"}]}`. I've updated the assertion as we now throw an error based on the response code.
2. I was originally planning to move the handling of "`200 OK` with an error body" up a level to de-dupe, and check for that condition in `BaseCratesService.fetch()`. However, given that the condition we were attempting to handle looks like it is now fixed (and that's what required us to update that test), I've decided to just completely remove the handling for this and treat a `200 OK` with an error body as a schema fail from now on. None of the calls in the comments now yield that result, all the tests pass, and I now don't have an example of a call that behaves this way. If it does happen, Joi will reject the response anyway, albeit with a more generic error.
3. I removed a `render()` method that just passes the value through.