### PR TITLE
disallow iframe embedding

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -551,6 +551,8 @@ class Server {
       // https://github.com/badges/shields/issues/10419
       res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin')
 
+      res.setHeader('X-Frame-Options', 'DENY')
+
       next()
     })
 


### PR DESCRIPTION
This is something that someone reported via the `security@` email.

In theory, shields can be embedded in an iframe anywhere which could lead to it being used in a ClickJacking attack. I think this is low severity, but the mitigation is "send a header" so.. meh. I don't think there's really a legitimate use-case for embedding us in an iframe.