### PR TITLE
Cache text only static badges for longer

### DIFF
--- a/core/base-service/base-static.js
+++ b/core/base-service/base-static.js
@@ -47,7 +47,11 @@ export default class BaseStaticService extends BaseService {
       const format = (match.slice(-1)[0] || '.svg').replace(/^\./, '')
       badgeData.format = format
 
-      setCacheHeadersForStaticResource(ask.res)
+      let maxAge = 24 * 3600 // 1 day
+      if (!queryParams.logo && !badgeData.isError) {
+        maxAge = 5 * 24 * 3600 // 5 days
+      }
+      setCacheHeadersForStaticResource(ask.res, maxAge)
 
       const svg = makeBadge(badgeData)
       makeSend(format, ask.res, end)(svg)

--- a/core/base-service/cache-headers.js
+++ b/core/base-service/cache-headers.js
@@ -90,8 +90,11 @@ function setCacheHeaders({
   setHeadersForCacheLength(res, cacheLengthSeconds)
 }
 
-const staticCacheControlHeader = `max-age=${24 * 3600}, s-maxage=${24 * 3600}` // 1 day.
-function setCacheHeadersForStaticResource(res) {
+function setCacheHeadersForStaticResource(
+  res,
+  maxAge = 24 * 3600, // 1 day
+) {
+  const staticCacheControlHeader = `max-age=${maxAge}, s-maxage=${maxAge}`
   res.setHeader('Cache-Control', staticCacheControlHeader)
   res.setHeader('Last-Modified', serverStartTimeGMTString)
 }

--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -111,8 +111,12 @@ export default function redirector(attrs) {
         ask.res.statusCode = 301
         ask.res.setHeader('Location', redirectUrl)
 
-        // To avoid caching mistakes for a long time, and to make this simpler
-        // to reason about, use the same cache semantics as the static badge.
+        /* To avoid caching mistakes forever
+           (in the absence of cache control directives that specify otherwise,
+           301 redirects are cached without any expiry date)
+           and to make this simpler to reason about,
+           use the same cache semantics as the static badge.
+        */
         setCacheHeadersForStaticResource(ask.res)
 
         ask.res.end()

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -59,8 +59,17 @@ describe('The server', function () {
       expect(headers['cache-control']).to.equal('max-age=300, s-maxage=300')
     })
 
-    it('should serve badges with custom maxAge', async function () {
+    it('should serve static badges without logo with maxAge=432000', async function () {
       const { headers } = await got(`${baseUrl}badge/foo-bar-blue`)
+      expect(headers['cache-control']).to.equal(
+        'max-age=432000, s-maxage=432000',
+      )
+    })
+
+    it('should serve badges with with logo with maxAge=86400', async function () {
+      const { headers } = await got(
+        `${baseUrl}badge/foo-bar-blue?logo=javascript`,
+      )
       expect(headers['cache-control']).to.equal('max-age=86400, s-maxage=86400')
     })
 


### PR DESCRIPTION
We serve a lot of static badges. `static_badge` is the single most popular badge on shields. Depending on the time of day it accounts for 10-15% of the traffic we serve from the origin (i.e: uncached). They are the least computationally expensive badges to serve, but there are a lot of them. Each one uses a connection, costs us some egress bandwidth, etc

In general, these badges don't really change. ![](https://img.shields.io/badge/foo-bar-blue) today is ![](https://img.shields.io/badge/foo-bar-blue) tomorrow.

We already serve these with quite a long cache on them (1 day), but I think we could go longer in some cases. There is a bit of churn of icon updates in simple-icons, so I think badges which use a logo should stay cached for a day, but for static badges that are just text, lets cache them for longer. I don't think we should say "cache forever". At some point, we will fix a font rendering issue or [change the default palette](https://github.com/badges/shields/pull/9916) or whatever, so I do want these things to expire after some interval. However, I think we can usefully make that interval longer than a day and meaningfully increase the number of requests served from the CDN instead of the origin.