### PR TITLE
fix [DockerVersion] service test

### DIFF
--- a/services/docker/docker-version.tester.js
+++ b/services/docker/docker-version.tester.js
@@ -2,12 +2,10 @@ import { isSemver } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('docker version (valid, library)')
-  .get('/_/memcached.json')
-  .expectBadge({
-    label: 'version',
-    message: isSemver,
-  })
+t.create('docker version (valid, library)').get('/_/python.json').expectBadge({
+  label: 'version',
+  message: isSemver,
+})
 
 t.create('docker version (valid, library with tag)')
   .get('/_/alpine/latest.json')

--- a/services/docker/docker-version.tester.js
+++ b/services/docker/docker-version.tester.js
@@ -3,10 +3,10 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('docker version (valid, library)')
-  .get('/_/docker-dev.json')
+  .get('/docker/example-voting-app-vote.json')
   .expectBadge({
     label: 'version',
-    message: isSemver,
+    message: 'latest',
   })
 
 t.create('docker version (valid, library with tag)')

--- a/services/docker/docker-version.tester.js
+++ b/services/docker/docker-version.tester.js
@@ -2,10 +2,12 @@ import { isSemver } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('docker version (valid, library)').get('/_/python.json').expectBadge({
-  label: 'version',
-  message: isSemver,
-})
+t.create('docker version (valid, library)')
+  .get('/_/docker-dev.json')
+  .expectBadge({
+    label: 'version',
+    message: isSemver,
+  })
 
 t.create('docker version (valid, library with tag)')
   .get('/_/alpine/latest.json')


### PR DESCRIPTION
Memcached tags don't follow semver, might fail depending on which  tag was last added.
~Python seems to follow semver for all tags.~
~docker-dev seems to follow semver and be stable as its deprecated~
OK, i suggest using the deprecated image by docker `docker/example-voting-app-vote` and test for the 'latest' tag which is last.
Image tags for this did not change in 8 years

fixes #10689

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
