### PR TITLE
Add latest Tag to Docker Release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date --rfc-3339=date)"
+        run: echo "date=$(date --rfc-3339=date)" >> $GITHUB_OUTPUT
 
       - name: Checkout branch "master"
         uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: shieldsio/shields:server-${{ steps.date.outputs.date }}
+          tags: shieldsio/shields:server-${{ steps.date.outputs.date }},shieldsio/shields:latest
           build-args: |
             version=server-${{ steps.date.outputs.date }}
 
@@ -68,6 +68,6 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/badges/shields:server-${{ steps.date.outputs.date }}
+          tags: ghcr.io/badges/shields:server-${{ steps.date.outputs.date }},shieldsio/shields:latest
           build-args: |
             version=server-${{ steps.date.outputs.date }}


### PR DESCRIPTION
One other change I would like to see, is adding a `latest` tag to the docker image that always points to the latest version published.

This will allow easily updating self-hosted deployments without having to make code changes every time.

I also updated the setting of the `date` output that is soon to be deprecated with the new format. Reference https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/