### PR TITLE
fix `parseDate()` test for different timezones

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prettier:check": "prettier --check \"**/*.@(cjs|js|ts|tsx|md|json|yml)\"",
     "danger": "danger",
     "test:e2e": "cypress run",
-    "test:core": "cross-env NODE_CONFIG_ENV=test mocha \"core/**/*.spec.js\" \"lib/**/*.spec.js\" \"services/**/*.spec.js\"",
+    "test:core": "cross-env TZ='UTC' NODE_CONFIG_ENV=test mocha \"core/**/*.spec.js\" \"lib/**/*.spec.js\" \"services/**/*.spec.js\"",
     "test:package": "mocha \"badge-maker/**/*.spec.js\"",
     "test:entrypoint": "cross-env NODE_CONFIG_ENV=test mocha entrypoint.spec.js",
     "test:integration": "cross-env NODE_CONFIG_ENV=test mocha \"core/**/*.integration.js\" \"services/**/*.integration.js\"",


### PR DESCRIPTION
The `parseDate` test fails on my machine:

![](https://github.com/user-attachments/assets/83741d81-a332-40cb-a692-b12be317523c)

I think it's related to the timezone of my machine (macOS). Here is my timezone info:

![](https://github.com/user-attachments/assets/ba8953f1-ddf9-4ac8-89cf-87c10740cef1)

![](https://github.com/user-attachments/assets/713de1a5-34c7-42d6-90fd-9d4d681145f5)

Should I specify the `TZ` from `package.json`?

Or apply the machine's timezone to the `dayjs` function to fix?