### PR TITLE
add content security policy header to SVG responses

### DIFF
--- a/core/base-service/legacy-result-sender.js
+++ b/core/base-service/legacy-result-sender.js
@@ -11,6 +11,7 @@ function streamFromString(str) {
 
 function sendSVG(res, askres, end) {
   askres.setHeader('Content-Type', 'image/svg+xml;charset=utf-8')
+  askres.setHeader('Content-Security-Policy', "script-src 'none';")
   askres.setHeader('Content-Length', Buffer.byteLength(res, 'utf8'))
   end(null, { template: streamFromString(res) })
 }

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -139,6 +139,27 @@ describe('The server', function () {
       expect(() => JSON.parse(body)).not.to.throw()
     })
 
+    describe('Content Security Policy', function () {
+      it('should disable javascript when serving SVG content (no extension)', async function () {
+        const { headers } = await got(`${baseUrl}:fruit-apple-green`)
+        expect(headers['content-security-policy']).to.equal(
+          "script-src 'none';",
+        )
+      })
+
+      it('should disable javascript when serving SVG content (with extension)', async function () {
+        const { headers } = await got(`${baseUrl}:fruit-apple-green.svg`)
+        expect(headers['content-security-policy']).to.equal(
+          "script-src 'none';",
+        )
+      })
+
+      it('should not send content security headers when serving JSON content', async function () {
+        const { headers } = await got(`${baseUrl}:fruit-apple-green.json`)
+        expect(headers).not.to.have.property('content-security-policy')
+      })
+    })
+
     it('should preserve label case', async function () {
       const { statusCode, body } = await got(`${baseUrl}:fRuiT-apple-green.svg`)
       expect(statusCode).to.equal(200)


### PR DESCRIPTION
This PR does not resolve an open security issue. However, it does proactively add another layer of protection on top of what we already do to prevent cross-site scripting issue.

SVGs can contain javascript.
When they're embedded with an `<img>` tag, SVGs are rendered in [secure static mode](https://www.w3.org/TR/SVG2/conform.html#secure-static-mode) which disables any embedded javascript, along with some other restrictions.
When they're embedded with a `<object>` tag or loaded directly, this is not the case.

While we take steps to prevent XSS issues, we have on at least one occasion discovered an escaping issue, which made it possible for someone to inject script into a badge image. Reference: https://github.com/badges/shields/pull/3511

In general, I think our escaping game is pretty solid these days.

That said, it is not impossible that someone might find a way around the mechanisms we have in place or we might introduce an escaping bug in some future refactor.

For this reason, I suggest we serve our SVG images with the `Content-Security-Policy: script-src 'none';` header. This is a content security policy header that basically says "no javascript allowed on this response" and offers a strong browser-level protection. This header is respected when the image is loaded directly, but also crucially when embedded with an `<object>` tag. Essentially, this would mean that even if someone found a way to sneak a `<script>` tag into a SVG response served from shields.io, any modern browser would refuse to run that script.