### PR TITLE
chore(deps): bump webextension-store-meta from 1.2.4 to 1.2.5; test [chromewebstore]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "smol-toml": "1.3.4",
         "svg-path-bbox": "^2.1.0",
         "svgpath": "^2.6.0",
-        "webextension-store-meta": "^1.2.4",
+        "webextension-store-meta": "^1.2.5",
         "xpath": "~0.0.34"
       },
       "devDependencies": {
@@ -33777,9 +33777,9 @@
       }
     },
     "node_modules/webextension-store-meta": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.4.tgz",
-      "integrity": "sha512-cyFEPs277pjm3FgLbfAzRxr7LkVKw5fzQmO/wcXN7i7/03nnMcB24OjVyot+ZT0OWknLsHs5ef6jlWzoK9A2tA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.5.tgz",
+      "integrity": "sha512-F2/QdKwZYfauXaDZ2yALgqAvEnkcjGEigw1Xx/W40MA2GRySF3yu9uvkMkPugRCSS+mMaSZOL9RRiJR3khuESw==",
       "license": "MIT",
       "dependencies": {
         "domhandler": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "smol-toml": "1.3.4",
     "svg-path-bbox": "^2.1.0",
     "svgpath": "^2.6.0",
-    "webextension-store-meta": "^1.2.4",
+    "webextension-store-meta": "^1.2.5",
     "xpath": "~0.0.34"
   },
   "scripts": {


### PR DESCRIPTION
fix https://github.com/badges/shields/issues/11193