### PR TITLE
fix [pypi] status badge when package has no 'Development Status' classifier

### DIFF
--- a/services/pypi/pypi-status.service.js
+++ b/services/pypi/pypi-status.service.js
@@ -32,6 +32,7 @@ export default class PypiStatus extends PypiBase {
       stable: 'brightgreen',
       mature: 'brightgreen',
       inactive: 'red',
+      unknown: 'lightgrey',
     }[status]
 
     return {
@@ -52,7 +53,7 @@ export default class PypiStatus extends PypiBase {
     // - Development Status :: 6 - Mature
     // - Development Status :: 7 - Inactive
     // https://pypi.org/pypi?%3Aaction=list_classifiers
-    const status = parseClassifiers(
+    let status = parseClassifiers(
       packageData,
       /^Development Status :: (\d - \S+)$/,
     )
@@ -60,6 +61,10 @@ export default class PypiStatus extends PypiBase {
       .map(classifier => classifier.split(' - ').pop())
       .map(classifier => classifier.replace(/production\/stable/i, 'stable'))
       .pop()
+
+    if (!status) {
+      status = 'Unknown'
+    }
 
     return this.constructor.render({ status })
   }

--- a/services/pypi/pypi-status.tester.js
+++ b/services/pypi/pypi-status.tester.js
@@ -13,6 +13,10 @@ t.create('status (valid, beta)')
   .get('/django/2.0rc1.json')
   .expectBadge({ label: 'status', message: 'beta' })
 
+t.create('status (status not specified)')
+  .get('/arcgis2geojson/3.0.2.json')
+  .expectBadge({ label: 'status', message: 'unknown' })
+
 t.create('status (invalid)')
   .get('/not-a-package.json')
   .expectBadge({ label: 'status', message: 'package or version not found' })


### PR DESCRIPTION
Currently if we request this badge for a package with no 'Development Status' classifier we render an 'empty' badge

e.g: ![](https://img.shields.io/pypi/status/arcgis2geojson/3.0.2) - https://img.shields.io/pypi/status/arcgis2geojson/3.0.2

This PR fixes that