### PR TITLE
Update region flag name in flyctl deploy command

### DIFF
--- a/.github/scripts/deploy-review-app.sh
+++ b/.github/scripts/deploy-review-app.sh
@@ -23,7 +23,7 @@ if ! flyctl status --app "$app"; then
 fi
 
 # Deploy
-flyctl deploy --app "$app" --region "$region"
+flyctl deploy --app "$app" --regions "$region"
 flyctl scale count 1 --app "$app" --yes
 
 # Post a comment on the PR


### PR DESCRIPTION
The review app creation script is failing in #7759 with the following error:
> Error: unknown flag: --region

According to the [deploy docs](https://fly.io/docs/flyctl/deploy/), only `regions` is available now. The [launch command](https://fly.io/docs/flyctl/launch/) still seems to support both variants, I've left it alone in this script for the time being.