### PR TITLE
Renew [Mastodon] docs and improve parameter handling

### DIFF
--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -9,7 +9,7 @@ const schema = Joi.object({
 })
 
 const queryParamSchema = Joi.object({
-  domain: optionalUrl,
+  domain: Joi.string().optional(),
 }).required()
 
 const description = `
@@ -67,13 +67,18 @@ export default class MastodonFollow extends BaseJsonService {
   async fetch({ id, domain }) {
     return this._requestJson({
       schema,
-      url: `${domain}/api/v1/accounts/${id}/`,
+      url: `https://${domain}/api/v1/accounts/${id}/`,
     })
   }
 
-  async handle({ id }, { domain = 'https://mastodon.social' }) {
+  async handle({ id }, { domain = 'mastodon.social' }) {
     if (isNaN(id))
       throw new NotFound({ prettyMessage: 'invalid user id format' })
+    if (domain.startsWith('https://')) {
+      domain = domain.substring(8)
+    } else if (domain.startsWith('http://')) {
+      domain = domain.substring(7)
+    }
     const data = await this.fetch({ id, domain })
     return this.constructor.render({
       username: data.username,

--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -70,11 +70,7 @@ export default class MastodonFollow extends BaseJsonService {
   async handle({ id }, { domain = 'mastodon.social' }) {
     if (isNaN(id))
       throw new NotFound({ prettyMessage: 'invalid user id format' })
-    if (domain.startsWith('https://')) {
-      domain = domain.substring(8)
-    } else if (domain.startsWith('http://')) {
-      domain = domain.substring(7)
-    }
+    domain = domain.replace(/^https?:\/\//, '')
     const data = await this.fetch({ id, domain })
     return this.constructor.render({
       username: data.username,

--- a/services/mastodon/mastodon-follow.service.js
+++ b/services/mastodon/mastodon-follow.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
-import { optionalUrl, nonNegativeInteger } from '../validators.js'
+import { nonNegativeInteger } from '../validators.js'
 import { BaseJsonService, NotFound, pathParam, queryParam } from '../index.js'
 
 const schema = Joi.object({
@@ -13,11 +13,7 @@ const queryParamSchema = Joi.object({
 }).required()
 
 const description = `
-To find your user id, you can use [this tool](https://prouser123.me/misc/mastodon-userid-lookup.html).
-
-Alternatively you can make a request to \`https://your.mastodon.server/.well-known/webfinger?resource=acct:<user>@<domain>\`
-
-Failing that, you can also visit your profile page, where your user ID will be in the header in a tag like this: \`<link href='https://your.mastodon.server/api/salmon/<your-user-id>' rel='salmon'>\`
+To find your user id, you can make a request to \`https://your.mastodon.server/api/v1/accounts/lookup?acct=yourusername\`.
 `
 
 export default class MastodonFollow extends BaseJsonService {
@@ -41,7 +37,7 @@ export default class MastodonFollow extends BaseJsonService {
           }),
           queryParam({
             name: 'domain',
-            example: 'https://mastodon.social',
+            example: 'mastodon.social',
           }),
         ],
       },
@@ -58,8 +54,8 @@ export default class MastodonFollow extends BaseJsonService {
       message: metric(followers),
       style: 'social',
       link: [
-        `${domain}/users/${username}`,
-        `${domain}/users/${username}/followers`,
+        `https://${domain}/users/${username}`,
+        `https://${domain}/users/${username}/followers`,
       ],
     }
   }

--- a/services/mastodon/mastodon-follow.tester.js
+++ b/services/mastodon/mastodon-follow.tester.js
@@ -28,6 +28,17 @@ t.create('Followers - default domain - invalid user ID (id not in use)')
   })
 
 t.create('Followers - alternate domain')
+  .get('/2214.json?domain=mastodon.xyz')
+  .expectBadge({
+    label: 'follow @PhotonQyv',
+    message: isMetric,
+    link: [
+      'https://mastodon.xyz/users/PhotonQyv',
+      'https://mastodon.xyz/users/PhotonQyv/followers',
+    ],
+  })
+
+t.create('Followers - alternate domain legacy')
   .get('/2214.json?domain=https%3A%2F%2Fmastodon.xyz')
   .expectBadge({
     label: 'follow @PhotonQyv',


### PR DESCRIPTION
It's me again 👋

I updated the docs to reflect the new ID lookup method from https://github.com/badges/shields/issues/4492.

Furthermore the `domain` parameter is now handled and documented as a domain and not as an URL anymore, because that's how it should be.  
To be exact, the parameter should be called `fqdn`, as subdomains are also allowed, but that would be a breaking change.

And don't worry, to not break existing badges URLs are still accepted and "converted" to domains.

---

Closes https://github.com/badges/shields/issues/4492