### PR TITLE
FIx [Gerrit] test

### DIFF
--- a/services/gerrit/gerrit.tester.js
+++ b/services/gerrit/gerrit.tester.js
@@ -2,10 +2,11 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 // Change open since September 2017, hopefully won't get merged or abandoned anytime soon.
+// https://android-review.googlesource.com/c/platform/bootable/recovery/+/494609
 t.create('Gerrit new change')
-  .get('/105728.json?baseUrl=https://git.eclipse.org/r')
+  .get('/494609.json?baseUrl=https://android-review.googlesource.com')
   .expectBadge({
-    label: 'change 105728',
+    label: 'change 494609',
     message: 'new',
     color: '#2cbe4e',
   })


### PR DESCRIPTION
The Eclipse Foundation has sunset most of its Gerrit infrastructure in favour of GitHub, let's update the tests accordingly.