### PR TITLE
remove libraries we don't need in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ COPY package.json package-lock.json /usr/src/app/
 # Without the badge-maker package.json and CLI script in place, `npm ci` will fail.
 COPY badge-maker /usr/src/app/badge-maker/
 
-RUN apk add python3 make g++
 RUN npm install -g "npm@^9.0.0"
 # We need dev deps to build the front end. We don't need Cypress, though.
 RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci


### PR DESCRIPTION
While I was thinking about https://github.com/badges/shields/pull/10441 I realised that these are hangovers from when we had the rasterisation libraries installed. We don't need any of these any more.
