### PR TITLE
refactor - usage renderVersionBadge - part 2 [amo archlinux aur bower cdnjs chromewebstore cocoapods conan conda cookbook cpan cran crates ctan curseforge debian docker dub eclipsemarketplace elmpackage f-droid factorio fedora feedz flathub galaxytoolshed gem gitea github gitlab greasyfork hackage hexpm homebrew itunes jenkins jetbrains jitpack jsr mavenmetadata modrinth nexus npm nuget openvsx opm ore packagist piwheels polymart pub puppetforge pypi ros scoop snapcraft spack spiget thunderstore twitch ubuntu vaadindirectory vcpkg visualstudioappcenter visualstudiomarketplace vpm wordpress]

### DIFF
--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -4,7 +4,7 @@ import {
   age as ageColor,
 } from '../color-formatters.js'
 import { renderLicenseBadge } from '../licenses.js'
-import { addv, metric, formatDate } from '../text-formatters.js'
+import { metric, formatDate } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import {
   BaseJsonService,
@@ -12,6 +12,7 @@ import {
   InvalidResponse,
   pathParams,
 } from '../index.js'
+import { renderVersionBadge } from '../version.js'
 
 const aurSchema = Joi.object({
   resultcount: nonNegativeInteger,
@@ -170,7 +171,7 @@ class AurVersion extends BaseAurService {
 
   static render({ version, outOfDate }) {
     const color = outOfDate === null ? 'blue' : 'orange'
-    return { message: addv(version), color }
+    return renderVersionBadge({ version, versionFormatter: () => color })
   }
 
   async handle({ packageName }) {

--- a/services/aur/aur.spec.js
+++ b/services/aur/aur.spec.js
@@ -6,11 +6,13 @@ describe('AurVersion', function () {
     given({ version: '1:1.1.42.622-1', outOfDate: 1 }).expect({
       color: 'orange',
       message: 'v1:1.1.42.622-1',
+      label: undefined,
     })
 
     given({ version: '7', outOfDate: null }).expect({
       color: 'blue',
       message: 'v7',
+      label: undefined,
     })
   })
 })

--- a/services/conda/conda-version.service.js
+++ b/services/conda/conda-version.service.js
@@ -1,6 +1,5 @@
 import { pathParams } from '../index.js'
-import { addv as versionText } from '../text-formatters.js'
-import { version as versionColor } from '../color-formatters.js'
+import { renderVersionBadge } from '../version.js'
 import BaseCondaService from './conda-base.js'
 
 export default class CondaVersion extends BaseCondaService {
@@ -33,20 +32,12 @@ export default class CondaVersion extends BaseCondaService {
     },
   }
 
-  static render({ variant, channel, version }) {
-    return {
-      label: variant === 'vn' ? channel : `conda | ${channel}`,
-      message: versionText(version),
-      color: versionColor(version),
-    }
-  }
-
   async handle({ variant, channel, packageName }) {
     const json = await this.fetch({ channel, packageName })
-    return this.constructor.render({
-      variant,
-      channel,
+    const defaultLabel = variant === 'vn' ? channel : `conda | ${channel}`
+    return renderVersionBadge({
       version: json.latest_version,
+      defaultLabel,
     })
   }
 }

--- a/services/npm/npm-base.spec.js
+++ b/services/npm/npm-base.spec.js
@@ -34,7 +34,7 @@ describe('npm', function () {
         await NpmVersion.invoke(defaultContext, config, { packageName: 'npm' }),
       ).to.deep.equal({
         color: 'orange',
-        label: undefined,
+        label: 'npm',
         message: 'v0.1.0',
       })
 

--- a/services/version.js
+++ b/services/version.js
@@ -234,6 +234,7 @@ function rangeStart(v) {
  * @param {string} options.version - The version number to display on the badge
  * @param {string} [options.tag] - The tag to display on the badge, such as "alpha" or "beta"
  * @param {string} [options.defaultLabel] - The default label to display on the badge, such as "npm" or "github"
+ * @param {string} [options.postfix] - The postfix to display on the message, such as "tested"
  * @param {Function} [options.versionFormatter=versionColor] - The function to use to format the color of the badge based on the version number
  * @returns {object} A badge object that has three properties: label, message, and color
  * @example
@@ -245,11 +246,12 @@ function renderVersionBadge({
   version,
   tag,
   defaultLabel,
+  postfix,
   versionFormatter = versionColor,
 }) {
   return {
     label: tag ? `${defaultLabel}@${tag}` : defaultLabel,
-    message: addv(version),
+    message: addv(version) + (postfix ? ` ${postfix}` : ''),
     color: versionFormatter(version),
   }
 }

--- a/services/version.js
+++ b/services/version.js
@@ -248,7 +248,7 @@ function renderVersionBadge({
   versionFormatter = versionColor,
 }) {
   return {
-    label: tag ? `${defaultLabel}@${tag}` : undefined,
+    label: tag ? `${defaultLabel}@${tag}` : defaultLabel,
     message: addv(version),
     color: versionFormatter(version),
   }

--- a/services/version.js
+++ b/services/version.js
@@ -234,6 +234,7 @@ function rangeStart(v) {
  * @param {string} options.version - The version number to display on the badge
  * @param {string} [options.tag] - The tag to display on the badge, such as "alpha" or "beta"
  * @param {string} [options.defaultLabel] - The default label to display on the badge, such as "npm" or "github"
+ * @param {string} [options.prefix]  - The prefix to display on the message, such as ">=", "v", overrides the default behavior of using addv
  * @param {string} [options.postfix] - The postfix to display on the message, such as "tested"
  * @param {Function} [options.versionFormatter=versionColor] - The function to use to format the color of the badge based on the version number
  * @returns {object} A badge object that has three properties: label, message, and color
@@ -246,12 +247,15 @@ function renderVersionBadge({
   version,
   tag,
   defaultLabel,
+  prefix,
   postfix,
   versionFormatter = versionColor,
 }) {
   return {
     label: tag ? `${defaultLabel}@${tag}` : defaultLabel,
-    message: addv(version) + (postfix ? ` ${postfix}` : ''),
+    message:
+      (prefix ? `${prefix}${version}` : addv(version)) +
+      (postfix ? ` ${postfix}` : ''),
     color: versionFormatter(version),
   }
 }

--- a/services/version.spec.js
+++ b/services/version.spec.js
@@ -150,5 +150,25 @@ describe('Version helpers', function () {
       message: 'v1.2.3',
       color: 'blue',
     })
+    given({ version: '1.2.3', defaultLabel: 'npm' }).expect({
+      label: 'npm',
+      message: 'v1.2.3',
+      color: 'blue',
+    })
+    given({ version: '1.2.3', postfix: 'tested' }).expect({
+      label: undefined,
+      message: 'v1.2.3 tested',
+      color: 'blue',
+    })
+    given({
+      version: '1.2.3',
+      tag: 'beta',
+      defaultLabel: 'github',
+      postfix: 'tested',
+    }).expect({
+      label: 'github@beta',
+      message: 'v1.2.3 tested',
+      color: 'blue',
+    })
   })
 })

--- a/services/version.spec.js
+++ b/services/version.spec.js
@@ -170,5 +170,49 @@ describe('Version helpers', function () {
       message: 'v1.2.3 tested',
       color: 'blue',
     })
+    given({ version: '1.2.3', prefix: '^' }).expect({
+      label: undefined,
+      message: '^1.2.3',
+      color: 'blue',
+    })
+    given({
+      version: '1.2.3',
+      tag: 'alpha',
+      defaultLabel: 'npm',
+      prefix: '^',
+    }).expect({
+      label: 'npm@alpha',
+      message: '^1.2.3',
+      color: 'blue',
+    })
+    given({
+      version: '1.2.3',
+      defaultLabel: 'npm',
+      prefix: '^',
+    }).expect({
+      label: 'npm',
+      message: '^1.2.3',
+      color: 'blue',
+    })
+    given({
+      version: '1.2.3',
+      prefix: '^',
+      postfix: 'tested',
+    }).expect({
+      label: undefined,
+      message: '^1.2.3 tested',
+      color: 'blue',
+    })
+    given({
+      version: '1.2.3',
+      tag: 'beta',
+      defaultLabel: 'github',
+      prefix: '^',
+      postfix: 'tested',
+    }).expect({
+      label: 'github@beta',
+      message: '^1.2.3 tested',
+      color: 'blue',
+    })
   })
 })

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -1,5 +1,4 @@
 import { NotFound, pathParams } from '../index.js'
-import { addv } from '../text-formatters.js'
 import { renderVersionBadge } from '../version.js'
 import { version as versionColor } from '../color-formatters.js'
 import { description, BaseWordpress } from './wordpress-base.js'
@@ -87,21 +86,18 @@ class WordpressPluginTestedVersion extends BaseWordpress {
 
   static defaultBadgeData = { label: 'wordpress' }
 
-  static async render({ testedVersion }) {
-    // Atypically, the `render()` function of this badge is `async` because it needs to pull
-    // data from the server.
-    return {
-      message: `${addv(testedVersion)} tested`,
-      color: await versionColorForWordpressVersion(testedVersion),
-    }
-  }
-
   async handle({ slug }) {
     const { tested: testedVersion } = await this.fetch({
       extensionType: 'plugin',
       slug,
     })
-    return this.constructor.render({ testedVersion })
+    // Atypically, pulling color data from the server with async operation.
+    const color = await versionColorForWordpressVersion(testedVersion)
+    return renderVersionBadge({
+      version: testedVersion,
+      postfix: 'tested',
+      versionFormatter: () => color,
+    })
   }
 }
 

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -1,6 +1,5 @@
 import { NotFound, pathParams } from '../index.js'
 import { renderVersionBadge } from '../version.js'
-import { version as versionColor } from '../color-formatters.js'
 import { description, BaseWordpress } from './wordpress-base.js'
 import { versionColorForWordpressVersion } from './wordpress-version-color.js'
 
@@ -132,14 +131,6 @@ function RequiresPHPVersionForType(extensionType) {
 
     static defaultBadgeData = { label: 'php' }
 
-    static render({ version }) {
-      return {
-        label: 'php',
-        message: `>=${version}`,
-        color: versionColor(version),
-      }
-    }
-
     async handle({ slug }) {
       const { requires_php: requiresPhp } = await this.fetch({
         extensionType,
@@ -152,9 +143,7 @@ function RequiresPHPVersionForType(extensionType) {
         })
       }
 
-      return this.constructor.render({
-        version: requiresPhp,
-      })
+      return renderVersionBadge({ version: requiresPhp, prefix: '>=' })
     }
   }
 }

--- a/services/wordpress/wordpress-platform.service.js
+++ b/services/wordpress/wordpress-platform.service.js
@@ -1,5 +1,6 @@
 import { NotFound, pathParams } from '../index.js'
 import { addv } from '../text-formatters.js'
+import { renderVersionBadge } from '../version.js'
 import { version as versionColor } from '../color-formatters.js'
 import { description, BaseWordpress } from './wordpress-base.js'
 import { versionColorForWordpressVersion } from './wordpress-version-color.js'
@@ -46,13 +47,6 @@ function WordpressRequiresVersion(extensionType) {
 
     static defaultBadgeData = { label: 'wordpress' }
 
-    static render({ wordpressVersion }) {
-      return {
-        message: addv(wordpressVersion),
-        color: versionColor(wordpressVersion),
-      }
-    }
-
     async handle({ slug }) {
       const { requires: wordpressVersion } = await this.fetch({
         extensionType,
@@ -65,7 +59,7 @@ function WordpressRequiresVersion(extensionType) {
         })
       }
 
-      return this.constructor.render({ wordpressVersion })
+      return renderVersionBadge({ version: wordpressVersion })
     }
   }
 }


### PR DESCRIPTION
This pull request refactors the codebase to use the `renderVersionBadge` function for rendering version badges.
Refactored services are wordpress, conda and aur.
The pull request also includes tests for all the new options.
This change is part of the ongoing work to address issue #2026 - refactor all versions to use  `renderVersionBadge`
And also helps archive user override for version prefix as mentioned in #10574

new optoins for `renderVersionBadge` added in this PR are prefix and postfix for the `renderVersionBadge` message.

we need to run tests for all services that use `renderVersionBadge` as i changed the function.