### PR TITLE
use metric() for [discord] and [revolt] badges

### DIFF
--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { nonNegativeInteger } from '../validators.js'
+import { metric } from '../text-formatters.js'
 import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
@@ -53,7 +54,7 @@ export default class Discord extends BaseJsonService {
 
   static render({ members }) {
     return {
-      message: `${members} online`,
+      message: `${metric(members)} online`,
       color: 'brightgreen',
     }
   }

--- a/services/discord/discord.tester.js
+++ b/services/discord/discord.tester.js
@@ -1,12 +1,13 @@
-import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
+import { isMetricWithPattern } from '../test-validators.js'
+
 export const t = await createServiceTester()
 
 t.create('gets status for Reactiflux')
   .get('/102860784329052160.json')
   .expectBadge({
     label: 'chat',
-    message: Joi.string().regex(/^[0-9]+ online$/),
+    message: isMetricWithPattern(/ online/),
     color: 'brightgreen',
   })
 

--- a/services/revolt/revolt.service.js
+++ b/services/revolt/revolt.service.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { BaseJsonService, pathParam, queryParam } from '../index.js'
+import { metric } from '../text-formatters.js'
 import { nonNegativeInteger, optionalUrl } from '../validators.js'
 
 const schema = Joi.object({
@@ -52,7 +53,7 @@ export default class RevoltServerInvite extends BaseJsonService {
 
   static render({ memberCount }) {
     return {
-      message: `${memberCount} members`,
+      message: `${metric(memberCount)} members`,
       color: 'brightgreen',
     }
   }

--- a/services/revolt/revolt.tester.js
+++ b/services/revolt/revolt.tester.js
@@ -1,5 +1,5 @@
-import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
+import { isMetricWithPattern } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
@@ -7,7 +7,7 @@ t.create('get status of #revolt')
   .get('/01F7ZSBSFHQ8TA81725KQCSDDP.json')
   .expectBadge({
     label: 'chat',
-    message: Joi.string().regex(/^[0-9]+ members$/),
+    message: isMetricWithPattern(/ members/),
     color: 'brightgreen',
   })
 
@@ -17,7 +17,7 @@ t.create('custom api url')
   )
   .expectBadge({
     label: 'chat',
-    message: Joi.string().regex(/^[0-9]+ members$/),
+    message: isMetricWithPattern(/ members/),
     color: 'brightgreen',
   })
 


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/10249#issuecomment-2171684953


These badges display exact values, but they should really use `metric()`