### PR TITLE
Add 0BSD license to licenseTypes and [PypiLicense]

### DIFF
--- a/services/licenses.js
+++ b/services/licenses.js
@@ -87,7 +87,7 @@ const licenseTypes = {
   },
   // public domain licenses do not require 'License and copyright notice' (https://choosealicense.com/appendix/#include-copyright)
   'public-domain': {
-    spdxLicenseIds: ['CC0-1.0', 'Unlicense', 'WTFPL'],
+    spdxLicenseIds: ['CC0-1.0', 'Unlicense', 'WTFPL', '0BSD'],
     aliases: ['CC0'],
     color: '7cd958',
     priority: '3',

--- a/services/licenses.spec.js
+++ b/services/licenses.spec.js
@@ -5,7 +5,7 @@ describe('license helpers', function () {
   test(licenseToColor, () => {
     forCases([given('MIT'), given('BSD')]).expect('green')
     forCases([given('MPL-2.0'), given('MPL')]).expect('orange')
-    forCases([given('Unlicense'), given('CC0')]).expect('7cd958')
+    forCases([given('Unlicense'), given('CC0'), given('0BSD')]).expect('7cd958')
     forCases([given('unknown-license'), given(null)]).expect('lightgrey')
 
     given(['CC0-1.0', 'MPL-2.0']).expect('7cd958')

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -69,6 +69,7 @@ function getLicenses(packageData) {
       'OSI Approved :: Apache Software License': 'Apache-2.0',
       'CC0 1.0 Universal (CC0 1.0) Public Domain Dedication': 'CC0-1.0',
       'OSI Approved :: GNU Affero General Public License v3': 'AGPL-3.0',
+      'OSI Approved :: Zero-Clause BSD (0BSD)': '0BSD',
     }
     let licenses = parseClassifiers(packageData, /^License :: (.+)$/, true)
       .map(classifier =>

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -167,6 +167,12 @@ describe('PyPI helpers', function () {
         ],
       },
     }).expect(['AGPL-3.0'])
+    given({
+      info: {
+        license: '',
+        classifiers: ['License :: OSI Approved :: Zero-Clause BSD (0BSD)'],
+      },
+    }).expect(['0BSD'])
   })
 
   test(getPackageFormats, () => {


### PR DESCRIPTION
- Added 0BSD license to public domain in licenseTypes
- Added licenseTypes tests in spec file
- Added 0BSD to PyPi helper with test in helper spec file

PyPi on production:
`https://img.shields.io/pypi/l/makemake90`
![image](https://github.com/badges/shields/assets/15849761/a5d8044d-7c29-41ba-a672-a964597a00ab)
After change:
![image](https://github.com/badges/shields/assets/15849761/7476e0e0-05da-415a-a353-e1c6b78e2443)

Github License on production:
`https://img.shields.io/github/license/arnavyc/aes-c`
![image](https://github.com/badges/shields/assets/15849761/d90f7c1d-6ed8-4369-9839-6b744686dfbb)
After change:
![image](https://github.com/badges/shields/assets/15849761/8a825060-e08a-4de9-9601-8e358ff9967b)


Part of issue #10058

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
