### PR TITLE
Update labels of deprecated services [GithubWorkflowStatus PubPopularity]

### DIFF
--- a/services/github/github-workflow-status.service.js
+++ b/services/github/github-workflow-status.service.js
@@ -10,11 +10,11 @@ export default class DeprecatedGithubWorkflowStatus extends BaseService {
 
   static openApi = {}
 
-  static defaultBadgeData = { label: 'build' }
+  static defaultBadgeData = { label: 'githubworkflowstatus' }
 
   async handle() {
     return {
-      label: 'build',
+      label: 'githubworkflowstatus',
       message: 'https://github.com/badges/shields/issues/8671',
       /*
       This is a 'special' deprecation because we are making a breaking change

--- a/services/github/github-workflow-status.tester.js
+++ b/services/github/github-workflow-status.tester.js
@@ -9,34 +9,34 @@ export const t = new ServiceTester({
 t.create('no longer available (previously nonexistent repo)')
   .get('/badges/shields-fakeness/fake.json')
   .expectBadge({
-    label: 'build',
+    label: 'githubworkflowstatus',
     message: 'https://github.com/badges/shields/issues/8671',
   })
 
 t.create('no longer available (previously nonexistent workflow)')
   .get('/actions/toolkit/not-a-real-workflow.json')
   .expectBadge({
-    label: 'build',
+    label: 'githubworkflowstatus',
     message: 'https://github.com/badges/shields/issues/8671',
   })
 
 t.create('no longer available (previously valid workflow)')
   .get('/actions/toolkit/toolkit-unit-tests.json')
   .expectBadge({
-    label: 'build',
+    label: 'githubworkflowstatus',
     message: 'https://github.com/badges/shields/issues/8671',
   })
 
 t.create('no longer available (previously valid workflow - branch)')
   .get('/actions/toolkit/toolkit-unit-tests/master.json')
   .expectBadge({
-    label: 'build',
+    label: 'githubworkflowstatus',
     message: 'https://github.com/badges/shields/issues/8671',
   })
 
 t.create('no longer available (previously valid workflow - event)')
   .get('/actions/toolkit/toolkit-unit-tests.json?event=push')
   .expectBadge({
-    label: 'build',
+    label: 'githubworkflowstatus',
     message: 'https://github.com/badges/shields/issues/8671',
   })

--- a/services/pub/pub-popularity.service.js
+++ b/services/pub/pub-popularity.service.js
@@ -6,6 +6,6 @@ export const PubPopularity = deprecatedService({
     base: 'pub/popularity',
     pattern: ':packageName',
   },
-  label: 'popularity',
+  label: 'pubpopularity',
   dateAdded: new Date('2025-05-11'),
 })

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -7,6 +7,6 @@ export const t = new ServiceTester({
 })
 
 t.create('pub popularity').get('/analysis_options.json').expectBadge({
-  label: 'popularity',
+  label: 'pubpopularity',
   message: 'no longer available',
 })


### PR DESCRIPTION
Revise deprecation labels for `GithubWorkflowStatus` and `PubPopularity` to comply with updated documentation requirements to present service name in label of deprecated services.

This change addresses issue #11368.