### PR TITLE
time out long running requests more aggressively

### DIFF
--- a/config/shields-io-production.yml
+++ b/config/shields-io-production.yml
@@ -22,4 +22,4 @@ public:
   rasterUrl: 'https://raster.shields.io'
   userAgentBase: 'Shields.io'
   requireCloudflare: true
-  requestTimeoutSeconds: 20
+  requestTimeoutSeconds: 8


### PR DESCRIPTION
We set a [hard limit](https://github.com/badges/shields/blob/007a7e6c4739be29479bb29236b5d5355f6345db/core/server/server.js#L561-L573) on how long we'll attempt to serve a request for before we give up. At the moment this is set to 20 seconds in production. I think we should make this timeout shorter. In this PR, I propose: If we've held a connection open for 8 seconds trying to serve a request and we don't have a badge yet, its time to serve a 408 and move on.