### PR TITLE
use metric() in [coderabbit] badge

### DIFF
--- a/services/coderabbit/coderabbit-pull-request.service.js
+++ b/services/coderabbit/coderabbit-pull-request.service.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { BaseJsonService, pathParams } from '../index.js'
+import { metric } from '../text-formatters.js'
 
 const schema = Joi.object({
   reviews: Joi.number().required(),
@@ -46,7 +47,7 @@ class CodeRabbitPullRequest extends BaseJsonService {
 
   static render({ reviews }) {
     return {
-      message: `${reviews}`,
+      message: metric(reviews),
       color: 'blue',
     }
   }

--- a/services/coderabbit/coderabbit-pull-request.tester.js
+++ b/services/coderabbit/coderabbit-pull-request.tester.js
@@ -1,5 +1,5 @@
-import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
@@ -7,7 +7,7 @@ t.create('live CodeRabbitPullRequest')
   .get('/prs/github/coderabbitai/ast-grep-essentials.json')
   .expectBadge({
     label: 'coderabbit reviews',
-    message: Joi.number().min(0),
+    message: isMetric,
   })
 
 t.create('live CodeRabbitPullRequest nonexistent org')


### PR DESCRIPTION
This is something we missed in the review of https://github.com/badges/shields/pull/10749
It is an easy one to overlook when the only examples show a really small number.