### PR TITLE
Switch [JenkinsCoverage] Cobertura job URL

### DIFF
--- a/services/jenkins/jenkins-coverage.service.js
+++ b/services/jenkins/jenkins-coverage.service.js
@@ -120,7 +120,7 @@ export default class JenkinsCoverage extends JenkinsBase {
           }),
           queryParam({
             name: 'jobUrl',
-            example: 'https://jenkins.sqlalchemy.org/job/alembic_coverage',
+            example: 'https://jenkins.sqlalchemy.org/job/dogpile_coverage',
             required: true,
           }),
         ],

--- a/services/jenkins/jenkins-coverage.tester.js
+++ b/services/jenkins/jenkins-coverage.tester.js
@@ -27,7 +27,7 @@ t.create('cobertura: job not found')
 
 t.create('cobertura: job found')
   .get(
-    '/cobertura.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_coverage',
+    '/cobertura.json?jobUrl=https://jenkins.sqlalchemy.org/job/dogpile_coverage',
   )
   .expectBadge({ label: 'coverage', message: isIntegerPercentage })
 


### PR DESCRIPTION
https://jenkins.sqlalchemy.org/job/alembic_coverage/ stopped reporting coverage via the Cobertura API. I noticed there had been a bunch of dependency updates and fixes related to testing in the corresponding repository, so maybe that had an impact. I've switched to https://jenkins.sqlalchemy.org/job/dogpile_coverage/ which is still configured as expected. If this breaks again in the near future, I suggest we switch to mocked tests.

Closes #8512.