### PR TITLE
auto suspend/resume review apps

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,6 +25,8 @@ processes = []
   processes = ["app"]
   protocol = "tcp"
   script_checks = []
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
 
   [services.concurrency]
     hard_limit = 25


### PR DESCRIPTION
This PR enables Fly's auto suspend/resume feature for review apps.
This will shut review app machines down if they've been idle for 5 mins and then restart them on demand on an incoming request (pretty much how the old heroku review apps used to work).
This should save us some money on review apps.
We could also consider moving the cleanup review apps job to run less frequently so we don't have to keep re-deploying the review apps if we have long-running reviews, although I have not done it in this PR.
