### PR TITLE
[thunderstore] Replace experimental API usage with newly available v1 API

### DIFF
--- a/services/thunderstore/thunderstore-base.js
+++ b/services/thunderstore/thunderstore-base.js
@@ -2,15 +2,10 @@ import Joi from 'joi'
 import { BaseJsonService } from '../index.js'
 import { nonNegativeInteger } from '../validators.js'
 
-const packageSchema = Joi.object({
-  latest: Joi.object({
-    version_number: Joi.string().required(),
-  }).required(),
-}).required()
-
 const packageMetricsSchema = Joi.object({
   downloads: nonNegativeInteger,
   rating_score: nonNegativeInteger,
+  latest_version: Joi.string().required(),
 })
 
 const description = `
@@ -58,22 +53,6 @@ const description = `
  */
 class BaseThunderstoreService extends BaseJsonService {
   static thunderstoreGreen = '23FFB0'
-
-  /**
-   * Fetches package metadata from the Thunderstore API.
-   *
-   * @param {object} pkg - Package specifier
-   * @param {string} pkg.namespace - the package namespace
-   * @param {string} pkg.packageName - the package name
-   * @returns {Promise<object>} - Promise containing validated package information
-   */
-  async fetchPackage({ namespace, packageName }) {
-    return this._requestJson({
-      schema: packageSchema,
-      url: `https://thunderstore.io/api/experimental/package/${namespace}/${packageName}`,
-    })
-  }
-
   /**
    * Fetches package metrics from the Thunderstore API.
    *

--- a/services/thunderstore/thunderstore-version.service.js
+++ b/services/thunderstore/thunderstore-version.service.js
@@ -34,9 +34,10 @@ export default class ThunderstoreVersion extends BaseThunderstoreService {
    * @returns {Promise<object>} - Promise containing the rendered badge payload
    */
   async handle({ namespace, packageName }) {
-    const {
-      latest: { version_number: version },
-    } = await this.fetchPackage({ namespace, packageName })
+    const { latest_version: version } = await this.fetchPackageMetrics({
+      namespace,
+      packageName,
+    })
     return renderVersionBadge({ version })
   }
 }


### PR DESCRIPTION
Closes badges/shields#9837.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
