### PR TITLE
set VM size to shared-cpu-1x/256Mb on staging apps

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -45,3 +45,7 @@ processes = []
     interval = "15s"
     restart_limit = 0
     timeout = "2s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"


### PR DESCRIPTION
Without an explicit config in here, fly brings up our review apps with the default settings. This means our review apps get allocated 1Gb Memory which is unnecessary. 256Mb is fine for a review app serving a handful of requests.
I suspect our monthly spend on review apps is not very high in the grand scheme of things, but this will shave a bit off that cost.