### PR TITLE
badge-maker 5.0.1 release

### DIFF
--- a/badge-maker/CHANGELOG.md
+++ b/badge-maker/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.0.1
+
+### Bug Fixes
+
+- Fix ESM type exports
+
+### Other Changes
+
+- Drop use-strict from badge-maker header
+
 ## 5.0.0
 
 ### Breaking Changes

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badge-maker",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "type": "module",
   "exports": {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
       }
     },
     "badge-maker": {
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "CC0-1.0",
       "dependencies": {
         "anafanafo": "2.0.0",


### PR DESCRIPTION
* Fix ESM type exports
* drop use-strict from badge-maker header

Some minor changes, should remove unused code and solve a bug with type export.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
