### PR TITLE
feat(endpoint-badge): add logoSize support; test [endpoint]

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -65,6 +65,7 @@ const serviceDataSchema = Joi.object({
   namedLogo: Joi.string(),
   logoSvg: Joi.string(),
   logoColor: optionalStringWhenNamedLogoPresent,
+  logoSize: optionalStringWhenNamedLogoPresent,
   logoWidth: optionalNumberWhenAnyLogoPresent,
   cacheSeconds: Joi.number().integer().min(0),
   style: Joi.string(),

--- a/services/endpoint-common.js
+++ b/services/endpoint-common.js
@@ -35,6 +35,7 @@ const endpointSchema = Joi.object({
   namedLogo: Joi.string(),
   logoSvg: Joi.string(),
   logoColor: optionalStringWhenNamedLogoPresent,
+  logoSize: optionalStringWhenNamedLogoPresent,
   logoWidth: optionalNumberWhenAnyLogoPresent,
   style: Joi.string(),
   cacheSeconds: Joi.number().integer().min(0),

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -94,6 +94,14 @@ The endpoint badge takes a single required query param: <code>url</code>, which 
         </td>
       </tr>
       <tr>
+      <td><code>logoSize</code></td>
+      <td>
+        Default: none. Make icons adaptively resize by setting <code>auto</code>.
+        Useful for some wider logos like <code>amd</code> and <code>amg</code>.
+        Supported for simple-icons logos only.
+      </td>
+    </tr>
+      <tr>
         <td><code>logoWidth</code></td>
         <td>
           Default: none. Same meaning as the query string. Can be overridden by
@@ -147,6 +155,7 @@ export default class Endpoint extends BaseJsonService {
     namedLogo,
     logoSvg,
     logoColor,
+    logoSize,
     logoWidth,
     style,
     cacheSeconds,
@@ -160,6 +169,7 @@ export default class Endpoint extends BaseJsonService {
       namedLogo,
       logoSvg,
       logoColor,
+      logoSize,
       logoWidth,
       style,
       // don't allow the user to set cacheSeconds any shorter than this._cacheLength

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -82,6 +82,22 @@ t.create('named logo with color')
     expect(body).to.include(getSimpleIcon({ name: 'github', color: 'blue' }))
   })
 
+t.create('named logo with size')
+  .get('.svg?url=https://example.com/badge')
+  .intercept(nock =>
+    nock('https://example.com/').get('/badge').reply(200, {
+      schemaVersion: 1,
+      label: 'hey',
+      message: 'yo',
+      namedLogo: 'github',
+      logoSize: 'auto',
+    }),
+  )
+  .after((err, res, body) => {
+    expect(err).not.to.be.ok
+    expect(body).to.include(getSimpleIcon({ name: 'github', size: 'auto' }))
+  })
+
 const logoSvg = Buffer.from(
   getSimpleIcon({ name: 'npm' }).replace('data:image/svg+xml;base64,', ''),
   'base64',


### PR DESCRIPTION
Currently, the endpoint badge response schema does not support `logoSize` parameter.