### PR TITLE
Switch Dependadot to monthly update schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
@@ -16,6 +16,8 @@ updates:
       # https://caniuse.com/js-regexp-lookbehind
       - dependency-name: 'decamelize'
       - dependency-name: 'humanize-string'
+      # simple-icons is handled by separate weekly schedule below
+      - dependency-name: 'simple-icons'
     groups:
       # All official @docusaurus/* packages should have the exact same version as @docusaurus/core.
       # From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups:
@@ -30,11 +32,24 @@ updates:
         applies-to: security-updates
         patterns:
           - '@docusaurus/*'
+
+  # simple-icons package - weekly updates
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: friday
+      time: '12:00'
+    allow:
+      - dependency-name: 'simple-icons'
+    open-pull-requests-limit: 99
+    rebase-strategy: disabled
+
   # badge-maker package dependencies
   - package-ecosystem: npm
     directory: '/badge-maker'
     schedule:
-      interval: weekly
+      interval: monthly
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99
@@ -52,7 +67,7 @@ updates:
       - '/.github/actions/service-tests'
       - '/.github/actions/setup'
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 99
     rebase-strategy: disabled
 
@@ -60,7 +75,7 @@ updates:
   - package-ecosystem: npm
     directory: '/.github/actions/docusaurus-swizzled-warning'
     schedule:
-      interval: weekly
+      interval: monthly
       day: friday
       time: '12:00'
     open-pull-requests-limit: 99


### PR DESCRIPTION
Dealing with Dependabot updates adds overhead, a luxury we cannot afford given our current lack of active project maintainers. The vast majority of updates has virtually no benefit to Shields.io (read "fix typo in doc", "add new exotic parameter", "refactor methods", etc.). Switching to a monthly update cadence will help bundle updates together for packages that are frequently updated, reducing the overall number of update PRs we need to deal with.

I've kept the weekly schedule for simple-icons, as users are generally eager to get the new icons available quickly (example in #11143). Goes without being said, if we need to to urgently update a package outside the monthly cadence, we can do so manually as required.
