### PR TITLE
fix: live test for [githubpipenv] wrong validation

### DIFF
--- a/services/github/github-pipenv.tester.js
+++ b/services/github/github-pipenv.tester.js
@@ -1,7 +1,6 @@
 import Joi from 'joi'
 import { ServiceTester } from '../tester.js'
 import {
-  isCommitHash,
   isVPlusDottedVersionAtLeastOne,
   isVPlusDottedVersionNClausesWithOptionalSuffix,
 } from '../test-validators.js'
@@ -85,5 +84,5 @@ t.create('Locked version of VCS dependency')
   .get('/locked/dependency-version/pypa/pipenv/dev/pypiserver.json')
   .expectBadge({
     label: 'pypiserver',
-    message: isCommitHash,
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
   })

--- a/services/github/github-pipenv.tester.js
+++ b/services/github/github-pipenv.tester.js
@@ -84,6 +84,6 @@ t.create('Locked version of unknown dependency')
 t.create('Locked version of VCS dependency')
   .get('/locked/dependency-version/ykdojo/editdojo/tweepy.json')
   .expectBadge({
-    label: 'pypiserver',
+    label: 'tweepy',
     message: isCommitHash,
   })

--- a/services/github/github-pipenv.tester.js
+++ b/services/github/github-pipenv.tester.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import { ServiceTester } from '../tester.js'
 import {
+  isCommitHash,
   isVPlusDottedVersionAtLeastOne,
   isVPlusDottedVersionNClausesWithOptionalSuffix,
 } from '../test-validators.js'
@@ -81,8 +82,8 @@ t.create('Locked version of unknown dependency')
   })
 
 t.create('Locked version of VCS dependency')
-  .get('/locked/dependency-version/pypa/pipenv/dev/pypiserver.json')
+  .get('/locked/dependency-version/ykdojo/editdojo/tweepy.json')
   .expectBadge({
     label: 'pypiserver',
-    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+    message: isCommitHash,
   })


### PR DESCRIPTION
Change the message for the locked version of the VCS dependency badge to utilize version validation instead of commit hash validation.

Looked at past pypiserver version names and i think `isVPlusDottedVersionNClausesWithOptionalSuffix` is the best fit here