### PR TITLE
deprecate TAS

### DIFF
--- a/services/tas/tas-tests.service.js
+++ b/services/tas/tas-tests.service.js
@@ -1,111 +1,13 @@
-import Joi from 'joi'
-import { BaseJsonService } from '../index.js'
-import {
-  testResultQueryParamSchema,
-  renderTestResultBadge,
-} from '../test-results.js'
-import { nonNegativeInteger } from '../../services/validators.js'
+import { deprecatedService } from '../index.js'
 
-const commonAttrs = {
-  namedParams: {
-    provider: 'github',
-    org: 'tasdemo',
-    repo: 'axios',
-  },
-  queryParams: {
-    passed_label: 'passed',
-    failed_label: 'failed',
-    skipped_label: 'skipped',
-    compact_message: null,
-  },
-}
-
-const schema = Joi.object({
-  badge: Joi.object({
-    passed: nonNegativeInteger,
-    failed: nonNegativeInteger,
-    skipped: nonNegativeInteger,
-    total_tests: nonNegativeInteger,
-    status: Joi.string().required(),
-  }).required(),
-}).required()
-
-export default class TasBuildStatus extends BaseJsonService {
-  static category = 'test-results'
-
-  static route = {
+const TasBuildStatus = deprecatedService({
+  category: 'test-results',
+  route: {
     base: 'tas/tests',
     pattern: ':provider/:org/:repo',
-    queryParamSchema: testResultQueryParamSchema,
-  }
+  },
+  label: 'tests',
+  dateAdded: new Date('2024-01-29'),
+})
 
-  static examples = [
-    {
-      title: 'TAS Tests',
-      staticPreview: this.render({
-        passed: 20,
-        failed: 1,
-        skipped: 1,
-        total: 22,
-      }),
-      ...commonAttrs,
-    },
-  ]
-
-  static defaultBadgeData = { label: 'tests' }
-
-  static render({
-    passed,
-    failed,
-    skipped,
-    total,
-    passedLabel,
-    failedLabel,
-    skippedLabel,
-    isCompact,
-  }) {
-    return renderTestResultBadge({
-      passed,
-      failed,
-      skipped,
-      total,
-      passedLabel,
-      failedLabel,
-      skippedLabel,
-      isCompact,
-    })
-  }
-
-  async fetch({ provider, org, repo }) {
-    return this._requestJson({
-      schema,
-      url: `https://api.tas.lambdatest.com/repo/badge?git_provider=${provider}&org=${org}&repo=${repo}`,
-      httpErrors: {
-        401: 'private project not supported',
-        404: 'project not found',
-      },
-    })
-  }
-
-  async handle(
-    { provider, org, repo },
-    {
-      compact_message: compactMessage,
-      passed_label: passedLabel,
-      failed_label: failedLabel,
-      skipped_label: skippedLabel,
-    },
-  ) {
-    const { badge } = await this.fetch({ provider, org, repo })
-    return this.constructor.render({
-      passed: badge.passed,
-      failed: badge.failed,
-      skipped: badge.skipped,
-      total: badge.total_tests,
-      passedLabel,
-      failedLabel,
-      skippedLabel,
-      isCompact: compactMessage !== undefined,
-    })
-  }
-}
+export default TasBuildStatus

--- a/services/tas/tas-tests.tester.js
+++ b/services/tas/tas-tests.tester.js
@@ -1,62 +1,11 @@
-import { createServiceTester } from '../tester.js'
-import {
-  isDefaultTestTotals,
-  isCustomTestTotals,
-  isCustomCompactTestTotals,
-} from '../test-validators.js'
+import { ServiceTester } from '../tester.js'
 
-export const t = await createServiceTester()
+export const t = new ServiceTester({
+  id: 'tas',
+  title: 'TasBuildStatus',
+  pathPrefix: '/tas/tests',
+})
 
 t.create('Test status')
   .get('/github/tasdemo/axios.json')
-  .expectBadge({ label: 'tests', message: isDefaultTestTotals })
-
-t.create('Test status with custom labels')
-  .get('/github/tasdemo/axios.json', {
-    qs: {
-      passed_label: 'good',
-      failed_label: 'bad',
-      skipped_label: 'n/a',
-    },
-  })
-  .expectBadge({ label: 'tests', message: isCustomTestTotals })
-
-t.create('Test status with compact message and custom labels')
-  .get('/github/tasdemo/axios.json', {
-    qs: {
-      compact_message: null,
-      passed_label: '💃',
-      failed_label: '🤦‍♀️',
-      skipped_label: '🤷',
-    },
-  })
-  .expectBadge({
-    label: 'tests',
-    message: isCustomCompactTestTotals,
-  })
-
-t.create('Test status on project that does not exist')
-  .get('/github/tasdemo/doesntexist.json')
-  .expectBadge({
-    label: 'tests',
-    message: 'project not found',
-    color: 'red',
-  })
-
-t.create('Test status on private project')
-  .get('/github/tasdemo/nexe-private.json')
-  .intercept(nock =>
-    nock('https://api.tas.lambdatest.com')
-      .get('/repo/badge')
-      .query({
-        git_provider: 'github',
-        org: 'tasdemo',
-        repo: 'nexe-private',
-      })
-      .reply(401),
-  )
-  .expectBadge({
-    label: 'tests',
-    message: 'private project not supported',
-    color: 'lightgrey',
-  })
+  .expectBadge({ label: 'tests', message: 'no longer available' })


### PR DESCRIPTION
This has been failing for a long time. As far as I can tell the upstream API endpoint is gone and has not been replaced.

Suggest we just bin this service.