### PR TITLE
catch xml ParseError in [DynamicXml] badge

### DIFF
--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -75,7 +75,13 @@ export default class DynamicXml extends BaseService {
     const pathIsAttr = (
       pathExpression.split('/').slice(-1)[0] || ''
     ).startsWith('@')
-    const parsed = new DOMParser().parseFromString(buffer, 'text/xml')
+
+    let parsed
+    try {
+      parsed = new DOMParser().parseFromString(buffer, 'text/xml')
+    } catch (e) {
+      throw new InvalidResponse({ prettyMessage: e.message })
+    }
 
     let values
     try {


### PR DESCRIPTION
So we deployed https://github.com/badges/shields/pull/10481
and a few of these popped up
https://shields.sentry.io/issues/5811374190
https://github.com/badges/shields/pull/10481#issuecomment-2336400034
This is not a completely new source of error. For example
https://shields.sentry.io/issues/4386982653
has been happening occasionally for a while.
I'm not really sure exactly what input triggers either of those and we might still end up making further changes following https://github.com/badges/shields/pull/10481#discussion_r1740961975
but fundamentally, a document that doesn't parse shouldn't be an unhandled error on an endpoint where we accept arbitrary input. So lets fix that.