### PR TITLE
Fix [GithubPullRequestCheckState] test

### DIFF
--- a/services/github/github-pull-request-check-state.tester.js
+++ b/services/github/github-pull-request-check-state.tester.js
@@ -17,7 +17,7 @@ t.create(
     nock =>
       nock('https://api.github.com', { allowUnmocked: true })
         .get('/repos/badges/shields/pulls/1110')
-        .reply(200, JSON.stringify({ head: { sha: 'abc123' } })), // Looks like a real ref, but isn't.
+        .reply(200, JSON.stringify({ head: { sha: 'abcde12356' } })), // Looks like a real ref, but isn't.
   )
   .networkOn()
   .expectBadge({


### PR DESCRIPTION
This is an amusing issue. `abc123` recently became a real ref on the repository (https://github.com/badges/shields/commit/abc123de1d2d3a83b256ccca5e17e6a4b6088097), which started making this test fail. `abcde12356` should be safe for a little while longer. 😄 