### PR TITLE
limit label and message to 255 chars

### DIFF
--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -152,7 +152,7 @@ export default function coalesceBadge(
     })
   }
 
-  return {
+  const badgeData = {
     // Use `coalesce()` to support empty labels and messages, as in the static
     // badge.
     label: coalesce(overrideLabel, serviceLabel, defaultLabel, category),
@@ -178,4 +178,13 @@ export default function coalesceBadge(
     links: toArray(overrideLink || serviceLink),
     cacheLengthSeconds: coalesce(serviceCacheSeconds, defaultCacheSeconds),
   }
+  badgeData.label =
+    typeof badgeData.label === 'string'
+      ? badgeData.label.slice(0, 255)
+      : badgeData.label
+  badgeData.message =
+    typeof badgeData.message === 'string'
+      ? badgeData.message.slice(0, 255)
+      : badgeData.message
+  return badgeData
 }

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -28,6 +28,22 @@ describe('coalesceBadge', function () {
         coalesceBadge({ label: 'purr count' }, { label: 'purrs' }, {}),
       ).to.include({ label: 'purr count' })
     })
+
+    it('truncates really long labels', function () {
+      expect(
+        coalesceBadge(
+          {},
+          {
+            label:
+              'This is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long',
+          },
+          {},
+        ),
+      ).to.include({
+        label:
+          'This is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really lo',
+      })
+    })
   })
 
   describe('Message', function () {
@@ -43,6 +59,22 @@ describe('coalesceBadge', function () {
       // `render()` to always return a string.
       expect(coalesceBadge({}, { message: 10 }, {})).to.include({
         message: 10,
+      })
+    })
+
+    it('truncates really long messages', function () {
+      expect(
+        coalesceBadge(
+          {},
+          {
+            message:
+              'This is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really long',
+          },
+          {},
+        ),
+      ).to.include({
+        message:
+          'This is really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really really lo',
       })
     })
   })


### PR DESCRIPTION
Currently we don't place any limit on the size of a label or message
This means you can make badges with really long text, for example:

![](https://img.shields.io/badge/long-It%20was%20the%20best%20of%20times%2C%20it%20was%20the%20worst%20of%20times%2C%20it%20was%20the%20age%20of%20wisdom%2C%20it%20was%20the%20age%20of%20foolishness%2C%20it%20was%20the%20epoch%20of%20belief%2C%20it%20was%20the%20epoch%20of%20incredulity%2C%20it%20was%20the%20season%20of%20Light%2C%20it%20was%20the%20season%20of%20Darkness%2C%20it%20was%20the%20spring%20of%20hope%2C%20it%20was%20the%20winter%20of%20despair%2C%20we%20had%20everything%20before%20us%2C%20we%20had%20nothing%20before%20us%2C%20we%20were%20all%20going%20direct%20to%20Heaven%2C%20we%20were%20all%20going%20direct%20the%20other%20way%E2%80%94in%20short%2C%20the%20period%20was%20so%20far%20like%20the%20present%20period%2C%20that%20some%20of%20its%20noisiest%20authorities%20insisted%20on%20its%20being%20received%2C%20for%20good%20or%20for%20evil%2C%20in%20the%20superlative%20degree%20of%20comparison%20only-blue) - https://img.shields.io/badge/long-It%20was%20the%20best%20of%20times%2C%20it%20was%20the%20worst%20of%20times%2C%20it%20was%20the%20age%20of%20wisdom%2C%20it%20was%20the%20age%20of%20foolishness%2C%20it%20was%20the%20epoch%20of%20belief%2C%20it%20was%20the%20epoch%20of%20incredulity%2C%20it%20was%20the%20season%20of%20Light%2C%20it%20was%20the%20season%20of%20Darkness%2C%20it%20was%20the%20spring%20of%20hope%2C%20it%20was%20the%20winter%20of%20despair%2C%20we%20had%20everything%20before%20us%2C%20we%20had%20nothing%20before%20us%2C%20we%20were%20all%20going%20direct%20to%20Heaven%2C%20we%20were%20all%20going%20direct%20the%20other%20way%E2%80%94in%20short%2C%20the%20period%20was%20so%20far%20like%20the%20present%20period%2C%20that%20some%20of%20its%20noisiest%20authorities%20insisted%20on%20its%20being%20received%2C%20for%20good%20or%20for%20evil%2C%20in%20the%20superlative%20degree%20of%20comparison%20only-blue

That is not particularly useful. With the dyanmic and endpoint badges you can construct relatively small requests that force us to render a single SVG containing up to about 10Mb of text (the largest response size we will accept from an upstream URL). Here's a less extreme example that proves the concept:

![](https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Foronoa%2Fredoc_sample%2F8c98482a7eb649aa1fa0f9992ef78997c5217371%2Finfo.yml&query=%24.info.description) - https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Foronoa%2Fredoc_sample%2F8c98482a7eb649aa1fa0f9992ef78997c5217371%2Finfo.yml&query=%24.info.description

In this PR, I propose imposing a limit on the size of the message and label fields we will render. 255 characters seems like more than enough to render all useful badges.

I've done this in shields.io core rather than badge-maker. Badge-maker library users can render any length of text