### PR TITLE
randomize tokens on token pool init

### DIFF
--- a/core/token-pooling/sql-token-persistence.js
+++ b/core/token-pooling/sql-token-persistence.js
@@ -15,7 +15,9 @@ export default class SqlTokenPersistence {
     } else {
       this.pool = new pg.Pool({ connectionString: this.url })
     }
-    const result = await this.pool.query(`SELECT token FROM ${this.table};`)
+    const result = await this.pool.query(
+      `SELECT token FROM ${this.table} ORDER BY RANDOM();`,
+    )
     return result.rows.map(row => row.token)
   }
 


### PR DESCRIPTION
While I was worrying about https://github.com/badges/shields/issues/9978 I spent a bit of time digging into the token pool code.

I don't think this is related as such, but one of the things I realised is that when we bootstrap the server, all the VMs in the cluster load all the tokens in the same order.

Grabbing the tokens in a random order will do a better job of spreading the traffic out over the available tokens we have.