### PR TITLE
Allowing to "omit" a character when pulling data for dynamic badges

### DIFF
--- a/services/dynamic-common.js
+++ b/services/dynamic-common.js
@@ -74,6 +74,7 @@ function transformAndValidate({ data, key }) {
  * @param {any} attrs.value Value or array of value to be used for the badge message
  * @param {string} [attrs.prefix] If provided then the badge message will use this value as a prefix
  * @param {string} [attrs.suffix] If provided then the badge message will use this value as a suffix
+ * @param {string} [attrs.omitChar] If provided then the badge message will remove this character from its content
  * @returns {object} Badge with label, message and color properties
  */
 function renderDynamicBadge({
@@ -82,9 +83,12 @@ function renderDynamicBadge({
   value,
   prefix = '',
   suffix = '',
+  omitChar = '',
 }) {
-  const renderedValue =
+  let renderedValue =
     value === undefined ? 'not specified' : toArray(value).join(', ')
+
+  if (omitChar) renderedValue = renderedValue.replaceAll(omitChar, '')
   return {
     label: tag ? `${defaultLabel}@${tag}` : defaultLabel,
     message: `${prefix}${renderedValue}${suffix}`,

--- a/services/dynamic/dynamic-helpers.js
+++ b/services/dynamic/dynamic-helpers.js
@@ -6,6 +6,7 @@ const queryParamSchema = Joi.object({
   query: Joi.string().required(),
   prefix: Joi.alternatives().try(Joi.string(), Joi.number()),
   suffix: Joi.alternatives().try(Joi.string(), Joi.number()),
+  omitChar: Joi.string(),
 })
   .rename('uri', 'url', { ignoreUndefined: true, override: true })
   .required()

--- a/services/dynamic/dynamic-json.service.js
+++ b/services/dynamic/dynamic-json.service.js
@@ -41,6 +41,11 @@ export default class DynamicJson extends jsonPath(BaseJsonService) {
             description: 'Optional suffix to append to the value',
             example: ']',
           },
+          {
+            name: 'omitChar',
+            description: 'Optional character to remove from output',
+            example: '^',
+          },
         ),
       },
     },

--- a/services/dynamic/dynamic-json.tester.js
+++ b/services/dynamic/dynamic-json.tester.js
@@ -222,3 +222,17 @@ t.create('JSON contains a string')
     label: 'custom badge',
     message: 'foo',
   })
+
+t.create('can omit specific character')
+  .get(
+    `.json?url=https://example.test/json&query=$.somePackage&omitChar=${encodeURIComponent('^')}`,
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/json')
+      .reply(200, JSON.stringify({ somePackage: '^1.2.3' })),
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '1.2.3',
+  })

--- a/services/dynamic/dynamic-toml.service.js
+++ b/services/dynamic/dynamic-toml.service.js
@@ -41,6 +41,11 @@ export default class DynamicToml extends jsonPath(BaseTomlService) {
             description: 'Optional suffix to append to the value',
             example: ']',
           },
+          {
+            name: 'omitChar',
+            description: 'Optional character to remove from output',
+            example: '^',
+          },
         ),
       },
     },

--- a/services/dynamic/dynamic-toml.tester.js
+++ b/services/dynamic/dynamic-toml.tester.js
@@ -105,3 +105,17 @@ t.create('TOML contains a string')
     message: 'unparseable toml response',
     color: 'lightgrey',
   })
+
+t.create('can omit specific character')
+  .get(
+    `.json?url=https://example.test/toml&query=$.somePackage&omitChar=${encodeURIComponent('^')}`,
+  )
+  .intercept(nock =>
+    nock('https://example.test')
+      .get('/toml')
+      .reply(200, 'somePackage = "^1.2.3"'),
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '1.2.3',
+  })

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -133,7 +133,10 @@ export default class DynamicXml extends BaseService {
     return { values }
   }
 
-  async handle(_namedParams, { url, query: pathExpression, prefix, suffix }) {
+  async handle(
+    _namedParams,
+    { url, query: pathExpression, prefix, suffix, omitChar },
+  ) {
     const { buffer, res } = await this._request({
       url,
       options: { headers: { Accept: 'application/xml, text/xml' } },
@@ -152,6 +155,6 @@ export default class DynamicXml extends BaseService {
       contentType,
     })
 
-    return renderDynamicBadge({ value, prefix, suffix })
+    return renderDynamicBadge({ value, prefix, suffix, omitChar })
   }
 }

--- a/services/dynamic/dynamic-xml.service.js
+++ b/services/dynamic/dynamic-xml.service.js
@@ -65,6 +65,11 @@ export default class DynamicXml extends BaseService {
             description: 'Optional suffix to append to the value',
             example: ']',
           },
+          {
+            name: 'omitChar',
+            description: 'Optional character to remove from output',
+            example: '^',
+          },
         ),
       },
     },

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -228,3 +228,18 @@ t.create('query HTML document')
     message: 'Herman Melville - Moby-Dick',
     color: 'blue',
   })
+
+t.create('can omit specific character')
+  .get(
+    `.json?${queryString.stringify({
+      url: exampleUrl,
+      query: "//book[@id='bk101']/price",
+      omitChar: '.',
+    })}`,
+  )
+  .intercept(withExampleXml)
+  .expectBadge({
+    label: 'custom badge',
+    message: '4495',
+    color: 'blue',
+  })

--- a/services/dynamic/dynamic-yaml.service.js
+++ b/services/dynamic/dynamic-yaml.service.js
@@ -41,6 +41,11 @@ export default class DynamicYaml extends jsonPath(BaseYamlService) {
             description: 'Optional suffix to append to the value',
             example: ']',
           },
+          {
+            name: 'omitChar',
+            description: 'Optional character to remove from output',
+            example: '^',
+          },
         ),
       },
     },

--- a/services/dynamic/dynamic-yaml.tester.js
+++ b/services/dynamic/dynamic-yaml.tester.js
@@ -110,3 +110,15 @@ t.create('YAML contains a string')
     label: 'custom badge',
     message: 'foo',
   })
+
+t.create('can omit specific character')
+  .get(
+    `.json?url=https://example.test/yaml&query=$.somePackage&omitChar=${encodeURIComponent('^')}`,
+  )
+  .intercept(nock =>
+    nock('https://example.test').get('/yaml').reply(200, 'somePackage: ^1.2.3'),
+  )
+  .expectBadge({
+    label: 'custom badge',
+    message: '1.2.3',
+  })

--- a/services/dynamic/json-path.js
+++ b/services/dynamic/json-path.js
@@ -36,7 +36,10 @@ export default superclass =>
       )
     }
 
-    async handle(namedParams, { url, query: pathExpression, prefix, suffix }) {
+    async handle(
+      namedParams,
+      { url, query: pathExpression, prefix, suffix, omitChar },
+    ) {
       const data = await this.fetch({
         schema: Joi.any(),
         url,
@@ -63,7 +66,6 @@ export default superclass =>
       if (!values || !values.length) {
         throw new InvalidResponse({ prettyMessage: 'no result' })
       }
-
-      return renderDynamicBadge({ value: values, prefix, suffix })
+      return renderDynamicBadge({ value: values, prefix, suffix, omitChar })
     }
   }


### PR DESCRIPTION
I wanted to be able to remove specific characters from a pulled `package.json` file, mainly some `semver` noise.

Example :

https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbadges%2Fshields%2Frefs%2Fheads%2Fmaster%2Fpackage.json&query=%24.devDependencies.react

![React Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbadges%2Fshields%2Frefs%2Fheads%2Fmaster%2Fpackage.json&query=%24.devDependencies.react)


This is now possible with the `omitChar` parameter.

Query would look like this :
https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbadges%2Fshields%2Frefs%2Fheads%2Fmaster%2Fpackage.json&query=%24.devDependencies.react&omitChar=%5E

![image](https://github.com/user-attachments/assets/f65f515d-5feb-408d-a00a-191a147b6438)


<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
