### PR TITLE
Deprecate [HackageDeps] service

### DIFF
--- a/services/hackage/hackage-deps.service.js
+++ b/services/hackage/hackage-deps.service.js
@@ -1,48 +1,11 @@
-import { BaseService, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-export default class HackageDeps extends BaseService {
-  static category = 'dependencies'
-
-  static route = {
+export const HackageDeps = deprecatedService({
+  category: 'dependencies',
+  route: {
     base: 'hackage-deps/v',
     pattern: ':packageName',
-  }
-
-  static openApi = {
-    '/hackage-deps/v/{packageName}': {
-      get: {
-        summary: 'Hackage Dependencies',
-        parameters: pathParams({
-          name: 'packageName',
-          example: 'lens',
-        }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'dependencies' }
-
-  static render({ isOutdated }) {
-    if (isOutdated) {
-      return { message: 'outdated', color: 'orange' }
-    } else {
-      return { message: 'up to date', color: 'brightgreen' }
-    }
-  }
-
-  async handle({ packageName }) {
-    const reverseUrl = `http://packdeps.haskellers.com/licenses/${packageName}`
-    const feedUrl = `http://packdeps.haskellers.com/feed/${packageName}`
-
-    // first call /reverse to check if the package exists
-    // this will throw a 404 if it doesn't
-    await this._request({ url: reverseUrl })
-
-    // if the package exists, then query /feed to check the dependencies
-    const { buffer } = await this._request({ url: feedUrl })
-
-    const outdatedStr = `Outdated dependencies for ${packageName} `
-    const isOutdated = buffer.includes(outdatedStr)
-    return this.constructor.render({ isOutdated })
-  }
-}
+  },
+  label: 'hackagedeps',
+  dateAdded: new Date('2024-10-18'),
+})

--- a/services/hackage/hackage-deps.tester.js
+++ b/services/hackage/hackage-deps.tester.js
@@ -1,14 +1,10 @@
-import Joi from 'joi'
-import { createServiceTester } from '../tester.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
+export const t = new ServiceTester({
+  id: 'hackagedeps',
+  title: 'Hackage Dependencies',
+  pathPrefix: '/hackage-deps/v',
+})
 
-t.create('hackage deps (valid)')
-  .get('/lens.json')
-  .expectBadge({
-    label: 'dependencies',
-    message: Joi.string().regex(/^(up to date|outdated)$/),
-  })
-
-t.create('hackage deps (not found)')
-  .get('/not-a-package.json')
-  .expectBadge({ label: 'dependencies', message: 'not found' })
+t.create('hackage deps (deprecated)')
+  .get('/package.json')
+  .expectBadge({ label: 'hackagedeps', message: 'no longer available' })


### PR DESCRIPTION
Badge will always return up to date falsely as the upstream site is closed and looking for someone to take over.

The first test if a package exist will always return 200 OK even when non existing as we get the landing page.

Then we will never get "outdated dependencies" as the landing page doesn't include that text.

I looked into the https://hackage.haskell.org/api and couldn't find a quick way to replace the current upstream.

Therefor i propose we remove this badge, this is misleading at best as it's now.

![image](https://github.com/user-attachments/assets/36ef1149-a198-4a2d-8ba5-0d82ec3b4382)
