### PR TITLE
cleanly handle null or undefined result from jsonpath-plus in [dynamic] badges

### DIFF
--- a/services/dynamic/json-path.js
+++ b/services/dynamic/json-path.js
@@ -60,7 +60,7 @@ export default superclass =>
         }
       }
 
-      if (!values.length) {
+      if (!values || !values.length) {
         throw new InvalidResponse({ prettyMessage: 'no result' })
       }
 


### PR DESCRIPTION
Resolves https://shields.sentry.io/issues/6027856222

I don't have an example of an input that reduces this behaviour, but it looks like there is some circumstance in which `jp()` returns undefined. Lets handle this cleanly instead of throwing an unhandled runtime exception.