### PR TITLE
The return of daily tests

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -1,0 +1,71 @@
+name: Run Daily Tests
+on:
+  schedule:
+    - cron: '45 3 * * *'
+    # At 03:45, daily
+  workflow_dispatch:
+
+jobs:
+  daily-tests:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ci_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - name: Core tests
+        if: always()
+        uses: ./.github/actions/core-tests
+
+      - name: Package tests
+        if: always()
+        uses: ./.github/actions/package-tests
+
+      - name: Integration Tests (with PAT)
+        if: always()
+        uses: ./.github/actions/integration-tests
+        with:
+          github-token: '${{ secrets.GH_PAT }}'
+
+      - name: Run Service tests
+        run: npm run test:services -- --reporter json --reporter-option 'output=reports/service-tests.json'
+        if: always()
+        env:
+          RETRY_COUNT: 3
+          GH_TOKEN: '${{ secrets.GH_PAT }}'
+          LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
+          OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
+          OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'
+          PEPY_KEY: '${{ secrets.SERVICETESTS_PEPY_KEY }}'
+          SL_INSIGHT_USER_UUID: '${{ secrets.SERVICETESTS_SL_INSIGHT_USER_UUID }}'
+          SL_INSIGHT_API_TOKEN: '${{ secrets.SERVICETESTS_SL_INSIGHT_API_TOKEN }}'
+          TWITCH_CLIENT_ID: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_ID }}'
+          TWITCH_CLIENT_SECRET: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_SECRET }}'
+          WHEELMAP_TOKEN: '${{ secrets.SERVICETESTS_WHEELMAP_TOKEN }}'
+          YOUTUBE_API_KEY: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
+
+      - name: Write Service Tests Markdown Summary
+        if: always()
+        run: |
+          echo '# Services' >> $GITHUB_STEP_SUMMARY
+          node scripts/mocha2md.js Report reports/service-tests.json >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/8821

This PR adds a GitHub Workflow that runs our tests every day and spits out a markdown summary.

Here's an example run: https://github.com/badges/shields/actions/runs/9749868442

This doesn't completely replicate all of the functionality of the old daily tests repo. That repo also measured and reported code coverage. However, I encountered two problems implementing this:

1. Both the markdown summary and coverage reports are implemented as mocha reporters. Out of the box, it is not possible to tell mocha to use 2 reporters at once, but there may be a way to work round this. I do want to produce human readable output as well as coverage XML though.
2. There's an issue with c8 that causes builds to fail when measuring coverage on Node 20. There's an unmerged upstream PR at https://github.com/bcoe/v8-coverage/pull/2

I think both of those problems can be solved in time:
- I can work on finding a way round the reporters issue.
- The c8 bugfix may be merged upstream. If not, eventually node 22 (which doesn't have this issue) will be our target platform.

That said, right now I have a working PR for an action which runs all the tests every day and outputs a summary we can read. That's more than we have now, so I suggest lets do this as step one rather than blocking on those things. Lets not let perfect be the enemy of good. Regaining visibility on what is failing will help us start fixing stuff.