### PR TITLE
respect arch param when sort=semver in [DockerVersion] badge

### DIFF
--- a/services/docker/docker-fixtures.js
+++ b/services/docker/docker-fixtures.js
@@ -2998,6 +2998,49 @@ const versionDataWithVaryingArchitectures = [
   { name: '2.6', images: [] },
 ]
 
+const versionDataWithArchSpecificVersions = [
+  {
+    name: '3.8-arm64',
+    images: [
+      {
+        digest:
+          'sha256:3d62c3ceeba113f72efaaf3a35d83081963fa2cd29be76ed1aaa87b59f6f8eae',
+        architecture: 'arm64',
+      },
+    ],
+  },
+  {
+    name: '3.8-amd64',
+    images: [
+      {
+        digest:
+          'sha256:661bdba24d94ee8f1e4002eb3a87d7062244dd2583fb294471e9e00a7bfba45d',
+        architecture: 'amd64',
+      },
+    ],
+  },
+  {
+    name: '3.9-arm64',
+    images: [
+      {
+        digest:
+          'sha256:1c1d100e50a7684afcbdc82929de1bc79bee8adcaafd367c38e5aa7eed4d6e19',
+        architecture: 'arm64',
+      },
+    ],
+  },
+  {
+    name: '3.9-amd64',
+    images: [
+      {
+        digest:
+          'sha256:faf4f034c82d40b66a7285a5e9d305f543a2726961cc6da11206770ef013244e',
+        architecture: 'amd64',
+      },
+    ],
+  },
+]
+
 export {
   sizeDataNoTagSemVerSort,
   versionDataNoTagDateSort,
@@ -3005,4 +3048,5 @@ export {
   versionDataNoTagSemVerSort,
   versionDataWithTag,
   versionDataWithVaryingArchitectures,
+  versionDataWithArchSpecificVersions,
 }

--- a/services/docker/docker-version.service.js
+++ b/services/docker/docker-version.service.js
@@ -131,7 +131,14 @@ export default class DockerVersion extends BaseJsonService {
       const { digest } = imageTag
       return { version: getDigestSemVerMatches({ data: pagedData, digest }) }
     } else if (!tag && sort === 'semver') {
-      const matches = data.map(d => d.name)
+      const matches = data
+        .filter(d => d.images.some(image => image.architecture === arch))
+        .map(d => d.name)
+      if (matches.length === 0) {
+        throw new InvalidResponse({
+          prettyMessage: `no images found for arch ${arch}`,
+        })
+      }
       return { version: latest(matches) }
     } else {
       version = data.find(d => d.name === tag)

--- a/services/docker/docker-version.spec.js
+++ b/services/docker/docker-version.spec.js
@@ -8,6 +8,7 @@ import {
   versionDataNoTagSemVerSort,
   versionDataWithTag,
   versionDataWithVaryingArchitectures,
+  versionDataWithArchSpecificVersions,
 } from './docker-fixtures.js'
 
 describe('DockerVersion', function () {
@@ -64,6 +65,13 @@ describe('DockerVersion', function () {
       arch: 'ppc64le',
     }).expect({
       version: '3.10.4',
+    })
+    given({
+      data: versionDataWithArchSpecificVersions,
+      sort: 'semver',
+      arch: 'arm64',
+    }).expect({
+      version: '3.9-arm64',
     })
   })
 


### PR DESCRIPTION
Refs https://github.com/badges/shields/discussions/10904

This is a bit of a "remove [spacebar heating](https://xkcd.com/1172/)" change

I think my reading here is that this change fundamentally brings the code into line with the documented behaviour, so we could consider it a non-breaking change.

That said, this probably is going to change the result of this badge for some projects in the wild which rely on the fact the semver variant ignores architectures (because it assumes projects follow the more normal pattern where you push multiple architectures to a single version tag).

As such, this is a bit of a debatable one. I can see that we could equally choose to not merge this to preserve backwards compatibility and document more clearly the existing behaviour.