### PR TITLE
Fix branch in [Bitrise] tests

### DIFF
--- a/services/bitrise/bitrise.service.js
+++ b/services/bitrise/bitrise.service.js
@@ -45,7 +45,7 @@ export default class Bitrise extends BaseJsonService {
           }),
           pathParam({
             name: 'branch',
-            example: 'master',
+            example: 'develop',
           }),
           queryParam({
             name: 'token',

--- a/services/bitrise/bitrise.tester.js
+++ b/services/bitrise/bitrise.tester.js
@@ -10,7 +10,7 @@ t.create('deploy status')
   })
 
 t.create('deploy status with branch')
-  .get('/e736852157296019/master.json?token=vhgAmaiF3tWZoQyFLkKM7g')
+  .get('/e736852157296019/develop.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({
     label: 'bitrise',
     message: isBuildStatus,
@@ -25,5 +25,5 @@ t.create('invalid token')
   .expectBadge({ label: 'bitrise', message: 'app not found or invalid token' })
 
 t.create('invalid App ID')
-  .get('/invalid/master.json?token=vhgAmaiF3tWZoQyFLkKM7g')
+  .get('/invalid/develop.json?token=vhgAmaiF3tWZoQyFLkKM7g')
   .expectBadge({ label: 'bitrise', message: 'app not found or invalid token' })


### PR DESCRIPTION
The `master` branch no longer exists, let's switch to the default `develop` branch.