### PR TITLE
[Hexpm] Fix badges for pre-release only versions

### DIFF
--- a/services/hexpm/hexpm.service.js
+++ b/services/hexpm/hexpm.service.js
@@ -14,7 +14,7 @@ const hexSchema = Joi.object({
   meta: Joi.object({
     licenses: Joi.array().required(),
   }).required(),
-  latest_stable_version: Joi.string(),
+  latest_stable_version: Joi.string().allow(null),
   latest_version: Joi.string().required(),
 }).required()
 

--- a/services/hexpm/hexpm.tester.js
+++ b/services/hexpm/hexpm.tester.js
@@ -50,6 +50,7 @@ t.create('version (no stable version)')
       .get('/api/packages/prima_opentelemetry_ex')
       .reply(200, {
         downloads: { all: 100 },
+        latest_stable_version: null,
         latest_version: '1.0.0-rc.3',
         meta: { licenses: ['MIT'] },
       }),


### PR DESCRIPTION
Hex.pm's API now seems to return `null` for `latest_stable_version`, where I assume from `shields`' code that it previously did not return the property at all:

```
  },
  "html_url": "https://hex.pm/packages/nodelix",
  "latest_stable_version": null
}
```
[source](https://hex.pm/api/packages/nodelix)

This PR aims to support that in order for badges of pre-release-only version packages work again.

Example of a broken badge:
[![](https://img.shields.io/hexpm/dt/nodelix.svg)](https://img.shields.io/hexpm/dt/nodelix.svg)

Error logs from `npm run badge -- /hexpm/dt/nodelix` on `master`:
```
 Response did not match schema  🤷 
 "latest_stable_version" must be a string
 Handled error  🙅 
 [ValidationError: "latest_stable_version" must be a string] {
  prettyMessage: 'invalid response data',
  cacheSeconds: undefined,
  response: undefined
}
```