### PR TITLE
cache matrix badges for 4 hours

### DIFF
--- a/services/matrix/matrix.service.js
+++ b/services/matrix/matrix.service.js
@@ -81,7 +81,7 @@ export default class Matrix extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 30
+  static _cacheLength = 14400
 
   static defaultBadgeData = { label: 'chat' }
 


### PR DESCRIPTION
Refs #10776

This isn't a fix, but one of the things that came up in that issue is we should be caching this for a lot longer. The current `cacheLength` of 30 seconds is likely a copy & paste from elsewhere rather than a sensible value for this badge.