### PR TITLE
use brightgreen for build passing in package docs

### DIFF
--- a/badge-maker/README.md
+++ b/badge-maker/README.md
@@ -16,7 +16,7 @@ npm install badge-maker
 
 ```sh
 npm install -g badge-maker
-badge build passed :green > mybadge.svg
+badge build passed :brightgreen > mybadge.svg
 ```
 
 ### As a library
@@ -37,7 +37,7 @@ import { makeBadge, ValidationError } from 'badge-maker'
 const format = {
   label: 'build',
   message: 'passed',
-  color: 'green',
+  color: 'brightgreen',
 }
 
 const svg = makeBadge(format)


### PR DESCRIPTION
Minor thing I noticed while working on https://github.com/badges/shields/pull/9916
The semantic colour for build pass is brightgreen so lets get that right in the package docs