### PR TITLE
update failing test to use package iptables in [archlinux]

### DIFF
--- a/services/archlinux/archlinux.tester.js
+++ b/services/archlinux/archlinux.tester.js
@@ -3,7 +3,7 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('Arch Linux package (valid)')
-  .get('/core/x86_64/pacman.json')
+  .get('/core/x86_64/iptables.json')
   .expectBadge({
     label: 'arch linux',
     message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,


### PR DESCRIPTION
use iptables as its a stable long term package that uses more standard version numbers
archlinux uses upstream versions which makes version regex for tests hard to predict

see also failed test at https://github.com/badges/shields/actions/runs/11364173280?pr=10615
in PR #10615

see also https://wiki.archlinux.org/title/PKGBUILD#Version for info about pkg versions. might include letters and dates rather then fixed regex.