### PR TITLE
Remove failing [Packagist] tests

### DIFF
--- a/services/packagist/packagist-stars.tester.js
+++ b/services/packagist/packagist-stars.tester.js
@@ -14,29 +14,15 @@ t.create('Stars (invalid package)')
     message: 'not found',
   })
 
-t.create('Stars (valid package, valid custom server)')
+t.create('Stars (valid package, custom server)')
   .get('/guzzlehttp/guzzle.json?server=https%3A%2F%2Fpackagist.org')
   .expectBadge({
     label: 'stars',
     message: isMetric,
   })
 
-t.create('Stars (invalid package, valid custom server)')
+t.create('Stars (invalid package, custom server)')
   .get('/frodo/is-not-a-package.json?server=https%3A%2F%2Fpackagist.org')
-  .expectBadge({
-    label: 'stars',
-    message: 'not found',
-  })
-
-t.create('Stars (valid package, invalid custom server)')
-  .get('/guzzlehttp/guzzle.json?server=https%3A%2F%2Fexample.com')
-  .expectBadge({
-    label: 'stars',
-    message: 'not found',
-  })
-
-t.create('Stars (invalid package, invalid custom server)')
-  .get('/frodo/is-not-a-package.json?server=https%3A%2F%2Fexample.com')
   .expectBadge({
     label: 'stars',
     message: 'not found',


### PR DESCRIPTION
This tests started failing because example.com now returns a 500 for its not found pages:
![Screenshot 2024-09-07 163315](https://github.com/user-attachments/assets/af9bce54-b51e-4853-a673-ae68df0d9577)

I feel that these tests don't bring much value, we're exercising the base error handlers with no Packagist-specific logic. Rather than fixing them, I suggest we get rid of them.