### PR TITLE
Update number of badges served each month

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ and legible badges in SVG and raster format, which can easily be included in
 GitHub readmes or any other web page. The service supports dozens of
 continuous integration services, package registries, distributions, app
 stores, social networks, code coverage services, and code analysis services.
-Every month it serves over 870 million images and is used by some of the
+Every month it serves over 1.6 billion images and is used by some of the
 world's most popular open-source projects, [VS Code][vscode], [Vue.js][vue]
 and [Bootstrap][bootstrap] to name a few.
 


### PR DESCRIPTION
It's been a while since we last updated this number (#7723), Cloudfare statistics have since then doubled:
![Screenshot 2024-05-25 115431](https://github.com/badges/shields/assets/10694593/5ab2b504-f2a4-439d-90cc-e46985765756)
