### PR TITLE
[certificate] Add certificate expiration badge

### DIFF
--- a/services/certificate/certificate-expiration.service.js
+++ b/services/certificate/certificate-expiration.service.js
@@ -57,11 +57,12 @@ export default class CertificateExpiration extends BaseService {
       return { expiresStr: resp.res.req.socket.getPeerCertificate().valid_to }
     } catch (err) {
       // since got will throw on a redirect, we need to catch it here and possibly return the expiration date we found
-      const expiresStr = resp?.res?.req?.socket?.getPeerCertificate()?.valid_to
+      const expiresStr =
+        err.response?.req?.socket?.getPeerCertificate()?.valid_to
       trace.logTrace(
         'outbound',
         emojic.noGoodWoman,
-        'fetch error',
+        'cert fetch error',
         hostname,
         expiresStr,
         err,

--- a/services/certificate/certificate-expiration.service.js
+++ b/services/certificate/certificate-expiration.service.js
@@ -1,0 +1,126 @@
+import tls from 'tls'
+import emojic from 'emojic'
+import Joi from 'joi'
+import { BaseService, pathParam, queryParam } from '../index.js'
+import trace from '../../core/base-service/trace.js'
+
+const queryParamSchema = Joi.object({
+  warningDays: Joi.number().min(0),
+  dangerDays: Joi.number().min(0),
+}).required()
+
+export default class CertificateExpiration extends BaseService {
+  static category = 'monitoring'
+
+  static route = {
+    base: 'certificate/expiration',
+    pattern: ':hostname',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/certificate/expiration/{hostname}': {
+      get: {
+        summary: 'Certificate Expiration',
+        parameters: [
+          pathParam({ name: 'hostname', example: 'shields.io' }),
+          queryParam({
+            name: 'warningDays',
+            schema: { type: 'number' },
+            description:
+              'Warning (yellow) if less than this many days remain (default=30)',
+            example: '30',
+          }),
+          queryParam({
+            name: 'dangerDays',
+            schema: { type: 'number' },
+            description:
+              'Danger (red) if less than this many days remain (default=7)',
+            example: '7',
+          }),
+        ],
+      },
+    },
+  }
+
+  static _cacheLength = 0
+
+  async fetch({ hostname }) {
+    let expires = null
+    trace.logTrace('outbound', emojic.womanCook, 'trying', hostname)
+    try {
+      await this._request({
+        cache: false,
+        method: 'GET',
+        url: `https://${hostname}/`,
+        options: {
+          // explicitly set followRedirect to false to avoid getting the post-redirect certificate
+          followRedirect: false,
+          headers: {
+            'cache-control': 'no-cache',
+          },
+          https: {
+            checkServerIdentity: (innerhost, certificate) => {
+              const mismatchErr = tls.checkServerIdentity(hostname, certificate)
+              if (mismatchErr) {
+                return mismatchErr
+              }
+              trace.logTrace('validate', emojic.dart, 'cert found', certificate)
+              if (certificate?.valid_to != null) {
+                expires = new Date()
+                expires.setTime(Date.parse(certificate?.valid_to))
+              }
+              return undefined
+            },
+          },
+          // we don't actually care about 4xx/5xx HTTP errors, we just want the expiration date
+          throwHttpErrors: false,
+        },
+      })
+    } catch (err) {
+      // since got will throw on a redirect, we need to catch it here and possibly return the expiration date we found
+      trace.logTrace(
+        'outbound',
+        emojic.noGoodWoman,
+        'fetch error',
+        hostname,
+        expires,
+        err,
+      )
+      return { expires }
+    }
+    trace.logTrace('outbound', emojic.womanCook, 'success', hostname, expires)
+    return { expires }
+  }
+
+  async handle({ hostname }, { warningDays = 30, dangerDays = 7 }) {
+    try {
+      const { expires } = await this.fetch({ hostname })
+      const warningThreshold =
+        new Date().getTime() + warningDays * 24 * 60 * 60 * 1000
+      const dangerThreshold =
+        new Date().getTime() + dangerDays * 24 * 60 * 60 * 1000
+      const message = expires.toISOString().slice(0, 10)
+      let color = 'green'
+      if (expires.getTime() < dangerThreshold) {
+        color = 'red'
+      } else if (expires.getTime() < warningThreshold) {
+        color = 'yellow'
+      }
+      return {
+        label: hostname,
+        color,
+        message,
+      }
+    } catch (err) {
+      trace.logTrace(
+        'unhandledError',
+        emojic.noGoodWoman,
+        'handle error',
+        hostname,
+        err,
+      )
+      return { label: hostname, color: 'red', message: 'error' }
+    }
+  }
+}

--- a/services/certificate/certificate-expiration.tester.js
+++ b/services/certificate/certificate-expiration.tester.js
@@ -25,17 +25,17 @@ t.create('Certificate Expiration: good, green')
   })
 
 t.create('Certificate Expiration: good, yellow')
-  .get('/github.com.json?warningDays=365&dangerDays=0')
+  .get('/shields.io.json?warningDays=365&dangerDays=0')
   .expectBadge({
-    label: 'github.com',
+    label: 'shields.io',
     color: 'yellow',
     message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
   })
 
 t.create('Certificate Expiration: good, red')
-  .get('/github.io.json?dangerDays=365')
+  .get('/shields.io.json?dangerDays=365')
   .expectBadge({
-    label: 'github.io',
+    label: 'shields.io',
     color: 'red',
     message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
   })

--- a/services/certificate/certificate-expiration.tester.js
+++ b/services/certificate/certificate-expiration.tester.js
@@ -1,0 +1,49 @@
+import Joi from 'joi'
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'certificate-expiration',
+  title: 'Certificate Expiration',
+  pathPrefix: '/certificate/expiration',
+})
+
+// NOTE: test hostnames are from https://badssl.com/dashboard/
+
+t.create('Certificate Expiration: good, any color')
+  .get('/letsencrypt.org.json')
+  .expectBadge({
+    label: 'letsencrypt.org',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+t.create('Certificate Expiration: good, green')
+  .get('/shields.io.json?warningDays=0&dangerDays=0')
+  .expectBadge({
+    label: 'shields.io',
+    color: 'green',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+t.create('Certificate Expiration: good, yellow')
+  .get('/github.com.json?warningDays=365&dangerDays=0')
+  .expectBadge({
+    label: 'github.com',
+    color: 'yellow',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+t.create('Certificate Expiration: good, red')
+  .get('/github.io.json?dangerDays=365')
+  .expectBadge({
+    label: 'github.io',
+    color: 'red',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+t.create('Certificate Expiration: actually expired')
+  .get('/expired.badssl.com.json')
+  .expectBadge({ label: 'expired.badssl.com', color: 'red' })
+
+t.create('Certificate Expiration: mismatch')
+  .get('/wrong.host.badssl.com.json')
+  .expectBadge({ label: 'wrong.host.badssl.com', color: 'red' })

--- a/services/certificate/certificate-expiration.tester.js
+++ b/services/certificate/certificate-expiration.tester.js
@@ -7,8 +7,6 @@ export const t = new ServiceTester({
   pathPrefix: '/certificate/expiration',
 })
 
-// NOTE: test hostnames are from https://badssl.com/dashboard/
-
 t.create('Certificate Expiration: good, any color')
   .get('/letsencrypt.org.json')
   .expectBadge({
@@ -39,6 +37,26 @@ t.create('Certificate Expiration: good, red')
     color: 'red',
     message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
   })
+
+// remote redirect to https://www.cloudflare.com/
+t.create(
+  'Certificate Expiration: good, any color, redirected to different host',
+)
+  .get('/cloudflare.com.json')
+  .expectBadge({
+    label: 'cloudflare.com',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+// local redirect to /en/
+t.create('Certificate Expiration: good, any color, redirected to same host')
+  .get('/www.worldbank.org.json')
+  .expectBadge({
+    label: 'www.worldbank.org',
+    message: Joi.string().regex(/\d{4}-\d{2}-\d{2}/),
+  })
+
+// NOTE: test hostnames are from https://badssl.com/dashboard/
 
 t.create('Certificate Expiration: actually expired')
   .get('/expired.badssl.com.json')


### PR DESCRIPTION
Hi!  I have this, and it is basically working (i.e. tests pass), but there is some caching going on that is causing problems.

If you try to get the same hostname within 60ish seconds, it will not call `checkServerIdentity` and you'll get an error.  It works again after a bit, and other hostnames will also work (but just once) during the interval.

I think it is something being cached or re-used in guts of got.js, but couldn't find a workaround.  I'm happy to bypass got.js and call node.js `https.request` directly, but wanted to check if this would be acceptable first.

Separate question: I have a website with a page to check certificates [example](https://resolve.rs/http/cert-check.html?hostname=shields.io).  Is it okay to use it for the `link`?