### PR TITLE
Change [Nexus] test for valid version

### DIFF
--- a/services/nexus/nexus.tester.js
+++ b/services/nexus/nexus.tester.js
@@ -258,7 +258,7 @@ t.create('Nexus 3 - search release version of an nonexistent artifact')
 
 t.create('Nexus 3 - search snapshot version valid snapshot artifact')
   .get(
-    '/s/com.tomkeuper.bedwars/bedwars-api.json?server=https://repo.tomkeuper.com&nexusVersion=3',
+    '/s/net.voxelpi.event/event.json?server=https://repo.voxelpi.net&nexusVersion=3',
   )
   .expectBadge({
     label: 'nexus',


### PR DESCRIPTION
This pull request updates the Nexus test to search for a valid version of the artifact "event" from the repository "https://repo.voxelpi.net". The previous test was searching for the artifact "bedwars-api" from the repository "https://repo.tomkeuper.com" which started failing the test recently, see also https://github.com/badges/shields/actions/runs/11306263530?pr=10608 & PR #10608