### PR TITLE
badge-maker: fix exports so that it can also be required

### DIFF
--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -5,7 +5,8 @@
   "exports": {
     ".": {
       "import": "./lib/index.js",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./lib/index.js"
     }
   },
   "description": "Shields.io badge library",


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
Requiring ESM was ported back to version 20.19.0 of NodeJS, so this PR fixes the exports field so that you can do so. Only requirement is that there is no top-level await for it to work, which doesn't look like this package relies on anyway.

before
```bash
Welcome to Node.js v20.19.2.
Type ".help" for more information.
> require('badge-maker')
Uncaught:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /.../node_modules/badge-maker/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:322:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:613:13)
    at resolveExports (node:internal/modules/cjs/loader:636:36)
    at Module._findPath (node:internal/modules/cjs/loader:716:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1198:27)
    at Module._load (node:internal/modules/cjs/loader:1043:27)
    at Module.require (node:internal/modules/cjs/loader:1298:19)
    at require (node:internal/modules/helpers:182:18) {
  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
}
```

after
```bash
Welcome to Node.js v20.19.2.
Type ".help" for more information.
> require('badge-maker')
[Module: null prototype] {
  ValidationError: [class ValidationError extends Error],
  makeBadge: [Function: makeBadge]
}
```