### PR TITLE
Deprecate [JenkinsPluginInstalls] per version

### DIFF
--- a/services/downloads.js
+++ b/services/downloads.js
@@ -22,8 +22,6 @@ import { metric } from './text-formatters.js'
  *    value instead of the color being based on the count of downloads
  * @param {string} [attrs.messageSuffixOverride] If provided then the badge message will
  *    will have this value added to the download count, separated with a space
- * @param {string} [attrs.versionedLabelPrefix] If provided then the badge label will use
- *    this value as the prefix for versioned badges, e.g. `foobar@v1.23`. Defaults to 'downloads'
  * @returns {object} Badge
  */
 function renderDownloadsBadge({
@@ -33,7 +31,6 @@ function renderDownloadsBadge({
   labelOverride,
   colorOverride,
   messageSuffixOverride,
-  versionedLabelPrefix = 'downloads',
 }) {
   let messageSuffix = ''
   if (messageSuffixOverride) {
@@ -46,7 +43,7 @@ function renderDownloadsBadge({
   if (labelOverride) {
     label = labelOverride
   } else if (version) {
-    label = `${versionedLabelPrefix}@${version}`
+    label = `downloads@${version}`
   }
 
   return {

--- a/services/downloads.spec.js
+++ b/services/downloads.spec.js
@@ -22,15 +22,6 @@ describe('downloads', function () {
     })
     given({
       downloads,
-      versionedLabelPrefix: 'installs',
-      version: 'v1.0.0',
-    }).expect({
-      label: 'installs@v1.0.0',
-      color,
-      message,
-    })
-    given({
-      downloads,
       messageSuffixOverride: '[foo.tar.gz]',
       interval: 'week',
     }).expect({

--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -1,22 +1,13 @@
 import Joi from 'joi'
 import { renderDownloadsBadge } from '../downloads.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService, NotFound, pathParams } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schemaInstallations = Joi.object()
   .keys({
     installations: Joi.object()
       .required()
       .pattern(nonNegativeInteger, nonNegativeInteger)
-      .min(1),
-  })
-  .required()
-
-const schemaInstallationsPerVersion = Joi.object()
-  .keys({
-    installationsPerVersion: Joi.object()
-      .required()
-      .pattern(Joi.string(), nonNegativeInteger)
       .min(1),
   })
   .required()
@@ -39,61 +30,38 @@ export default class JenkinsPluginInstalls extends BaseJsonService {
         }),
       },
     },
-    '/jenkins/plugin/i/{plugin}/{version}': {
-      get: {
-        summary: 'Jenkins Plugin installs (version)',
-        parameters: pathParams(
-          {
-            name: 'plugin',
-            example: 'view-job-filters',
-          },
-          {
-            name: 'version',
-            example: '1.26',
-          },
-        ),
-      },
-    },
   }
 
   static defaultBadgeData = { label: 'installs' }
 
-  static render({ installs: downloads, version }) {
-    return renderDownloadsBadge({
-      downloads,
-      versionedLabelPrefix: 'installs',
-      version,
-    })
+  static render({ installs: downloads }) {
+    return renderDownloadsBadge({ downloads })
   }
 
-  async fetch({ plugin, version }) {
+  async fetch({ plugin }) {
     return this._requestJson({
       url: `https://stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`,
-      schema: version ? schemaInstallationsPerVersion : schemaInstallations,
+      schema: schemaInstallations,
       httpErrors: {
         404: 'plugin not found',
       },
     })
   }
 
-  static transform({ json, version }) {
-    if (!version) {
-      const latestDate = Object.keys(json.installations).sort().slice(-1)[0]
-      return { installs: json.installations[latestDate] }
-    }
-
-    const installs = json.installationsPerVersion[version]
-    if (!installs) {
-      throw new NotFound({
-        prettyMessage: 'version not found',
-      })
-    }
-    return { installs }
+  static transform({ json }) {
+    const latestDate = Object.keys(json.installations).sort().slice(-1)[0]
+    return { installs: json.installations[latestDate] }
   }
 
   async handle({ plugin, version }) {
-    const json = await this.fetch({ plugin, version })
-    const { installs } = this.constructor.transform({ json, version })
-    return this.constructor.render({ installs, version })
+    if (version) {
+      return {
+        message: 'no longer available per version',
+        color: 'lightgrey',
+      }
+    }
+    const json = await this.fetch({ plugin })
+    const { installs } = this.constructor.transform({ json })
+    return this.constructor.render({ installs })
   }
 }

--- a/services/jenkins/jenkins-plugin-installs.tester.js
+++ b/services/jenkins/jenkins-plugin-installs.tester.js
@@ -15,24 +15,10 @@ t.create('total installs | not found')
 
 // version installs
 
-t.create('version installs | valid: numeric version')
+t.create('version installs | no longer available')
   .get('/view-job-filters/1.26.json')
   .expectBadge({
-    label: 'installs@1.26',
-    message: isMetric,
+    label: 'installs',
+    message: 'no longer available per version',
+    color: 'lightgrey'
   })
-
-t.create('version installs | valid: alphanumeric version')
-  .get('/build-failure-analyzer/1.17.2-DRE3.21.json')
-  .expectBadge({
-    label: 'installs@1.17.2-DRE3.21',
-    message: isMetric,
-  })
-
-t.create('version installs | not found: non-existent plugin')
-  .get('/not-a-plugin/1.26.json')
-  .expectBadge({ label: 'installs', message: 'plugin not found' })
-
-t.create('version installs | not found: non-existent version')
-  .get('/view-job-filters/1.1-NOT-FOUND.json')
-  .expectBadge({ label: 'installs', message: 'version not found' })


### PR DESCRIPTION
The corresponding tests started failing over a month ago, the API is consistently returning an empty `installationsPerVersion` field. I tried following up on an issue about this, but the response wasn't terribly helpful. I suggest we deprecate the version flavour of the badge, the total installs part of the API still seems to be returning sensible results for now.