### PR TITLE
chore(deps): bump simple-icons from 15.2.0 to 15.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "query-string": "^9.2.1",
         "re2": "^1.22.1",
         "semver": "~7.7.2",
-        "simple-icons": "15.2.0",
+        "simple-icons": "15.5.0",
         "smol-toml": "1.3.4",
         "svg-path-bbox": "^2.1.0",
         "svgpath": "^2.6.0",
@@ -30261,9 +30261,9 @@
       }
     },
     "node_modules/simple-icons": {
-      "version": "15.2.0",
-      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-15.2.0.tgz",
-      "integrity": "sha512-g36ByZgkbd1VIP7RTGhBXVLqrPFtwfcKISA1r+sx3rEhrNJBAaEMrAVo/gOJm6DqlCd8YyKWl85g5z4nXngObA==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-15.5.0.tgz",
+      "integrity": "sha512-6Q8dz2aDi6I65TiUGVdxYfWXjoSwWgTCFX6pwsf1dPrlH8dewcn9gqrcZv7MwuPTN76m9HlDrKKobkDoX8YIHQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "query-string": "^9.2.1",
     "re2": "^1.22.1",
     "semver": "~7.7.2",
-    "simple-icons": "15.2.0",
+    "simple-icons": "15.5.0",
     "smol-toml": "1.3.4",
     "svg-path-bbox": "^2.1.0",
     "svgpath": "^2.6.0",


### PR DESCRIPTION
Added due to requests in #11143 to update so latest icons are deployed.
Note to self, there is an API change in 15.5.0 that I might need to consider at #10955
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
