### PR TITLE
Use ellipsis when many versions returned for [ModrinthGameVersions]

### DIFF
--- a/services/modrinth/modrinth-game-versions.service.js
+++ b/services/modrinth/modrinth-game-versions.service.js
@@ -25,6 +25,12 @@ export default class ModrinthGameVersions extends BaseModrinthService {
   static defaultBadgeData = { label: 'game versions' }
 
   static render({ versions }) {
+    if (versions.length > 5) {
+      return {
+        message: `${versions[0]} | ${versions[1]} | ... | ${versions[versions.length - 2]} | ${versions[versions.length - 1]}`,
+        color: 'blue',
+      }
+    }
     return {
       message: versions.join(' | '),
       color: 'blue',

--- a/services/modrinth/modrinth-game-versions.spec.js
+++ b/services/modrinth/modrinth-game-versions.spec.js
@@ -1,0 +1,22 @@
+import { test, given } from 'sazerac'
+import ModrinthGameVersions from './modrinth-game-versions.service.js'
+
+describe('render function', function () {
+  it('displays up to five versions', async function () {
+    test(ModrinthGameVersions.render, () => {
+      given({ versions: ['1.1', '1.2', '1.3', '1.4', '1.5'] }).expect({
+        message: '1.1 | 1.2 | 1.3 | 1.4 | 1.5',
+        color: 'blue',
+      })
+    })
+  })
+
+  it('uses ellipsis for six versions or more', async function () {
+    test(ModrinthGameVersions.render, () => {
+      given({ versions: ['1.1', '1.2', '1.3', '1.4', '1.5', '1.6'] }).expect({
+        message: '1.1 | 1.2 | ... | 1.5 | 1.6',
+        color: 'blue',
+      })
+    })
+  })
+})

--- a/services/modrinth/modrinth-game-versions.tester.js
+++ b/services/modrinth/modrinth-game-versions.tester.js
@@ -1,3 +1,4 @@
+import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
 import { withRegex } from '../test-validators.js'
 
@@ -7,7 +8,12 @@ t.create('Game Versions')
   .get('/AANobbMI.json')
   .expectBadge({
     label: 'game versions',
-    message: withRegex(/\d+\.\d+(\.\d+)?( \| )?/),
+    message: Joi.alternatives().try(
+      withRegex(/^(\d+\.\d+(\.\d+)?( \| )?)+$/),
+      withRegex(
+        /^\d+\.\d+(\.\d+)? \| \d+\.\d+(\.\d+)? \| \.\.\. \| \d+\.\d+(\.\d+)? \| \d+\.\d+(\.\d+)?$/,
+      ),
+    ),
   })
 
 t.create('Game Versions (not found)')


### PR DESCRIPTION
Fixes #10346.

To make sure the ellipsis falls in the "middle", the list of game versions must be sorted. All the examples I've tried seem to return sorted results from the API, so I'm running under that assumption and have kept the implementation simple. We can always revisit later if need-be.