### PR TITLE
Ignore package.json files in eslint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -224,6 +224,7 @@ const config = [
       'badge-maker/node_modules/',
       '!.github/',
       'frontend/.docusaurus/**',
+      '**/package.json',
     ],
   },
 


### PR DESCRIPTION
ignore package.json in eslint.
vscode marks all package.json files as having issues without that ignore.