### PR TITLE
add tests for dynamic xml with lowercase doctype

### DIFF
--- a/services/dynamic/dynamic-xml.spec.js
+++ b/services/dynamic/dynamic-xml.spec.js
@@ -156,6 +156,16 @@ describe('DynamicXml', function () {
     }).expect({
       values: ['Herman Melville - Moby-Dick'],
     })
+
+    // lowercase doctype
+    // https://github.com/badges/shields/issues/10827
+    given({
+      pathExpression: '//h1[1]',
+      buffer: exampleHtml.replace('<!DOCTYPE html>', '<!doctype html>'),
+      contentType: 'text/html',
+    }).expect({
+      values: ['Herman Melville - Moby-Dick'],
+    })
   })
 
   test(DynamicXml.prototype.getmimeType, () => {


### PR DESCRIPTION
Refs:
- https://github.com/badges/shields/issues/10827
- https://github.com/badges/shields/pull/10830
- https://github.com/badges/shields/pull/10842

xmldom@0.9.7 fixes this issue. In this PR, I'm just adding a quick regression test for it