### PR TITLE
add created timestamp to tokens table

### DIFF
--- a/migrations/1727809177709_add-created.cjs
+++ b/migrations/1727809177709_add-created.cjs
@@ -1,0 +1,15 @@
+exports.shorthands = undefined
+
+exports.up = pgm => {
+  pgm.addColumn('github_user_tokens', {
+    created: {
+      type: 'TIMESTAMP',
+      notNull: true,
+      default: pgm.func('CURRENT_TIMESTAMP'),
+    },
+  })
+}
+
+exports.down = pgm => {
+  pgm.dropColumn('github_user_tokens', 'created')
+}


### PR DESCRIPTION
One of the things that has come out of https://github.com/badges/shields-ops/issues/38 is: It would be quite useful to know how long we've held a given token for in a more explicit way then relying on the id sequence. In some ways I'm a bit late to the party, but better late than never.

This PR creates a migration that adds a column called `created` to the `github_user_tokens` table. We'll need to manually run this migration on production after deploying it.

The `created` column defaults to `CURRENT_TIMESTAMP` which means:

- When we apply the migration it will set the `created` timestamp to now when we apply the migration for any existing records
- The existing code can run with or without this migration applied
- When we add new tokens they'll automatically be timestamped at `INSERT` time with no code changes
