### PR TITLE
[Packagist] Update default domain for repo metadata

### DIFF
--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -32,7 +32,7 @@ class BasePackagistService extends BaseJsonService {
    * @param {string} attrs.server URL for the packagist registry server (Optional)
    * @returns {object} Parsed response
    */
-  async fetch({ user, repo, schema, server = 'https://packagist.org' }) {
+  async fetch({ user, repo, schema, server = 'https://repo.packagist.org' }) {
     const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}.json`
 
     return this._requestJson({
@@ -56,7 +56,7 @@ class BasePackagistService extends BaseJsonService {
    * @param {string} attrs.server URL for the packagist registry server (Optional)
    * @returns {object} Parsed response
    */
-  async fetchDev({ user, repo, schema, server = 'https://packagist.org' }) {
+  async fetchDev({ user, repo, schema, server = 'https://repo.packagist.org' }) {
     const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}~dev.json`
 
     return this._requestJson({

--- a/services/packagist/packagist-base.js
+++ b/services/packagist/packagist-base.js
@@ -56,7 +56,12 @@ class BasePackagistService extends BaseJsonService {
    * @param {string} attrs.server URL for the packagist registry server (Optional)
    * @returns {object} Parsed response
    */
-  async fetchDev({ user, repo, schema, server = 'https://repo.packagist.org' }) {
+  async fetchDev({
+    user,
+    repo,
+    schema,
+    server = 'https://repo.packagist.org',
+  }) {
     const url = `${server}/p2/${user.toLowerCase()}/${repo.toLowerCase()}~dev.json`
 
     return this._requestJson({


### PR DESCRIPTION
Packagist.org & Composer maintainer here.. We are trying to phase out the packagist.org/p2/... URLs as we are serving the repo.packagist.org domain via a CDN which is much more efficient for everyone involved. These URLs were historically present but right now I see a lot of the requests for these files on the main domain come from shields.io, and we will shutdown access soon so please make sure /p2/ URLs are not fetched from there. The /packages/... URLs used in fetchByJsonAPI are fine though as those hit our API which is another endpoint.

