### PR TITLE
feat: global version category prefix query param [amo archlinux aur bower cdnjs chromewebstore cocoapods conan conda cookbook cpan cran crates ctan curseforge debian dockerVersion dub eclipsemarketplace elmpackage f-droid factorio fedora feedz flathub galaxytoolshed gem gitea]

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -20,7 +20,7 @@ import {
   Deprecated,
 } from './errors.js'
 import { fetch } from './got.js'
-import { getEnum } from './openapi.js'
+import { getEnum, categoryGlobalQueryParams } from './openapi.js'
 import {
   makeFullUrl,
   assertValidRoute,
@@ -200,6 +200,25 @@ class BaseService {
           `Inconsistent Open Api spec and Route found for service ${this.name}`,
         )
       }
+    }
+  }
+
+  static addGlobalCategoryQueryParams() {
+    if (!categoryGlobalQueryParams[this.category.toLowerCase()]) {
+      return
+    }
+    for (const path of Object.values(this.openApi)) {
+      path?.get?.parameters.push(
+        ...categoryGlobalQueryParams[this.category.toLowerCase()].openApiParams,
+      )
+    }
+    if (this.route.queryParamSchema) {
+      this.route.queryParamSchema = this.route.queryParamSchema.concat(
+        categoryGlobalQueryParams[this.category.toLowerCase()].joiSchema,
+      )
+    } else {
+      this.route.queryParamSchema =
+        categoryGlobalQueryParams[this.category.toLowerCase()].joiSchema
     }
   }
 

--- a/core/base-service/loader.js
+++ b/core/base-service/loader.js
@@ -67,6 +67,8 @@ async function loadServiceClasses(servicePaths) {
         serviceClass.serviceFamily = servicePath
           .replace(serviceDir, '')
           .split(path.sep)[1]
+        // add global category specific query params
+        serviceClass.addGlobalCategoryQueryParams()
         serviceClass.validateDefinition()
         return serviceClasses.push(serviceClass)
       }

--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -1,3 +1,5 @@
+import Joi from 'joi'
+
 /**
  * Functions for publishing the shields.io URL schema as an OpenAPI Document
  *
@@ -17,7 +19,20 @@ const globalParamRefs = [
   { $ref: '#/components/parameters/link' },
 ]
 
-const categoryGlobalQueryParams = {}
+const categoryGlobalQueryParams = {
+  version: {
+    openApiParams: queryParams({
+      name: 'versionPrefix',
+      example: 'v',
+      schema: { type: 'string' },
+      description:
+        'Overide version prefix. Can be used to remove default v prefix or replace it.',
+    }),
+    joiSchema: Joi.object({
+      versionPrefix: Joi.string(),
+    }).required(),
+  },
+}
 
 function getCodeSamples(altText) {
   return [

--- a/services/amo/amo-version.service.js
+++ b/services/amo/amo-version.service.js
@@ -16,8 +16,11 @@ export default class AmoVersion extends BaseAmoService {
     },
   }
 
-  async handle({ addonId }) {
+  async handle({ addonId }, { versionPrefix }) {
     const data = await this.fetch({ addonId })
-    return renderVersionBadge({ version: data.current_version.version })
+    return renderVersionBadge({
+      version: data.current_version.version,
+      prefix: versionPrefix,
+    })
   }
 }

--- a/services/archlinux/archlinux.service.js
+++ b/services/archlinux/archlinux.service.js
@@ -37,7 +37,7 @@ export default class ArchLinux extends BaseJsonService {
 
   static defaultBadgeData = { label: 'arch linux' }
 
-  async handle({ repository, architecture, packageName }) {
+  async handle({ repository, architecture, packageName }, { versionPrefix }) {
     const data = await this._requestJson({
       schema,
       url: `https://www.archlinux.org/packages/${encodeURIComponent(
@@ -46,6 +46,6 @@ export default class ArchLinux extends BaseJsonService {
         packageName,
       )}/json/`,
     })
-    return renderVersionBadge({ version: data.pkgver })
+    return renderVersionBadge({ version: data.pkgver, prefix: versionPrefix })
   }
 }

--- a/services/aur/aur.service.js
+++ b/services/aur/aur.service.js
@@ -169,18 +169,23 @@ class AurVersion extends BaseAurService {
 
   static _cacheLength = 3600
 
-  static render({ version, outOfDate }) {
+  static render({ version, outOfDate, versionPrefix }) {
     const color = outOfDate === null ? 'blue' : 'orange'
-    return renderVersionBadge({ version, versionFormatter: () => color })
+    return renderVersionBadge({
+      version,
+      versionFormatter: () => color,
+      prefix: versionPrefix,
+    })
   }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const {
       results: [{ Version: version, OutOfDate: outOfDate }],
     } = await this.fetch({ packageName })
     return this.constructor.render({
       version,
       outOfDate,
+      versionPrefix,
     })
   }
 }

--- a/services/bower/bower-version.service.js
+++ b/services/bower/bower-version.service.js
@@ -30,10 +30,10 @@ export default class BowerVersion extends BaseBowerService {
     return version
   }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const data = await this.fetch({ packageName })
     const version = this.constructor.transform(data)
 
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/cdnjs/cdnjs.service.js
+++ b/services/cdnjs/cdnjs.service.js
@@ -25,10 +25,6 @@ export default class Cdnjs extends BaseJsonService {
 
   static defaultBadgeData = { label: 'cdnjs' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
   async fetch({ library }) {
     const url = `https://api.cdnjs.com/libraries/${library}?fields=version`
     return this._requestJson({
@@ -37,7 +33,7 @@ export default class Cdnjs extends BaseJsonService {
     })
   }
 
-  async handle({ library }) {
+  async handle({ library }, { versionPrefix }) {
     const json = await this.fetch({ library })
 
     if (Object.keys(json).length === 0) {
@@ -46,6 +42,6 @@ export default class Cdnjs extends BaseJsonService {
       throw new NotFound()
     }
 
-    return this.constructor.render({ version: json.version })
+    return renderVersionBadge({ version: json.version, prefix: versionPrefix })
   }
 }

--- a/services/chrome-web-store/chrome-web-store-version.service.js
+++ b/services/chrome-web-store/chrome-web-store-version.service.js
@@ -20,12 +20,12 @@ export default class ChromeWebStoreVersion extends BaseChromeWebStoreService {
 
   static defaultBadgeData = { label: 'chrome web store' }
 
-  async handle({ storeId }) {
+  async handle({ storeId }, { versionPrefix }) {
     const chromeWebStore = await this.fetch({ storeId })
     const version = chromeWebStore.version()
     if (version == null) {
       throw new NotFound({ prettyMessage: 'not found' })
     }
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/cocoapods/cocoapods-version.service.js
+++ b/services/cocoapods/cocoapods-version.service.js
@@ -20,8 +20,8 @@ export default class CocoapodsVersion extends BaseCocoaPodsService {
 
   static defaultBadgeData = { label: 'pod' }
 
-  async handle({ spec }) {
+  async handle({ spec }, { versionPrefix }) {
     const { version } = await this.fetch({ spec })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/conan/conan-version.service.js
+++ b/services/conan/conan-version.service.js
@@ -24,7 +24,7 @@ export default class ConanVersion extends ConditionalGithubAuthV3Service {
 
   static defaultBadgeData = { label: 'conan' }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const configContent = await fetchRepoContent(this, {
       user: 'conan-io',
       repo: 'conan-center-index',
@@ -34,6 +34,6 @@ export default class ConanVersion extends ConditionalGithubAuthV3Service {
 
     const version = parseLatestVersionFromConfig(configContent)
 
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/conda/conda-version.service.js
+++ b/services/conda/conda-version.service.js
@@ -32,12 +32,13 @@ export default class CondaVersion extends BaseCondaService {
     },
   }
 
-  async handle({ variant, channel, packageName }) {
+  async handle({ variant, channel, packageName }, { versionPrefix }) {
     const json = await this.fetch({ channel, packageName })
     const defaultLabel = variant === 'vn' ? channel : `conda | ${channel}`
     return renderVersionBadge({
       version: json.latest_version,
       defaultLabel,
+      prefix: versionPrefix,
     })
   }
 }

--- a/services/cookbook/cookbook.service.js
+++ b/services/cookbook/cookbook.service.js
@@ -27,8 +27,8 @@ export default class Cookbook extends BaseJsonService {
     return this._requestJson({ schema, url })
   }
 
-  async handle({ cookbook }) {
+  async handle({ cookbook }, { versionPrefix }) {
     const { version } = await this.fetch({ cookbook })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/cpan/cpan-version.service.js
+++ b/services/cpan/cpan-version.service.js
@@ -19,8 +19,8 @@ export default class CpanVersion extends BaseCpanService {
     },
   }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const { version } = await this.fetch({ packageName })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/cran/cran.service.js
+++ b/services/cran/cran.service.js
@@ -62,13 +62,9 @@ class CranVersion extends BaseCranService {
     },
   }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const data = await this.fetch({ packageName })
-    return this.constructor.render({ version: data.Version })
+    return renderVersionBadge({ version: data.Version, prefix: versionPrefix })
   }
 }
 

--- a/services/crates/crates-version.service.js
+++ b/services/crates/crates-version.service.js
@@ -19,9 +19,9 @@ export default class CratesVersion extends BaseCratesService {
     },
   }
 
-  async handle({ crate }) {
+  async handle({ crate }, { versionPrefix }) {
     const json = await this.fetch({ crate })
     const version = this.constructor.getLatestVersion(json)
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/ctan/ctan.service.js
+++ b/services/ctan/ctan.service.js
@@ -72,21 +72,18 @@ class CtanVersion extends BaseCtanService {
     },
   }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
-  async handle({ library }) {
+  async handle({ library }, { versionPrefix }) {
     const json = await this.fetch({ library })
     const version = json.version.number
     if (version !== '') {
-      return renderVersionBadge({ version })
+      return renderVersionBadge({ version, prefix: versionPrefix })
     } else {
       const date = json.version.date
       if (date !== '') {
         return renderVersionBadge({
           version: date,
           versionFormatter: color => 'blue',
+          prefix: versionPrefix,
         })
       } else {
         return new InvalidResponse({

--- a/services/curseforge/curseforge-version.service.js
+++ b/services/curseforge/curseforge-version.service.js
@@ -25,8 +25,8 @@ export default class CurseForgeVersion extends BaseCurseForgeService {
 
   static defaultBadgeData = { label: 'version' }
 
-  async handle({ projectId }) {
+  async handle({ projectId }, { versionPrefix }) {
     const { version } = await this.fetchMod({ projectId })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/debian/debian.service.js
+++ b/services/debian/debian.service.js
@@ -57,7 +57,10 @@ export default class Debian extends BaseJsonService {
 
   static defaultBadgeData = { label: 'debian' }
 
-  async handle({ packageName, distribution = defaultDistribution }) {
+  async handle(
+    { packageName, distribution = defaultDistribution },
+    { versionPrefix },
+  ) {
     const data = await this._requestJson({
       schema,
       url: 'https://api.ftp-master.debian.org/madison',
@@ -84,6 +87,9 @@ export default class Debian extends BaseJsonService {
       throw new NotFound()
     }
     const versions = Object.keys(packageData[distKeys[0]])
-    return renderVersionBadge({ version: latest(versions) })
+    return renderVersionBadge({
+      version: latest(versions),
+      prefix: versionPrefix,
+    })
   }
 }

--- a/services/docker/docker-version.service.js
+++ b/services/docker/docker-version.service.js
@@ -99,10 +99,6 @@ export default class DockerVersion extends BaseJsonService {
 
   static defaultBadgeData = { label: 'version', color: 'blue' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
   async fetch({ user, repo, page }) {
     page = page ? `&page=${page}` : ''
     return await fetch(this, {
@@ -152,7 +148,7 @@ export default class DockerVersion extends BaseJsonService {
     }
   }
 
-  async handle({ user, repo, tag }, { sort, arch }) {
+  async handle({ user, repo, tag }, { sort, arch, versionPrefix }) {
     let data, pagedData
 
     if (!tag && sort === 'date') {
@@ -182,6 +178,6 @@ export default class DockerVersion extends BaseJsonService {
       pagedData,
       arch,
     })
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/dub/dub-version.service.js
+++ b/services/dub/dub-version.service.js
@@ -28,8 +28,8 @@ export default class DubVersion extends BaseJsonService {
     })
   }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const version = await this.fetch({ packageName })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/eclipse-marketplace/eclipse-marketplace-version.service.js
+++ b/services/eclipse-marketplace/eclipse-marketplace-version.service.js
@@ -32,16 +32,12 @@ export default class EclipseMarketplaceVersion extends EclipseMarketplaceBase {
 
   static defaultBadgeData = { label: 'eclipse marketplace' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
-  async handle({ name }) {
+  async handle({ name }, { versionPrefix }) {
     const { marketplace } = await this.fetch({
       name,
       schema: versionResponseSchema,
     })
     const version = marketplace.node.version
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/elm-package/elm-package.service.js
+++ b/services/elm-package/elm-package.service.js
@@ -28,11 +28,7 @@ export default class ElmPackage extends BaseJsonService {
 
   static defaultBadgeData = { label: 'elm package' }
 
-  static render(props) {
-    return renderVersionBadge(props)
-  }
-
-  async handle({ user, packageName }) {
+  async handle({ user, packageName }, { versionPrefix }) {
     const url = `https://package.elm-lang.org/packages/${user}/${packageName}/latest/elm.json`
     const { version } = await this._requestJson({
       schema,
@@ -41,6 +37,6 @@ export default class ElmPackage extends BaseJsonService {
         404: 'package not found',
       },
     })
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/f-droid/f-droid.service.js
+++ b/services/f-droid/f-droid.service.js
@@ -71,10 +71,10 @@ export default class FDroid extends BaseJsonService {
     return { version }
   }
 
-  async handle({ appId }, { include_prereleases: includePre }) {
+  async handle({ appId }, { include_prereleases: includePre, versionPrefix }) {
     const json = await this.fetch({ appId })
     const suggested = includePre === undefined
     const { version } = this.transform({ json, suggested })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/factorio-mod-portal/factorio-mod-portal.service.js
+++ b/services/factorio-mod-portal/factorio-mod-portal.service.js
@@ -64,13 +64,12 @@ class FactorioModPortalLatestVersion extends BaseFactorioModPortalService {
 
   static defaultBadgeData = { label: 'latest version' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
-  async handle({ modName }) {
+  async handle({ modName, versionPrefix }) {
     const resp = await this.fetch({ modName })
-    return this.constructor.render({ version: resp.latest_release.version })
+    return renderVersionBadge({
+      version: resp.latest_release.version,
+      prefix: versionPrefix,
+    })
   }
 }
 
@@ -97,14 +96,10 @@ class FactorioModPortalFactorioVersion extends BaseFactorioModPortalService {
 
   static defaultBadgeData = { label: 'factorio version' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version })
-  }
-
-  async handle({ modName }) {
+  async handle({ modName }, { versionPrefix }) {
     const resp = await this.fetch({ modName })
     const version = resp.latest_release.info_json.factorio_version
-    return this.constructor.render({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }
 

--- a/services/fedora/fedora.service.js
+++ b/services/fedora/fedora.service.js
@@ -46,7 +46,7 @@ export default class Fedora extends BaseJsonService {
 
   static defaultBadgeData = { label: 'fedora' }
 
-  async handle({ packageName, branch = defaultBranch }) {
+  async handle({ packageName, branch = defaultBranch }, { versionPrefix }) {
     const data = await this._requestJson({
       schema,
       url: `https://apps.fedoraproject.org/mdapi/${encodeURIComponent(
@@ -56,6 +56,6 @@ export default class Fedora extends BaseJsonService {
         400: 'branch not found',
       },
     })
-    return renderVersionBadge({ version: data.version })
+    return renderVersionBadge({ version: data.version, prefix: versionPrefix })
   }
 }

--- a/services/feedz/feedz.service.js
+++ b/services/feedz/feedz.service.js
@@ -112,7 +112,10 @@ class FeedzVersionService extends BaseJsonService {
     }
   }
 
-  async handle({ variant, organization, repository, packageName }) {
+  async handle(
+    { variant, organization, repository, packageName },
+    { versionPrefix },
+  ) {
     const includePrereleases = variant === 'vpre'
     const baseUrl = this.apiUrl({ organization, repository })
     const json = await this.fetch({ baseUrl, packageName })
@@ -121,6 +124,7 @@ class FeedzVersionService extends BaseJsonService {
     return renderVersionBadge({
       version,
       defaultLabel: FeedzVersionService.defaultBadgeData.label,
+      prefix: versionPrefix,
     })
   }
 }

--- a/services/flathub/flathub.service.js
+++ b/services/flathub/flathub.service.js
@@ -28,7 +28,7 @@ export default class Flathub extends BaseJsonService {
 
   static defaultBadgeData = { label: 'flathub' }
 
-  async handle({ packageName }) {
+  async handle({ packageName }, { versionPrefix }) {
     const data = await this._requestJson({
       schema,
       url: `https://flathub.org/api/v1/apps/${encodeURIComponent(packageName)}`,
@@ -40,6 +40,9 @@ export default class Flathub extends BaseJsonService {
       throw new NotFound()
     }
 
-    return renderVersionBadge({ version: data.currentReleaseVersion })
+    return renderVersionBadge({
+      version: data.currentReleaseVersion,
+      prefix: versionPrefix,
+    })
   }
 }

--- a/services/galaxytoolshed/galaxytoolshed-version.service.js
+++ b/services/galaxytoolshed/galaxytoolshed-version.service.js
@@ -92,7 +92,7 @@ export class GalaxyToolshedVersion extends GalaxyToolshedService {
     return response[1].changeset_revision
   }
 
-  async handle({ repository, owner, tool, requirement }) {
+  async handle({ repository, owner, tool, requirement }, { versionPrefix }) {
     const response = await this.fetchLastOrderedInstallableRevisionsSchema({
       repository,
       owner,
@@ -102,6 +102,6 @@ export class GalaxyToolshedVersion extends GalaxyToolshedService {
       tool,
       requirement,
     })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }

--- a/services/gem/gem-version.service.js
+++ b/services/gem/gem-version.service.js
@@ -47,8 +47,12 @@ export default class GemVersion extends BaseJsonService {
 
   static defaultBadgeData = { label: 'gem' }
 
-  static render({ version }) {
-    return renderVersionBadge({ version, versionFormatter: versionColor })
+  static render({ version, prefix }) {
+    return renderVersionBadge({
+      version,
+      versionFormatter: versionColor,
+      prefix,
+    })
   }
 
   async fetch({ gem }) {
@@ -69,10 +73,16 @@ export default class GemVersion extends BaseJsonService {
     if (queryParams && typeof queryParams.include_prereleases !== 'undefined') {
       const data = await this.fetchLatest({ gem })
       const versions = data.map(version => version.number)
-      return this.constructor.render({ version: latest(versions) })
+      return this.constructor.render({
+        version: latest(versions),
+        prefix: queryParams.versionPrefix,
+      })
     } else {
       const { version } = await this.fetch({ gem })
-      return this.constructor.render({ version })
+      return this.constructor.render({
+        version,
+        prefix: queryParams.versionPrefix,
+      })
     }
   }
 }

--- a/services/gitea/gitea-release.service.js
+++ b/services/gitea/gitea-release.service.js
@@ -126,6 +126,7 @@ export default class GiteaRelease extends GiteaBase {
       sort,
       display_name: displayName,
       date_order_by: orderBy,
+      versionPrefix,
     },
   ) {
     const isSemver = sort === 'semver'
@@ -141,6 +142,6 @@ export default class GiteaRelease extends GiteaBase {
       includePrereleases: pre !== undefined,
       displayName,
     })
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version, prefix: versionPrefix })
   }
 }


### PR DESCRIPTION
Altho i am aware of #6135 this is an attempt to make this manageable.
I dont mind if this ends up unused as i took this as an opportunity to play a bit with the codebase internals.

Let me know if you think this change is elegant and easy to maintain or more of an anchor might risks confusion in the codebase.

Introduce global category-specific query parameters and add versionPrefix support across version badges.