### PR TITLE
link to upptime

### DIFF
--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -116,6 +116,10 @@ const config = {
             items: [
               {
                 label: 'Service Status',
+                href: 'https://badges.github.io/uptime-monitoring/',
+              },
+              {
+                label: 'NodePing',
                 href: 'https://nodeping.com/reports/status/YBISBQB254',
               },
               {


### PR DESCRIPTION
For one reason or another, we lost our uptimerobot service status page.
In https://github.com/badges/shields/pull/10780 I replaced it with a link to nodeping. Nodeping is cool, but its not amazing as a public-facing status page.
I decided to set up upptime https://upptime.js.org/ which gives us a slightly nicer UI for this