### PR TITLE
un-pin buildx version

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.9.1
 
       - name: Set Git Short SHA
         run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.9.1
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/publish-docker-next.yml
+++ b/.github/workflows/publish-docker-next.yml
@@ -16,8 +16,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          version: v0.9.1
 
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS Builder
+FROM node:20-alpine AS builder
 
 RUN mkdir -p /usr/src/app
 RUN mkdir /usr/src/app/private
@@ -30,7 +30,7 @@ LABEL fly.version=$version
 ENV NODE_ENV production
 
 WORKDIR /usr/src/app
-COPY --from=Builder --chown=0:0 /usr/src/app /usr/src/app
+COPY --from=builder --chown=0:0 /usr/src/app /usr/src/app
 
 CMD node server
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ ENV NODE_ENV=production
 WORKDIR /usr/src/app
 COPY --from=builder --chown=0:0 /usr/src/app /usr/src/app
 
-CMD node server
+CMD ["node", "server"]
 
 EXPOSE 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ LABEL version=$version
 LABEL fly.version=$version
 
 # Run the server using production configs.
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 WORKDIR /usr/src/app
 COPY --from=builder --chown=0:0 /usr/src/app /usr/src/app


### PR DESCRIPTION
We originally did this in https://github.com/badges/shields/pull/8862 due to issues deploying on fly.io

This problem has actually been fixed upstream for quite some time
https://community.fly.io/t/images-built-with-the-latest-docker-buildx-and-or-github-actions-work-again/10816
so we don't really need to be pinned to this old version any more.