### PR TITLE
[sourceforge] add repo param to last commit service

### DIFF
--- a/services/sourceforge/sourceforge-last-commit-redirect.service.js
+++ b/services/sourceforge/sourceforge-last-commit-redirect.service.js
@@ -1,0 +1,15 @@
+import { redirector } from '../index.js'
+
+export default redirector({
+  // SourceForge last commit service used to only have project name as a parameter
+  // and the repository name was always `git`.
+  // The service was later updated to have the repository name as a parameter.
+  // This redirector is used to keep the old URLs working.
+  category: 'activity',
+  route: {
+    base: 'sourceforge/last-commit',
+    pattern: ':project',
+  },
+  transformPath: ({ project }) => `/sourceforge/last-commit/${project}/git`,
+  dateAdded: new Date('2025-03-08'),
+})

--- a/services/sourceforge/sourceforge-last-commit-redirect.tester.js
+++ b/services/sourceforge/sourceforge-last-commit-redirect.tester.js
@@ -1,0 +1,6 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('last commit (redirect)')
+  .get('/guitarix.json')
+  .expectRedirect('/sourceforge/last-commit/guitarix/git.json')

--- a/services/sourceforge/sourceforge-last-commit.service.js
+++ b/services/sourceforge/sourceforge-last-commit.service.js
@@ -17,35 +17,43 @@ export default class SourceforgeLastCommit extends BaseJsonService {
 
   static route = {
     base: 'sourceforge/last-commit',
-    pattern: ':project',
+    pattern: ':project/:repo',
   }
 
   static openApi = {
-    '/sourceforge/last-commit/{project}': {
+    '/sourceforge/last-commit/{project}/{repo}': {
       get: {
         summary: 'SourceForge Last Commit',
-        parameters: pathParams({
-          name: 'project',
-          example: 'guitarix',
-        }),
+        parameters: pathParams(
+          {
+            name: 'project',
+            example: 'guitarix',
+          },
+          {
+            name: 'repo',
+            example: 'git',
+            description:
+              'The repository name, usually `git` but might be different.',
+          },
+        ),
       },
     },
   }
 
   static defaultBadgeData = { label: 'last commit' }
 
-  async fetch({ project }) {
+  async fetch({ project, repo }) {
     return this._requestJson({
-      url: `https://sourceforge.net/rest/p/${project}/git/commits`,
+      url: `https://sourceforge.net/rest/p/${project}/${repo}/commits`,
       schema,
       httpErrors: {
-        404: 'project not found',
+        404: 'project or repo not found',
       },
     })
   }
 
-  async handle({ project }) {
-    const body = await this.fetch({ project })
+  async handle({ project, repo }) {
+    const body = await this.fetch({ project, repo })
     return renderDateBadge(body.commits[0].committed_date)
   }
 }

--- a/services/sourceforge/sourceforge-last-commit.tester.js
+++ b/services/sourceforge/sourceforge-last-commit.tester.js
@@ -3,9 +3,17 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('last commit')
-  .get('/guitarix.json')
+  .get('/guitarix/git.json')
+  .expectBadge({ label: 'last commit', message: isFormattedDate })
+
+t.create('last commit (non default repo)')
+  .get('/opencamera/code.json')
   .expectBadge({ label: 'last commit', message: isFormattedDate })
 
 t.create('last commit (project not found)')
-  .get('/that-doesnt-exist.json')
-  .expectBadge({ label: 'last commit', message: 'project not found' })
+  .get('/that-doesnt-exist/fake.json')
+  .expectBadge({ label: 'last commit', message: 'project or repo not found' })
+
+t.create('last commit (repo not found)')
+  .get('/guitarix/fake-repo.json')
+  .expectBadge({ label: 'last commit', message: 'project or repo not found' })


### PR DESCRIPTION
some sourceforge projects have multiple repositories, so we need to
specify the repository to use for the last commit service.

should be backward compitable with redirect

fixes #10921

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
