### PR TITLE
deprecate [pub] popularity badge

### DIFF
--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -1,54 +1,11 @@
-import Joi from 'joi'
-import { floorCount } from '../color-formatters.js'
-import { BaseJsonService, pathParams } from '../index.js'
-import { baseDescription } from './pub-common.js'
+import { deprecatedService } from '../index.js'
 
-const description = `${baseDescription}
-  <p>This badge shows a measure of how many developers use a package, providing insight into what other developers are using.</p>`
-
-const schema = Joi.object({
-  popularityScore: Joi.number().min(0).max(1).required(),
-}).required()
-
-export default class PubPopularity extends BaseJsonService {
-  static category = 'rating'
-
-  static route = { base: 'pub/popularity', pattern: ':packageName' }
-
-  static openApi = {
-    '/pub/popularity/{packageName}': {
-      get: {
-        summary: 'Pub Popularity',
-        description,
-        parameters: pathParams({
-          name: 'packageName',
-          example: 'analysis_options',
-        }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'popularity' }
-
-  static render({ popularityScore }) {
-    const roundedScore = Math.round(popularityScore * 100)
-    return {
-      label: 'popularity',
-      message: `${roundedScore}%`,
-      color: floorCount(roundedScore, 40, 60, 80),
-    }
-  }
-
-  async fetch({ packageName }) {
-    return this._requestJson({
-      schema,
-      url: `https://pub.dev/api/packages/${packageName}/score`,
-    })
-  }
-
-  async handle({ packageName }) {
-    const score = await this.fetch({ packageName })
-    const popularityScore = score.popularityScore
-    return this.constructor.render({ popularityScore })
-  }
-}
+export const PubPopularity = deprecatedService({
+  category: 'rating',
+  route: {
+    base: 'pub/popularity',
+    pattern: ':packageName',
+  },
+  label: 'popularity',
+  dateAdded: new Date('2025-05-11'),
+})

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -1,23 +1,12 @@
-import { isIntegerPercentage } from '../test-validators.js'
-import { createServiceTester } from '../tester.js'
+import { ServiceTester } from '../tester.js'
 
-export const t = await createServiceTester()
-
-t.create('pub popularity (valid)').get('/analysis_options.json').expectBadge({
-  label: 'popularity',
-  message: isIntegerPercentage,
+export const t = new ServiceTester({
+  id: 'PubPopularity',
+  title: 'PubPopularity',
+  pathPrefix: '/pub/popularity',
 })
 
-t.create('pub popularity (not found)')
-  .get('/analysisoptions.json')
-  .expectBadge({
-    label: 'popularity',
-    message: 'not found',
-    color: 'red',
-  })
-
-t.create('pub popularity (invalid)').get('/analysis-options.json').expectBadge({
+t.create('pub popularity').get('/analysis_options.json').expectBadge({
   label: 'popularity',
-  message: 'invalid',
-  color: 'lightgrey',
+  message: 'no longer available',
 })


### PR DESCRIPTION
The `/score` endpoint no longer returns a `.popularityScore` property.

I think we have actually ended up relying on an undocumented API endpoint here, which is just used for the pub.dev frontend :angry:  I think the relevant upstream PR is: https://github.com/dart-lang/pub-dev/pull/8435 so it seems the change is intentional. The other pub badges can continue to work.
