### PR TITLE
Support logoSize=auto for custom logos

### DIFF
--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -1,3 +1,4 @@
+import { imageSize } from 'image-size'
 import {
   decodeDataUrlFromQueryParam,
   prepareNamedLogo,
@@ -116,6 +117,19 @@ export default function coalesceBadge(
     const overrideLogoSvgBase64 = decodeDataUrlFromQueryParam(overrideLogo)
     if (overrideLogoSvgBase64) {
       logoSvgBase64 = overrideLogoSvgBase64
+      logoSize = coalesce(overrideLogoSize, serviceLogoSize)
+
+      if (logoSize === 'auto') {
+        const [, base64Image] = overrideLogoSvgBase64.split(';base64,')
+        const dimensions = base64Image
+          ? imageSize(Buffer.from(base64Image, 'base64'))
+          : null
+
+        if (dimensions) {
+          logoWidth =
+            (dimensions.width / dimensions.height) * DEFAULT_LOGO_HEIGHT
+        }
+      }
     } else {
       namedLogo = overrideLogo
       // If the logo has been overridden it does not make sense to inherit the

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -261,6 +261,43 @@ describe('coalesceBadge', function () {
         ),
       ).to.include({ logo: logoSvg })
     })
+
+    it('uses default width when custom svg is provided and logoSize is not auto', function () {
+      const logoSvg =
+        'data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHdpZHRoPSI1IiBoZWlnaHQ9IjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PC9zdmc+'
+
+      expect(coalesceBadge({ logo: logoSvg }, {}, {}).logoWidth).to.be.undefined
+    })
+
+    it('uses default width when custom svg is provided that is not base64-encoded', function () {
+      const logoSvg = 'data:,HelloWorld'
+
+      expect(coalesceBadge({ logo: logoSvg }, {}, {}).logoWidth).to.be.undefined
+    })
+
+    it('uses image width when custom svg is provided and logoSize is auto', function () {
+      const logoSvg =
+        'data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHdpZHRoPSI1IiBoZWlnaHQ9IjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PC9zdmc+'
+
+      expect(
+        coalesceBadge({ logo: logoSvg, logoSize: 'auto' }, {}, {}),
+      ).to.include({
+        logoSize: 'auto',
+        logoWidth: 70,
+      })
+    })
+
+    it('uses image width when custom non-svg is provided and logoSize is auto', function () {
+      const logoSvg =
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAABCAIAAACZnPOkAAAAAXNSR0IB2cksfwAAAARnQU1BAACxjwv8YQUAAAAgY0hSTQAAeiYAAICEAAD6AAAAgOgAAHUwAADqYAAAOpgAABdwnLpRPAAAAAlwSFlzAAAuIwAALiMBeKU/dgAAAAd0SU1FB+kFDwkfDkgvZ9oAAAALSURBVAjXY2BABQAAEAABocUhwQAAAABJRU5ErkJggg=='
+
+      expect(
+        coalesceBadge({ logo: logoSvg, logoSize: 'auto' }, {}, {}),
+      ).to.include({
+        logoSize: 'auto',
+        logoWidth: 70,
+      })
+    })
   })
 
   describe('Logo size', function () {

--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -146,7 +146,7 @@ function category2openapi({ category, services, sort = false }) {
           in: 'query',
           required: false,
           description:
-            'Make icons adaptively resize by setting `auto`. Useful for some wider logos like `amd` and `amg`. Supported for simple-icons logos but not for custom logos.',
+            'Make icons adaptively resize by setting `auto`. Useful for some wider logos like `amd` and `amg`. Supported for both simple-icons logos and custom logos.',
           schema: {
             type: 'string',
           },

--- a/core/base-service/openapi.spec.js
+++ b/core/base-service/openapi.spec.js
@@ -97,7 +97,7 @@ const expected = {
         in: 'query',
         required: false,
         description:
-          'Make icons adaptively resize by setting `auto`. Useful for some wider logos like `amd` and `amg`. Supported for simple-icons logos but not for custom logos.',
+          'Make icons adaptively resize by setting `auto`. Useful for some wider logos like `amd` and `amg`. Supported for both simple-icons logos and custom logos.',
         schema: {
           type: 'string',
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "got": "^14.4.7",
         "graphql": "16.11.0",
         "graphql-tag": "^2.12.6",
+        "image-size": "^2.0.2",
         "joi": "17.13.3",
         "joi-extension-semver": "5.0.0",
         "js-yaml": "^4.1.0",
@@ -3693,6 +3694,22 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
@@ -17875,14 +17892,10 @@
       "dev": true
     },
     "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
-      "dev": true,
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
       "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -28527,6 +28540,7 @@
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "got": "^14.4.7",
     "graphql": "16.11.0",
     "graphql-tag": "^2.12.6",
+    "image-size": "^2.0.2",
     "joi": "17.13.3",
     "joi-extension-semver": "5.0.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
Addresses #11092 

I've added support for `logoSize=auto` for custom logos. This involves adding the `image-width` package as a dependency. I've added some unit tests but if you'd like more testing, do please indicate what you'd like me to add.

>  PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests

Can someone give me some guidance as to which tests I should be running for this change (i.e. what to put in the `[]` in the PR title)?