### PR TITLE
Release badge-maker version 5.0.2

### DIFF
--- a/badge-maker/CHANGELOG.md
+++ b/badge-maker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 5.0.2
+
+### Bug Fixes
+
+- Fix export for require
+
 ## 5.0.1
 
 ### Bug Fixes

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badge-maker",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "type": "module",
   "exports": {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,7 @@
       }
     },
     "badge-maker": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "CC0-1.0",
       "dependencies": {
         "anafanafo": "2.0.0",


### PR DESCRIPTION
Update the version to 5.0.2 to release a bugfix for issue using require with current export (see #11181).