### PR TITLE
adjust brightness threshold

### DIFF
--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -17,7 +17,7 @@ function capitalize(s) {
 }
 
 function colorsForBackground(color) {
-  const brightnessThreshold = 0.69
+  const brightnessThreshold = 0.65
   if (brightness(color) <= brightnessThreshold) {
     return { textColor: '#fff', shadowColor: '#010101' }
   } else {


### PR DESCRIPTION
```markdown
![](https://img.shields.io/badge/Construct%203-00FFDA?logo=construct3)
![](https://img.shields.io/badge/Construct%203-123-00FFDA?logo=construct3)
```

![](https://img.shields.io/badge/Construct%203-00FFDA?logo=construct3)
![](https://img.shields.io/badge/Construct%203-123-00FFDA?logo=construct3)

The current threshold does not look good for some colors. The brightness value of `#00FFDA` is `0.68`. I adjusted the threshold value to `0.65` for better visuals.

I didn't change the threshold values in `logos.js` because they are different. We can consider refactoring more code for logos in a separate PR.