### PR TITLE
Fix npm badges when `maintainers` not in response; run [NpmCollaborators NpmDependencyVersion NpmDownloads NpmLicense NpmTypeDefinitions NpmUnpackedSize NpmVersion]

### DIFF
--- a/services/npm/npm-base.js
+++ b/services/npm/npm-base.js
@@ -21,7 +21,7 @@ const packageDataSchema = Joi.object({
   maintainers: Joi.array()
     // We don't need the keys here, just the length.
     .items(Joi.object({}))
-    .required(),
+    .default([]),
   types: Joi.string(),
   // `typings` is an alias for `types` and often used
   // https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

--- a/services/npm/npm-collaborators.tester.js
+++ b/services/npm/npm-collaborators.tester.js
@@ -16,3 +16,12 @@ t.create('contributor count for unknown package')
     label: 'npm collaborators',
     message: 'package not found',
   })
+
+t.create('contributor count for package package without a maintainers property')
+  .get('/package-without-maintainers.json')
+  .intercept(nock =>
+    nock('https://registry.npmjs.org')
+      .get('/package-without-maintainers/latest')
+      .reply(200, {}),
+  )
+  .expectBadge({ label: 'npm collaborators', message: '0' })


### PR DESCRIPTION
I published a new version of badge-maker today and.. our NPM badges broke:

- ![npm license](https://img.shields.io/npm/l/badge-maker) - https://img.shields.io/npm/l/badge-maker
- ![npm type definitions](https://img.shields.io/npm/types/badge-maker) - https://img.shields.io/npm/types/badge-maker

Looks like NPM API responses no longer necessarily include a `maintainers` property.

This PR makes this property optional and assumes `[]` if it is missing. This is the same approach we take with the `files` property.