### PR TITLE
Drop popout style fallback

### DIFF
--- a/badge-maker/lib/index.spec.js
+++ b/badge-maker/lib/index.spec.js
@@ -94,12 +94,6 @@ describe('makeBadge function', function () {
       'Field `style` must be one of (plastic,flat,flat-square,for-the-badge,social)',
     )
     expect(() =>
-      makeBadge({ label: 'build', message: 'passed', style: 'popout' }),
-    ).to.throw(
-      ValidationError,
-      'Field `style` must be one of (plastic,flat,flat-square,for-the-badge,social)',
-    )
-    expect(() =>
       makeBadge({ label: 'build', message: 'passed', idSuffix: '\\' }),
     ).to.throw(
       ValidationError,

--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -93,12 +93,6 @@ export default function coalesceBadge(
   } = defaultBadgeData
 
   let style = coalesce(overrideStyle, serviceStyle)
-  if (typeof style !== 'string') {
-    style = 'flat'
-  }
-  if (style.startsWith('popout')) {
-    style = style.replace('popout', 'flat')
-  }
   const styleValues = [
     'plastic',
     'flat',

--- a/core/base-service/coalesce-badge.spec.js
+++ b/core/base-service/coalesce-badge.spec.js
@@ -303,15 +303,6 @@ describe('coalesceBadge', function () {
         style: 'flat',
       })
     })
-
-    it('replaces legacy popout styles', function () {
-      expect(coalesceBadge({ style: 'popout' }, {}, {})).to.include({
-        style: 'flat',
-      })
-      expect(coalesceBadge({ style: 'popout-square' }, {}, {})).to.include({
-        style: 'flat-square',
-      })
-    })
   })
 
   describe('Cache length', function () {


### PR DESCRIPTION
We dropped support for the popout badge styles all the way back in July 2019 (see #3635 for more information). We've since had a fallback that maps the `popout` style to `flat` and the `popout-square` style to `flat-square`.

By dropping this explicit fallback, we'll essentially redirect both `popout` and  `popout-square`to `flat`, by virtue of the `if (!styleValues.includes(style)) { style = 'flat' }` catch-all. This is effectively a breaking change for those who still leverage `popout-square` in their badges, the style will change to rounded corners. However, few users leverage the legacy style (a [couple of thousands](https://github.com/search?q=style%3Dpopout-square&type=code) according to GitHub code search, to put in perspective with the several millions of badges across GitHub). Users can easily edit their badge URL to get back to `flat-square`. Impact is very low in my opinion.

This is a critical part of our code, run a billion times per month. Let's face it, removing these few bits an pieces won't be a game changer when it comes to performance and maintenance burden, but given how constrained we are are in terms of server capacity and available maintainers, I'm keen on seizing all little opportunities. Additionally, we know that people have a tendency to copy paste badge URLs around; if some folks update their `popout-square` style as a result of this change, we'll reduce the spread of these invalid styles, which is appreciable.
