### PR TITLE
[PyPI] Fix license for packages following PEP 639

### DIFF
--- a/services/pypi/pypi-base.js
+++ b/services/pypi/pypi-base.js
@@ -9,6 +9,7 @@ const schema = Joi.object({
     // https://github.com/badges/shields/issues/2022
     // https://github.com/badges/shields/issues/7728
     license: Joi.string().allow('').allow(null),
+    license_expression: Joi.string().allow('').allow(null),
     classifiers: Joi.array().items(Joi.string()).required(),
   }).required(),
   urls: Joi.array()

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -52,6 +52,10 @@ function getLicenses(packageData) {
   } = packageData
 
   /*
+  The .license_expression field contains an SPDX expression, and it
+  is the preferred way of documenting a Python project's license.
+  See https://peps.python.org/pep-0639/
+
   The .license field may either contain
   - a short license description (e.g: 'MIT' or 'GPL-3.0') or
   - the full text of a license
@@ -60,7 +64,9 @@ function getLicenses(packageData) {
   See https://github.com/badges/shields/issues/8689 and
   https://github.com/badges/shields/pull/8690 for more info.
   */
-  if (license && license.length < 40) {
+  if (packageData.info.license_expression) {
+    return [packageData.info.license_expression]
+  } else if (license && license.length < 40) {
     return [license]
   } else {
     const parenthesizedAcronymRegex = /\(([^)]+)\)/

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -47,17 +47,16 @@ function parseClassifiers(parsedData, pattern, preserveCase = false) {
 }
 
 function getLicenses(packageData) {
-  const {
-    info: { license },
-  } = packageData
+  const license = packageData.info.license
+  const licenseExpression = packageData.info.license_expression
 
-  if (packageData.info.license_expression) {
+  if (licenseExpression) {
     /*
     The .license_expression field contains an SPDX expression, and it
     is the preferred way of documenting a Python project's license.
     See https://peps.python.org/pep-0639/
     */
-    return [packageData.info.license_expression]
+    return [licenseExpression]
   } else if (license && license.length < 40) {
     /*
     The .license field may either contain

--- a/services/pypi/pypi-helpers.js
+++ b/services/pypi/pypi-helpers.js
@@ -51,24 +51,26 @@ function getLicenses(packageData) {
     info: { license },
   } = packageData
 
-  /*
-  The .license_expression field contains an SPDX expression, and it
-  is the preferred way of documenting a Python project's license.
-  See https://peps.python.org/pep-0639/
-
-  The .license field may either contain
-  - a short license description (e.g: 'MIT' or 'GPL-3.0') or
-  - the full text of a license
-  but there is nothing in the response that tells us explicitly.
-  We have to make an assumption based on the length.
-  See https://github.com/badges/shields/issues/8689 and
-  https://github.com/badges/shields/pull/8690 for more info.
-  */
   if (packageData.info.license_expression) {
+    /*
+    The .license_expression field contains an SPDX expression, and it
+    is the preferred way of documenting a Python project's license.
+    See https://peps.python.org/pep-0639/
+    */
     return [packageData.info.license_expression]
   } else if (license && license.length < 40) {
+    /*
+    The .license field may either contain
+    - a short license description (e.g: 'MIT' or 'GPL-3.0') or
+    - the full text of a license
+    but there is nothing in the response that tells us explicitly.
+    We have to make an assumption based on the length.
+    See https://github.com/badges/shields/issues/8689 and
+    https://github.com/badges/shields/pull/8690 for more info.
+    */
     return [license]
   } else {
+    // else fall back to trove classifiers
     const parenthesizedAcronymRegex = /\(([^)]+)\)/
     const bareAcronymRegex = /^[a-z0-9]+$/
     const spdxAliases = {

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -118,12 +118,14 @@ describe('PyPI helpers', function () {
       given({
         info: {
           license: null,
+          license_expression: null,
           classifiers: ['License :: OSI Approved :: MIT License'],
         },
       }),
       given({
         info: {
           license: '',
+          license_expression: null,
           classifiers: ['License :: OSI Approved :: MIT License'],
         },
       }),
@@ -131,12 +133,14 @@ describe('PyPI helpers', function () {
         info: {
           license:
             'this text is really really really really really really long',
+          license_expression: null,
           classifiers: ['License :: OSI Approved :: MIT License'],
         },
       }),
       given({
         info: {
           license: '',
+          license_expression: null,
           classifiers: [
             'License :: OSI Approved :: MIT License',
             'License :: DFSG approved',
@@ -147,24 +151,28 @@ describe('PyPI helpers', function () {
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: ['License :: Public Domain'],
       },
     }).expect(['Public Domain'])
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: ['License :: Netscape Public License (NPL)'],
       },
     }).expect(['NPL'])
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: ['License :: OSI Approved :: Apache Software License'],
       },
     }).expect(['Apache-2.0'])
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: [
           'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         ],
@@ -173,6 +181,7 @@ describe('PyPI helpers', function () {
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: [
           'License :: OSI Approved :: GNU Affero General Public License v3',
         ],
@@ -181,6 +190,7 @@ describe('PyPI helpers', function () {
     given({
       info: {
         license: '',
+        license_expression: null,
         classifiers: ['License :: OSI Approved :: Zero-Clause BSD (0BSD)'],
       },
     }).expect(['0BSD'])

--- a/services/pypi/pypi-helpers.spec.js
+++ b/services/pypi/pypi-helpers.spec.js
@@ -100,10 +100,21 @@ describe('PyPI helpers', function () {
   })
 
   test(getLicenses, () => {
-    forCases([given({ info: { license: 'MIT', classifiers: [] } })]).expect([
-      'MIT',
-    ])
     forCases([
+      given({
+        info: {
+          license: null,
+          license_expression: 'MIT',
+          classifiers: [],
+        },
+      }),
+      given({
+        info: {
+          license: 'MIT',
+          license_expression: null,
+          classifiers: [],
+        },
+      }),
       given({
         info: {
           license: null,


### PR DESCRIPTION
PEP 639 states that the preferred way of documenting a Python project's license is an SPDX expression in a `License-Expression` metadata field. PyPI exposes this information in `info.license_expression` in its JSON data.

Fixes: #11000