### PR TITLE
update monitoring docs/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This repo hosts:
 - amount of [Liberapay](https://liberapay.com/) donations per week: ![receives](https://img.shields.io/badge/receives-2.00%20USD%2Fweek-yellow)
 - Python package downloads: ![downloads](https://img.shields.io/badge/downloads-13k%2Fmonth-brightgreen)
 - Chrome Web Store extension rating: ![rating](https://img.shields.io/badge/rating-★★★★☆-brightgreen)
-- [Uptime Robot](https://uptimerobot.com) percentage: ![uptime](https://img.shields.io/badge/uptime-100%25-brightgreen)
+- Uptime Robot uptime percentage: ![uptime](https://img.shields.io/badge/uptime-100%25-brightgreen)
 
 [Make your own badges!][custom badges]
 (Quick example: `https://img.shields.io/badge/left-right-f39f37`)

--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -32,7 +32,6 @@ Production hosting is managed by the Shields ops team:
 | DNS                           | Read-only account access    | @espadrine, @paulmelnikow, @chris48s                            |
 | Sentry                        | Error reports               | @espadrine, @paulmelnikow                                       |
 | Metrics server                | Owner                       | @platan                                                         |
-| UptimeRobot                   | Account owner               | @paulmelnikow                                                   |
 | More metrics                  | Owner                       | @RedSparr0w                                                     |
 
 ## Attached state
@@ -119,19 +118,15 @@ The canonical and only recommended domain for badge URLs is `img.shields.io`. Cu
 ## Monitoring
 
 Overall server performance and requests by service are monitored using
-[Prometheus and Grafana][metrics].
+[Prometheus and Grafana][server metrics].
 
 Request performance is monitored in two places:
 
-- [Status][] (using [UptimeRobot][])
+- [Status][] (using NodePing)
 - [Server metrics][] using Prometheus and Grafana
-- [@RedSparr0w's monitor][monitor] which posts [notifications][] to a private
   [#monitor chat room][monitor discord]
 
 [metrics]: https://metrics.shields.io/
-[status]: https://stats.uptimerobot.com/PjXogHB5p
+[status]: https://nodeping.com/reports/status/YBISBQB254
 [server metrics]: https://metrics.shields.io/
-[uptimerobot]: https://uptimerobot.com/
-[monitor]: https://shields.redsparr0w.com/1568/
-[notifications]: http://shields.redsparr0w.com/discord_notification
 [monitor discord]: https://discordapp.com/channels/308323056592486420/470700909182320646

--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -115,7 +115,7 @@ const config = {
             items: [
               {
                 label: 'Service Status',
-                href: 'https://stats.uptimerobot.com/PjXogHB5p',
+                href: 'https://nodeping.com/reports/status/YBISBQB254',
               },
               {
                 label: 'Metrics dashboard',

--- a/frontend/src/pages/community.md
+++ b/frontend/src/pages/community.md
@@ -61,7 +61,4 @@ Shields.io is possible thanks to the people and companies who donate money, serv
     <li>
         <a href="https://github.com/">GitHub</a>
     </li>
-    <li>
-        <a href="https://uptimerobot.com/">Uptime Robot</a>
-    </li>
 </ul>


### PR DESCRIPTION
https://stats.uptimerobot.com/PjXogHB5p has not worked for a long time. Same goes for https://shields.redsparr0w.com/1568/
We still have working monitoring at nodeping https://nodeping.com/reports/status/YBISBQB254
Link to that instead, ditch mentions of uptimerobot

