### PR TITLE
improve performance of getIconSize()

### DIFF
--- a/lib/svg-helpers.js
+++ b/lib/svg-helpers.js
@@ -1,6 +1,8 @@
 import SVGPathCommander from 'svg-path-commander'
 import loadSimpleIcons from './load-simple-icons.js'
 
+const simpleIcons = loadSimpleIcons()
+
 function svg2base64(svg) {
   return `data:image/svg+xml;base64,${Buffer.from(svg.trim()).toString(
     'base64',
@@ -8,8 +10,6 @@ function svg2base64(svg) {
 }
 
 function getIconSize(iconKey) {
-  const simpleIcons = loadSimpleIcons()
-
   if (!(iconKey in simpleIcons)) {
     return undefined
   }


### PR DESCRIPTION
I attempted to deploy https://github.com/badges/shields/pull/9191

This happened

![9191-deploy](https://github.com/badges/shields/assets/6025893/3da1f6f3-62c2-43e5-9676-25ad6bc6d503)

There's something in that change that has caused a big performance issue.

I haven't really benchmarked this, but my instinct is that loading the whole simple-icons set every time we invoke `getIconSize()` is at least part of the problem.

This PR moves to doing this once at module load time instead of every time we call the function.