### PR TITLE
Fix JSDocs syntax

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -32,6 +32,8 @@ import { assertValidServiceDefinition } from './service-definitions.js'
 import trace from './trace.js'
 import validate from './validate.js'
 
+/** @import { openApiSchema } from './service-definitions.js' */
+
 const defaultBadgeDataSchema = Joi.object({
   label: Joi.string(),
   color: Joi.string(),
@@ -143,7 +145,8 @@ class BaseService {
    *
    * @abstract
    * @see https://swagger.io/specification/#paths-object
-   * @type {import('./service-definitions').openApiSchema}
+   * @see {@link module:core/base-service/service-definitions~openApiSchema}
+   * @type {openApiSchema}
    */
   static openApi = {}
 

--- a/core/base-service/service-definitions.js
+++ b/core/base-service/service-definitions.js
@@ -8,6 +8,7 @@ const arrayOfStrings = Joi.array().items(Joi.string()).min(0).required()
 /**
  * Joi schema describing the subset of OpenAPI paths we use in this application
  *
+ * @typedef {object} openApiSchema
  * @see https://swagger.io/specification/#paths-object
  */
 const openApiSchema = Joi.object()

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,7 +85,7 @@
         "eslint-plugin-cypress": "5.1.1",
         "eslint-plugin-icedfrisby": "0.2.0",
         "eslint-plugin-import": "2.32.0",
-        "eslint-plugin-jsdoc": "60.7.0",
+        "eslint-plugin-jsdoc": "60.8.1",
         "eslint-plugin-mocha": "11.1.0",
         "eslint-plugin-prettier": "5.5.4",
         "eslint-plugin-promise": "7.2.1",
@@ -4913,9 +4913,9 @@
       "license": "MIT"
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.65.2",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.65.2.tgz",
-      "integrity": "sha512-/rrj5oayCc7xdoQZ24Tz/+V41IDm+9ILYpTFJOZgav9vfncMNApKR0t/4d1oRXYTcyLZEcGHGOg4xBsD0Doing==",
+      "version": "0.68.1",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.68.1.tgz",
+      "integrity": "sha512-wJJXnfG2Pq7ZC8IeOupkkAVtEH6OYy1uVxRTeshXDQfSNsZneS7FUQlNf710osZ5Yz/b5ev9xChvybTT7CM63g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4923,7 +4923,7 @@
         "@typescript-eslint/types": "^8.45.0",
         "comment-parser": "1.4.1",
         "esquery": "^1.6.0",
-        "jsdoc-type-pratt-parser": "~6.1.2"
+        "jsdoc-type-pratt-parser": "6.3.3"
       },
       "engines": {
         "node": ">=20.11.0"
@@ -15128,13 +15128,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "60.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-60.7.0.tgz",
-      "integrity": "sha512-y1AYoLoWNIOzjctcem9MjIZb9XDoTBI6D9lyaWT0W8/t6jpNvTuMQJljRzaQyjTDDFbONAEcuufdu0DXtCUP8A==",
+      "version": "60.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-60.8.1.tgz",
+      "integrity": "sha512-LDcQpH4cYzU+EEri907GSzr16U2UOBiQcm95dK8ka5SnTwIT3Y7bC0iiY/MKyOotTRXaw4MY3Ec9BgHIfDBvHQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.65.2",
+        "@es-joy/jsdoccomment": "~0.68.1",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
         "debug": "^4.4.3",
@@ -19667,9 +19667,9 @@
       }
     },
     "node_modules/jsdoc-type-pratt-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.1.2.tgz",
-      "integrity": "sha512-ruy+JcplsWkqnYq1m/qokaErhEURwf/vhdTzlPNpei7RJabVWxPxGWoCPSCP0sbsz03d590hTkjLdXjyMxH0iA==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-6.3.3.tgz",
+      "integrity": "sha512-N1HQK15ZXdwgmXsALjUWW9Cwyg1BQS5hfP8KzDkbR4mjb+Ep8Uxcfwz+OU1tsNCRg99rk62d8GMNdG8Qz4k+Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "eslint-plugin-cypress": "5.1.1",
     "eslint-plugin-icedfrisby": "0.2.0",
     "eslint-plugin-import": "2.32.0",
-    "eslint-plugin-jsdoc": "60.7.0",
+    "eslint-plugin-jsdoc": "60.8.1",
     "eslint-plugin-mocha": "11.1.0",
     "eslint-plugin-prettier": "5.5.4",
     "eslint-plugin-promise": "7.2.1",

--- a/services/website-status.js
+++ b/services/website-status.js
@@ -7,6 +7,8 @@
 import Joi from 'joi'
 import { queryParams as qP } from './index.js'
 
+/** @import { OpenApiParam } from '../core/base-service/openapi.js' */
+
 /**
  * Joi schema for validating query params.
  * Checks if the query params object has valid up_message, down_message, up_color and down_color properties.
@@ -25,7 +27,8 @@ const queryParamSchema = Joi.object({
  * up_message, down_message, up_color and down_color
  * query params
  *
- * @type {Array.<import('../base-service/openapi').OpenApiParam>}
+ * @type {Array.<OpenApiParam>}
+ * @see {@link module:core/base-service/openapi~OpenApiParam}
  */
 const queryParams = qP(
   { name: 'up_message', example: 'online' },


### PR DESCRIPTION
Follow up to #11394. The docs build broke with the upgrade ([example job](https://github.com/badges/shields/actions/runs/18176567067/job/51743737754)):

> Run npm run build-docs
> 
> shields.io@0.0.0 build-docs
> rimraf api-docs/ && jsdoc --pedantic -c ./jsdoc.json . && echo 'contributing.shields.io' > api-docs/CNAME
> 
> ERROR: Unable to parse a tag's type expression for source file /home/runner/work/shields/shields/core/base-service/base.js in line 140 with tag title "type" and text "{import('./service-definitions').openApiSchema}": Invalid type expression "import('./service-definitions').openApiSchema": Expected "!", "=", "?", "[]", "|", or end of input but "(" found.
> ERROR: Unable to parse a tag's type expression for source file /home/runner/work/shields/shields/core/base-service/base.js in line 148 with tag title "type" and text "{import('./service-definitions').openApiSchema}": Invalid type expression "import('./service-definitions').openApiSchema": Expected "!", "=", "?", "[]", "|", or end of input but "(" found.
> ERROR: Unable to parse a tag's type expression for source file /home/runner/work/shields/shields/services/website-status.js in line 23 with tag title "type" and text "{Array.<import('../base-service/openapi').OpenApiParam>}": Invalid type expression "Array.<import('../base-service/openapi').OpenApiParam>": Expected "!", ",", "=", ">", "?", "[]", or "|" but "(" found.
> ERROR: Unable to parse a tag's type expression for source file /home/runner/work/shields/shields/services/website-status.js in line 30 with tag title "type" and text "{Array.<import('../base-service/openapi').OpenApiParam>}": Invalid type expression "Array.<import('../base-service/openapi').OpenApiParam>": Expected "!", ",", "=", ">", "?", "[]", or "|" but "(" found.
> Error: Process completed with exit code 1.

I switched to the new JSDoc `@import` syntax documented [here](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#type-imports-in-jsdoc) and added `@see` links. This should ensure:
* The type resolution works as expected in IDEs:
  <img width="536" height="391" alt="Screenshot 2025-10-05 at 18 51 09" src="https://github.com/user-attachments/assets/aa96e6bd-42b0-4b4a-a5f0-859027cce354" />
* Clickable links are available on the website:
  <img width="878" height="251" alt="Screenshot 2025-10-05 at 18 51 43" src="https://github.com/user-attachments/assets/50b5c921-a752-435c-8f55-78fb8a1084b6" />

