### PR TITLE
remove docker pull command from homepage

### DIFF
--- a/frontend/src/components/homepage-features.js
+++ b/frontend/src/components/homepage-features.js
@@ -59,8 +59,6 @@ const FeatureList = [
         >
           docker image
         </a>
-        <br />
-        <code>docker pull shieldsio/shields</code>
       </>
     ),
   },


### PR DESCRIPTION
Closes https://github.com/badges/shields/issues/10853

As noted in that issue, inviting users to call `docker pull shieldsio/shields` is not particularly useful because we don't publish a default tag.

More importantly, I've also replaced the description over on DockerHub with a minimal readme that just describes the docker image and available tags, rather than the full README for the repo.
See https://hub.docker.com/r/shieldsio/shields/