### PR TITLE
[GitHubGoMod] Ignore comment after version (fixes #10079)

### DIFF
--- a/services/github/github-go-mod.service.js
+++ b/services/github/github-go-mod.service.js
@@ -9,7 +9,7 @@ const queryParamSchema = Joi.object({
   filename: Joi.string(),
 }).required()
 
-const goVersionRegExp = /^go (.+)$/m
+const goVersionRegExp = /^go ([^/\s]+)(\s*\/.+)?$/m
 
 const filenameDescription =
   'The `filename` param can be used to specify the path to `go.mod`. By default, we look for `go.mod` in the repo root'

--- a/services/github/github-go-mod.spec.js
+++ b/services/github/github-go-mod.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import { test, given } from 'sazerac'
+import { InvalidResponse } from '../index.js'
+import GithubGoModGoVersion from './github-go-mod.service.js'
+
+describe('GithubGoModGoVersion', function () {
+  describe('valid cases', function () {
+    test(GithubGoModGoVersion.transform, () => {
+      given('go 1.18').expect({ go: '1.18' })
+      given('go 1.18 // inline comment').expect({ go: '1.18' })
+      given('go 1.18// inline comment').expect({ go: '1.18' })
+      given('go 1.18 /* block comment */').expect({ go: '1.18' })
+      given('go 1.18/* block comment */').expect({ go: '1.18' })
+      given('go 1').expect({ go: '1' })
+      given('go 1.2.3').expect({ go: '1.2.3' })
+      given('go string').expect({ go: 'string' })
+    })
+  })
+
+  describe('invalid cases', function () {
+    expect(() => GithubGoModGoVersion.transform('')).to.throw(InvalidResponse)
+    expect(() =>
+      GithubGoModGoVersion.transform("doesn't start with go"),
+    ).to.throw(InvalidResponse)
+  })
+})


### PR DESCRIPTION
Fixes #10079.
Ignore a comment after the version in the `go.mod` file.