### PR TITLE
docs: add note to [GithubContributors] about co-authors limitations

### DIFF
--- a/services/github/github-contributors.service.js
+++ b/services/github/github-contributors.service.js
@@ -8,10 +8,10 @@ import { documentation, httpErrorsFor } from './github-helpers.js'
 // All we do is check its length.
 const schema = Joi.array().items(Joi.object())
 
-const descriptionWithNote = `${documentation}
-
-Note: Co-authors are not included in the count due to endpoint limitations.
-`
+const documentationWithNote = [
+  documentation,
+  'Note: Co-authors are not included in the count due to endpoint limitations.',
+].join('\n\n')
 
 export default class GithubContributors extends GithubAuthV3Service {
   static category = 'activity'
@@ -26,7 +26,7 @@ export default class GithubContributors extends GithubAuthV3Service {
     '/github/{metric}/{user}/{repo}': {
       get: {
         summary: 'GitHub contributors',
-        description: descriptionWithNote,
+        description: documentationWithNote,
         parameters: pathParams(
           {
             name: 'metric',

--- a/services/github/github-contributors.service.js
+++ b/services/github/github-contributors.service.js
@@ -8,6 +8,11 @@ import { documentation, httpErrorsFor } from './github-helpers.js'
 // All we do is check its length.
 const schema = Joi.array().items(Joi.object())
 
+const descriptionWithNote = `${documentation}
+
+Note: Co-authors are not included in the count due to endpoint limitations.
+`
+
 export default class GithubContributors extends GithubAuthV3Service {
   static category = 'activity'
   static route = {
@@ -21,7 +26,7 @@ export default class GithubContributors extends GithubAuthV3Service {
     '/github/{metric}/{user}/{repo}': {
       get: {
         summary: 'GitHub contributors',
-        description: documentation,
+        description: descriptionWithNote,
         parameters: pathParams(
           {
             name: 'metric',


### PR DESCRIPTION
Found at #11244 that the endpoint does not include co-auth contriboturs.
We should clearly state that in the badge's page to avoid confusion.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
