### PR TITLE
use simple-icons main export entry

### DIFF
--- a/lib/load-simple-icons.js
+++ b/lib/load-simple-icons.js
@@ -1,4 +1,4 @@
-import * as originalSimpleIcons from 'simple-icons/icons'
+import * as originalSimpleIcons from 'simple-icons'
 
 function loadSimpleIcons() {
   const simpleIcons = new Map()


### PR DESCRIPTION
See https://github.com/simple-icons/simple-icons/issues/13520.

We're planning to deprecate the `import from 'simple-icons/icons'` entry since it's doing the same thing as `import from 'simple-icons'`.

