### PR TITLE
include gituhb contributors badge in docs site

### DIFF
--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -84,7 +84,7 @@ function services2openapi(services, sort) {
     for (const [key, value] of Object.entries(
       addGlobalProperties(service.openApi),
     )) {
-      if (key in paths && key !== '/github/{variant}/{user}/{repo}') {
+      if (key in paths) {
         throw new Error(`Conflicting route: ${key}`)
       }
       paths[key] = value

--- a/services/github/github-contributors.service.js
+++ b/services/github/github-contributors.service.js
@@ -12,19 +12,23 @@ export default class GithubContributors extends GithubAuthV3Service {
   static category = 'activity'
   static route = {
     base: 'github',
-    pattern: ':variant(contributors|contributors-anon)/:user/:repo',
+    // note we call this param 'metric' instead of 'variant' because of
+    // https://github.com/badges/shields/issues/10323
+    pattern: ':metric(contributors|contributors-anon)/:user/:repo',
   }
 
   static openApi = {
-    '/github/{variant}/{user}/{repo}': {
+    '/github/{metric}/{user}/{repo}': {
       get: {
         summary: 'GitHub contributors',
         description: documentation,
         parameters: pathParams(
           {
-            name: 'variant',
+            name: 'metric',
             example: 'contributors',
-            schema: { type: 'string', enum: this.getEnum('variant') },
+            schema: { type: 'string', enum: this.getEnum('metric') },
+            description:
+              '`contributors-anon` includes anonymous commits, whereas `contributors` excludes them.',
           },
           {
             name: 'user',
@@ -45,8 +49,8 @@ export default class GithubContributors extends GithubAuthV3Service {
     return renderContributorBadge({ contributorCount })
   }
 
-  async handle({ variant, user, repo }) {
-    const isAnon = variant === 'contributors-anon'
+  async handle({ metric, user, repo }) {
+    const isAnon = metric === 'contributors-anon'
 
     const { res, buffer } = await this._request({
       url: `/repos/${user}/${repo}/contributors`,


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/10323
Refs https://github.com/badges/shields/discussions/10322

This PR does two things:

1. Include GitHub Contributors badge in docs site.
   Fundamentally, the Open API spec dictates that this must be laid out as an object keyed on the route so each route must be unique within each category. The way I've chosen to solve this is by renaming the param from `variant` to `metric` in this one case. I also considered moving one of the badges to a different category, but I think they do really both belong in Activity.
2. Explain the difference between the two versions of this badge.