### PR TITLE
ignore a couple of docusaurus warnings

### DIFF
--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -45,6 +45,8 @@ const config = {
         blog: {
           showReadingTime: true,
           editUrl: 'https://github.com/badges/shields/tree/master/frontend',
+          onInlineAuthors: 'ignore',
+          onUntruncatedBlogPosts: 'ignore',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
The latest version of docusaurus outputs a few warnings while compiling our site:

```
Note that we recommend to declare authors once in a "authors.yml" file and reference them by key in blog posts front matter to avoid author info duplication.
But if you want to allow inline blog authors, you can disable this message by setting onInlineAuthors: 'ignore' in your blog plugin options.
More info at https://docusaurus.io/docs/blog
```

and

```
We recommend using truncation markers (`<!-- truncate -->` or `{/* truncate */}`) in blog posts to create shorter previews on blog paginated lists.
Tip: turn this security off with the `onUntruncatedBlogPosts: 'ignore'` blog plugin option.
```

I'm not particularly worried about the way we are doing this so I'm going to suggest we just silence them.