### PR TITLE
provide a non-repository scoped version of [githubcodesearch]

### DIFF
--- a/services/github/github-search.tester.js
+++ b/services/github/github-search.tester.js
@@ -3,9 +3,18 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('hit counter')
-  .get('/badges/shields/async%20handle.json')
+  .get('/search.json?query=async%20handle')
   .expectBadge({ label: 'async handle counter', message: isMetric })
 
-t.create('hit counter for nonexistent repo')
-  .get('/badges/puppets/async%20handle.json')
-  .expectBadge({ label: 'async handle counter', message: '0' })
+t.create('hit counter, zero results')
+  .get('/search.json?query=async%20handle%20repo%3Abadges%2Fpuppets')
+  .expectBadge({
+    label: 'async handle repo:badges/puppets counter',
+    message: '0',
+  })
+
+t.create('legacy redirect')
+  .get('/search/badges/shields/async%20handle.svg')
+  .expectRedirect(
+    '/github/search.svg?query=async%20handle%20repo%3Abadges%2Fshields',
+  )


### PR DESCRIPTION
provide a non-repository scoped version of Github Code Search badge

and redirect `/github/search/user/repo/query` to `/github/search?query=query%20repo:user/repo`

Closes #10686
Refs #10687