### PR TITLE
Add CF-Ray header value to Sentry errors if available

### DIFF
--- a/core/base-service/check-error-response.js
+++ b/core/base-service/check-error-response.js
@@ -6,6 +6,8 @@ const defaultErrorMessages = {
   429: 'rate limited by upstream service',
 }
 
+const headersToInclude = ['cf-ray']
+
 export default function checkErrorResponse(httpErrors = {}, logErrors = [429]) {
   return async function ({ buffer, res }) {
     let error
@@ -28,7 +30,17 @@ export default function checkErrorResponse(httpErrors = {}, logErrors = [429]) {
     }
 
     if (logErrors.includes(res.statusCode)) {
-      log.error(new Error(`${res.statusCode} calling ${res.requestUrl.origin}`))
+      const tags = {}
+      for (const headerKey of headersToInclude) {
+        const headerValue = res.headers[headerKey]
+        if (headerValue) {
+          tags[`header-${headerKey}`] = headerValue
+        }
+      }
+      log.error(
+        new Error(`${res.statusCode} calling ${res.requestUrl.origin}`),
+        tags,
+      )
     }
 
     if (error) {

--- a/core/base-service/check-error-response.spec.js
+++ b/core/base-service/check-error-response.spec.js
@@ -47,7 +47,11 @@ describe('async error handler', function () {
 
   context('when status is 429', function () {
     const buffer = Buffer.from('some stuff')
-    const res = { statusCode: 429, requestUrl: new URL('https://example.com/') }
+    const res = {
+      statusCode: 429,
+      headers: { 'some-key': 'some-value' },
+      requestUrl: new URL('https://example.com/'),
+    }
 
     it('throws InvalidResponse', async function () {
       try {

--- a/core/server/log.js
+++ b/core/server/log.js
@@ -28,10 +28,12 @@ const log = (...msg) => {
   console.log(d, ...msg)
 }
 
-const error = err => {
+const error = (err, tags) => {
   const d = date()
   listeners.forEach(f => f(d, err))
-  Sentry.captureException(err)
+  Sentry.captureException(err, {
+    tags,
+  })
   console.error(d, err)
 }
 


### PR DESCRIPTION
Discord had requested Ray IDs to help investigate #10223, unfortunately we didn't have those available. I've added them as tags on the errors we log to Sentry. These IDs may be helpful for other services that are fronted by Cloudfare, I didn't condition on Discord. We can easily add other tags in the future if need-be.

Tested with Sentry hooked up to my local Shields.io copy, tweaking slightly `logErrors` to include 404s as those are easier to reproduce:
![Screenshot_20240708_144733_Firefox](https://github.com/badges/shields/assets/10694593/643c33b0-dde1-42b0-9c20-59081d8486ef)
