### PR TITLE
drop use-strict from badge-maker header

### DIFF
--- a/badge-maker/lib/badge-cli.spec.js
+++ b/badge-maker/lib/badge-cli.spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { spawn } from 'child-process-promise'

--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import anafanafo from 'anafanafo'
 import { brightness } from './color.js'
 import { XmlElement, ElementList } from './xml.js'

--- a/badge-maker/lib/color.js
+++ b/badge-maker/lib/color.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { fromString } from 'css-color-converter'
 
 // When updating these, be sure also to update the list in `badge-maker/README.md`.

--- a/badge-maker/lib/color.spec.js
+++ b/badge-maker/lib/color.spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { test, given, forCases } from 'sazerac'
 import { isHexColor, normalizeColor, toSvgColor, brightness } from './color.js'
 

--- a/badge-maker/lib/index.js
+++ b/badge-maker/lib/index.js
@@ -1,4 +1,3 @@
-'use strict'
 /**
  * @module badge-maker
  */

--- a/badge-maker/lib/index.spec.js
+++ b/badge-maker/lib/index.spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { expect } from 'chai'
 import { makeBadge, ValidationError } from './index.js'
 

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -1,5 +1,3 @@
-'use strict'
-
 import { test, given, forCases } from 'sazerac'
 import { expect } from 'chai'
 import snapshot from 'snap-shot-it'


### PR DESCRIPTION
The `'use strict'` is no longer needed since the package is ESM.