### PR TITLE
increase cache length for [VisualStudioMarketplace]

### DIFF
--- a/services/visual-studio-marketplace/visual-studio-marketplace-base.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-base.js
@@ -52,6 +52,12 @@ const statisticSchema = Joi.object().keys({
 })
 
 export default class VisualStudioMarketplaceBase extends BaseJsonService {
+  static get _cacheLength() {
+    // we reached rate limit, insted of fine tune for each service
+    // we add a multipler to the default category cache length
+    return Math.floor(super._cacheLength * 1.2)
+  }
+
   static defaultBadgeData = {
     label: 'vs marketplace',
     color: 'blue',


### PR DESCRIPTION
We get for some time 429 from vs marketplace.
To handle this without fine tune to every marketplace service I introduced a new cache scale for all vs marketplace services.

I picked 1.2 as cache time scale as we hit in the last 24h about 407k requests and had about 47k 429 errors.
1.2 seems like a good balance that still gives us a bit of headroom but also does not increase the cache time by too much.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
