### PR TITLE
Update [SourceForge] commit count badge to support repository parameter

### DIFF
--- a/services/sourceforge/sourceforge-commit-count-redirect.service.js
+++ b/services/sourceforge/sourceforge-commit-count-redirect.service.js
@@ -1,0 +1,15 @@
+import { redirector } from '../index.js'
+
+export default redirector({
+  // SourceForge commit count service used to only have project name as a parameter
+  // and the repository name was always `git`.
+  // The service was later updated to have the repository name as a parameter.
+  // This redirector is used to keep the old URLs working.
+  category: 'activity',
+  route: {
+    base: 'sourceforge/commit-count',
+    pattern: ':project',
+  },
+  transformPath: ({ project }) => `/sourceforge/commit-count/${project}/git`,
+  dateAdded: new Date('2025-03-15'),
+})

--- a/services/sourceforge/sourceforge-commit-count-redirect.tester.js
+++ b/services/sourceforge/sourceforge-commit-count-redirect.tester.js
@@ -1,0 +1,6 @@
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('commit count (redirect)')
+  .get('/guitarix.json')
+  .expectRedirect('/sourceforge/commit-count/guitarix/git.json')

--- a/services/sourceforge/sourceforge-commit-count.service.js
+++ b/services/sourceforge/sourceforge-commit-count.service.js
@@ -11,17 +11,25 @@ export default class SourceforgeCommitCount extends BaseJsonService {
 
   static route = {
     base: 'sourceforge/commit-count',
-    pattern: ':project',
+    pattern: ':project/:repo',
   }
 
   static openApi = {
     '/sourceforge/commit-count/{project}': {
       get: {
         summary: 'SourceForge Commit Count',
-        parameters: pathParams({
-          name: 'project',
-          example: 'guitarix',
-        }),
+        parameters: pathParams(
+          {
+            name: 'project',
+            example: 'guitarix',
+          },
+          {
+            name: 'repo',
+            example: 'git',
+            description:
+              'The repository name, usually `git` but might be different.',
+          },
+        ),
       },
     },
   }
@@ -35,18 +43,18 @@ export default class SourceforgeCommitCount extends BaseJsonService {
     }
   }
 
-  async fetch({ project }) {
+  async fetch({ project, repo }) {
     return this._requestJson({
-      url: `https://sourceforge.net/rest/p/${project}/git`,
+      url: `https://sourceforge.net/rest/p/${project}/${repo}`,
       schema,
       httpErrors: {
-        404: 'project not found',
+        404: 'project or repo not found',
       },
     })
   }
 
-  async handle({ project }) {
-    const body = await this.fetch({ project })
+  async handle({ project, repo }) {
+    const body = await this.fetch({ project, repo })
     return this.constructor.render({
       commitCount: body.commit_count,
     })

--- a/services/sourceforge/sourceforge-commit-count.service.js
+++ b/services/sourceforge/sourceforge-commit-count.service.js
@@ -15,7 +15,7 @@ export default class SourceforgeCommitCount extends BaseJsonService {
   }
 
   static openApi = {
-    '/sourceforge/commit-count/{project}': {
+    '/sourceforge/commit-count/{project}/{repo}': {
       get: {
         summary: 'SourceForge Commit Count',
         parameters: pathParams(

--- a/services/sourceforge/sourceforge-commit-count.tester.js
+++ b/services/sourceforge/sourceforge-commit-count.tester.js
@@ -3,9 +3,17 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('commit count')
-  .get('/guitarix.json')
+  .get('/guitarix/git.json')
+  .expectBadge({ label: 'commit count', message: isMetric })
+
+t.create('commit count (non default repo)')
+  .get('/opencamera/code.json')
   .expectBadge({ label: 'commit count', message: isMetric })
 
 t.create('commit count (project not found)')
-  .get('/that-doesnt-exist.json')
-  .expectBadge({ label: 'commit count', message: 'project not found' })
+  .get('/that-doesnt-exist/git.json')
+  .expectBadge({ label: 'commit count', message: 'project or repo not found' })
+
+t.create('commit count (repo not found)')
+  .get('/guitarix/invalid-repo.json')
+  .expectBadge({ label: 'commit count', message: 'project or repo not found' })


### PR DESCRIPTION
Add support for a repository parameter in the SourceForge commit count service, for projects using non default or multiple repo names.
Includes a redirector for legacy use.

this is a follow up for #10935