### PR TITLE
Ignore VS Code workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 
 # Visual Studio Code User Settings
 .vscode/settings.json
+*.code-workspace
 
 # eclipse
 .project


### PR DESCRIPTION
I occasionally use VS Code to work on this repository, and typically set my projects up as workspaces. Others may do the same. Let's ignore those configuration files.