### PR TITLE
remove reference to CircleCI

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
+++ b/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
@@ -18,10 +18,6 @@ labels: 'keep-service-tests-green'
 
 <!-- Indicate whether or not the live badge is working. -->
 
-:link: **CircleCI link**
-
-<!-- Provide a link to the failing test in CircleCI. -->
-
 :lady_beetle: **Stack trace**
 
 ```


### PR DESCRIPTION
We don't use Circle CI anymore.
It is not particularly easy to link directly to one individual test in the GH Actions markdown summary, so I suggest we just ditch this section.