### PR TITLE
Fix broken URL for pingpong.one

### DIFF
--- a/services/pingpong/pingpong-base.js
+++ b/services/pingpong/pingpong-base.js
@@ -4,7 +4,7 @@ export const description = `
 [PingPong](https://pingpong.one/) is a status page and monitoring service.
 
 To see more details about this badge and obtain your api key, visit
-[https://my.pingpong.one/integrations/badge-status/](https://my.pingpong.one/integrations/badge-status/)
+[https://my.pingpong.one/integrations/badge-uptime/](https://my.pingpong.one/integrations/badge-uptime/)
 `
 
 export const baseUrl = 'https://api.pingpong.one/widget/shields'


### PR DESCRIPTION
Fix broken URL for https://pingpong.one for uptime status monitoring.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
