### PR TITLE
Fix [AmoVersion] test

### DIFF
--- a/services/amo/amo-version.tester.js
+++ b/services/amo/amo-version.tester.js
@@ -2,7 +2,7 @@ import { isVPlusDottedVersionAtLeastOne } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('Version').get('/IndieGala-Helper.json').expectBadge({
+t.create('Version').get('/night-video-tuner.json').expectBadge({
   label: 'mozilla add-on',
   message: isVPlusDottedVersionAtLeastOne,
 })


### PR DESCRIPTION
Mozilla added this weird `resigned1` suffix to versions of old (bumping the last updated field in the process and making old add-ons look like they were recently updated, what a silly thing to do :facepalm:):
> ValidationError: message mismatch: "value" with value "v4.5.3resigned1" fails to match the required pattern: /^v\d+(\.\d+)?(\.\d+)?$/
