### PR TITLE
improve performance of lookup simple-icons

### DIFF
--- a/lib/load-simple-icons.js
+++ b/lib/load-simple-icons.js
@@ -1,7 +1,7 @@
 import * as originalSimpleIcons from 'simple-icons/icons'
 
 function loadSimpleIcons() {
-  const simpleIcons = {}
+  const simpleIcons = new Map()
   // As of v5 the exported keys are the svg slugs
   // Historically, Shields has supported logo specification via
   // name, name with spaces replaced by hyphens, and partially slugs
@@ -28,14 +28,14 @@ function loadSimpleIcons() {
     // Starting in v7, the exported object with the full icon set has updated the keys
     // to include a lowercase `si` prefix, and utilizes proper case naming conventions.
     if (!(`si${title}` in originalSimpleIcons)) {
-      simpleIcons[title.toLowerCase()] = icon
+      simpleIcons.set(title.toLowerCase(), icon)
     }
     const legacyTitle = title.replace(/ /g, '-')
     if (!(`si${legacyTitle}` in originalSimpleIcons)) {
-      simpleIcons[legacyTitle.toLowerCase()] = icon
+      simpleIcons.set(legacyTitle.toLowerCase(), icon)
     }
 
-    simpleIcons[slug] = icon
+    simpleIcons.set(slug, icon)
   })
   return simpleIcons
 }

--- a/lib/load-simple-icons.spec.js
+++ b/lib/load-simple-icons.spec.js
@@ -8,7 +8,7 @@ describe('loadSimpleIcons', function () {
   })
 
   it('prepares three color themes', function () {
-    expect(simpleIcons.sentry.styles).to.have.all.keys(
+    expect(simpleIcons.get('sentry').styles).to.have.all.keys(
       'default',
       'light',
       'dark',
@@ -19,22 +19,17 @@ describe('loadSimpleIcons', function () {
     // As of v5 of simple-icons the slug and exported key is `linuxfoundation`
     // with a name of `Linux Foundation`, so ensure we support both as well
     // as the legacy mapping of `linux-foundation` for backwards compatibility.
-    expect(simpleIcons).to.include.key('linuxfoundation')
-    expect(simpleIcons).to.include.key('linux foundation')
-    expect(simpleIcons).to.include.key('linux-foundation')
-  })
-
-  // https://github.com/badges/shields/issues/4016
-  it('excludes "get" function provided by the simple-icons', function () {
-    expect(simpleIcons).to.not.have.property('get')
+    expect(simpleIcons.has('linuxfoundation')).to.be.true
+    expect(simpleIcons.has('linux foundation')).to.be.true
+    expect(simpleIcons.has('linux-foundation')).to.be.true
   })
 
   it('maps overlapping icon titles correctly', function () {
     // Both of these icons have the same title: 'Hive', so make sure
     // the proper slugs are still mapped to the correct logo
-    expect(simpleIcons.hive.slug).to.equal('hive')
-    expect(simpleIcons.hive.title).to.equal('Hive')
-    expect(simpleIcons.hive_blockchain.slug).to.equal('hive_blockchain')
-    expect(simpleIcons.hive_blockchain.title).to.equal('Hive')
+    expect(simpleIcons.get('hive').slug).to.equal('hive')
+    expect(simpleIcons.get('hive').title).to.equal('Hive')
+    expect(simpleIcons.get('hive_blockchain').slug).to.equal('hive_blockchain')
+    expect(simpleIcons.get('hive_blockchain').title).to.equal('Hive')
   })
 })

--- a/lib/logos.js
+++ b/lib/logos.js
@@ -76,25 +76,27 @@ function getSimpleIconStyle({ icon, style }) {
 function getSimpleIcon({ name, color, style, size }) {
   const key = name.replace(/ /g, '-')
 
-  if (!(key in simpleIcons)) {
+  if (!simpleIcons.has(key)) {
     return undefined
   }
 
   let iconSvg
 
   const svgColor = toSvgColor(color)
+  const icon = simpleIcons.get(key)
+
   if (svgColor) {
-    iconSvg = simpleIcons[key].svg.replace('<svg', `<svg fill="${svgColor}"`)
+    iconSvg = icon.svg.replace('<svg', `<svg fill="${svgColor}"`)
   } else {
-    const iconStyle = getSimpleIconStyle({ icon: simpleIcons[key], style })
-    iconSvg = simpleIcons[key].styles[iconStyle]
+    const iconStyle = getSimpleIconStyle({ icon, style })
+    iconSvg = icon.styles[iconStyle]
   }
 
   if (size === 'auto') {
     const { width: iconWidth, height: iconHeight } = getIconSize(key)
 
     if (iconWidth !== iconHeight) {
-      const path = resetIconPosition(simpleIcons[key].path)
+      const path = resetIconPosition(icon.path)
       iconSvg = iconSvg
         .replace(
           'viewBox="0 0 24 24"',

--- a/lib/svg-helpers.js
+++ b/lib/svg-helpers.js
@@ -11,11 +11,11 @@ function svg2base64(svg) {
 }
 
 function getIconSize(iconKey) {
-  if (!(iconKey in simpleIcons)) {
+  if (!simpleIcons.has(iconKey)) {
     return undefined
   }
 
-  const [x0, y0, x1, y1] = svgPathBbox(simpleIcons[iconKey].path)
+  const [x0, y0, x1, y1] = svgPathBbox(simpleIcons.get(iconKey).path)
   return { width: x1 - x0, height: y1 - y0 }
 }
 


### PR DESCRIPTION
Map vs Object (real-world) Performance - https://measurethat.net/Benchmarks/Show/11290/4/map-vs-object-real-world-performance#latest_results_block

I also removed the outdated test for checking the `get` property from the `simpleIcons` object.