### PR TITLE
perf: faster `resetIconPosition` avoiding to parse path twice

### DIFF
--- a/lib/svg-helpers.js
+++ b/lib/svg-helpers.js
@@ -19,9 +19,10 @@ function getIconSize(iconKey) {
   return { width: x1 - x0, height: y1 - y0 }
 }
 
-function resetIconPosition(path) {
+function resetIconPosition(d) {
+  const path = svgpath(d)
   const [offsetX, offsetY] = svgPathBbox(path)
-  const pathReset = svgpath(path).translate(-offsetX, -offsetY).toString()
+  const pathReset = path.translate(-offsetX, -offsetY).toString()
   return pathReset
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "semver": "~7.6.3",
         "simple-icons": "13.7.0",
         "smol-toml": "1.3.0",
-        "svg-path-bbox": "^2.0.0",
+        "svg-path-bbox": "^2.1.0",
         "svgpath": "^2.6.0",
         "webextension-store-meta": "^1.2.3",
         "xpath": "~0.0.34"
@@ -28166,10 +28166,9 @@
       "dev": true
     },
     "node_modules/svg-path-bbox": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/svg-path-bbox/-/svg-path-bbox-2.0.0.tgz",
-      "integrity": "sha512-DP/dcKuwjfJ2GXiM1RsIKcWv+aGazBXTYPuAH9pWYZVm5+pZ6ho70BeLB0inqUGDCCHDmcUlQ2OcLlGuwhmkKQ==",
-      "license": "BSD-3-Clause",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/svg-path-bbox/-/svg-path-bbox-2.1.0.tgz",
+      "integrity": "sha512-PEoSQFbBvL7FOCE4cN8Knej6L7bXdNkjPcUYsfMMpq0HpnqiO0sE2mcXTd7LX160aOyh5HbaeN/SoY8thMk5Kg==",
       "dependencies": {
         "svgpath": "^2.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "semver": "~7.6.3",
     "simple-icons": "13.7.0",
     "smol-toml": "1.3.0",
-    "svg-path-bbox": "^2.0.0",
+    "svg-path-bbox": "^2.1.0",
     "svgpath": "^2.6.0",
     "webextension-store-meta": "^1.2.3",
     "xpath": "~0.0.34"


### PR DESCRIPTION
This is a continuation of #10488.

Just seen that PR and realized that the parsing of the path (d) is done twice. One in `svgpath(path)` and another in `svgPathBbox(path)` as `svgPathBbox` uses `svgpath` internally.

So I released a [new version of `svg-path-bbox`](https://github.com/mondeja/svg-path-bbox/releases/tag/v2.1.0) that also accepts `SvgPath` interfaces to avoid the double parsing in situations like this. Instead of parsing again, `svgpath` clones the segments and is so much faster.