### PR TITLE
nodemon watch yml conf files and ignore .github

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
   },
   "nodemonConfig": {
     "verbose": true,
-    "ext": "js",
+    "ext": "js,yml",
     "ignore": [
       "package.json",
       "**/*.spec.js",
@@ -142,7 +142,8 @@
       "**/*.integration.js",
       "frontend/",
       "build/",
-      "cypress/"
+      "cypress/",
+      ".github/"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #10923

this change makes nodemon restart on every configuration change

Scanned the project for all other yml files and we have some at cypress and .github, both don't seem to add value for nodemon reload so i added .github to the ignore list (sypress was already there)

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
