### PR TITLE
Add [JSR] version service

### DIFF
--- a/services/jsr/jsr-version.service.js
+++ b/services/jsr/jsr-version.service.js
@@ -35,7 +35,7 @@ export default class JsrVersion extends BaseJsonService {
   }
 
   static defaultBadgeData = {
-    label: 'JSR',
+    label: 'jsr',
   }
 
   static render({ version }) {

--- a/services/jsr/jsr-version.service.js
+++ b/services/jsr/jsr-version.service.js
@@ -1,0 +1,60 @@
+import Joi from 'joi'
+import { renderVersionBadge } from '../version.js'
+import { BaseJsonService, pathParams } from '../index.js'
+
+const schema = Joi.object({
+  latest: Joi.string().required(),
+}).required()
+
+export default class JsrVersion extends BaseJsonService {
+  static category = 'version'
+
+  static route = {
+    base: 'jsr/v',
+    pattern: ':scope(@[^/]+)/:packageName',
+  }
+
+  static openApi = {
+    '/jsr/v/{scope}/{packageName}': {
+      get: {
+        summary: 'JSR Version',
+        description:
+          '[JSR](https://jsr.io/) is a modern package registry for JavaScript and TypeScript.',
+        parameters: pathParams(
+          {
+            name: 'scope',
+            example: '@luca',
+          },
+          {
+            name: 'packageName',
+            example: 'flag',
+          },
+        ),
+      },
+    },
+  }
+
+  static defaultBadgeData = {
+    label: 'JSR',
+  }
+
+  static render({ version }) {
+    return renderVersionBadge({ version })
+  }
+
+  async fetch({ scope, packageName }) {
+    // see https://jsr.io/docs/api#package-version-metadata
+    return this._requestJson({
+      schema,
+      url: `https://jsr.io/${scope}/${packageName}/meta.json`,
+      httpErrors: {
+        404: 'package not found',
+      },
+    })
+  }
+
+  async handle({ scope, packageName }) {
+    const { latest } = await this.fetch({ scope, packageName })
+    return this.constructor.render({ version: latest })
+  }
+}

--- a/services/jsr/jsr-version.tester.js
+++ b/services/jsr/jsr-version.tester.js
@@ -1,0 +1,15 @@
+import { isSemver } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('gets the version of @luca/flag')
+  .get('/@luca/flag.json')
+  .expectBadge({ label: 'JSR', message: isSemver })
+
+t.create('gets the version of @std/assert')
+  .get('/@std/assert.json')
+  .expectBadge({ label: 'JSR', message: isSemver })
+
+t.create('returns an error when getting a non-existent')
+  .get('/@std/this-is-a-non-existent-package-name.json')
+  .expectBadge({ label: 'JSR', message: 'package not found' })

--- a/services/jsr/jsr-version.tester.js
+++ b/services/jsr/jsr-version.tester.js
@@ -4,12 +4,12 @@ export const t = await createServiceTester()
 
 t.create('gets the version of @luca/flag')
   .get('/@luca/flag.json')
-  .expectBadge({ label: 'JSR', message: isSemver })
+  .expectBadge({ label: 'jsr', message: isSemver })
 
 t.create('gets the version of @std/assert')
   .get('/@std/assert.json')
-  .expectBadge({ label: 'JSR', message: isSemver })
+  .expectBadge({ label: 'jsr', message: isSemver })
 
 t.create('returns an error when getting a non-existent')
   .get('/@std/this-is-a-non-existent-package-name.json')
-  .expectBadge({ label: 'JSR', message: 'package not found' })
+  .expectBadge({ label: 'jsr', message: 'package not found' })


### PR DESCRIPTION
Hi, this PR adds a version service for [JSR](https://jsr.io/) packages.

Path: `/jsr/v/:scope(@[^/]+)/:packageName`

Example:

![jsr version](https://github.com/badges/shields/assets/86521894/ccc2f3b1-71bc-4b8e-91c9-5f71da04b479)

Related to #10007