### PR TITLE
remove chris48s from maintainer team in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,13 @@ You can read more about [the project's inception][thread],
 Maintainers:
 
 - [calebcartwright](https://github.com/calebcartwright)
-- [chris48s](https://github.com/chris48s)
 - [jNullj](https://github.com/jnullj)
 - [paulmelnikow](https://github.com/paulmelnikow)
 - [PyvesB](https://github.com/PyvesB)
 
 Alumni:
 
+- [chris48s](https://github.com/chris48s)
 - [Daniel15](https://github.com/Daniel15)
 - [espadrine](https://github.com/espadrine)
 - [olivierlacan](https://github.com/olivierlacan)

--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -3,7 +3,7 @@
 Production hosting is managed by the Shields ops team:
 
 - [calebcartwright](https://github.com/calebcartwright)
-- [chris48s](https://github.com/chris48s)
+- [jNullj](https://github.com/jnullj)
 - [paulmelnikow](https://github.com/paulmelnikow)
 - [PyvesB](https://github.com/PyvesB)
 


### PR DESCRIPTION
I've left mentions of myself in the table in
https://github.com/badges/shields/blob/master/doc/production-hosting.md
as I do still have access to those systems but feel free to remove me as and when access is revoked