### PR TITLE
Fix [CodeFactor] test

### DIFF
--- a/services/codefactor/codefactor-grade.tester.js
+++ b/services/codefactor/codefactor-grade.tester.js
@@ -8,7 +8,7 @@ t.create('Grade').get('/github/microsoft/powertoys.json').expectBadge({
 })
 
 t.create('Grade (branch)')
-  .get('/github/spring-projects/spring-boot/main.json')
+  .get('/github/microsoft/powertoys/main.json')
   .expectBadge({
     label: 'code quality',
     message: isValidGrade,


### PR DESCRIPTION
Spring Boot is no longer available on CodeFactor (see [here](https://www.codefactor.io/repository/github/spring-projects/spring-boot)), whereas PowerToys is (see [here](https://www.codefactor.io/repository/github/microsoft/powertoys)).