### PR TITLE
increase [SourceforgeDownloads] cache time

### DIFF
--- a/services/sourceforge/sourceforge-downloads.service.js
+++ b/services/sourceforge/sourceforge-downloads.service.js
@@ -67,7 +67,7 @@ export default class SourceforgeDownloads extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 300
+  static _cacheLength = 2400
 
   static defaultBadgeData = { label: 'sourceforge' }
 


### PR DESCRIPTION
In the last two weeks we started hitting the rate limit for this endpoint with 1k 429 events.

I could not find any rate limit, and the api has no auth or quata we can discuss.

Therefor this change increase cache from the default 120 to 300.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
