### PR TITLE
instruct dependabot to monitor composite actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,7 +29,15 @@ updates:
 
   # GH actions
   - package-ecosystem: 'github-actions'
-    directory: '/'
+    # all composite actions must be individually listed here
+    # https://github.com/dependabot/dependabot-core/issues/6704
+    directories:
+      - '/'
+      - '/.github/actions/core-tests'
+      - '/.github/actions/integration-tests'
+      - '/.github/actions/package-tests'
+      - '/.github/actions/service-tests'
+      - '/.github/actions/setup'
     schedule:
       interval: weekly
     open-pull-requests-limit: 99


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/10135

Having read over, https://github.com/dependabot/dependabot-core/issues/6704 this should work
but I can't really confirm until I merge it.
