### PR TITLE
improve performance of [GithubLastCommit] [GitlabLastCommit] [GiteaLastCommit]

### DIFF
--- a/services/gitea/gitea-last-commit.service.js
+++ b/services/gitea/gitea-last-commit.service.js
@@ -126,7 +126,7 @@ export default class GiteaLastCommit extends GiteaBase {
     return super.fetch({
       schema,
       url: `${baseUrl}/api/v1/repos/${user}/${repo}/commits`,
-      options: { searchParams: { sha: branch, path } },
+      options: { searchParams: { sha: branch, path, limit: 1 } },
       httpErrors: httpErrorsFor(),
     })
   }

--- a/services/github/github-last-commit.service.js
+++ b/services/github/github-last-commit.service.js
@@ -98,7 +98,7 @@ export default class GithubLastCommit extends GithubAuthV3Service {
   async fetch({ user, repo, branch, path }) {
     return this._requestJson({
       url: `/repos/${user}/${repo}/commits`,
-      options: { searchParams: { sha: branch, path } },
+      options: { searchParams: { sha: branch, path, per_page: 1 } },
       schema,
       httpErrors: httpErrorsFor(),
     })
@@ -106,7 +106,7 @@ export default class GithubLastCommit extends GithubAuthV3Service {
 
   async handle({ user, repo, branch }, queryParams) {
     const { path, display_timestamp: displayTimestamp } = queryParams
-    const body = await this.fetch({ user, repo, branch, path, per_page: 1 })
+    const body = await this.fetch({ user, repo, branch, path })
     const [commit] = body.map(obj => obj.commit)
 
     if (!commit) throw new NotFound({ prettyMessage: 'no commits found' })

--- a/services/github/github-last-commit.service.js
+++ b/services/github/github-last-commit.service.js
@@ -106,7 +106,7 @@ export default class GithubLastCommit extends GithubAuthV3Service {
 
   async handle({ user, repo, branch }, queryParams) {
     const { path, display_timestamp: displayTimestamp } = queryParams
-    const body = await this.fetch({ user, repo, branch, path })
+    const body = await this.fetch({ user, repo, branch, path, per_page: 1 })
     const [commit] = body.map(obj => obj.commit)
 
     if (!commit) throw new NotFound({ prettyMessage: 'no commits found' })

--- a/services/gitlab/gitlab-last-commit.service.js
+++ b/services/gitlab/gitlab-last-commit.service.js
@@ -79,7 +79,7 @@ export default class GitlabLastCommit extends GitLabBase {
       url: `${baseUrl}/api/v4/projects/${encodeURIComponent(
         project,
       )}/repository/commits`,
-      options: { searchParams: { ref_name: ref, path } },
+      options: { searchParams: { ref_name: ref, path, per_page: 1 } },
       schema,
       httpErrors: httpErrorsFor('project not found'),
     })


### PR DESCRIPTION
This is something I noticed while I was testing https://github.com/badges/shields/pull/10041
It isn't a new problem introduced by that PR, so I decided not to scope creep it there.

Basically the deal here is we only care about the most recent commit, but we're requesting an entire page of results to just use the first object. Only requesting the most recent one means we can request less data from the upstream and render the badge faster. Note this optimisation doesn't work in all situations. Specifically, Gitea ignores limit when the path param is also supplied (see https://docs.gitea.com/api/1.20/#tag/repository/operation/repoGetAllCommits ), but we might as well do this whenever we can.

Note that @ReubenFrankel has already applied the equivalent optimisation in https://github.com/badges/shields/pull/10043 :+1: which adds the corresponding BitBucket badges.