### PR TITLE
docs: instruct to rename label to service name at deprecation

### DIFF
--- a/doc/deprecating-badges.md
+++ b/doc/deprecating-badges.md
@@ -11,7 +11,11 @@ Deprecating a badge involves two steps:
 
 Locate the source file(s) for the service, which can be found in `*.service.js` files located within the directory for the service (`./services/:service-name/`) such as `./services/imagelayers/imagelayers.service.js`.
 
-Replace the existing service class implementation with the `DeprecatedService` class from `./core/base-service/deprecated-service.js` using the respective `category`, `route`, and `label` values for that service. For example:
+Replace the existing service class implementation with the `DeprecatedService` class from `./core/base-service/deprecated-service.js` using the respective `category`, `route`, and `label` values for that service.
+
+Set the badge label to the service name. This ensures users can immediately identify which service is no longer available at a glance.
+
+For example:
 
 ```js
 import { deprecatedService } from '../index.js'


### PR DESCRIPTION
Follow up for #11321 .
As discussed at https://github.com/badges/shields/pull/11321#discussion_r2314395170

After the merge open issue about deprecated services that does not follow updated docs:
- ansible-*
- chrome-web-store-price
- github-workflow-status
- pub-popularity
- synk-vulnerability-*
- tas-tests

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
