### PR TITLE
adjust import conditions

### DIFF
--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -4,8 +4,8 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/index.js",
       "types": "./index.d.ts",
+      "import": "./lib/index.js",
       "default": "./lib/index.js"
     }
   },


### PR DESCRIPTION
According to the https://nodejs.org/api/packages.html#community-conditions-definitions recommended. We'd better to move the `types` condition to the top.