### PR TITLE
Revert simple-icons 11.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "qs": "^6.12.0",
         "query-string": "^9.0.0",
         "semver": "~7.6.0",
-        "simple-icons": "11.11.0",
+        "simple-icons": "11.10.0",
         "smol-toml": "1.1.4",
         "webextension-store-meta": "^1.1.0",
         "xpath": "~0.0.34"
@@ -26214,9 +26214,9 @@
       }
     },
     "node_modules/simple-icons": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-11.11.0.tgz",
-      "integrity": "sha512-jF4FvxqJ5LGRgScMy6IWHYBuKG7SImwzsTDKHhmAB2RQVKEqvGWI8qmAHWYPKEGM8/oRA/VvKTVIbWdg7YPRsg==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-11.10.0.tgz",
+      "integrity": "sha512-3jhPx5xgbDCx/tuegpnW82VmUc4xe7yVd5r/BwIhfei02hS3IbOfgLKPPczd2OasngeNEd0J31vU19/0jmfxrQ==",
       "engines": {
         "node": ">=0.12.18"
       },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "qs": "^6.12.0",
     "query-string": "^9.0.0",
     "semver": "~7.6.0",
-    "simple-icons": "11.11.0",
+    "simple-icons": "11.10.0",
     "smol-toml": "1.1.4",
     "webextension-store-meta": "^1.1.0",
     "xpath": "~0.0.34"


### PR DESCRIPTION
This reverts commit d1703c0592371c99db1c46cc3ead9cd4bc09a22e.

Not really sure what happened here.
Checked this on a review app and locally - no issues, but if I try to deploy docker image `sha256:e77392c2f4cfa1a9da6a7754fd26911f560bc522e3fc0d56ee7386b910b0c5b1` to staging, it won't pass a health check. Previous images deploy fine.

Going to try reverting this for now.