### PR TITLE
docs: add blog post for Simple Icons 14 upgrade

### DIFF
--- a/frontend/blog/2024-12-27-simpleicons14.md
+++ b/frontend/blog/2024-12-27-simpleicons14.md
@@ -1,0 +1,76 @@
+---
+slug: simple-icons-14
+title: Simple Icons 14
+authors:
+  name: jNullj
+  title: Shields.io Maintainer
+  url: https://github.com/jNullj
+  image_url: https://avatars.githubusercontent.com/u/15849761
+tags: []
+---
+
+Logos on Shields.io are provided by SimpleIcons. We've recently upgraded to SimpleIcons 14. This release removes 59 icons:
+
+- Adobe
+- Adobe Acrobat Reader
+- Adobe After Effects
+- Adobe Audition
+- Adobe Creative Cloud
+- Adobe Dreamweaver
+- Adobe Fonts
+- Adobe Illustrator
+- Adobe InDesign
+- Adobe Lightroom
+- Adobe Lightroom Classic
+- Adobe Photoshop
+- Adobe Premiere Pro
+- Adobe XD
+- ASKfm
+- Caffeine
+- CKEditor 4
+- Cliqz
+- Coil
+- D3.js
+- del.icio.us
+- El Jueves
+- Ello
+- FeatHub
+- Fluxus
+- Foursquare City Guide
+- Funimation
+- Game & Watch
+- Géant
+- Katacoda
+- LinkedIn
+- Magento
+- Marketo
+- Microgenetics
+- Nintendo
+- Nintendo 3DS
+- Nintendo DS
+- Nintendo GameCube
+- Nintendo Switch
+- Nuxt.js
+- Oracle
+- Pokémon
+- RadioPublic
+- Realm
+- Revue
+- Skyrock
+- smash.gg
+- Spinrilla
+- StackPath
+- Stitcher
+- Studyverse
+- T-Mobile
+- Tableau
+- Tencent QQ
+- Tutanota
+- Uptobox
+- Wii
+- Wii U
+- Zerply
+
+More detail can be found in the [release notes](https://github.com/simple-icons/simple-icons/releases/tag/14.0.0)
+
+Please remember that we are just consumers of SimpleIcons. Decisions about changes and removals are made by the [SimpleIcons](https://github.com/simple-icons/simple-icons) project.

--- a/frontend/blog/2024-12-27-simpleicons14.md
+++ b/frontend/blog/2024-12-27-simpleicons14.md
@@ -9,7 +9,18 @@ authors:
 tags: []
 ---
 
-Logos on Shields.io are provided by SimpleIcons. We've recently upgraded to SimpleIcons 14. This release removes 59 icons:
+Logos on Shields.io are provided by SimpleIcons. We've recently upgraded to SimpleIcons 14. This release removes 53 icons and renames 6:
+
+Renames:
+
+- D3.js to D3
+- Tencent QQ to QQ
+- T-Mobile to Deutsche Telekom
+- Nuxt.js to Nuxt
+- smash.gg start.gg
+- Tutanota to Tuta
+
+Removals:
 
 - Adobe
 - Adobe Acrobat Reader
@@ -30,7 +41,6 @@ Logos on Shields.io are provided by SimpleIcons. We've recently upgraded to Simp
 - CKEditor 4
 - Cliqz
 - Coil
-- D3.js
 - del.icio.us
 - El Jueves
 - Ello
@@ -50,22 +60,17 @@ Logos on Shields.io are provided by SimpleIcons. We've recently upgraded to Simp
 - Nintendo DS
 - Nintendo GameCube
 - Nintendo Switch
-- Nuxt.js
 - Oracle
 - Pokémon
 - RadioPublic
 - Realm
 - Revue
 - Skyrock
-- smash.gg
 - Spinrilla
 - StackPath
 - Stitcher
 - Studyverse
-- T-Mobile
 - Tableau
-- Tencent QQ
-- Tutanota
 - Uptobox
 - Wii
 - Wii U

--- a/frontend/blog/2024-12-27-simpleicons14.md
+++ b/frontend/blog/2024-12-27-simpleicons14.md
@@ -3,7 +3,7 @@ slug: simple-icons-14
 title: Simple Icons 14
 authors:
   name: jNullj
-  title: Shields.io Maintainer
+  title: Shields.io Core Team
   url: https://github.com/jNullj
   image_url: https://avatars.githubusercontent.com/u/15849761
 tags: []


### PR DESCRIPTION
Introduce a blog post detailing the upgrade to Simple Icons 14, highlighting the removal of 59 icons and providing a link to the release notes for further information.

follow up for PR #10771