### PR TITLE
add logoSize to globalQueryParams

### DIFF
--- a/core/base-service/legacy-request-handler.js
+++ b/core/base-service/legacy-request-handler.js
@@ -12,6 +12,7 @@ const globalQueryParams = new Set([
   'logo',
   'logoColor',
   'logoPosition',
+  'logoSize',
   'logoWidth',
   'link',
   'colorA',


### PR DESCRIPTION
After I merged https://github.com/badges/shields/pull/9191 I deployed it to staging, gave it a quick test and realised we missed something.
This param was only taking effect for static badges. It was ignored for dynamic ones.
This change fixes it, but it does also raise follow up questions which I'll note in an issue