### PR TITLE
Fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,6 @@ updates:
       # https://caniuse.com/js-regexp-lookbehind
       - dependency-name: 'decamelize'
       - dependency-name: 'humanize-string'
-      # simple-icons is handled by separate weekly schedule below
-      - dependency-name: 'simple-icons'
     groups:
       # All official @docusaurus/* packages should have the exact same version as @docusaurus/core.
       # From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups:
@@ -32,18 +30,6 @@ updates:
         applies-to: security-updates
         patterns:
           - '@docusaurus/*'
-
-  # simple-icons package - weekly updates
-  - package-ecosystem: npm
-    directory: '/'
-    schedule:
-      interval: weekly
-      day: friday
-      time: '12:00'
-    allow:
-      - dependency-name: 'simple-icons'
-    open-pull-requests-limit: 99
-    rebase-strategy: disabled
 
   # badge-maker package dependencies
   - package-ecosystem: npm


### PR DESCRIPTION
Following #11351, [CI broke](https://github.com/badges/shields/runs/51056081421) with the following error:
```
Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'npm' has overlapping directories.
```

TLDR: we can't easily have different update schedules for different packages. Right now, our top priority is to reduce maintenance overhead for the project. I suggest we switch to a monthly schedule for simple-icons as well. If users are eager to get a specific simple-icons update sooner, an intermediary dependency update PR can always be put together. As a positive side-effect, this might encourage more people to get involved in the project.