### PR TITLE
Fix [Gitea] not found message

### DIFF
--- a/services/gitea/gitea-helper.js
+++ b/services/gitea/gitea-helper.js
@@ -5,10 +5,10 @@ By default this badge looks for repositories on [gitea.com](https://gitea.com).
 To specify another instance like [codeberg](https://codeberg.org/), [forgejo](https://forgejo.org/) or a self-hosted instance, use the \`gitea_url\` query param.
 `
 
-function httpErrorsFor() {
+function httpErrorsFor(notFoundMessage = 'user or repo not found') {
   return {
     403: 'private repo',
-    404: 'user, repo or path not found',
+    404: notFoundMessage,
   }
 }
 

--- a/services/gitea/gitea-languages-count.service.js
+++ b/services/gitea/gitea-languages-count.service.js
@@ -61,7 +61,7 @@ export default class GiteaLanguageCount extends GiteaBase {
     return super.fetch({
       schema,
       url: `${baseUrl}/api/v1/repos/${user}/${repo}/languages`,
-      httpErrors: httpErrorsFor('user or repo not found'),
+      httpErrors: httpErrorsFor(),
     })
   }
 

--- a/services/gitea/gitea-last-commit.service.js
+++ b/services/gitea/gitea-last-commit.service.js
@@ -127,7 +127,7 @@ export default class GiteaLastCommit extends GiteaBase {
       schema,
       url: `${baseUrl}/api/v1/repos/${user}/${repo}/commits`,
       options: { searchParams: { sha: branch, path, limit: 1 } },
-      httpErrors: httpErrorsFor(),
+      httpErrors: httpErrorsFor('user, repo or path not found'),
     })
   }
 


### PR DESCRIPTION
#9995 accidentally changed the not found message for all Gitea services, even those that don't support paths.