### PR TITLE
[chocolatey powershellgallery resharper] Fix "not found" error for chocolatey badge

### DIFF
--- a/services/nuget/nuget-v2-service-family.js
+++ b/services/nuget/nuget-v2-service-family.js
@@ -1,4 +1,5 @@
 import Joi from 'joi'
+import queryString from 'query-string'
 import { nonNegativeInteger } from '../validators.js'
 import {
   BaseJsonService,
@@ -61,25 +62,26 @@ async function fetch(
   { odataFormat, baseUrl, packageName, includePrereleases = false },
 ) {
   const url = `${baseUrl}/Packages()`
-  const searchParams = {
-    $filter: createFilter({ packageName, includePrereleases }),
-  }
+  const searchParams = queryString.stringify(
+    {
+      $filter: createFilter({ packageName, includePrereleases }),
+    },
+    { encode: false },
+  )
 
   let packageData
   if (odataFormat === 'xml') {
     const data = await serviceInstance._requestXml({
       schema: xmlSchema,
-      url,
-      options: { searchParams },
+      url: `${url}?${searchParams}`,
     })
     packageData = odataToObject(data.feed.entry)
   } else if (odataFormat === 'json') {
     const data = await serviceInstance._requestJson({
       schema: jsonSchema,
-      url,
+      url: `${url}?${searchParams}`,
       options: {
         headers: { Accept: 'application/atom+json,application/json' },
-        searchParams,
       },
     })
     packageData = data.d.results[0]


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
Fixes #10045 

The "got" package encodes spaces in `searchParams` as `+` (see https://github.com/sindresorhus/got/issues/1113) but the Chocolatey API requires spaces to be encoded as `%20` instead.

I have tested that `npm run test:services -- --only=chocolatey,nuget` passes with these changes.

Example of failing query:
https://community.chocolatey.org/api/v2/Packages()?%24filter=Id+eq+%27windynamicdesktop%27+and+IsLatestVersion+eq+true

Example of working query:
https://community.chocolatey.org/api/v2/Packages()?%24filter=Id%20eq%20%27windynamicdesktop%27%20and%20IsLatestVersion%20eq%20true