### PR TITLE
chore: use the modern labels API for draft release action

### DIFF
--- a/.github/actions/draft-release/entrypoint.sh
+++ b/.github/actions/draft-release/entrypoint.sh
@@ -59,7 +59,10 @@ PR_RESP=$(curl https://api.github.com/repos/"$REPO_NAME"/pulls \
 
 # Add the 'release' label to the PR
 PR_API_URL=$(echo "$PR_RESP" | jq -r ._links.issue.href)
-curl "$PR_API_URL" \
-    -X POST \
-    -H "Authorization: token $GITHUB_TOKEN" \
-    --data '{"labels":["release"]}'
+curl -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "$PR_API_URL/labels" \
+  -d '{"labels":["release"]}'


### PR DESCRIPTION
Related to https://github.com/badges/shields/pull/11256

The script requested the `POST /repos/badges/shields/issues/11256` API successfully, but no label change.

Not sure if it's an API-related or permission-related issue. This PR is an approach to see if we can fix the updating label process by changing the endpoint.