### PR TITLE
Publish linux/amd64 docker images for snapshot builds only

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,9 +17,6 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'release')
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        architecture: [amd64, arm64]
 
     steps:
       - name: Get current date
@@ -40,7 +37,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -53,7 +50,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
           tags: shieldsio/shields:server-${{ steps.date.outputs.date }}
           build-args: |
             version=server-${{ steps.date.outputs.date }}
@@ -70,7 +67,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/badges/shields:server-${{ steps.date.outputs.date }}
           build-args: |
             version=server-${{ steps.date.outputs.date }}

--- a/.github/workflows/publish-docker-next.yml
+++ b/.github/workflows/publish-docker-next.yml
@@ -10,9 +10,6 @@ permissions:
 jobs:
   publish-docker-next:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        architecture: [amd64, arm64]
 
     steps:
       - name: Checkout
@@ -21,7 +18,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -38,7 +35,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
           tags: shieldsio/shields:next
           build-args: |
             version=${{ env.SHORT_SHA }}
@@ -58,7 +55,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/${{ matrix.architecture }}
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/badges/shields:next
           build-args: |
             version=${{ env.SHORT_SHA }}

--- a/doc/self-hosting.md
+++ b/doc/self-hosting.md
@@ -78,10 +78,7 @@ We publish images to:
 - DockerHub at https://registry.hub.docker.com/r/shieldsio/shields and
 - GitHub Container Registry at https://github.com/badges/shields/pkgs/container/shields
 
-The `next` tag is the latest build from `master`, or tagged snapshot releases are available:
-
-- https://registry.hub.docker.com/r/shieldsio/shields/tags
-- https://github.com/badges/shields/pkgs/container/shields/versions?filters%5Bversion_type%5D=tagged
+The `next` tag is the latest build from `master`. These are only available for linux/amd64
 
 ```sh
 # DockerHub
@@ -94,6 +91,13 @@ $ docker run shieldsio/shields:next
 $ docker pull ghcr.io/badges/shields:next
 $ docker pull ghcr.io/badges/shields:next
 ```
+
+Tagged snapshot releases are also available:
+
+- https://registry.hub.docker.com/r/shieldsio/shields/tags
+- https://github.com/badges/shields/pkgs/container/shields/versions?filters%5Bversion_type%5D=tagged
+
+We push both linux/amd64 and linux/arm64 snapshot images. We use the linux/amd64 image ourselves to host shields.io. We push a linux/arm64 image, but we don't consume it ourselves and it receives no testing beyond ensuring the docker image builds without error.
 
 ### Building Docker Image Locally
 


### PR DESCRIPTION
I did some research and it seems the correct way to publish a multi-architecture build under a single tag is to do it simultaneously.

```
0 shane@jammy [/home/shane]$ docker pull shieldsio/shields:next
next: Pulling from shieldsio/shields
no matching manifest for linux/amd64 in the manifest list entries
```

That will make the entire build take the full duration of ~35 minutes. At a glance I don't see master being merged to more frequently than 35 minutes apart, so I have also included the next build here, but that can easily be removed.