### PR TITLE
fix: cypress video

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -10,4 +10,6 @@ export default defineConfig({
     baseUrl: 'http://localhost:3000',
     supportFile: false,
   },
+  video: true,
+  videoCompression: true,
 })


### PR DESCRIPTION
Fixes #10828

Cypress v13 had breaking changes where the default value for video and videoCompression changed from true to false.
This re-adds video using the cypress config as mentioned in the migration [docs](https://docs.cypress.io/app/references/migration-guide#Migrating-to-Cypress-130)

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
