### PR TITLE
[OSSLifecycle] Add file_url param to pull from non-github sources

### DIFF
--- a/services/osslifecycle/osslifecycle.tester.js
+++ b/services/osslifecycle/osslifecycle.tester.js
@@ -60,3 +60,13 @@ t.create('oss metadata not found').get('/PyvesB/empty-repo.json').expectBadge({
   label: 'oss lifecycle',
   message: 'not found',
 })
+
+t.create('osslifecycle status (file)')
+  .get(
+    '.json?file_url=https://raw.githubusercontent.com/Netflix/osstracker/master/OSSMETADATA',
+  )
+  .expectBadge({
+    label: 'oss lifecycle',
+    message: 'active',
+    color: 'brightgreen',
+  })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
This PR addresses #10244 (OSS Lifecycle GitLab) by adding a queryParam of `file_url`. When this parameter is provided, we fetch the provided URL instead of defaulting to the GitHub RAW Content URL. Existing badges using the `{user}/{repo}` and `{user}/{repo}/{branch}` pattern are maintained, however providing `file_url` with these will still override the URL we fetch.

UI Changes:
- Added a `OSS Lifecycle (file)` OpenAPI entry for the new end point without path parameters
- Changed `OSS Lifecycle` to `OSS Lifecycle (GitHub)`
- Changed `OSS Lifecycle (branch)` to `OSS Lifecycle (GitHub branch)`

Changes to tests:
- Added new test to test using `file_url` against the Netflix OSS Tracker Repo

One potential improvement would be to rename the service class, currently it is `OssTracker` however everywhere else is referred to as `osslifecycle`.