### PR TITLE
[Amo] Switch to decimal rating for Firefox extension

### DIFF
--- a/services/amo/amo-rating.service.js
+++ b/services/amo/amo-rating.service.js
@@ -27,10 +27,12 @@ export default class AmoRating extends BaseAmoService {
   static _cacheLength = 7200
 
   static render({ format, rating }) {
-    rating = Math.round(rating)
     return {
       label: format,
-      message: format === 'stars' ? starRating(rating) : `${rating}/5`,
+      message:
+        format === 'stars'
+          ? starRating(rating)
+          : `${Math.round(rating * 10) / 10}/5`,
       color: floorCountColor(rating, 2, 3, 4),
     }
   }

--- a/services/amo/amo-rating.tester.js
+++ b/services/amo/amo-rating.tester.js
@@ -7,7 +7,7 @@ t.create('Rating')
   .get('/rating/IndieGala-Helper.json')
   .expectBadge({
     label: 'rating',
-    message: Joi.string().regex(/^\d\/\d$/),
+    message: Joi.string().regex(/^\d(\.\d)?\/\d$/),
   })
 
 t.create('Stars')


### PR DESCRIPTION
Changes the handling of decimal ratings for Firefox extensions.  
It replicates the behaviour of the Chrome extension rating badges.

Closes #11025 