### PR TITLE
Handle invalid [Crates] version

### DIFF
--- a/services/crates/crates-base.js
+++ b/services/crates/crates-base.js
@@ -43,7 +43,11 @@ class BaseCratesService extends BaseJsonService {
       ? `https://crates.io/api/v1/crates/${crate}/${version}`
       : `https://crates.io/api/v1/crates/${crate}?include=versions,downloads`
     const schema = version ? versionResponseSchema : crateResponseSchema
-    return this._requestJson({ schema, url })
+    return this._requestJson({
+      schema,
+      url,
+      httpErrors: version ? { 400: 'invalid version' } : {},
+    })
   }
 
   static getLatestVersion(response) {

--- a/services/crates/crates-downloads.tester.js
+++ b/services/crates/crates-downloads.tester.js
@@ -60,9 +60,13 @@ t.create('recent downloads (with version)')
     message: 'recent downloads not supported for specific versions',
   })
 
-t.create('downloads (invalid version)')
-  .get('/d/libc/7.json')
+t.create('downloads (non-existent version)')
+  .get('/d/libc/7.0.0.json')
   .expectBadge({ label: 'crates.io', message: 'not found' })
+
+t.create('downloads (invalid version)')
+  .get('/d/libc/7.json') // Does not follow semver
+  .expectBadge({ label: 'crates.io', message: 'invalid version' })
 
 t.create('downloads (not found)')
   .get('/d/not-a-real-package.json')


### PR DESCRIPTION
We've been having the following test failure for some time:
```
CratesDownloads [live] downloads (invalid version)
[ GET /d/libc/7.json ]

AssertionError: message mismatch: expected 'invalid' to equal 'not found'
    at IcedFrisbyNock._expectField (file:///home/runner/work/shields/shields/core/service-test-runner/icedfrisby-shields.js:85:51)
    at IcedFrisbyNock.<anonymous> (file:///home/runner/work/shields/shields/core/service-test-runner/icedfrisby-shields.js:70:26)
    at IcedFrisbyNock.<anonymous> (node_modules/icedfrisby/lib/icedfrisby.js:954:10)
    at invokeNextHook (node_modules/icedfrisby/lib/icedfrisby.js:1003:24)
    at /home/runner/work/shields/shields/node_modules/icedfrisby/lib/icedfrisby.js:1017:7
    at new Promise (<anonymous>)
    at IcedFrisbyNock._runHooks (node_modules/icedfrisby/lib/icedfrisby.js:976:12)
    at IcedFrisbyNock.run (node_modules/icedfrisby/lib/icedfrisby.js:1276:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Context.<anonymous> (node_modules/icedfrisby/lib/icedfrisby.js:1348:9)
```

The API now return a 400 status code with an error along the lines of `{"errors":[{"detail":"Invalid URL: unexpected end of input while parsing major version number"}]}` when called without a semver-compliant version number ([example](https://crates.io/api/v1/crates/libc/531267)). We essentially need to distinguish between invalid version and not found cases.