### PR TITLE
Deprecate [TreewareTrees] service

### DIFF
--- a/services/treeware/treeware-trees.service.js
+++ b/services/treeware/treeware-trees.service.js
@@ -1,65 +1,11 @@
-import crypto from 'crypto'
-import Joi from 'joi'
-import { metric } from '../text-formatters.js'
-import { floorCount } from '../color-formatters.js'
-import { BaseJsonService, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const apiSchema = Joi.object({
-  total: Joi.number().required(),
-}).required()
-
-export default class TreewareTrees extends BaseJsonService {
-  static category = 'other'
-
-  static route = {
+export const TreewareTrees = deprecatedService({
+  category: 'other',
+  route: {
     base: 'treeware/trees',
-    pattern: ':owner/:packageName',
-  }
-
-  static openApi = {
-    '/treeware/trees/{owner}/{packageName}': {
-      get: {
-        summary: 'Treeware (Trees)',
-        parameters: pathParams(
-          {
-            name: 'owner',
-            example: 'stoplightio',
-          },
-          {
-            name: 'packageName',
-            example: 'spectral',
-          },
-        ),
-      },
-    },
-  }
-
-  static defaultBadgeData = {
-    label: 'trees',
-  }
-
-  static render({ count }) {
-    return { message: metric(count), color: floorCount(count, 10, 50, 100) }
-  }
-
-  async fetch({ reference }) {
-    const url = 'https://public.offset.earth/users/treeware/trees'
-    return this._requestJson({
-      url,
-      schema: apiSchema,
-      options: {
-        searchParams: { ref: reference },
-      },
-    })
-  }
-
-  async handle({ owner, packageName }) {
-    const reference = crypto
-      .createHash('md5')
-      .update(`${owner}/${packageName}`)
-      .digest('hex')
-    const { total } = await this.fetch({ reference })
-
-    return this.constructor.render({ count: total })
-  }
-}
+    pattern: ':various*',
+  },
+  label: 'trees',
+  dateAdded: new Date('2024-08-18'),
+})

--- a/services/treeware/treeware-trees.tester.js
+++ b/services/treeware/treeware-trees.tester.js
@@ -1,27 +1,14 @@
-import { createServiceTester } from '../tester.js'
-import { isMetric } from '../test-validators.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'TreewareTrees',
+  title: 'TreewareTrees',
+  pathPrefix: '/treeware/trees',
+})
 
 t.create('request for existing package')
   .get('/stoplightio/spectral.json')
   .expectBadge({
     label: 'trees',
-    message: isMetric,
+    message: 'no longer available',
   })
-
-t.create('request for existing package (mock)')
-  .get('/stoplightio/spectral.json')
-  .intercept(nock =>
-    nock('https://public.offset.earth')
-      .get('/users/treeware/trees?ref=65c6e3e942e7464b4591e0c8b70d11d5')
-      .reply(200, { total: 50 }),
-  )
-  .expectBadge({
-    label: 'trees',
-    message: '50',
-    color: 'green',
-  })
-
-t.create('invalid package')
-  .get('/non-existent-user/non-existent-package.json')
-  .expectBadge({ label: 'trees', message: '0', color: 'red' })


### PR DESCRIPTION
The Treeware API has been unresponsive for some time now. I reported the issue a month ago in https://github.com/TreewareEarth/treeware.earth/issues/35, but haven't heard back. Given low usage numbers (43 renders last Thursday for example), I think we can go ahead and start the deprecation process.

Cc @owenvoke who contributed the badge in the first place.