### PR TITLE
WIP use `latest` property for maven badges; affects [maven gradle]

### DIFF
--- a/services/gradle-plugin-portal/gradle-plugin-portal.service.js
+++ b/services/gradle-plugin-portal/gradle-plugin-portal.service.js
@@ -1,5 +1,4 @@
-import { redirector, pathParam, queryParam } from '../index.js'
-import { description } from '../maven-metadata/maven-metadata.js'
+import { redirector, pathParam } from '../index.js'
 
 export default redirector({
   category: 'version',
@@ -12,19 +11,8 @@ export default redirector({
     '/gradle-plugin-portal/v/{pluginId}': {
       get: {
         summary: 'Gradle Plugin Portal Version',
-        description,
         parameters: [
           pathParam({ name: 'pluginId', example: 'com.gradle.plugin-publish' }),
-          queryParam({
-            name: 'versionPrefix',
-            example: '0.10',
-            description: 'Filter only versions with this prefix.',
-          }),
-          queryParam({
-            name: 'versionSuffix',
-            example: '.1',
-            description: 'Filter only versions with this suffix.',
-          }),
         ],
       },
     },

--- a/services/maven-central/maven-central.service.js
+++ b/services/maven-central/maven-central.service.js
@@ -1,5 +1,4 @@
-import { redirector, pathParam, queryParam } from '../index.js'
-import { description } from '../maven-metadata/maven-metadata.js'
+import { redirector, pathParam } from '../index.js'
 
 export default redirector({
   category: 'version',
@@ -12,20 +11,9 @@ export default redirector({
     '/maven-central/v/{groupId}/{artifactId}': {
       get: {
         summary: 'Maven Central Version',
-        description,
         parameters: [
           pathParam({ name: 'groupId', example: 'com.google.guava' }),
           pathParam({ name: 'artifactId', example: 'guava' }),
-          queryParam({
-            name: 'versionPrefix',
-            example: '29',
-            description: 'Filter only versions with this prefix.',
-          }),
-          queryParam({
-            name: 'versionSuffix',
-            example: '-android',
-            description: 'Filter only versions with this suffix.',
-          }),
         ],
       },
     },

--- a/services/maven-central/maven-central.tester.js
+++ b/services/maven-central/maven-central.tester.js
@@ -9,10 +9,10 @@ t.create('latest version redirection')
     )}`,
   )
 
-t.create('latest 0.8 version redirection')
-  .get('/com.github.fabriziocucci/yacl4j/0.8.json') // http://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/
-  .expectRedirect(
-    `/maven-metadata/v.json?label=maven-central&metadataUrl=${encodeURIComponent(
-      'https://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/maven-metadata.xml',
-    )}&versionPrefix=0.8`,
-  )
+t.create('deprecated versionPrefix path param')
+  .get('/com.github.fabriziocucci/yacl4j/0.8.json', {
+    followRedirect: true,
+  })
+  .expectBadge({
+    message: 'versionPrefix and versionSuffix params have been removed',
+  })

--- a/services/maven-metadata/maven-metadata.js
+++ b/services/maven-metadata/maven-metadata.js
@@ -1,9 +1,0 @@
-'use strict'
-
-// the file contains common constants for badges uses maven-metadata
-
-export const description = `
-<code>versionPrefix</code> and <code>versionSuffix</code> allow narrowing down
-the range of versions the badge will take into account,
-but they are completely optional.
-`

--- a/services/maven-metadata/maven-metadata.service.js
+++ b/services/maven-metadata/maven-metadata.service.js
@@ -12,9 +12,7 @@ const queryParamSchema = Joi.object({
 const schema = Joi.object({
   metadata: Joi.object({
     versioning: Joi.object({
-      versions: Joi.object({
-        version: Joi.array().items(Joi.string().required()).single().required(),
-      }).required(),
+      latest: Joi.string().required(),
     }).required(),
   }).required(),
 }).required()
@@ -62,8 +60,6 @@ export default class MavenMetadata extends BaseXmlService {
       })
     }
     const data = await this.fetch({ metadataUrl })
-    const versions = data.metadata.versioning.versions.version.reverse()
-    const version = versions[0]
-    return renderVersionBadge({ version })
+    return renderVersionBadge({ version: data.metadata.versioning.latest })
   }
 }

--- a/services/maven-metadata/maven-metadata.tester.js
+++ b/services/maven-metadata/maven-metadata.tester.js
@@ -1,4 +1,3 @@
-import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
 import { isVPlusDottedVersionAtLeastOne } from '../test-validators.js'
 export const t = await createServiceTester()
@@ -10,33 +9,6 @@ t.create('valid maven-metadata.xml uri')
   .expectBadge({
     label: 'maven',
     message: isVPlusDottedVersionAtLeastOne,
-  })
-
-t.create('with version prefix')
-  .get(
-    '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/google/guava/guava/maven-metadata.xml&versionPrefix=27.',
-  )
-  .expectBadge({
-    label: 'maven',
-    message: 'v27.1-jre',
-  })
-
-t.create('with version suffix')
-  .get(
-    '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/google/guava/guava/maven-metadata.xml&versionSuffix=-android',
-  )
-  .expectBadge({
-    label: 'maven',
-    message: Joi.string().regex(/-android$/),
-  })
-
-t.create('with version prefix and suffix')
-  .get(
-    '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/google/guava/guava/maven-metadata.xml&versionPrefix=27.&versionSuffix=-android',
-  )
-  .expectBadge({
-    label: 'maven',
-    message: 'v27.1-android',
   })
 
 t.create('version ending with zero')
@@ -71,21 +43,3 @@ t.create('invalid maven-metadata.xml uri')
     '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/google/code/gson/gson/foobar.xml',
   )
   .expectBadge({ label: 'maven', message: 'not found' })
-
-t.create('inexistent version prefix')
-  .get(
-    '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/maven-metadata.xml&versionPrefix=99',
-  )
-  .expectBadge({
-    label: 'maven',
-    message: 'version prefix or suffix not found',
-  })
-
-t.create('inexistent version suffix')
-  .get(
-    '/v.json?metadataUrl=https://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/maven-metadata.xml&versionSuffix=test',
-  )
-  .expectBadge({
-    label: 'maven',
-    message: 'version prefix or suffix not found',
-  })


### PR DESCRIPTION
Refs https://github.com/badges/shields/issues/6188

In this PR I propose implementing the second suggestion I made in https://github.com/badges/shields/issues/6188#issuecomment-2525176102 This isn't completely clear-cut because I am proposing the removal of a feature which some people will be using. However, I think this is the most correct way to fix this.