### PR TITLE
remove obsolete [CratesSize] test for null size

### DIFF
--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -4,8 +4,7 @@ import { BaseJsonService, InvalidResponse } from '../index.js'
 
 const versionSchema = Joi.object({
   downloads: nonNegativeInteger,
-  // Crate size is not available for all versions.
-  crate_size: nonNegativeInteger.allow(null),
+  crate_size: nonNegativeInteger,
   num: Joi.string().required(),
   license: Joi.string().required().allow(null),
   rust_version: Joi.string().allow(null),

--- a/services/crates/crates-size.service.js
+++ b/services/crates/crates-size.service.js
@@ -1,5 +1,5 @@
 import prettyBytes from 'pretty-bytes'
-import { InvalidResponse, pathParams } from '../index.js'
+import { pathParams } from '../index.js'
 import { BaseCratesService, description } from './crates-base.js'
 
 export default class CratesSize extends BaseCratesService {
@@ -49,11 +49,6 @@ export default class CratesSize extends BaseCratesService {
   async handle({ crate, version }) {
     const json = await this.fetch({ crate, version })
     const size = this.constructor.getVersionObj(json).crate_size
-
-    if (size == null) {
-      throw new InvalidResponse({ prettyMessage: 'unknown' })
-    }
-
     return this.render({ size })
   }
 }

--- a/services/crates/crates-size.tester.js
+++ b/services/crates/crates-size.tester.js
@@ -10,10 +10,6 @@ t.create('size (with version)')
   .get('/tokio/1.32.0.json')
   .expectBadge({ label: 'size', message: '725 kB' })
 
-t.create('size (with version where version doesnt have size)')
-  .get('/tokio/0.1.6.json')
-  .expectBadge({ label: 'crates.io', message: 'unknown' })
-
 t.create('size (not found)')
   .get('/not-a-crate.json')
   .expectBadge({ label: 'crates.io', message: 'not found' })


### PR DESCRIPTION
Eliminate a test case that is no longer relevant due to upstream changes that removed all null crate sizes.

see also upstream merge that removed null for versions.crate_size upstream at rust-lang/crates.io#9926