### PR TITLE
Fix [EcologiCarbonOffset] test

### DIFF
--- a/services/ecologi/ecologi-carbon.tester.js
+++ b/services/ecologi/ecologi-carbon.tester.js
@@ -1,12 +1,12 @@
 import { createServiceTester } from '../tester.js'
-import { withRegex } from '../test-validators.js'
+import { isMetricWithPattern } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('request for existing username')
   .get('/ecologi.json')
   .expectBadge({
     label: 'carbon offset',
-    message: withRegex(/[\d.]+ tonnes/),
+    message: isMetricWithPattern(/ tonnes/),
   })
 
 t.create('invalid username').get('/non-existent-username.json').expectBadge({


### PR DESCRIPTION
This test had started failing with the following error:
> ValidationError: message mismatch: "value" with value "1.2k tonnes" fails to match the required pattern: /[\d.]+ tonnes/

Let's use a more suitable validator.