### PR TITLE
badge-maker: Fix ESM type exports

### DIFF
--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -16,6 +16,7 @@
     "image",
     "shields.io"
   ],
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/badges/shields.git",

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -2,7 +2,12 @@
   "name": "badge-maker",
   "version": "5.0.0",
   "type": "module",
-  "exports": "./lib/index.js",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js",
+      "types": "./index.d.ts"
+    }
+  },
   "description": "Shields.io badge library",
   "keywords": [
     "GitHub",
@@ -11,7 +16,6 @@
     "image",
     "shields.io"
   ],
-  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/badges/shields.git",


### PR DESCRIPTION
Fixes typescript definition export error:
> Could not find a declaration file for module 'badge-maker'. '…/node_modules/badge-maker/lib/index.js' implicitly has an 'any' type.
>  There are types at '…/node_modules/badge-maker/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'badge-maker' library may need to update its package.json or typings.

Because the `exports` field is present and tells tools to resolve `import 'badge-maker'` (the `"."` export) to `./lib/index.js` (for both require and import conditions), TypeScript follows that path. Since the `exports` for that specific entry point does not have a corresponding `"types"` condition pointing to .`./index.d.ts`, TypeScript fails to find the types via the `exports` map, even though it knows a type file exists elsewhere in the package.