### PR TITLE
chore: replace `css-color-converter` with `color`

### DIFF
--- a/badge-maker/README.md
+++ b/badge-maker/README.md
@@ -102,6 +102,7 @@ There are three ways to specify `color` and `labelColor`:
 
 - `rgb(...)`, `rgba(...)`
 - `hsl(...)`, `hsla(...)`
+- `hwb(...)`
 - ![][aqua] ![][fuchsia] ![][lightslategray] etc.
 
 [brightgreen]: https://img.shields.io/badge/brightgreen-brightgreen.svg

--- a/badge-maker/lib/color.js
+++ b/badge-maker/lib/color.js
@@ -1,4 +1,4 @@
-import { fromString } from 'css-color-converter'
+import colour from 'color'
 
 // When updating these, be sure also to update the list in `badge-maker/README.md`.
 export const namedColors = {
@@ -35,24 +35,38 @@ export function isHexColor(s = '') {
   return hexColorRegex.test(s)
 }
 
-function isCSSColor(color) {
-  return typeof color === 'string' && fromString(color.trim())
+function getCssColor(color) {
+  if (typeof color !== 'string') return undefined
+  try {
+    const cssColor = colour(color.trim())
+    return cssColor
+  } catch (error) {
+    console.error(color, error)
+    return undefined
+  }
 }
 
 export function normalizeColor(color) {
   if (color === undefined) {
     return undefined
-  } else if (color in namedColors) {
-    return color
-  } else if (color in aliases) {
-    return aliases[color]
-  } else if (isHexColor(color)) {
-    return `#${color.toString().toLowerCase()}`
-  } else if (isCSSColor(color)) {
-    return color.toLowerCase()
-  } else {
-    return undefined
   }
+  if (color in namedColors) {
+    return color
+  }
+  if (color in aliases) {
+    return aliases[color]
+  }
+  if (isHexColor(color)) {
+    return `#${color.toString().toLowerCase()}`
+  }
+  const cssColor = getCssColor(color)
+  if (cssColor) {
+    if (color.startsWith('hwb(')) {
+      return cssColor.hwb().string()
+    }
+    return color.toLowerCase()
+  }
+  return undefined
 }
 
 export function toSvgColor(color) {
@@ -67,12 +81,14 @@ export function toSvgColor(color) {
 }
 
 export function brightness(color) {
-  if (color) {
-    const cssColor = fromString(color)
+  if (!color) return 0
+  try {
+    const cssColor = colour(color)
+
     if (cssColor) {
-      const rgb = cssColor.toRgbaArray()
+      const rgb = cssColor.rgb().array()
       return +((rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 255000).toFixed(2)
     }
-  }
+  } catch {}
   return 0
 }

--- a/badge-maker/lib/color.spec.js
+++ b/badge-maker/lib/color.spec.js
@@ -33,20 +33,23 @@ test(normalizeColor, () => {
   given('rgb(100%, 200%, 222%)').expect('rgb(100%, 200%, 222%)')
   given('rgb(122, 200, 222)').expect('rgb(122, 200, 222)')
   given('rgb(122, 200, 222, 1)').expect('rgb(122, 200, 222, 1)')
+  given('rgb(-100, 20, 111)').expect('rgb(-100, 20, 111)')
+  given('rgba(-100, 20, 111, 1.1)').expect('rgba(-100, 20, 111, 1.1)')
   given('rgba(100, 20, 111, 1)').expect('rgba(100, 20, 111, 1)')
   given('hsl(122, 200%, 222%)').expect('hsl(122, 200%, 222%)')
   given('hsla(122, 200%, 222%, 1)').expect('hsla(122, 200%, 222%, 1)')
+  given('hwb(122, 200%, 222%)').expect('hwb(122, 100%, 100%)')
+  given('hwb(122, 200%, 222%, 1)').expect('hwb(122, 100%, 100%)')
   forCases([
     given(),
     given(''),
     given('not-a-color'),
     given('#ABCFGH'),
-    given('rgb(-100, 20, 111)'),
     given('rgb(100%, 200, 222)'),
-    given('rgba(-100, 20, 111, 1.1)'),
     given('hsl(122, 200, 222, 1)'),
     given('hsl(122, 200, 222)'),
     given('hsl(122, 200, 222%)'),
+    given('hwba(122, 200%, 222, 1)'),
     given(undefined),
     given(null),
     given(true),

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "anafanafo": "2.0.0",
-    "css-color-converter": "^2.0.0"
+    "color": "^5.0.3"
   },
   "scripts": {
     "test": "echo 'Run tests from parent dir'; false"

--- a/core/base-service/openapi.js
+++ b/core/base-service/openapi.js
@@ -135,7 +135,7 @@ function category2openapi({ category, services, sort = false }) {
           in: 'query',
           required: false,
           description:
-            'The color of the logo (hex, rgb, rgba, hsl, hsla and css named colors supported). Supported for simple-icons logos but not for custom logos.',
+            'The color of the logo (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported). Supported for simple-icons logos but not for custom logos.',
           schema: {
             type: 'string',
           },
@@ -168,7 +168,7 @@ function category2openapi({ category, services, sort = false }) {
           in: 'query',
           required: false,
           description:
-            'Background color of the left part (hex, rgb, rgba, hsl, hsla and css named colors supported).',
+            'Background color of the left part (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported).',
           schema: {
             type: 'string',
           },
@@ -179,7 +179,7 @@ function category2openapi({ category, services, sort = false }) {
           in: 'query',
           required: false,
           description:
-            'Background color of the right part (hex, rgb, rgba, hsl, hsla and css named colors supported).',
+            'Background color of the right part (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported).',
           schema: {
             type: 'string',
           },

--- a/core/base-service/openapi.spec.js
+++ b/core/base-service/openapi.spec.js
@@ -88,7 +88,7 @@ const expected = {
         in: 'query',
         required: false,
         description:
-          'The color of the logo (hex, rgb, rgba, hsl, hsla and css named colors supported). Supported for simple-icons logos but not for custom logos.',
+          'The color of the logo (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported). Supported for simple-icons logos but not for custom logos.',
         schema: { type: 'string' },
         example: 'violet',
       },
@@ -117,7 +117,7 @@ const expected = {
         in: 'query',
         required: false,
         description:
-          'Background color of the left part (hex, rgb, rgba, hsl, hsla and css named colors supported).',
+          'Background color of the left part (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported).',
         schema: { type: 'string' },
         example: 'abcdef',
       },
@@ -126,7 +126,7 @@ const expected = {
         in: 'query',
         required: false,
         description:
-          'Background color of the right part (hex, rgb, rgba, hsl, hsla and css named colors supported).',
+          'Background color of the right part (hex, rgb, rgba, hsl, hsla, hwb and css named colors supported).',
         schema: { type: 'string' },
         example: 'fedcba',
       },

--- a/frontend/docs/logos.md
+++ b/frontend/docs/logos.md
@@ -20,7 +20,7 @@ Any custom logo can be passed in a URL parameter by base64 encoding it. e.g:
 
 ## logoColor parameter
 
-The `logoColor` param can be used to set the color of the SimpleIcons named logo. Hex, rgb, rgba, hsl, hsla and css named colors can all be used.
+The `logoColor` param can be used to set the color of the SimpleIcons named logo. Hex, rgb, rgba, hsl, hsla, hwb and css named colors can all be used.
 
 - ![](https://img.shields.io/badge/logo-javascript-blue?logo=javascript) - https://img.shields.io/badge/logo-javascript-blue?logo=javascript
 - ![](https://img.shields.io/badge/logo-javascript-blue?logo=javascript&logoColor=f5f5f5) - https://img.shields.io/badge/logo-javascript-blue?logo=javascript&logoColor=f5f5f5

--- a/package-lock.json
+++ b/package-lock.json
@@ -124,7 +124,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "anafanafo": "2.0.0",
-        "css-color-converter": "^2.0.0"
+        "color": "^5.0.3"
       },
       "bin": {
         "badge": "lib/badge-cli.js"
@@ -11103,6 +11103,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -11117,6 +11130,48 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -11800,26 +11855,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/css-color-converter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-converter/-/css-color-converter-2.0.0.tgz",
-      "integrity": "sha512-oLIG2soZz3wcC3aAl/7Us5RS8Hvvc6I8G8LniF/qfMmrm7fIKQ8RIDDRZeKyGL2SrWfNqYspuLShbnjBMVWm8g==",
-      "dependencies": {
-        "color-convert": "^0.5.2",
-        "color-name": "^1.1.4",
-        "css-unit-converter": "^1.1.2"
-      }
-    },
-    "node_modules/css-color-converter/node_modules/color-convert": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-      "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
-    },
-    "node_modules/css-color-converter/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "node_modules/css-declaration-sorter": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
@@ -12030,11 +12065,6 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
-    },
-    "node_modules/css-unit-converter": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
     },
     "node_modules/css-what": {
       "version": "6.1.0",

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -56,7 +56,7 @@ The endpoint badge takes a single required query param: <code>url</code>, which 
         <td><code>color</code></td>
         <td>
           Default: <code>lightgrey</code>. The right color. Supports the eight
-          named colors above, as well as hex, rgb, rgba, hsl, hsla and css named
+          named colors above, as well as hex, rgb, rgba, hsl, hsla, hwb, and css named
           colors. This can be overridden by the query string.
         </td>
       </tr>

--- a/services/static-badge/static-badge.service.js
+++ b/services/static-badge/static-badge.service.js
@@ -54,7 +54,7 @@ Examples of additional options:
   </li>
 </ul>
 
-<i>Hex, rgb, rgba, hsl, hsla and css named colors may be used. <b>Note:</b> Some named colors may differ from CSS color values. For a list of named colors, see the <a href="https://github.com/badges/shields/tree/master/badge-maker#colors" target="_blank">badge-maker readme</a>.</i>
+<i>Hex, rgb, rgba, hsl, hsla, hwb and css named colors may be used. For a list of named colors, see the <a href="https://github.com/badges/shields/tree/master/badge-maker#colors" target="_blank">badge-maker readme</a>.</i>
 `
 
 export default class StaticBadge extends BaseStaticService {


### PR DESCRIPTION
It looks like the `css-color-converter` is lacking maintenance. Here I replaced the [`css-color-converter`](https://npmjs.com/css-color-converter) with the [`color`](https://npmjs.com/color) library. The `color` library is pure ESM and more modern.

I'm also the maintainer of the `color` projects ([`color`](https://github.com/Qix-/color), [`color-convert`](https://github.com/Qix-/color-convert), [`color-string`](https://github.com/Qix-/color-string)). And the author of the `color` project [Qix-](https://github.com/Qix-) is also the maintainer of the most popular ANSI color library - [Chalk](https://github.com/chalk/chalk).

Here are some slight differences between `color` and `css-color-converter`:

||`color`|`css-color-converter`|
|:-:|:-:|:-:|
|rgb|Yes|Yes|
|rgba|Yes|Yes|
|hsl|Yes|Yes|
|hsla|Yes|Yes|
|CSS keywords|Yes|Yes|
|Hex colors|Yes|Yes|
|hwb|Yes|No|
|Negative values|Yes|No|

I've updated the documentation for the new HWB support.

There are some unrelated changes because Prettier reported some code style problems while running `npm test`. I've fixed them with `npx pretter --write .`.