### PR TITLE
catch queries that cause TypeError in [dynamicjson]

### DIFF
--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -160,12 +160,25 @@ t.create('query with parse error')
   })
 
 // Example from https://stackoverflow.com/q/11670384/893113
-const badQuery =
+const invalidTokenQuery =
   "$[?(en|**|(@.object.property.one=='other') && (@.object.property.two=='something(abc/def)'))]"
 t.create('query with invalid token')
   .get(
     `.json?url=https://github.com/badges/shields/raw/master/package.json&query=${encodeURIComponent(
-      badQuery,
+      invalidTokenQuery,
+    )}`,
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: 'query not supported',
+    color: 'red',
+  })
+
+const invalidEscapequery = "$.definitions.common.properties.['@id'].format"
+t.create('query with invalid escape')
+  .get(
+    `.json?url=https://raw.githubusercontent.com/json-ld/json-ld.org/refs/heads/main/schemas/jsonld-schema.json&query=${encodeURIComponent(
+      invalidEscapequery,
     )}`,
   )
   .expectBadge({

--- a/services/dynamic/json-path.js
+++ b/services/dynamic/json-path.js
@@ -48,7 +48,10 @@ export default superclass =>
         values = jp({ json: data, path: pathExpression, eval: false })
       } catch (e) {
         const { message } = e
-        if (message.includes('prevented in JSONPath expression')) {
+        if (
+          message.includes('prevented in JSONPath expression') ||
+          e instanceof TypeError
+        ) {
           throw new InvalidParameter({
             prettyMessage: 'query not supported',
           })


### PR DESCRIPTION
After we merged https://github.com/badges/shields/pull/10551 yesterday a new error popped up in Sentry https://shields.sentry.io/issues/5906771741?project=251614

Here's an example of a document and query that cause this

https://raw.githubusercontent.com/json-ld/json-ld.org/refs/heads/main/schemas/jsonld-schema.json

`$.definitions.common.properties.['@id'].format`

This particular document/query combination is an example of https://github.com/JSONPath-Plus/JSONPath/issues/166 but I suspect there is a wider range of cases where we can hit this
https://github.com/JSONPath-Plus/JSONPath/blob/0c8dbcf656523fadc738cacee254ee8b96894bd7/src/jsonpath.js#L527-L528

In any case, we should catch this error and return an error badge, rather than falling over with an unhandled exception.