### PR TITLE
run tests on node 22

### DIFF
--- a/.github/workflows/test-integration-22.yml
+++ b/.github/workflows/test-integration-22.yml
@@ -1,4 +1,4 @@
-name: Integration@node 21
+name: Integration@node 22
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -8,7 +8,7 @@ on:
       - 'dependabot/**'
 
 jobs:
-  test-integration-21:
+  test-integration-22:
     runs-on: ubuntu-latest
     env:
       PAT_EXISTS: ${{ secrets.GH_PAT != '' }}
@@ -35,7 +35,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 21
+          node-version: 22
         env:
           NPM_CONFIG_ENGINE_STRICT: 'false'
 

--- a/.github/workflows/test-main-22.yml
+++ b/.github/workflows/test-main-22.yml
@@ -1,4 +1,4 @@
-name: Main@node 21
+name: Main@node 22
 on:
   pull_request:
     types: [opened, reopened, synchronize]
@@ -8,7 +8,7 @@ on:
       - 'dependabot/**'
 
 jobs:
-  test-main-21:
+  test-main-22:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -17,7 +17,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 21
+          node-version: 22
         env:
           NPM_CONFIG_ENGINE_STRICT: 'false'
 

--- a/.github/workflows/test-package-cli.yml
+++ b/.github/workflows/test-package-cli.yml
@@ -19,6 +19,7 @@ jobs:
           - node: '16'
           - node: '18'
           - node: '20'
+          - node: '22'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-package-lib.yml
+++ b/.github/workflows/test-package-lib.yml
@@ -22,6 +22,9 @@ jobs:
           - node: '20'
             npm: '^10'
             engine-strict: 'true'
+          - node: '22'
+            npm: '^10'
+            engine-strict: 'false'
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-services-22.yml
+++ b/.github/workflows/test-services-22.yml
@@ -1,4 +1,4 @@
-name: Services@node 21
+name: Services@node 22
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
@@ -7,7 +7,7 @@ on:
       - 'gh-readonly-queue/**'
 
 jobs:
-  test-services-21:
+  test-services-22:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +17,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 21
+          node-version: 22
         env:
           NPM_CONFIG_ENGINE_STRICT: 'false'
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you intend on reporting or contributing a fix related to security vulnerabili
 ## Development
 
 1. Install Node 20 or later. You can use the [package manager][] of your choice.
-   Tests need to pass in Node 20 and 21.
+   Tests need to pass in Node 20 and 22.
 2. Clone this repository.
 3. Run `npm ci` to install the dependencies.
 4. Run `npm start` to start the badge server and the frontend dev server.


### PR DESCRIPTION
Node 22 is now out :tada: 

We should migrate to node 22 at some point, but for the moment lets just start running the tests against it in preparation. I'll also do some testing with it when I'm developing locally.