### PR TITLE
fix: test-bug-run-badge workflow link extraction

### DIFF
--- a/.github/workflows/test-bug-run-badge.yml
+++ b/.github/workflows/test-bug-run-badge.yml
@@ -17,7 +17,7 @@ jobs:
           ISSUE_BODY: '${{ github.event.issue.body }}'
         run: |
           product=$(echo "$ISSUE_BODY" | grep -A2 "Are you experiencing an issue with.*" | tail -n 1)
-          link=$(echo "$ISSUE_BODY" | grep -A2 "Link to the badge.*" | tail -n 1)
+          link=$(echo "$ISSUE_BODY" | grep -A2 "### 🔗 Link to the badge" | tail -n 1 | grep -oE 'https://img\.shields\.io[^\S)]+')
 
           if [[ "$product" == "shields.io" && "$link" == "https://img.shields.io"* ]]; then
             echo "runNext=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Make sure the link extraction is more generic and can handle extraction of links inside a markdown image format.

Fixes #11217

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
