### PR TITLE
URL validator tidyup; affects [discourse dynamic endpoint gerrit jira maven nexus osslifecycle python vpm website] securityheaders sonar swagger w3c

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -16,7 +16,12 @@ import { makeSend } from '../base-service/legacy-result-sender.js'
 import { handleRequest } from '../base-service/legacy-request-handler.js'
 import { clearResourceCache } from '../base-service/resource-cache.js'
 import { rasterRedirectUrl } from '../badge-urls/make-badge-url.js'
-import { fileSize, nonNegativeInteger } from '../../services/validators.js'
+import {
+  fileSize,
+  nonNegativeInteger,
+  optionalUrl,
+  url as requiredUrl,
+} from '../../services/validators.js'
 import log from './log.js'
 import PrometheusMetrics from './prometheus-metrics.js'
 import InfluxMetrics from './influx-metrics.js'
@@ -54,8 +59,6 @@ const Joi = originalJoi
     },
   }))
 
-const optionalUrl = Joi.string().uri({ scheme: ['http', 'https'] })
-const requiredUrl = optionalUrl.required()
 const origins = Joi.arrayFromString().items(Joi.string().origin())
 const defaultService = Joi.object({ authorizedOrigins: origins }).default({
   authorizedOrigins: [],

--- a/services/discourse/discourse.service.js
+++ b/services/discourse/discourse.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
-import { nonNegativeInteger, optionalUrl } from '../validators.js'
+import { nonNegativeInteger, url } from '../validators.js'
 import { BaseJsonService, queryParams } from '../index.js'
 
 const schemaSingular = Joi.object({
@@ -20,7 +20,7 @@ const schemaPlural = Joi.object({
 const schema = Joi.alternatives(schemaSingular, schemaPlural)
 
 const queryParamSchema = Joi.object({
-  server: optionalUrl.required(),
+  server: url,
 }).required()
 
 function singular(variant) {

--- a/services/dynamic/dynamic-helpers.js
+++ b/services/dynamic/dynamic-helpers.js
@@ -1,8 +1,8 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 
 const queryParamSchema = Joi.object({
-  url: optionalUrl.required(),
+  url,
   query: Joi.string().required(),
   prefix: Joi.alternatives().try(Joi.string(), Joi.number()),
   suffix: Joi.alternatives().try(Joi.string(), Joi.number()),

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -1,14 +1,14 @@
 import { URL } from 'url'
 import Joi from 'joi'
 import { httpErrors } from '../dynamic-common.js'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { fetchEndpointData } from '../endpoint-common.js'
 import { BaseJsonService, InvalidParameter, queryParams } from '../index.js'
 
 const blockedDomains = ['github.com', 'shields.io']
 
 const queryParamSchema = Joi.object({
-  url: optionalUrl.required(),
+  url,
 }).required()
 
 const description = `

--- a/services/gerrit/gerrit.service.js
+++ b/services/gerrit/gerrit.service.js
@@ -1,9 +1,9 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseJsonService, pathParam, queryParam } from '../index.js'
 
 const queryParamSchema = Joi.object({
-  baseUrl: optionalUrl.required(),
+  baseUrl: url,
 }).required()
 
 const schema = Joi.object({

--- a/services/jira/jira-issue.service.js
+++ b/services/jira/jira-issue.service.js
@@ -1,10 +1,10 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseJsonService, pathParam, queryParam } from '../index.js'
 import { authConfig } from './jira-common.js'
 
 const queryParamSchema = Joi.object({
-  baseUrl: optionalUrl.required(),
+  baseUrl: url,
 }).required()
 
 const schema = Joi.object({

--- a/services/jira/jira-sprint.service.js
+++ b/services/jira/jira-sprint.service.js
@@ -1,10 +1,10 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseJsonService, pathParam, queryParam } from '../index.js'
 import { authConfig } from './jira-common.js'
 
 const queryParamSchema = Joi.object({
-  baseUrl: optionalUrl.required(),
+  baseUrl: url,
 }).required()
 
 const schema = Joi.object({

--- a/services/maven-metadata/maven-metadata.service.js
+++ b/services/maven-metadata/maven-metadata.service.js
@@ -1,11 +1,11 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { renderVersionBadge } from '../version.js'
 import { BaseXmlService, NotFound, queryParams } from '../index.js'
 import { description } from './maven-metadata.js'
 
 const queryParamSchema = Joi.object({
-  metadataUrl: optionalUrl.required(),
+  metadataUrl: url,
   versionPrefix: Joi.string().optional(),
   versionSuffix: Joi.string().optional(),
 }).required()

--- a/services/nexus/nexus.service.js
+++ b/services/nexus/nexus.service.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { renderVersionBadge } from '../version.js'
 import {
-  optionalUrl,
+  url,
   optionalDottedVersionNClausesWithOptionalSuffix,
 } from '../validators.js'
 import {
@@ -49,7 +49,7 @@ const nexus2ResolveApiSchema = Joi.object({
 }).required()
 
 const queryParamSchema = Joi.object({
-  server: optionalUrl.required(),
+  server: url,
   queryOpt: Joi.string()
     .regex(/(:[\w.]+=[^:]*)+/i)
     .optional(),

--- a/services/osslifecycle/osslifecycle.service.js
+++ b/services/osslifecycle/osslifecycle.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseService, InvalidResponse, queryParam } from '../index.js'
 
 const description = `
@@ -12,7 +12,7 @@ can be viewed on the [OSS Tracker repository](https://github.com/Netflix/osstrac
 `
 
 const queryParamSchema = Joi.object({
-  file_url: optionalUrl.required(),
+  file_url: url,
 }).required()
 
 export default class OssTracker extends BaseService {

--- a/services/python/python-version-from-toml.service.js
+++ b/services/python/python-version-from-toml.service.js
@@ -1,10 +1,10 @@
 import Joi from 'joi'
 import BaseTomlService from '../../core/base-service/base-toml.js'
 import { queryParams } from '../index.js'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 
 const queryParamSchema = Joi.object({
-  tomlFilePath: optionalUrl.required(),
+  tomlFilePath: url,
 }).required()
 
 const schema = Joi.object({

--- a/services/security-headers/security-headers.service.js
+++ b/services/security-headers/security-headers.service.js
@@ -1,9 +1,9 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseService, NotFound, queryParams } from '../index.js'
 
 const queryParamSchema = Joi.object({
-  url: optionalUrl.required(),
+  url,
   ignoreRedirects: Joi.equal(''),
 }).required()
 

--- a/services/sonar/sonar-helpers.js
+++ b/services/sonar/sonar-helpers.js
@@ -1,7 +1,7 @@
 import Joi from 'joi'
 import { queryParams } from '../index.js'
 import { colorScale } from '../color-formatters.js'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 
 const ratingPercentageScaleSteps = [10, 20, 50, 100]
 const ratingScaleColors = [
@@ -38,7 +38,7 @@ const sonarVersionSchema = Joi.alternatives(
 
 const queryParamSchema = Joi.object({
   sonarVersion: sonarVersionSchema,
-  server: optionalUrl.required(),
+  server: url,
 }).required()
 
 const openApiQueryParams = queryParams(
@@ -48,7 +48,7 @@ const openApiQueryParams = queryParams(
 
 const queryParamWithFormatSchema = Joi.object({
   sonarVersion: sonarVersionSchema,
-  server: optionalUrl.required(),
+  server: url,
   format: Joi.string().allow('short', 'long').optional(),
 }).required()
 

--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseJsonService, NotFound, queryParams } from '../index.js'
 
 const schema = Joi.object()
@@ -14,7 +14,7 @@ const schema = Joi.object()
   .required()
 
 const queryParamSchema = Joi.object({
-  specUrl: optionalUrl.required(),
+  specUrl: url,
 }).required()
 
 export default class SwaggerValidatorService extends BaseJsonService {

--- a/services/twitter/twitter.service.js
+++ b/services/twitter/twitter.service.js
@@ -1,9 +1,9 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseService, pathParams, queryParams } from '../index.js'
 
 const queryParamSchema = Joi.object({
-  url: optionalUrl.required(),
+  url,
 }).required()
 
 class TwitterUrl extends BaseService {

--- a/services/validators.js
+++ b/services/validators.js
@@ -71,6 +71,13 @@ export const optionalDottedVersionNClausesWithOptionalSuffix =
 export const optionalUrl = Joi.string().uri({ scheme: ['http', 'https'] })
 
 /**
+ * Joi validator that checks if a value is a URL and the value must be present.
+ *
+ * @type {Joi}
+ */
+export const url = optionalUrl.required()
+
+/**
  * Joi validator for a file size we are going to pass to bytes.parse
  * see https://github.com/visionmedia/bytes.js#bytesparsestringnumber-value-numbernull
  *

--- a/services/vpm/vpm-version.service.js
+++ b/services/vpm/vpm-version.service.js
@@ -1,10 +1,10 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { latest, renderVersionBadge } from '../version.js'
 import { BaseJsonService, NotFound, pathParam, queryParam } from '../index.js'
 
 const queryParamSchema = Joi.object({
-  repository_url: optionalUrl.required(),
+  repository_url: url,
   include_prereleases: Joi.equal(''),
 }).required()
 

--- a/services/w3c/w3c-validation.service.js
+++ b/services/w3c/w3c-validation.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import { BaseJsonService, NotFound, pathParam, queryParam } from '../index.js'
 import {
   description,
@@ -25,7 +25,7 @@ const schema = Joi.object({
 }).required()
 
 const queryParamSchema = Joi.object({
-  targetUrl: optionalUrl.required(),
+  targetUrl: url,
   preset: Joi.string().regex(presetRegex).allow(''),
 }).required()
 

--- a/services/website/website.service.js
+++ b/services/website/website.service.js
@@ -2,7 +2,7 @@ import emojic from 'emojic'
 import Joi from 'joi'
 import trace from '../../core/base-service/trace.js'
 import { BaseService, queryParams } from '../index.js'
-import { optionalUrl } from '../validators.js'
+import { url } from '../validators.js'
 import {
   queryParamSchema,
   renderWebsiteStatus,
@@ -20,7 +20,7 @@ A site will be classified as "down" if it fails to respond within 3.5 seconds.
 `
 
 const urlQueryParamSchema = Joi.object({
-  url: optionalUrl.required(),
+  url,
 }).required()
 
 export default class Website extends BaseService {


### PR DESCRIPTION
For most validators where we need an optional and required version, we have two. For example `optionalNonNegativeInteger` and `nonNegativeInteger`

There were lots of places where we were using `optionalUrl.required()` so I made a url validator.

Also, we were defining this validator again in server.js, so I removed that duplication.

I've skipped the tests for securityheaders, sonar, swagger, and w3c, which are all failing for unrelated reasons