### PR TITLE
Update c8 configuration

### DIFF
--- a/.c8rc.json
+++ b/.c8rc.json
@@ -9,10 +9,8 @@
     "**/test-helpers.js",
     "**/*-test-helpers.js",
     "**/*-fixtures.js",
-    "**/mocha-*.js",
     "**/*.test-d.ts",
     "dangerfile.js",
-    "gatsby-*.js",
     "core/service-test-runner",
     "core/got-test-client.js",
     "services/**/*.tester.js",
@@ -23,6 +21,9 @@
     "coverage",
     "build",
     ".github",
-    "**/public/"
+    "**/public/",
+    "cypress",
+    "frontend",
+    "migrations"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -50,9 +50,6 @@ lib-cov
 # Coverage directory used by tools like istanbul
 coverage
 
-# nyc test coverage
-.nyc_output
-
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "coverage:test:entrypoint": "c8 npm run test:entrypoint",
     "coverage:test:integration": "c8 npm run test:integration",
     "coverage:test:services": "c8 npm run test:services",
-    "coverage:clean": "rimraf .nyc_output coverage",
+    "coverage:clean": "rimraf coverage",
     "precoverage:test": "cross-env BASE_URL=http://localhost:8080 run-s --silent coverage:clean defs",
     "coverage:test": "run-s --silent --continue-on-error coverage:test:core coverage:test:package coverage:test:entrypoint coverage:test:integration",
     "coverage:report:generate": "c8 report",


### PR DESCRIPTION
* adds a few extra ignored folders and deletes no-longer relevant ones.
* renames `.nycrc.json` to `.c8rc.json`, we hadn't done so in #6778 as we were still evaluating c8 at the time.
* stops attempting to clean up `.nyc_output`, we hadn't done so in #6778 as we were still evaluating c8 at the time.