### PR TITLE
remove docusaurus css hacks

### DIFF
--- a/frontend/src/css/custom.css
+++ b/frontend/src/css/custom.css
@@ -30,23 +30,3 @@ html[data-theme="dark"] .docusaurus-highlight-code-line {
 .opencollective-image {
   color-scheme: initial;
 }
-
-/*
-TODO: remove these three styles when
-we can upgrade to docusaurus-theme-openapi@0.6.5
-*/
-
-input[type="text"], :not(#fakeID#fakeId#fakeID) select {
-  border-color: var(--ifm-color-primary-lightest);
-  border-style: solid;
-  border-width: 1px;
-}
-
-div.api-code-tab-group {
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-div.api-code-tab-group button.api-code-tab  {
-  width: unset;
-}


### PR DESCRIPTION
This PR removes some workarounds I put in place and then forgot to remove.
We don't need these any more because the problems were fixed upstream in docusaurus-theme-openapi. I just forgot to remove these when we upgraded.