### PR TITLE
tweaks to libraries.io token pooling code

### DIFF
--- a/services/librariesio/librariesio-api-provider.js
+++ b/services/librariesio/librariesio-api-provider.js
@@ -48,7 +48,8 @@ export default class LibrariesIoApiProvider {
     // If the header is absent, we just use the current timestamp to
     // advance the value to _something_
     const retryAfter = headers['retry-after']
-    const nextReset = Date.now() + (retryAfter ? +retryAfter * 1000 : 0)
+    const nextReset =
+      ((Date.now() + (retryAfter ? +retryAfter * 1000 : 0)) / 1000) >>> 0
 
     return {
       rateLimit,

--- a/services/librariesio/librariesio-api-provider.js
+++ b/services/librariesio/librariesio-api-provider.js
@@ -17,7 +17,7 @@ export default class LibrariesIoApiProvider {
     })
 
     if (this.withPooling) {
-      this.standardTokens = new TokenPool({ batchSize: 45 })
+      this.standardTokens = new TokenPool({ batchSize: 10 })
       tokens.forEach(t => this.standardTokens.add(t, {}, defaultRateLimit))
     }
   }

--- a/services/librariesio/librariesio-api-provider.spec.js
+++ b/services/librariesio/librariesio-api-provider.spec.js
@@ -80,7 +80,7 @@ describe('LibrariesIoApiProvider', function () {
 
       expect(token.update).to.have.been.calledWith(
         remaining,
-        nextReset * 1000 + tickTime,
+        ((nextReset * 1000 + tickTime) / 1000) >>> 0,
       )
       expect(token.invalidate).not.to.have.been.called
     })
@@ -98,7 +98,10 @@ describe('LibrariesIoApiProvider', function () {
       const mockRequest = sinon.stub().resolves(response)
       await provider.fetch(mockRequest, '/npm/badge-maker')
 
-      expect(token.update).to.have.been.calledWith(remaining, tickTime)
+      expect(token.update).to.have.been.calledWith(
+        remaining,
+        (tickTime / 1000) >>> 0,
+      )
       expect(token.invalidate).not.to.have.been.called
     })
 
@@ -109,7 +112,10 @@ describe('LibrariesIoApiProvider', function () {
       const mockRequest = sinon.stub().resolves(response)
       await provider.fetch(mockRequest, '/npm/badge-maker')
 
-      expect(token.update).to.have.been.calledWith(remaining - 1, tickTime)
+      expect(token.update).to.have.been.calledWith(
+        remaining - 1,
+        (tickTime / 1000) >>> 0,
+      )
       expect(token.invalidate).not.to.have.been.called
     })
   })


### PR DESCRIPTION
Refs #9839

Couple of things here: 1 is a fix for the mismatch in units comparing times
The other is: The rate limit on one of these tokens is 60/minute, so it feels like 45 is too big a batchSize. Reduce that so we switch every 10 requests,