### PR TITLE
tweak default cache lengths by category

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -150,12 +150,18 @@ class BaseService {
   static get _cacheLength() {
     const cacheLengths = {
       build: 30,
-      license: 3600,
-      version: 300,
       debug: 60,
-      downloads: 900,
-      rating: 900,
-      social: 900,
+
+      'platform-support': 300,
+      size: 300,
+      version: 300,
+
+      chat: 1800,
+      downloads: 1800,
+      rating: 1800,
+      social: 1800,
+
+      license: 14400,
     }
     return cacheLengths[this.category]
   }


### PR DESCRIPTION
Quick refresher on how we set max-age:

- Individual badge classes can set a `_cacheLength` specific to that service
- If the badge class itself doesn't define a `_cacheLength` we fall back and use the default for that category. This is the code I am changing in this PR
- If there is no default set for the category, we fall back and use `defaultCacheLengthSeconds` (which we set to 120 seconds in production)

The basic principles of setting defaults by category are:
- There are some data points that need change more frequently than others. Whether your build is passing or failing might change quite frequently. You rarely change your project's license.
- There are some badges that show quite a precise value (build status, version number), whereas others show a more indicative metric (number of downloads/stars/likes). These are usually rounded with `metric()`. It is less crucial for an indicative metric to be fresh.

In this PR I am suggesting we tweak the category defaults a bit and add some categories that were previously using the global default of 2 mins. The broad result of all of this being: Cache more things for longer. I am focussing on categories that make up a large proportion of our traffic.

We can always continue to tweak these thresholds.

Also:
- This doesn't change any situations where we've set a `_cacheLength` on individual badge classes - those continue to override the defaults by category
- If there are specific badges where we want to set a shorter length than the category default then we can