### PR TITLE
update [PythonVersionFromToml] test example

### DIFF
--- a/services/python/python-version-from-toml.tester.js
+++ b/services/python/python-version-from-toml.tester.js
@@ -22,6 +22,6 @@ t.create(
   'python versions - valid toml with missing python-requires field (invalid)',
 )
   .get(
-    '/python/required-version-toml.json?tomlFilePath=https://raw.githubusercontent.com/django/django/main/pyproject.toml',
+    '/python/required-version-toml.json?tomlFilePath=https://raw.githubusercontent.com/psf/requests/main/pyproject.toml',
   )
   .expectBadge({ label: 'python', message: 'invalid response data' })


### PR DESCRIPTION
Django does now specify a `python-requires` in their `pyproject.toml`. I've switched to a different repo. We could consider mocking this. This badge takes the URL to any file as a query param so we're not really testing for breaking changes in a service here.
