### PR TITLE
[GitHubHacktoberfest] 2024 support

### DIFF
--- a/services/github/github-hacktoberfest.service.js
+++ b/services/github/github-hacktoberfest.service.js
@@ -52,7 +52,7 @@ export default class GithubHacktoberfestCombinedStatus extends GithubAuthV4Servi
   static category = 'issue-tracking'
   static route = {
     base: 'github/hacktoberfest',
-    pattern: ':year(2019|2020|2021|2022|2023)/:user/:repo',
+    pattern: ':year(2019|2020|2021|2022|2023|2024)/:user/:repo',
     queryParamSchema,
   }
 
@@ -64,7 +64,7 @@ export default class GithubHacktoberfestCombinedStatus extends GithubAuthV4Servi
         parameters: [
           pathParam({
             name: 'year',
-            example: '2023',
+            example: '2024',
             schema: { type: 'string', enum: this.getEnum('year') },
           }),
           pathParam({ name: 'user', example: 'tmrowco' }),


### PR DESCRIPTION
This should have probably been done a few weeks ago, but hey, better late than never. Maybe we could put in a Google calendar reminder or something like that for next year.