### PR TITLE
Refactor version rendering in [wordpress nexus] and [f-droid] services

### DIFF
--- a/services/f-droid/f-droid.service.js
+++ b/services/f-droid/f-droid.service.js
@@ -3,8 +3,7 @@ import {
   optionalNonNegativeInteger,
   nonNegativeInteger,
 } from '../validators.js'
-import { addv } from '../text-formatters.js'
-import { version as versionColor } from '../color-formatters.js'
+import { renderVersionBadge } from '../version.js'
 import { BaseJsonService, NotFound, pathParam, queryParam } from '../index.js'
 
 const schema = Joi.object({
@@ -46,13 +45,6 @@ export default class FDroid extends BaseJsonService {
 
   static defaultBadgeData = { label: 'f-droid' }
 
-  static render({ version }) {
-    return {
-      message: addv(version),
-      color: versionColor(version),
-    }
-  }
-
   async fetch({ appId }) {
     const url = `https://f-droid.org/api/v1/packages/${appId}`
     return this._requestJson({
@@ -83,6 +75,6 @@ export default class FDroid extends BaseJsonService {
     const json = await this.fetch({ appId })
     const suggested = includePre === undefined
     const { version } = this.transform({ json, suggested })
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version })
   }
 }

--- a/services/nexus/nexus.service.js
+++ b/services/nexus/nexus.service.js
@@ -1,6 +1,5 @@
 import Joi from 'joi'
-import { version as versionColor } from '../color-formatters.js'
-import { addv } from '../text-formatters.js'
+import { renderVersionBadge } from '../version.js'
 import {
   optionalUrl,
   optionalDottedVersionNClausesWithOptionalSuffix,
@@ -141,13 +140,6 @@ export default class Nexus extends BaseJsonService {
 
   static defaultBadgeData = {
     label: 'nexus',
-  }
-
-  static render({ version }) {
-    return {
-      message: addv(version),
-      color: versionColor(version),
-    }
   }
 
   addQueryParamsToQueryString({ searchParams, queryOpt }) {
@@ -321,6 +313,6 @@ export default class Nexus extends BaseJsonService {
     })
 
     const { version } = this.transform({ repo, json, actualNexusVersion })
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version })
   }
 }

--- a/services/nexus/nexus.spec.js
+++ b/services/nexus/nexus.spec.js
@@ -154,6 +154,7 @@ describe('Nexus', function () {
           },
         ),
       ).to.deep.equal({
+        label: undefined,
         message: 'v2.3.4',
         color: 'blue',
       })

--- a/services/wordpress/wordpress-version.service.js
+++ b/services/wordpress/wordpress-version.service.js
@@ -1,6 +1,5 @@
 import { pathParams } from '../index.js'
-import { addv } from '../text-formatters.js'
-import { version as versionColor } from '../color-formatters.js'
+import { renderVersionBadge } from '../version.js'
 import { description, BaseWordpress } from './wordpress-base.js'
 
 function VersionForExtensionType(extensionType) {
@@ -43,19 +42,12 @@ function VersionForExtensionType(extensionType) {
 
     static defaultBadgeData = { label: extensionType }
 
-    static render({ version }) {
-      return {
-        message: addv(version),
-        color: versionColor(version),
-      }
-    }
-
     async handle({ slug }) {
       const { version } = await this.fetch({
         extensionType,
         slug,
       })
-      return this.constructor.render({ version })
+      return renderVersionBadge({ version })
     }
   }
 }


### PR DESCRIPTION
We mostly use the short more elegant `renderVersionBadge` but some services still use older method of directly calling addv and versionColor.

These changes refactor the WordpressVersion, Nexus and FDroid services to fit usage of `renderVersionBadge`