### PR TITLE
Remove namedLogo from defaultBadgeData of non-social badges

### DIFF
--- a/services/github/github-commits-difference.service.js
+++ b/services/github/github-commits-difference.service.js
@@ -35,7 +35,7 @@ export default class GithubCommitsDifference extends GithubAuthV3Service {
     },
   }
 
-  static defaultBadgeData = { label: 'commits difference', namedLogo: 'github' }
+  static defaultBadgeData = { label: 'commits difference' }
 
   static render({ commitCount }) {
     return {

--- a/services/github/github-commits-since.service.js
+++ b/services/github/github-commits-since.service.js
@@ -79,7 +79,7 @@ export default class GithubCommitsSince extends GithubAuthV3Service {
     },
   }
 
-  static defaultBadgeData = { label: 'github', namedLogo: 'github' }
+  static defaultBadgeData = { label: 'github' }
 
   static render({ version, commitCount }) {
     return {

--- a/services/github/github-downloads.service.js
+++ b/services/github/github-downloads.service.js
@@ -107,7 +107,7 @@ export default class GithubDownloads extends GithubAuthV3Service {
     },
   }
 
-  static defaultBadgeData = { label: 'downloads', namedLogo: 'github' }
+  static defaultBadgeData = { label: 'downloads' }
 
   static render({ tag: version, assetName, downloads }) {
     const messageSuffixOverride =

--- a/services/github/github-pull-request-check-state.service.js
+++ b/services/github/github-pull-request-check-state.service.js
@@ -66,7 +66,7 @@ export default class GithubPullRequestCheckState extends GithubAuthV3Service {
     },
   }
 
-  static defaultBadgeData = { label: 'checks', namedLogo: 'github' }
+  static defaultBadgeData = { label: 'checks' }
 
   static render({ variant, state, stateCounts }) {
     let message

--- a/services/github/github-release.service.js
+++ b/services/github/github-release.service.js
@@ -44,7 +44,7 @@ class GithubRelease extends GithubAuthV3Service {
     },
   }
 
-  static defaultBadgeData = { label: 'release', namedLogo: 'github' }
+  static defaultBadgeData = { label: 'release' }
 
   static render({ version, sort, isPrerelease }) {
     let color = 'blue'

--- a/services/liberapay/liberapay-base.js
+++ b/services/liberapay/liberapay-base.js
@@ -42,10 +42,7 @@ function renderCurrencyBadge({ label, amount, currency }) {
 class LiberapayBase extends BaseJsonService {
   static category = 'funding'
 
-  static defaultBadgeData = {
-    label: 'liberapay',
-    namedLogo: 'liberapay',
-  }
+  static defaultBadgeData = { label: 'liberapay' }
 
   async fetch({ entity }) {
     return this._requestJson({


### PR DESCRIPTION
According to our [badge guidelines](https://github.com/badges/shields/blob/master/CONTRIBUTING.md#badge-guidelines):
> Except for badges using the social style, logos and links should be turned off by default.

The following line of code does remove the logo when the badge has a non-social style, so we're not violating our guidelines per say:
https://github.com/badges/shields/blob/d68217295114c653d0a803463f368df3f146acda/core/base-service/coalesce-badge.js#L153

However, I think it's best to remove the `namedLogo` from the very few non-social badges where it is included, both from a consistency perspective, and to avoid any confusion (for example in #7759). Having something specified that is then overridden deep down somewhere else in the code is not exactly intuitive.