### PR TITLE
Support [Matrix] summary endpoint

### DIFF
--- a/services/matrix/matrix.service.js
+++ b/services/matrix/matrix.service.js
@@ -40,6 +40,9 @@ const matrixSummarySchema = Joi.object({
 const description = `
 In order for this badge to work, the host of your room must allow guest accounts or dummy accounts to register, and the room must be world readable (chat history visible to anyone).
 
+Alternatively access via the experimental <code>summary</code> endpoint ([MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266)) can be configured with the query parameter <code>fetchMode</code> for less server load and better performance, if supported by the homeserver<br/>
+For the <code>matrix.org</code> homeserver <code>fetchMode</code> is hard-coded to <code>summary</code>.
+
 The following steps will show you how to setup the badge URL using the Element Matrix client.
 
 <ul>
@@ -85,7 +88,7 @@ export default class Matrix extends BaseJsonService {
           queryParam({
             name: 'fetchMode',
             example: 'guest',
-            description: `If not specified, the default fetch mode is "guest" using guest access (except for matrix.org). Alternatively the experimental "summary" endpoint ([MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266)) can be used if enabled for the homeserver, which reduces requests and has better performance.`,
+            description: `If not specified, the default fetch mode is <code>guest</code> (except for matrix.org).`,
             schema: {
               type: 'string',
               enum: ['guest', 'summary'],

--- a/services/matrix/matrix.service.js
+++ b/services/matrix/matrix.service.js
@@ -7,9 +7,13 @@ import {
 } from '../index.js'
 import { nonNegativeInteger } from '../validators.js'
 
+const fetchModeEnum = ['guest', 'summary']
+
 const queryParamSchema = Joi.object({
   server_fqdn: Joi.string().hostname(),
-  fetchMode: Joi.string().optional(),
+  fetchMode: Joi.string()
+    .valid(...fetchModeEnum)
+    .default('guest'),
 }).required()
 
 const matrixRegisterSchema = Joi.object({
@@ -91,7 +95,7 @@ export default class Matrix extends BaseJsonService {
             description: `If not specified, the default fetch mode is <code>guest</code> (except for matrix.org).`,
             schema: {
               type: 'string',
-              enum: ['guest', 'summary'],
+              enum: fetchModeEnum,
             },
           }),
         ],

--- a/services/matrix/matrix.service.js
+++ b/services/matrix/matrix.service.js
@@ -92,7 +92,7 @@ export default class Matrix extends BaseJsonService {
           queryParam({
             name: 'fetchMode',
             example: 'guest',
-            description: `If not specified, the default fetch mode is <code>guest</code> (except for matrix.org).`,
+            description: `<code>guest</code> configures guest authentication while <code>summary</code> configures usage of the experimental "summary" endpoint ([MSC3266](https://github.com/matrix-org/matrix-spec-proposals/pull/3266)). If not specified, the default fetch mode is <code>guest</code> (except for matrix.org).`,
             schema: {
               type: 'string',
               enum: fetchModeEnum,

--- a/services/matrix/matrix.service.js
+++ b/services/matrix/matrix.service.js
@@ -237,10 +237,10 @@ export default class Matrix extends BaseJsonService {
     }
     if (host.toLowerCase() === 'matrix.org' || fetchMode === 'summary') {
       // summary endpoint (default for matrix.org)
-      return this.fetchSummary({ host, roomAlias })
+      return await this.fetchSummary({ host, roomAlias })
     } else {
       // guest access
-      return this.fetchGuest({ host, roomAlias })
+      return await this.fetchGuest({ host, roomAlias })
     }
   }
 

--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -541,7 +541,7 @@ t.create('specify the homeserver fqdn for summary')
     color: 'brightgreen',
   })
 
-t.create('test fetchMode override for matrix.org')
+t.create('test fetchMode=guest is ignored for matrix.org')
   .get('/ALIAS:DUMMY.dumb.json?server_fqdn=matrix.org&fetchMode=guest')
   .intercept(nock =>
     nock('https://matrix.org/')

--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -152,6 +152,26 @@ t.create('get room state as member (backup method)')
     color: 'brightgreen',
   })
 
+t.create('get room summary')
+  .get('/ALIAS:DUMMY.dumb.json?fetchMode=summary')
+  .intercept(nock =>
+    nock('https://DUMMY.dumb/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb/summary',
+      )
+      .reply(
+        200,
+        JSON.stringify({
+          num_joined_members: 4,
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: '4 users',
+    color: 'brightgreen',
+  })
+
 t.create('bad server or connection')
   .get('/ALIAS:DUMMY.dumb.json')
   .networkOff()
@@ -263,6 +283,27 @@ t.create('unknown request')
     color: 'lightgrey',
   })
 
+t.create('unknown summary request')
+  .get('/ALIAS:DUMMY.dumb.json?fetchMode=summary')
+  .intercept(nock =>
+    nock('https://DUMMY.dumb/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb/summary',
+      )
+      .reply(
+        400,
+        JSON.stringify({
+          errcode: 'M_UNRECOGNIZED',
+          error: 'Unrecognized request',
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: 'unknown request',
+    color: 'lightgrey',
+  })
+
 t.create('unknown alias')
   .get('/ALIAS:DUMMY.dumb.json')
   .intercept(nock =>
@@ -288,6 +329,27 @@ t.create('unknown alias')
   .expectBadge({
     label: 'chat',
     message: 'room not found',
+    color: 'red',
+  })
+
+t.create('unknown summary alias')
+  .get('/ALIAS:DUMMY.dumb.json?fetchMode=summary')
+  .intercept(nock =>
+    nock('https://DUMMY.dumb/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb/summary',
+      )
+      .reply(
+        404,
+        JSON.stringify({
+          errcode: 'M_NOT_FOUND',
+          error: 'Room alias #ALIAS%3ADUMMY.dumb not found.',
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: 'room or endpoint not found',
     color: 'red',
   })
 
@@ -368,6 +430,26 @@ t.create('server uses a custom port')
     color: 'brightgreen',
   })
 
+t.create('server uses a custom port for summary')
+  .get('/ALIAS:DUMMY.dumb:5555.json?fetchMode=summary')
+  .intercept(nock =>
+    nock('https://DUMMY.dumb:5555/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb%3A5555/summary',
+      )
+      .reply(
+        200,
+        JSON.stringify({
+          num_joined_members: 4,
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: '4 users',
+    color: 'brightgreen',
+  })
+
 t.create('specify the homeserver fqdn')
   .get('/ALIAS:DUMMY.dumb.json?server_fqdn=matrix.DUMMY.dumb')
   .intercept(nock =>
@@ -439,7 +521,36 @@ t.create('specify the homeserver fqdn')
     color: 'brightgreen',
   })
 
-t.create('test on real matrix room for API compliance')
+t.create('specify the homeserver fqdn for summary')
+  .get('/ALIAS:DUMMY.dumb.json?server_fqdn=matrix.DUMMY.dumb&fetchMode=summary')
+  .intercept(nock =>
+    nock('https://matrix.DUMMY.dumb/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb/summary',
+      )
+      .reply(
+        200,
+        JSON.stringify({
+          num_joined_members: 4,
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: '4 users',
+    color: 'brightgreen',
+  })
+
+t.create('test on real matrix room for guest API compliance')
+  .get('/ndcube:openastronomy.org.json?server_fqdn=openastronomy.modular.im')
+  .timeout(10000)
+  .expectBadge({
+    label: 'chat',
+    message: Joi.string().regex(/^[0-9]+ users$/),
+    color: 'brightgreen',
+  })
+
+t.create('test on real matrix room for summary API compliance')
   .get('/twim:matrix.org.json')
   .timeout(10000)
   .expectBadge({

--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -541,6 +541,26 @@ t.create('specify the homeserver fqdn for summary')
     color: 'brightgreen',
   })
 
+t.create('test fetchMode override for matrix.org')
+  .get('/ALIAS:DUMMY.dumb.json?server_fqdn=matrix.org&fetchMode=guest')
+  .intercept(nock =>
+    nock('https://matrix.org/')
+      .get(
+        '/_matrix/client/unstable/im.nheko.summary/rooms/%23ALIAS%3ADUMMY.dumb/summary',
+      )
+      .reply(
+        200,
+        JSON.stringify({
+          num_joined_members: 4,
+        }),
+      ),
+  )
+  .expectBadge({
+    label: 'chat',
+    message: '4 users',
+    color: 'brightgreen',
+  })
+
 t.create('test on real matrix room for guest API compliance')
   .get('/ndcube:openastronomy.org.json?server_fqdn=openastronomy.modular.im')
   .expectBadge({

--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -543,7 +543,6 @@ t.create('specify the homeserver fqdn for summary')
 
 t.create('test on real matrix room for guest API compliance')
   .get('/ndcube:openastronomy.org.json?server_fqdn=openastronomy.modular.im')
-  .timeout(10000)
   .expectBadge({
     label: 'chat',
     message: Joi.string().regex(/^[0-9]+ users$/),
@@ -552,7 +551,6 @@ t.create('test on real matrix room for guest API compliance')
 
 t.create('test on real matrix room for summary API compliance')
   .get('/twim:matrix.org.json')
-  .timeout(10000)
   .expectBadge({
     label: 'chat',
     message: Joi.string().regex(/^[0-9]+ users$/),


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Refs #10776

Implements support for https://github.com/matrix-org/matrix-spec-proposals/pull/3266.  
Can be configured with the new parameter `fetchMode` and is enforced for `matrix.org` rooms.

Combined with https://github.com/badges/shields/pull/10778 (increases cache duration by a factor of 480), the amount of requests is reduced by a **factor of 1440**!

The performance is much better than the current implementation (few test runs as an example):

<img width="400" src="https://github.com/user-attachments/assets/6e7a96b8-145e-4173-8604-d089d1c001f4" />

<img width="400" src="https://github.com/user-attachments/assets/1634c502-c6d0-4f23-8c21-7ec368b0b9ba" />

<img width="400" src="https://github.com/user-attachments/assets/be26f982-6275-4c92-b960-acf4685bed28" />