### PR TITLE
devop: enable auto concurrency for eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "coverage:report:generate": "c8 report",
     "coverage:report:open": "open-cli coverage/lcov-report/index.html",
     "coverage:report": "run-s --silent coverage:report:generate coverage:report:open",
-    "lint": "eslint \"**/*.@(cjs|mjs|js|ts)\"",
+    "lint": "eslint --concurrency auto \"**/*.@(cjs|mjs|js|ts)\"",
     "prettier": "prettier --write \"**/*.@(cjs|mjs|js|ts|md|json|yml)\"",
     "prettier:check": "prettier --check \"**/*.@(cjs|mjs|js|ts|md|json|yml)\"",
     "danger": "danger",
@@ -127,7 +127,7 @@
   },
   "lint-staged": {
     "**/*.@(cjs|mjs|js|ts)": [
-      "eslint --fix",
+      "eslint --fix --concurrency auto",
       "prettier --write"
     ],
     "**/*.@(md|json|yml)": [


### PR DESCRIPTION
As posted in [recent blog post](https://eslint.org/blog/2025/08/multithread-linting/)
The recently version we upgraded to of eslint 9.34.0 supports now multi threading.

On my local machine i did see some boost to linter run time.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
