### PR TITLE
Add code coverage action

### DIFF
--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -30,7 +30,11 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
         with:
-          node-version: 20
+          # Even though we're currently deploying on Node 20, we run coverage test on Node 22
+          # to work around https://github.com/bcoe/v8-coverage/pull/2.
+          node-version: 22
+        env:
+          NPM_CONFIG_ENGINE_STRICT: 'false'
 
       - name: Migrate DB
         run: npm run migrate up

--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -1,5 +1,9 @@
 name: Coveralls Code Coverage
-on: push
+on:
+  schedule:
+    - cron: '10 7 * * *'
+    # At 07:10, daily
+  workflow_dispatch:
 
 jobs:
   coveralls-code-coverage:

--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -42,8 +42,15 @@ jobs:
           POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/ci_test
         shell: bash
 
-      - name: Coverage Tests
-        run: npm run coverage:test coverage:test:services
+      - name: Coverage for Main Tests
+        run: npm run coverage:test
+        env:
+          GH_TOKEN: '${{ secrets.GH_PAT }}'
+          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/ci_test
+        shell: bash
+
+      - name: Coverage for Service Tests
+        run: npm run coverage:test:services
         continue-on-error: true
         env:
           RETRY_COUNT: 3
@@ -58,7 +65,6 @@ jobs:
           TWITCH_CLIENT_SECRET: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_SECRET }}'
           WHEELMAP_TOKEN: '${{ secrets.SERVICETESTS_WHEELMAP_TOKEN }}'
           YOUTUBE_API_KEY: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
-          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/ci_test
         shell: bash
 
       - name: Coveralls GitHub Action

--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -1,0 +1,61 @@
+name: Coveralls Code Coverage
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  coveralls-code-coverage:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ci_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+        with:
+          node-version: 20
+
+      - name: Migrate DB
+        run: npm run migrate up
+        env:
+          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/ci_test
+        shell: bash
+
+      - name: Coverage Tests
+        run: npm run coverage:test coverage:test:services
+        continue-on-error: true
+        env:
+          RETRY_COUNT: 3
+          GH_TOKEN: '${{ secrets.GH_PAT }}'
+          LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
+          OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
+          OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'
+          PEPY_KEY: '${{ secrets.SERVICETESTS_PEPY_KEY }}'
+          SL_INSIGHT_USER_UUID: '${{ secrets.SERVICETESTS_SL_INSIGHT_USER_UUID }}'
+          SL_INSIGHT_API_TOKEN: '${{ secrets.SERVICETESTS_SL_INSIGHT_API_TOKEN }}'
+          TWITCH_CLIENT_ID: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_ID }}'
+          TWITCH_CLIENT_SECRET: '${{ secrets.SERVICETESTS_TWITCH_CLIENT_SECRET }}'
+          WHEELMAP_TOKEN: '${{ secrets.SERVICETESTS_WHEELMAP_TOKEN }}'
+          YOUTUBE_API_KEY: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
+          POSTGRES_URL: postgresql://postgres:postgres@localhost:5432/ci_test
+        shell: bash
+
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2

--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -1,8 +1,5 @@
 name: Coveralls Code Coverage
-on:
-  push:
-    branches:
-      - master
+on: push
 
 jobs:
   coveralls-code-coverage:


### PR DESCRIPTION
It's been exactly three years today since we last submitted a coverage report to Coveralls. This PR introduces a GitHub workflow that runs whenever a commit is pushed to master. To make sure everything was running as intended, I temporarily removed the master branch constraint before opening this PR, here's an example run: https://coveralls.io/builds/68519008