### PR TITLE
update [pub] points service test

### DIFF
--- a/services/pub/pub-points.tester.js
+++ b/services/pub/pub-points.tester.js
@@ -7,7 +7,7 @@ t.create('pub points (valid)')
   .get('/analysis_options.json')
   .expectBadge({
     label: 'points',
-    message: Joi.string().regex(/^\d+\/140$/),
+    message: Joi.string().regex(/^\d+\/\d+$/),
   })
 
 t.create('pub points (not found)').get('/analysisoptions.json').expectBadge({


### PR DESCRIPTION
Pub scores are now out of 160, not 140.
Instead of hard-coding this number, lets just accept a pattern.
The colours are based on `grantedPoints / maxPoints` rather than the raw score, so I think we don't really care if this number changes.