### PR TITLE
Connect Package to Repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN npm cache clean --force
 # Use multi-stage build to reduce size
 FROM node:20-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/badges/shields"
+
 ARG version=dev
 ENV DOCKER_SHIELDS_VERSION=$version
 LABEL version=$version


### PR DESCRIPTION
I just noticed the GHCR package is actually public but not connected to the repository. Connecting it to the repository makes it show up on the repository sidebar and displays the README.md file on the package listing. Example:

https://github.com/smashedr/shields/pkgs/container/shields

![20240904-162247359](https://github.com/user-attachments/assets/f1e36b89-bbf1-407e-8115-d33e0071eb0d)

The label is not required, and from my experience, also requires manually connecting the package to the repository, but GitHub recommends adding it.

This PR can be closed without merging; however, first someone MUST go to the Package, click on the `Package Settings` and find the hit the `Connect to Repository` button, choose this repository, and save. Once successful, you should see the packages in the side bar as pictured above.

![firefox-20240904-163157479](https://github.com/user-attachments/assets/03c31816-53b7-4553-81f5-b2d55f4f4269)

Let me know if you have any questions. I can also add this change to #10498 if preferred, but did not want to block one change with another. 