### PR TITLE
Switch to shields server ID in [Discord] example and test

### DIFF
--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -42,7 +42,7 @@ export default class Discord extends BaseJsonService {
         description,
         parameters: pathParams({
           name: 'serverId',
-          example: '102860784329052160',
+          example: '308323056592486420',
         }),
       },
     },

--- a/services/discord/discord.tester.js
+++ b/services/discord/discord.tester.js
@@ -3,8 +3,8 @@ import { isMetricWithPattern } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
-t.create('gets status for Reactiflux')
-  .get('/102860784329052160.json')
+t.create('gets status for shields')
+  .get('/308323056592486420.json')
   .expectBadge({
     label: 'chat',
     message: isMetricWithPattern(/ online/),


### PR DESCRIPTION
The widget was apparently disabled on the previous Discord server that we were targetting, let's switch to our own server.