### PR TITLE
[DepsRs] Add Deps.rs dependency status badges

### DIFF
--- a/services/deps-rs/deps-rs-base.js
+++ b/services/deps-rs/deps-rs-base.js
@@ -1,0 +1,47 @@
+import Joi from 'joi'
+import { BaseJsonService } from '../index.js'
+
+const depsResponseSchema = Joi.object({
+  schemaVersion: Joi.number().required(),
+  label: Joi.string().required(),
+  message: Joi.string().required(),
+  color: Joi.string().required(),
+}).required()
+
+class BaseDepsRsService extends BaseJsonService {
+  static defaultBadgeData = { label: 'dependencies' }
+
+  /**
+   * Fetches data from the deps.rs API.
+   *
+   * @param {object} options - The options for the request
+   * @param {string} options.crate - The crate name.
+   * @param {string} [options.version] - The crate version number (optional).
+   * @returns {Promise<object>} the JSON response from the API.
+   */
+  async fetchCrate({ crate, version }) {
+    const url = version
+      ? `https://deps.rs/crate/${crate}/${version}/shield.json`
+      : `https://deps.rs/crate/${crate}/latest/shield.json`
+    return this._requestJson({ schema: depsResponseSchema, url })
+  }
+
+  /**
+   * Fetches data from the deps.rs API for a repository.
+   *
+   * @param {object} options - The options for the request
+   * @param {string} options.site - The repository site (e.g., 'github').
+   * @param {string} options.user - The repository owner/user.
+   * @param {string} options.repo - The repository name.
+   * @returns {Promise<object>} the JSON response from the API.
+   */
+  async fetchRepo({ site, user, repo }) {
+    const url = `https://deps.rs/repo/${site}/${user}/${repo}/shield.json`
+    return this._requestJson({ schema: depsResponseSchema, url })
+  }
+}
+
+const description =
+  '[Deps.rs](https://deps.rs/) is a service that checks dependency security status in Rust projects.'
+
+export { BaseDepsRsService, description }

--- a/services/deps-rs/deps-rs-base.js
+++ b/services/deps-rs/deps-rs-base.js
@@ -16,13 +16,11 @@ class BaseDepsRsService extends BaseJsonService {
    *
    * @param {object} options - The options for the request
    * @param {string} options.crate - The crate name.
-   * @param {string} [options.version] - The crate version number (optional).
+   * @param {string} options.version - The crate version number or 'latest'.
    * @returns {Promise<object>} the JSON response from the API.
    */
   async fetchCrate({ crate, version }) {
-    const url = version
-      ? `https://deps.rs/crate/${crate}/${version}/shield.json`
-      : `https://deps.rs/crate/${crate}/latest/shield.json`
+    const url = `https://deps.rs/crate/${crate}/${version}/shield.json`
     return this._requestJson({ schema: depsResponseSchema, url })
   }
 

--- a/services/deps-rs/deps-rs-crate.service.js
+++ b/services/deps-rs/deps-rs-crate.service.js
@@ -3,12 +3,12 @@ import { BaseDepsRsService, description } from './deps-rs-base.js'
 
 export default class DepsRsCrate extends BaseDepsRsService {
   static category = 'dependencies'
-  static route = { base: 'deps-rs', pattern: ':crate/:version?' }
+  static route = { base: 'deps-rs', pattern: ':crate/:version' }
 
   static openApi = {
-    '/deps-rs/{crate}': {
+    '/deps-rs/{crate}/latest': {
       get: {
-        summary: 'Deps.rs Crate Dependencies',
+        summary: 'Deps.rs Crate Dependencies (latest)',
         description,
         parameters: pathParams({
           name: 'crate',
@@ -18,7 +18,7 @@ export default class DepsRsCrate extends BaseDepsRsService {
     },
     '/deps-rs/{crate}/{version}': {
       get: {
-        summary: 'Deps.rs Crate Dependencies (version)',
+        summary: 'Deps.rs Crate Dependencies (specific version)',
         description,
         parameters: pathParams(
           {

--- a/services/deps-rs/deps-rs-crate.service.js
+++ b/services/deps-rs/deps-rs-crate.service.js
@@ -18,12 +18,8 @@ export default class DepsRsCrate extends BaseDepsRsService {
           },
           {
             name: 'version',
-            example: 'latest',
+            example: '2.0.101',
             description: 'Version number or "latest"',
-            schema: {
-              type: 'string',
-              examples: ['latest', '2.0.101', '1.0.0'],
-            },
           },
         ),
       },

--- a/services/deps-rs/deps-rs-crate.service.js
+++ b/services/deps-rs/deps-rs-crate.service.js
@@ -1,0 +1,45 @@
+import { pathParams } from '../index.js'
+import { BaseDepsRsService, description } from './deps-rs-base.js'
+
+export default class DepsRsCrate extends BaseDepsRsService {
+  static category = 'dependencies'
+  static route = { base: 'deps-rs', pattern: ':crate/:version?' }
+
+  static openApi = {
+    '/deps-rs/{crate}': {
+      get: {
+        summary: 'Deps.rs Crate Dependencies',
+        description,
+        parameters: pathParams({
+          name: 'crate',
+          example: 'syn',
+        }),
+      },
+    },
+    '/deps-rs/{crate}/{version}': {
+      get: {
+        summary: 'Deps.rs Crate Dependencies (version)',
+        description,
+        parameters: pathParams(
+          {
+            name: 'crate',
+            example: 'syn',
+          },
+          {
+            name: 'version',
+            example: '2.0.101',
+          },
+        ),
+      },
+    },
+  }
+
+  async handle({ crate, version }) {
+    const json = await this.fetchCrate({ crate, version })
+    return {
+      label: json.label,
+      message: json.message,
+      color: json.color,
+    }
+  }
+}

--- a/services/deps-rs/deps-rs-crate.service.js
+++ b/services/deps-rs/deps-rs-crate.service.js
@@ -6,28 +6,24 @@ export default class DepsRsCrate extends BaseDepsRsService {
   static route = { base: 'deps-rs', pattern: ':crate/:version' }
 
   static openApi = {
-    '/deps-rs/{crate}/latest': {
-      get: {
-        summary: 'Deps.rs Crate Dependencies (latest)',
-        description,
-        parameters: pathParams({
-          name: 'crate',
-          example: 'syn',
-        }),
-      },
-    },
     '/deps-rs/{crate}/{version}': {
       get: {
-        summary: 'Deps.rs Crate Dependencies (specific version)',
+        summary: 'Deps.rs Crate Dependencies',
         description,
         parameters: pathParams(
           {
             name: 'crate',
             example: 'syn',
+            description: 'The name of the Rust crate',
           },
           {
             name: 'version',
-            example: '2.0.101',
+            example: 'latest',
+            description: 'Version number or "latest"',
+            schema: {
+              type: 'string',
+              examples: ['latest', '2.0.101', '1.0.0'],
+            },
           },
         ),
       },

--- a/services/deps-rs/deps-rs-crate.service.js
+++ b/services/deps-rs/deps-rs-crate.service.js
@@ -6,9 +6,20 @@ export default class DepsRsCrate extends BaseDepsRsService {
   static route = { base: 'deps-rs', pattern: ':crate/:version' }
 
   static openApi = {
+    '/deps-rs/{crate}/latest': {
+      get: {
+        summary: 'Deps.rs Crate Dependencies (latest)',
+        description,
+        parameters: pathParams({
+          name: 'crate',
+          example: 'syn',
+          description: 'The name of the Rust crate',
+        }),
+      },
+    },
     '/deps-rs/{crate}/{version}': {
       get: {
-        summary: 'Deps.rs Crate Dependencies',
+        summary: 'Deps.rs Crate Dependencies (specific version)',
         description,
         parameters: pathParams(
           {
@@ -19,7 +30,7 @@ export default class DepsRsCrate extends BaseDepsRsService {
           {
             name: 'version',
             example: '2.0.101',
-            description: 'Version number or "latest"',
+            description: 'Version number',
           },
         ),
       },

--- a/services/deps-rs/deps-rs-crate.tester.js
+++ b/services/deps-rs/deps-rs-crate.tester.js
@@ -2,12 +2,14 @@ import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('dependencies (valid crate)').get('/syn.json').expectBadge({
-  label: 'dependencies',
-  message: Joi.string(),
-})
+t.create('dependencies (valid crate, latest version)')
+  .get('/syn/latest.json')
+  .expectBadge({
+    label: 'dependencies',
+    message: Joi.string(),
+  })
 
-t.create('dependencies (valid crate with version)')
+t.create('dependencies (valid crate with specific version)')
   .get('/syn/2.0.101.json')
   .expectBadge({
     label: 'dependencies',
@@ -15,5 +17,5 @@ t.create('dependencies (valid crate with version)')
   })
 
 t.create('dependencies (not found)')
-  .get('/not-a-real-package.json')
+  .get('/not-a-real-package/latest.json')
   .expectBadge({ label: 'dependencies', message: 'not found' })

--- a/services/deps-rs/deps-rs-crate.tester.js
+++ b/services/deps-rs/deps-rs-crate.tester.js
@@ -1,0 +1,19 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('dependencies (valid crate)').get('/syn.json').expectBadge({
+  label: 'dependencies',
+  message: Joi.string(),
+})
+
+t.create('dependencies (valid crate with version)')
+  .get('/syn/2.0.101.json')
+  .expectBadge({
+    label: 'dependencies',
+    message: Joi.string(),
+  })
+
+t.create('dependencies (not found)')
+  .get('/not-a-real-package.json')
+  .expectBadge({ label: 'dependencies', message: 'not found' })

--- a/services/deps-rs/deps-rs-repo.service.js
+++ b/services/deps-rs/deps-rs-repo.service.js
@@ -1,0 +1,39 @@
+import { pathParams } from '../index.js'
+import { BaseDepsRsService, description } from './deps-rs-base.js'
+
+export default class DepsRsRepo extends BaseDepsRsService {
+  static category = 'dependencies'
+  static route = { base: 'deps-rs/repo', pattern: ':site/:user/:repo' }
+
+  static openApi = {
+    '/deps-rs/repo/{site}/{user}/{repo}': {
+      get: {
+        summary: 'Deps.rs Repository Dependencies',
+        description,
+        parameters: pathParams(
+          {
+            name: 'site',
+            example: 'github',
+          },
+          {
+            name: 'user',
+            example: 'dtolnay',
+          },
+          {
+            name: 'repo',
+            example: 'syn',
+          },
+        ),
+      },
+    },
+  }
+
+  async handle({ site, user, repo }) {
+    const json = await this.fetchRepo({ site, user, repo })
+    return {
+      label: json.label,
+      message: json.message,
+      color: json.color,
+    }
+  }
+}

--- a/services/deps-rs/deps-rs-repo.tester.js
+++ b/services/deps-rs/deps-rs-repo.tester.js
@@ -1,0 +1,14 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('dependencies (valid repo)')
+  .get('/github/dtolnay/syn.json')
+  .expectBadge({
+    label: 'dependencies',
+    message: Joi.string(),
+  })
+
+t.create('dependencies (not found)')
+  .get('/github/not-a-real-user/not-a-real-repo.json')
+  .expectBadge({ label: 'dependencies', message: 'not found' })


### PR DESCRIPTION
Adds support for Deps.rs dependency status badges for Rust projects.

## New badges:
- `/deps-rs/{crate}/latest` - dependency status for latest version of crates
- `/deps-rs/{crate}/{version}` - dependency status for specific crate versions
- `/deps-rs/repo/{site}/{user}/{repo}` - dependency status for repositories

## Examples:
- `https://img.shields.io/deps-rs/syn/latest`
- `https://img.shields.io/deps-rs/syn/2.0.101`
- `https://img.shields.io/deps-rs/repo/github/dtolnay/syn`

Closes https://github.com/badges/shields/issues/7219