### PR TITLE
[YOUTRACK] Add YouTrack Issues

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -142,6 +142,7 @@ const publicConfigSchema = Joi.object({
     sonar: defaultService,
     teamcity: defaultService,
     weblate: defaultService,
+    youtrack: defaultService,
     trace: Joi.boolean().required(),
   }).required(),
   cacheHeaders: { defaultCacheLengthSeconds: nonNegativeInteger },
@@ -205,6 +206,7 @@ const privateConfigSchema = Joi.object({
   influx_password: Joi.string(),
   weblate_api_key: Joi.string(),
   youtube_api_key: Joi.string(),
+  youtrack_token: Joi.string(),
 }).required()
 const privateMetricsInfluxConfigSchema = privateConfigSchema.append({
   influx_username: Joi.string().required(),

--- a/doc/server-secrets.md
+++ b/doc/server-secrets.md
@@ -364,6 +364,15 @@ and create an API key for the YouTube Data API v3.
 
 [youtube credentials]: https://console.developers.google.com/apis/credentials
 
+### YouTrack
+
+- `YOUTRACK_ORIGINS` (yml: `public.services.youtrack.authorizedOrigins`)
+- `YOUTRACK_TOKEN` (yml: `private.youtrack_token`)
+
+A Youtrack [Permanent Access Token][youtrack-pat] is required for accessing private content. If you need a Youtrack token for your self-hosted Shields server then we recommend limiting the scopes to the minimal set necessary for the badges you are using.
+
+[youtrack-pat]: https://www.jetbrains.com/help/youtrack/devportal/Manage-Permanent-Token.html
+
 ## Error reporting
 
 - `SENTRY_DSN` (yml: `private.sentry_dsn`)

--- a/services/youtrack/youtrack-base.js
+++ b/services/youtrack/youtrack-base.js
@@ -7,15 +7,12 @@ export default class YoutrackBase extends BaseJsonService {
   }
 
   async fetch({ url, options, schema, httpErrors }) {
-    console.log(url)
-    console.log(options)
-
     return this._requestJson(
       this.authHelper.withBearerAuthHeader({
         schema,
         url,
         options,
-        httpErrors: { 500: 'invalid query' },
+        httpErrors: { 500: 'invalid query', ...httpErrors },
       }),
     )
   }

--- a/services/youtrack/youtrack-base.js
+++ b/services/youtrack/youtrack-base.js
@@ -1,0 +1,22 @@
+import { BaseJsonService } from '../index.js'
+
+export default class YoutrackBase extends BaseJsonService {
+  static auth = {
+    passKey: 'youtrack_token',
+    serviceKey: 'youtrack',
+  }
+
+  async fetch({ url, options, schema, httpErrors }) {
+    console.log(url)
+    console.log(options)
+
+    return this._requestJson(
+      this.authHelper.withBearerAuthHeader({
+        schema,
+        url,
+        options,
+        httpErrors: { 500: 'invalid query' },
+      }),
+    )
+  }
+}

--- a/services/youtrack/youtrack-base.js
+++ b/services/youtrack/youtrack-base.js
@@ -13,6 +13,9 @@ export default class YoutrackBase extends BaseJsonService {
         url,
         options,
         httpErrors: { 500: 'invalid query', ...httpErrors },
+        systemErrors: {
+          ETIMEOUT: { prettyMessage: 'timeout', cacheSeconds: 10 },
+        },
       }),
     )
   }

--- a/services/youtrack/youtrack-base.spec.js
+++ b/services/youtrack/youtrack-base.spec.js
@@ -1,0 +1,48 @@
+import Joi from 'joi'
+import { expect } from 'chai'
+import nock from 'nock'
+import { cleanUpNockAfterEach, defaultContext } from '../test-helpers.js'
+import YoutrackBase from './youtrack-base.js'
+
+class DummyYoutrackService extends YoutrackBase {
+  static route = { base: 'fake-base' }
+
+  async handle() {
+    const data = await this.fetch({
+      schema: Joi.any(),
+      url: 'https://youtrack.jetbrains.com//api/issuesGetter/count?fields=count',
+    })
+    return { message: data.message }
+  }
+}
+
+describe('YoutrackBase', function () {
+  describe('auth', function () {
+    cleanUpNockAfterEach()
+
+    const config = {
+      public: {
+        services: {
+          youtrack: {
+            authorizedOrigins: ['https://youtrack.jetbrains.com'],
+          },
+        },
+      },
+      private: {
+        youtrack_token: 'fake-key',
+      },
+    }
+
+    it('sends the auth information as configured', async function () {
+      const scope = nock('https://youtrack.jetbrains.com')
+        .get('/api/issuesGetter/count?fields=count')
+        .matchHeader('Authorization', 'Bearer fake-key')
+        .reply(200, { message: 'fake message' })
+      expect(
+        await DummyYoutrackService.invoke(defaultContext, config, {}),
+      ).to.not.have.property('isError')
+
+      scope.done()
+    })
+  })
+})

--- a/services/youtrack/youtrack-base.spec.js
+++ b/services/youtrack/youtrack-base.spec.js
@@ -10,7 +10,7 @@ class DummyYoutrackService extends YoutrackBase {
   async handle() {
     const data = await this.fetch({
       schema: Joi.any(),
-      url: 'https://youtrack.jetbrains.com//api/issuesGetter/count?fields=count',
+      url: 'https://shields.youtrack.cloud/api/issuesGetter/count?fields=count',
     })
     return { message: data.message }
   }
@@ -24,7 +24,7 @@ describe('YoutrackBase', function () {
       public: {
         services: {
           youtrack: {
-            authorizedOrigins: ['https://youtrack.jetbrains.com'],
+            authorizedOrigins: ['https://shields.youtrack.cloud'],
           },
         },
       },
@@ -34,7 +34,7 @@ describe('YoutrackBase', function () {
     }
 
     it('sends the auth information as configured', async function () {
-      const scope = nock('https://youtrack.jetbrains.com')
+      const scope = nock('https://shields.youtrack.cloud')
         .get('/api/issuesGetter/count?fields=count')
         .matchHeader('Authorization', 'Bearer fake-key')
         .reply(200, { message: 'fake message' })

--- a/services/youtrack/youtrack-helper.js
+++ b/services/youtrack/youtrack-helper.js
@@ -1,0 +1,6 @@
+const description = `
+By default this badge looks for projects on [youtrack.jetbrains.com](https://youtrack.jetbrains.com).
+To specify a self-hosted instance, use the \`youtrack_url\` query param.
+`
+
+export { description }

--- a/services/youtrack/youtrack-helper.js
+++ b/services/youtrack/youtrack-helper.js
@@ -1,6 +1,7 @@
 const description = `
-By default this badge looks for projects on [youtrack.jetbrains.com](https://youtrack.jetbrains.com).
-To specify a self-hosted instance, use the \`youtrack_url\` query param.
+Returns the number of issues for the specified project based on the \`query\` parameter defined.
+
+NOTE: The \`youtrack_url\` query param is required.
 `
 
 export { description }

--- a/services/youtrack/youtrack-issues.service.js
+++ b/services/youtrack/youtrack-issues.service.js
@@ -5,12 +5,10 @@ import { metric } from '../text-formatters.js'
 import { description } from './youtrack-helper.js'
 import YoutrackBase from './youtrack-base.js'
 
-const schema = Joi.array().items(
-  Joi.object({
-    count: Joi.number().required(),
-    type: Joi.string().required(),
-  }),
-)
+const schema = Joi.object({
+  count: Joi.number().required(),
+  $type: Joi.equal('IssueCountResponse'),
+})
 
 const queryParamSchema = Joi.object({
   query: Joi.string(),
@@ -66,9 +64,7 @@ export default class YoutrackIssues extends YoutrackBase {
       schema,
       options: {
         method: 'POST',
-        searchParams: {
-          query,
-        },
+        json: { query },
       },
       url: `${baseUrl}/api/issuesGetter/count?fields=count`,
     })
@@ -78,16 +74,11 @@ export default class YoutrackIssues extends YoutrackBase {
     { project },
     { youtrack_url: baseUrl = 'https://youtrack.jetbrains.com', query },
   ) {
-    const { res } = await this.fetch({
+    const data = await this.fetch({
       baseUrl,
       query: `project: ${project} ${query}`,
     })
 
-    console.log(res)
-
-    const data = this.constructor._validate(res.headers, schema)
-
-    const count = data.count()
-    return this.constructor.render({ count })
+    return this.constructor.render({ count: data.count })
   }
 }

--- a/services/youtrack/youtrack-issues.service.js
+++ b/services/youtrack/youtrack-issues.service.js
@@ -1,0 +1,93 @@
+import Joi from 'joi'
+import { pathParam, queryParam } from '../index.js'
+import { optionalUrl } from '../validators.js'
+import { metric } from '../text-formatters.js'
+import { description } from './youtrack-helper.js'
+import YoutrackBase from './youtrack-base.js'
+
+const schema = Joi.array().items(
+  Joi.object({
+    count: Joi.number().required(),
+    type: Joi.string().required(),
+  }),
+)
+
+const queryParamSchema = Joi.object({
+  query: Joi.string(),
+  youtrack_url: optionalUrl,
+}).required()
+
+export default class YoutrackIssues extends YoutrackBase {
+  static category = 'issue-tracking'
+
+  static route = {
+    base: 'youtrack/issues',
+    pattern: ':project+',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/youtrack/issues/{project}': {
+      get: {
+        summary: 'Youtrack Issues',
+        description,
+        parameters: [
+          pathParam({
+            name: 'project',
+            example: 'RIDER',
+          }),
+          queryParam({
+            name: 'youtrack_url',
+            example: 'https://youtrack.jetbrains.com',
+          }),
+          queryParam({
+            name: 'query',
+            example: 'bug #Unresolved',
+            description: 'A valid YouTrack search query.',
+          }),
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'issues', color: 'informational' }
+
+  static render({ count }) {
+    return {
+      label: 'issues',
+      message: metric(count),
+      color: count > 0 ? 'yellow' : 'brightgreen',
+    }
+  }
+
+  async fetch({ baseUrl, query }) {
+    // https://www.jetbrains.com.cn/en-us/help/youtrack/devportal/resource-api-issuesGetter-count.html
+    return super.fetch({
+      schema,
+      options: {
+        method: 'POST',
+        searchParams: {
+          query,
+        },
+      },
+      url: `${baseUrl}/api/issuesGetter/count?fields=count`,
+    })
+  }
+
+  async handle(
+    { project },
+    { youtrack_url: baseUrl = 'https://youtrack.jetbrains.com', query },
+  ) {
+    const { res } = await this.fetch({
+      baseUrl,
+      query: `project: ${project} ${query}`,
+    })
+
+    console.log(res)
+
+    const data = this.constructor._validate(res.headers, schema)
+
+    const count = data.count()
+    return this.constructor.render({ count })
+  }
+}

--- a/services/youtrack/youtrack-issues.service.js
+++ b/services/youtrack/youtrack-issues.service.js
@@ -36,7 +36,8 @@ export default class YoutrackIssues extends YoutrackBase {
           }),
           queryParam({
             name: 'youtrack_url',
-            example: 'https://youtrack.jetbrains.com',
+            example: 'https://shields.youtrack.cloud',
+            required: true,
           }),
           queryParam({
             name: 'query',
@@ -54,7 +55,7 @@ export default class YoutrackIssues extends YoutrackBase {
     return {
       label: 'issues',
       message: metric(count),
-      color: count > 0 ? 'yellow' : 'brightgreen',
+      color: count < 0 ? 'red' : count > 0 ? 'yellow' : 'brightgreen',
     }
   }
 

--- a/services/youtrack/youtrack-issues.service.js
+++ b/services/youtrack/youtrack-issues.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { pathParam, queryParam } from '../index.js'
+import { InvalidResponse, pathParam, queryParam } from '../index.js'
 import { optionalUrl } from '../validators.js'
 import { metric } from '../text-formatters.js'
 import { description } from './youtrack-helper.js'
@@ -55,7 +55,7 @@ export default class YoutrackIssues extends YoutrackBase {
     return {
       label: 'issues',
       message: metric(count),
-      color: count < 0 ? 'red' : count > 0 ? 'yellow' : 'brightgreen',
+      color: count > 0 ? 'yellow' : 'brightgreen',
     }
   }
 
@@ -80,6 +80,12 @@ export default class YoutrackIssues extends YoutrackBase {
       query: `project: ${project} ${query}`,
     })
 
+    if (data.count === -1) {
+      throw new InvalidResponse({
+        prettyMessage: 'processing',
+        cacheSeconds: 10,
+      })
+    }
     return this.constructor.render({ count: data.count })
   }
 }

--- a/services/youtrack/youtrack-issues.service.js
+++ b/services/youtrack/youtrack-issues.service.js
@@ -71,10 +71,7 @@ export default class YoutrackIssues extends YoutrackBase {
     })
   }
 
-  async handle(
-    { project },
-    { youtrack_url: baseUrl = 'https://youtrack.jetbrains.com', query },
-  ) {
+  async handle({ project }, { youtrack_url: baseUrl, query }) {
     const data = await this.fetch({
       baseUrl,
       query: `project: ${project} ${query}`,

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -10,6 +10,13 @@ t.create('Issues (DEMO) (Cloud)')
     message: isMetricAllowNegative,
   })
 
+t.create('Issues (DEMO) (Empty Query) (Cloud)')
+  .get('/DEMO.json?youtrack_url=https://shields.youtrack.cloud')
+  .expectBadge({
+    label: 'issues',
+    message: isMetricAllowNegative,
+  })
+
 t.create('Issues (DEMO) (Invalid State) (Cloud Hosted)')
   .get('/DEMO.json?https://shields.youtrack.cloud&query=%23ABCDEFG')
   .expectBadge({

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -3,20 +3,22 @@ import { isMetricAllowNegative } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
-t.create('Issues (IDEA)').get('/IDEA.json?query=%23Unresolved').expectBadge({
-  label: 'issues',
-  message: isMetricAllowNegative,
-})
+t.create('Issues (DEMO) (Cloud)')
+  .get('/DEMO.json?youtrack_url=https://shields.youtrack.cloud&query=%23Fixed')
+  .expectBadge({
+    label: 'issues',
+    message: isMetricAllowNegative,
+  })
 
-t.create('Issues (IDEA) (Invalid State)')
-  .get('/IDEA.json?query=%23ABCDEFG')
+t.create('Issues (DEMO) (Invalid State) (Cloud Hosted)')
+  .get('/DEMO.json?https://shields.youtrack.cloud&query=%23ABCDEFG')
   .expectBadge({
     label: 'issues',
     message: 'invalid',
   })
 
-t.create('Issues (DOESNOTEXIST) (Invalid Project)')
-  .get('/DOESNOTEXIST.json?query=%23Unresolved')
+t.create('Issues (DOESNOTEXIST) (Invalid Project) (Cloud Hosted)')
+  .get('/DOESNOTEXIST.json?https://shields.youtrack.cloud&query=%23Unresolved')
   .expectBadge({
     label: 'issues',
     message: 'invalid',

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -19,14 +19,18 @@ t.create('Issues (DEMO) (Empty Query) (Cloud)')
   })
 
 t.create('Issues (DEMO) (Invalid State) (Cloud Hosted)')
-  .get('/DEMO.json?https://shields.youtrack.cloud&query=%23ABCDEFG')
+  .get(
+    '/DEMO.json?youtrack_url=https://shields.youtrack.cloud&query=%23ABCDEFG',
+  )
   .expectBadge({
     label: 'issues',
     message: 'invalid',
   })
 
 t.create('Issues (DOESNOTEXIST) (Invalid Project) (Cloud Hosted)')
-  .get('/DOESNOTEXIST.json?https://shields.youtrack.cloud&query=%23Unresolved')
+  .get(
+    '/DOESNOTEXIST.json?youtrack_url=https://shields.youtrack.cloud&query=%23Unresolved',
+  )
   .expectBadge({
     label: 'issues',
     message: 'invalid',

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -1,9 +1,23 @@
 import { createServiceTester } from '../tester.js'
-import { isMetric } from '../test-validators.js'
+import { isMetricAllowNegative } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
-t.create('Issues (RIDER)').get('/RIDER?query=%23Unresolved').expectBadge({
+t.create('Issues (IDEA)').get('/IDEA.json?query=%23Unresolved').expectBadge({
   label: 'issues',
-  message: isMetric,
+  message: isMetricAllowNegative,
 })
+
+t.create('Issues (IDEA) (Invalid State)')
+  .get('/IDEA.json?query=%23ABCDEFG')
+  .expectBadge({
+    label: 'issues',
+    message: 'invalid',
+  })
+
+t.create('Issues (DOESNOTEXIST) (Invalid Project)')
+  .get('/DOESNOTEXIST.json?query=%23Unresolved')
+  .expectBadge({
+    label: 'issues',
+    message: 'invalid',
+  })

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -1,0 +1,9 @@
+import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
+
+export const t = await createServiceTester()
+
+t.create('Issues (RIDER)').get('/RIDER?query=#Unresolved').expectBadge({
+  label: 'issues',
+  message: isMetric,
+})

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -3,7 +3,7 @@ import { isMetric } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
-t.create('Issues (RIDER)').get('/RIDER?query=#Unresolved').expectBadge({
+t.create('Issues (RIDER)').get('/RIDER?query=%23Unresolved').expectBadge({
   label: 'issues',
   message: isMetric,
 })

--- a/services/youtrack/youtrack-issues.tester.js
+++ b/services/youtrack/youtrack-issues.tester.js
@@ -1,5 +1,6 @@
+import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
-import { isMetricAllowNegative } from '../test-validators.js'
+import { isMetric } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
@@ -7,14 +8,14 @@ t.create('Issues (DEMO) (Cloud)')
   .get('/DEMO.json?youtrack_url=https://shields.youtrack.cloud&query=%23Fixed')
   .expectBadge({
     label: 'issues',
-    message: isMetricAllowNegative,
+    message: Joi.alternatives().try(isMetric, 'processing', 'timeout'),
   })
 
 t.create('Issues (DEMO) (Empty Query) (Cloud)')
   .get('/DEMO.json?youtrack_url=https://shields.youtrack.cloud')
   .expectBadge({
     label: 'issues',
-    message: isMetricAllowNegative,
+    message: Joi.alternatives().try(isMetric, 'processing', 'timeout'),
   })
 
 t.create('Issues (DEMO) (Invalid State) (Cloud Hosted)')


### PR DESCRIPTION
Add support for YouTrack Cards/Issues as per #9997

A new Service Token and test is added, InvalidResponse of processing added when a -1 is returned, and cached for 10 seconds. This is expected when YouTrack isn't finished and is documented at https://www.jetbrains.com/help/youtrack/devportal/resource-api-issuesGetter-count.html#create-IssueCountResponse-method
> If the response returns "count": -1, it means that YouTrack hasn't finished counting the issues yet. Wait for a bit and repeat the request.

For CI purposes shields.youtrack.cloud was created and is used throughout all tests as this instance is under our control. The guest user is enabled read-only so that the CI tests can work in Github Actions without needing a token, but prevents people breaking the tests.

Only concern is whether or not cachedSeconds is working as IntelliJ IDE reports this doesn't match InvalidResponses definitions, but seems to work. And also, during testing when the cloud instance is idle for long periods, a timeout is received on the first test of a day, as such I added 'timeout' as a possible test response.