### PR TITLE
[GitlabGoModGoVersion] add GitLab go.mod Go version service

### DIFF
--- a/services/gitlab/gitlab-go-mod.service.js
+++ b/services/gitlab/gitlab-go-mod.service.js
@@ -1,0 +1,137 @@
+import Joi from 'joi'
+import { renderVersionBadge } from '../version.js'
+import { InvalidResponse, pathParam, queryParam } from '../index.js'
+import { description, httpErrorsFor } from './gitlab-helper.js'
+import GitLabBase from './gitlab-base.js'
+
+const queryParamSchema = Joi.object({
+  filename: Joi.string(),
+  gitlabUrl: Joi.string(),
+}).required()
+
+const goVersionRegExp = /^go ([^/\s]+)(\s*\/.+)?$/m
+
+const filenameDescription =
+  'The `filename` param can be used to specify the path to `go.mod`. By default, we look for `go.mod` in the repo root'
+
+export default class GitlabGoModGoVersion extends GitLabBase {
+  static category = 'platform-support'
+  static route = {
+    base: 'gitlab/go-mod/go-version',
+    pattern: ':user/:repo/:branch*',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/gitlab/go-mod/go-version/{user}/{repo}': {
+      get: {
+        summary: 'GitLab go.mod Go version',
+        description,
+        parameters: [
+          pathParam({
+            name: 'user',
+            example: 'gitlab-org',
+          }),
+          pathParam({
+            name: 'repo',
+            example: 'gitlab-runner',
+          }),
+          queryParam({
+            name: 'filename',
+            example: 'src/go.mod',
+            description: filenameDescription,
+          }),
+          queryParam({
+            name: 'gitlabUrl',
+            example: 'https://gitlab.example.com',
+          }),
+        ],
+      },
+    },
+    '/gitlab/go-mod/go-version/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'GitLab go.mod Go version (branch)',
+        description,
+        parameters: [
+          pathParam({
+            name: 'user',
+            example: 'gitlab-org',
+          }),
+          pathParam({
+            name: 'repo',
+            example: 'gitlab-runner',
+          }),
+          pathParam({
+            name: 'branch',
+            example: 'main',
+          }),
+          queryParam({
+            name: 'filename',
+            example: 'src/go.mod',
+            description: filenameDescription,
+          }),
+          queryParam({
+            name: 'gitlabUrl',
+            example: 'https://gitlab.example.com',
+          }),
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'Go' }
+
+  static render({ version, branch }) {
+    return renderVersionBadge({
+      version,
+      tag: branch,
+      defaultLabel: 'Go',
+    })
+  }
+
+  async fetch({ user, repo, branch, filename, gitlabUrl }) {
+    const project = `${user}/${repo}`
+    // https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
+    const url = `${gitlabUrl}/api/v4/projects/${encodeURIComponent(
+      project,
+    )}/repository/files/${encodeURIComponent(filename)}/raw`
+    const options = { searchParams: { ref: branch || 'HEAD' } }
+    const httpErrors = httpErrorsFor('project or file not found')
+    const { buffer } = await this._request(
+      this.authHelper.withBearerAuthHeader({
+        url,
+        options,
+        httpErrors,
+      }),
+    )
+    return buffer
+  }
+
+  static transform(content) {
+    const match = goVersionRegExp.exec(content)
+    if (!match) {
+      throw new InvalidResponse({
+        prettyMessage: 'Go version missing in go.mod',
+      })
+    }
+
+    return {
+      go: match[1],
+    }
+  }
+
+  async handle(
+    { user, repo, branch },
+    { filename = 'go.mod', gitlabUrl = 'https://gitlab.com' },
+  ) {
+    const content = await this.fetch({
+      user,
+      repo,
+      branch,
+      filename,
+      gitlabUrl,
+    })
+    const { go } = this.constructor.transform(content.toString())
+    return this.constructor.render({ version: go, branch })
+  }
+}

--- a/services/gitlab/gitlab-go-mod.tester.js
+++ b/services/gitlab/gitlab-go-mod.tester.js
@@ -1,0 +1,29 @@
+import { isVPlusDottedVersionAtLeastOne } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+const user = 'gitlab-org'
+const repo = 'gitlab-runner'
+
+t.create('go version in root')
+  .get(`/${user}/${repo}.json`)
+  .expectBadge({ label: 'Go', message: isVPlusDottedVersionAtLeastOne })
+
+t.create('go version in root (branch)')
+  .get(`/${user}/${repo}/main.json`)
+  .expectBadge({ label: 'Go@main', message: isVPlusDottedVersionAtLeastOne })
+
+t.create('project not found')
+  .get('/some-project/that-doesnt-exist.json')
+  .expectBadge({ label: 'Go', message: 'project or file not found' })
+
+t.create('go version in subdirectory')
+  .get(`/${user}/${repo}/main.json?filename=helpers/runner_wrapper/api/go.mod`)
+  .expectBadge({
+    label: 'Go@main',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
+t.create('file not found')
+  .get(`/${user}/${repo}/main.json?filename=nonexistent/go.mod`)
+  .expectBadge({ label: 'Go', message: 'project or file not found' })


### PR DESCRIPTION
This adds a new service that works the same way as the github-go-mod service but with GitLab. The service will get the go version from the go.mod file in the specified project.

- Tests have been added to work with a stable project ([GitLab Runner](https://gitlab.com/gitlab-org/gitlab-runner)).
- Code has been formatted with prettier.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
