### PR TITLE
docker: cleanup some building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,12 @@ node_modules/
 shields.env
 .git/
 .gitignore
+.github
 .vscode/
 fly.toml
+
+*.md
+doc/
 
 # Improve layer cacheability.
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,15 +10,14 @@ COPY package.json package-lock.json /usr/src/app/
 # Without the badge-maker package.json and CLI script in place, `npm ci` will fail.
 COPY badge-maker /usr/src/app/badge-maker/
 
+# We need dev deps to build the front end. We don't need Cypress, though.
+RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci
+
 COPY . /usr/src/app
 
-# We need dev deps to build the front end. We don't need Cypress, though.
-RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci \
-    && npm run build \
-    && npm prune --omit=dev \
-    && npm cache clean --force \
-    && rm -rf node_modules \
-    && npm install --omit=dev \
+RUN npm run build \
+    && npm prune --omit=dev --force \
+    && rm -rf node_modules/.cache \
     && rm -rf frontend package-lock.json
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:20-alpine AS builder
 
+RUN npm install -g "npm@^10"
+
 RUN mkdir -p /usr/src/app
 RUN mkdir /usr/src/app/private
 WORKDIR /usr/src/app
@@ -8,14 +10,17 @@ COPY package.json package-lock.json /usr/src/app/
 # Without the badge-maker package.json and CLI script in place, `npm ci` will fail.
 COPY badge-maker /usr/src/app/badge-maker/
 
-RUN npm install -g "npm@^10"
-# We need dev deps to build the front end. We don't need Cypress, though.
-RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci
-
 COPY . /usr/src/app
-RUN npm run build
-RUN npm prune --omit=dev
-RUN npm cache clean --force
+
+# We need dev deps to build the front end. We don't need Cypress, though.
+RUN NODE_ENV=development CYPRESS_INSTALL_BINARY=0 npm ci \
+    && npm run build \
+    && npm prune --omit=dev \
+    && npm cache clean --force \
+    && rm -rf node_modules \
+    && npm install --omit=dev \
+    && rm -rf frontend package-lock.json
+
 
 # Use multi-stage build to reduce size
 FROM node:20-alpine


### PR DESCRIPTION
Somehow `npm prune --omit=dev` does not properly remove unneeded dependencies, this is workarounded by deleting the `node_modules` folder and the running install again.

It also removes some unneeded large files in the docker container.


The container had a size of over 1gb before and now *just* 270MB:
```
moritz@moritz-cyra:~$ docker inspect -f "{{ .Size }}" shieldsio/shields:next
1135416085
moritz@moritz-cyra:~$ docker inspect -f "{{ .Size }}" sha256:1bf4a7778035604c8ce8b284ceffedcdec21671b362906583a743b2024fd887e
271256249
```