### PR TITLE
sort categories by title (except core)

### DIFF
--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -198,7 +198,13 @@ function addGlobalProperties(endpoints) {
   return paths
 }
 
-function services2openapi(services) {
+function sortPaths(obj) {
+  const entries = Object.entries(obj)
+  entries.sort((a, b) => a[1].get.summary.localeCompare(b[1].get.summary))
+  return Object.fromEntries(entries)
+}
+
+function services2openapi(services, sort) {
   const paths = {}
   for (const service of services) {
     if (service.openApi) {
@@ -221,10 +227,10 @@ function services2openapi(services) {
       }
     }
   }
-  return paths
+  return sort ? sortPaths(paths) : paths
 }
 
-function category2openapi(category, services) {
+function category2openapi({ category, services, sort = false }) {
   const spec = {
     openapi: '3.0.0',
     info: {
@@ -334,7 +340,7 @@ function category2openapi(category, services) {
         },
       },
     },
-    paths: services2openapi(services),
+    paths: services2openapi(services, sort),
   }
 
   return spec

--- a/core/base-service/openapi.spec.js
+++ b/core/base-service/openapi.spec.js
@@ -377,10 +377,13 @@ describe('category2openapi', function () {
   it('generates an Open API spec', function () {
     expect(
       clean(
-        category2openapi({ name: 'build' }, [
-          OpenApiService.getDefinition(),
-          LegacyService.getDefinition(),
-        ]),
+        category2openapi({
+          category: { name: 'build' },
+          services: [
+            OpenApiService.getDefinition(),
+            LegacyService.getDefinition(),
+          ],
+        }),
       ),
     ).to.deep.equal(expected)
   })

--- a/scripts/export-openapi-cli.js
+++ b/scripts/export-openapi-cli.js
@@ -27,7 +27,7 @@ function writeSpec(filename, spec) {
 
     writeSpec(
       path.join(specsPath, `${category.id}.yaml`),
-      category2openapi(category, services),
+      category2openapi({ category, services, sort: true }),
     )
   }
 
@@ -44,6 +44,10 @@ function writeSpec(filename, spec) {
   )
   writeSpec(
     path.join(specsPath, '1core.yaml'),
-    category2openapi({ name: 'Core' }, coreServices),
+    category2openapi({
+      category: { name: 'Core' },
+      services: coreServices,
+      sort: false,
+    }),
   )
 })()


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/9884

I've kept core unsorted so we can put "static badge" first. The other categories now sort by title