### PR TITLE
Update [Fedora] not found handling

### DIFF
--- a/services/fedora/fedora.service.js
+++ b/services/fedora/fedora.service.js
@@ -53,7 +53,7 @@ export default class Fedora extends BaseJsonService {
         branch,
       )}/pkg/${encodeURIComponent(packageName)}`,
       httpErrors: {
-        400: 'branch not found',
+        400: 'branch or package not found',
       },
     })
     return renderVersionBadge({ version: data.version })

--- a/services/fedora/fedora.tester.js
+++ b/services/fedora/fedora.tester.js
@@ -9,10 +9,10 @@ t.create('Fedora package (default branch, valid)')
     message: isVPlusDottedVersionNClausesWithOptionalSuffixAndEpoch,
   })
 
-t.create('Fedora package (not found)')
+t.create('Fedora package (package not found)')
   .get('/not-a-package/rawhide.json')
-  .expectBadge({ label: 'fedora', message: 'not found' })
+  .expectBadge({ label: 'fedora', message: 'branch or package not found' })
 
 t.create('Fedora package (branch not found)')
   .get('/not-a-package/not-a-branch.json')
-  .expectBadge({ label: 'fedora', message: 'branch not found' })
+  .expectBadge({ label: 'fedora', message: 'branch or package not found' })


### PR DESCRIPTION
We've had the following test failure for a while:
```
Fedora [live] Fedora package (not found)
[ GET /not-a-package/rawhide.json ]

AssertionError: message mismatch: expected 'branch not found' to equal 'not found'
    at IcedFrisbyNock._expectField (file:///home/runner/work/shields/shields/core/service-test-runner/icedfrisby-shields.js:85:51)
    at IcedFrisbyNock.<anonymous> (file:///home/runner/work/shields/shields/core/service-test-runner/icedfrisby-shields.js:70:26)
    at IcedFrisbyNock.<anonymous> (node_modules/icedfrisby/lib/icedfrisby.js:954:10)
    at invokeNextHook (node_modules/icedfrisby/lib/icedfrisby.js:1003:24)
    at /home/runner/work/shields/shields/node_modules/icedfrisby/lib/icedfrisby.js:1017:7
    at new Promise (<anonymous>)
    at IcedFrisbyNock._runHooks (node_modules/icedfrisby/lib/icedfrisby.js:976:12)
    at IcedFrisbyNock.run (node_modules/icedfrisby/lib/icedfrisby.js:1276:20)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Context.<anonymous> (node_modules/icedfrisby/lib/icedfrisby.js:1348:9)
```

The API would previously return a 404 when the package was not found. Nowadays it returns a 400, we can no longer distinguish between the invalid package and invalid branch cases.