### PR TITLE
chore: fix spelling of GitHub in badge descriptions

### DIFF
--- a/services/github/gist/github-gist-last-commit-redirect.tester.js
+++ b/services/github/gist/github-gist-last-commit-redirect.tester.js
@@ -2,7 +2,7 @@ import { ServiceTester } from '../../tester.js'
 
 export const t = new ServiceTester({
   id: 'GistLastCommitRedirect',
-  title: 'Github Gist Last Commit Redirect',
+  title: 'GitHub Gist Last Commit Redirect',
   pathPrefix: '/github-gist',
 })
 

--- a/services/github/gist/github-gist-stars.service.js
+++ b/services/github/gist/github-gist-stars.service.js
@@ -35,7 +35,7 @@ export default class GistStars extends GithubAuthV4Service {
   static openApi = {
     '/github/gist/stars/{gistId}': {
       get: {
-        summary: 'Github Gist stars',
+        summary: 'GitHub Gist stars',
         description,
         parameters: pathParams({
           name: 'gistId',

--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -169,7 +169,7 @@ class GithubApiProvider {
       } catch (e) {
         log.error(e)
         throw new ImproperlyConfigured({
-          prettyMessage: 'Unable to select next Github token from pool',
+          prettyMessage: 'Unable to select next GitHub token from pool',
         })
       }
       tokenString = token.id

--- a/services/github/github-created-at.service.js
+++ b/services/github/github-created-at.service.js
@@ -16,7 +16,7 @@ export default class GithubCreatedAt extends GithubAuthV3Service {
   static openApi = {
     '/github/created-at/{user}/{repo}': {
       get: {
-        summary: 'Github Created At',
+        summary: 'GitHub Created At',
         description: documentation,
         parameters: pathParams(
           {

--- a/services/github/github-lerna-json.service.js
+++ b/services/github/github-lerna-json.service.js
@@ -20,7 +20,7 @@ export default class GithubLernaJson extends ConditionalGithubAuthV3Service {
   static openApi = {
     '/github/lerna-json/v/{user}/{repo}': {
       get: {
-        summary: 'Github lerna version',
+        summary: 'GitHub lerna version',
         description: documentation,
         parameters: pathParams(
           {
@@ -36,7 +36,7 @@ export default class GithubLernaJson extends ConditionalGithubAuthV3Service {
     },
     '/github/lerna-json/v/{user}/{repo}/{branch}': {
       get: {
-        summary: 'Github lerna version (branch)',
+        summary: 'GitHub lerna version (branch)',
         description: documentation,
         parameters: pathParams(
           {

--- a/services/scrutinizer/scrutinizer-build.service.js
+++ b/services/scrutinizer/scrutinizer-build.service.js
@@ -47,7 +47,7 @@ class ScrutinizerBuild extends ScrutinizerBuildBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },
@@ -62,7 +62,7 @@ class ScrutinizerBuild extends ScrutinizerBuildBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },

--- a/services/scrutinizer/scrutinizer-coverage.service.js
+++ b/services/scrutinizer/scrutinizer-coverage.service.js
@@ -78,7 +78,7 @@ class ScrutinizerCoverage extends ScrutinizerCoverageBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },
@@ -93,7 +93,7 @@ class ScrutinizerCoverage extends ScrutinizerCoverageBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },

--- a/services/scrutinizer/scrutinizer-quality.service.js
+++ b/services/scrutinizer/scrutinizer-quality.service.js
@@ -67,7 +67,7 @@ class ScrutinizerQuality extends ScrutinizerQualityBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },
@@ -82,7 +82,7 @@ class ScrutinizerQuality extends ScrutinizerQualityBase {
           {
             name: 'vcs',
             example: 'g',
-            description: 'Platform: Either Github or Bitbucket',
+            description: 'Platform: Either GitHub or Bitbucket',
             schema: { type: 'string', enum: this.getEnum('vcs') },
           },
           { name: 'user', example: 'filp' },


### PR DESCRIPTION
Replaces "Github" with "GitHub" in user-facing texts (badge titles and descriptions)