### PR TITLE
Fix [Hangar] tests

### DIFF
--- a/services/hangar/hangar-downloads.tester.js
+++ b/services/hangar/hangar-downloads.tester.js
@@ -7,7 +7,7 @@ t.create('Essentials').get('/Essentials.json').expectBadge({
   message: isMetric,
 })
 
-t.create('Invalid Resource').get('/1.json').expectBadge({
+t.create('Invalid Resource').get('/does-not-exist.json').expectBadge({
   label: 'downloads',
   message: 'not found',
 })

--- a/services/hangar/hangar-stars.tester.js
+++ b/services/hangar/hangar-stars.tester.js
@@ -7,7 +7,7 @@ t.create('Essentials').get('/Essentials.json').expectBadge({
   message: isMetric,
 })
 
-t.create('Invalid Resource').get('/1.json').expectBadge({
+t.create('Invalid Resource').get('/does-not-exist.json').expectBadge({
   label: 'stars',
   message: 'not found',
 })

--- a/services/hangar/hangar-views.tester.js
+++ b/services/hangar/hangar-views.tester.js
@@ -7,7 +7,7 @@ t.create('Essentials').get('/Essentials.json').expectBadge({
   message: isMetric,
 })
 
-t.create('Invalid Resource').get('/1.json').expectBadge({
+t.create('Invalid Resource').get('/does-not-exist.json').expectBadge({
   label: 'views',
   message: 'not found',
 })

--- a/services/hangar/hangar-watchers.tester.js
+++ b/services/hangar/hangar-watchers.tester.js
@@ -7,7 +7,7 @@ t.create('Essentials').get('/Essentials.json').expectBadge({
   message: isMetric,
 })
 
-t.create('Invalid Resource').get('/1.json').expectBadge({
+t.create('Invalid Resource').get('/does-not-exist.json').expectBadge({
   label: 'watchers',
   message: 'not found',
 })


### PR DESCRIPTION
Looks like `1` has become a valid plugin name in the meantime.