### PR TITLE
[Bluesky] Add followers and posts badges

### DIFF
--- a/services/bluesky/bluesky-followers.service.js
+++ b/services/bluesky/bluesky-followers.service.js
@@ -1,28 +1,30 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   followersCount: nonNegativeInteger,
 }).required()
 
-const documentation = `
-Displays the number of Bluesky followers for a given handle.
-`
-
 export default class BlueskyFollowers extends BaseJsonService {
   static category = 'social'
   static route = { base: 'bluesky/followers', pattern: ':actor' }
 
-  static examples = [
-    {
-      title: 'Bluesky followers',
-      namedParams: { actor: 'chitvs.bsky.social' },
-      staticPreview: this.render({ followers: 123 }),
-      documentation,
+  static openApi = {
+    '/bluesky/followers/{actor}': {
+      get: {
+        summary: 'Bluesky followers',
+        description:
+          'Displays the number of Bluesky followers for a given handle using the public Bluesky API.',
+        parameters: pathParams({
+          name: 'actor',
+          description: 'Bluesky handle (user ID)',
+          example: 'chitvs.bsky.social',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'followers', namedLogo: 'bluesky' }
 
@@ -37,9 +39,8 @@ export default class BlueskyFollowers extends BaseJsonService {
   async fetch({ actor }) {
     return this._requestJson({
       schema,
+      url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
       options: {
-        method: 'GET',
-        url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
         searchParams: { actor },
       },
       httpErrors: {

--- a/services/bluesky/bluesky-followers.service.js
+++ b/services/bluesky/bluesky-followers.service.js
@@ -1,0 +1,56 @@
+import Joi from 'joi'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
+import { BaseJsonService } from '../index.js'
+
+const schema = Joi.object({
+  followersCount: nonNegativeInteger,
+}).required()
+
+const documentation = `
+Displays the number of Bluesky followers for a given handle.
+`
+
+export default class BlueskyFollowers extends BaseJsonService {
+  static category = 'social'
+  static route = { base: 'bluesky/followers', pattern: ':actor' }
+
+  static examples = [
+    {
+      title: 'Bluesky followers',
+      namedParams: { actor: 'chitvs.bsky.social' },
+      staticPreview: this.render({ followers: 123 }),
+      documentation,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'followers', namedLogo: 'bluesky' }
+
+  static render({ followers }) {
+    return {
+      message: metric(followers),
+      color: 'blue',
+      style: 'social',
+    }
+  }
+
+  async fetch({ actor }) {
+    return this._requestJson({
+      schema,
+      options: {
+        method: 'GET',
+        url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
+        searchParams: { actor },
+      },
+      httpErrors: {
+        400: 'invalid',
+        404: 'user not found',
+      },
+    })
+  }
+
+  async handle({ actor }) {
+    const data = await this.fetch({ actor })
+    return this.constructor.render({ followers: data.followersCount })
+  }
+}

--- a/services/bluesky/bluesky-followers.service.js
+++ b/services/bluesky/bluesky-followers.service.js
@@ -44,8 +44,7 @@ export default class BlueskyFollowers extends BaseJsonService {
         searchParams: { actor },
       },
       httpErrors: {
-        400: 'invalid',
-        404: 'user not found',
+        400: 'user not found',
       },
     })
   }

--- a/services/bluesky/bluesky-followers.tester.js
+++ b/services/bluesky/bluesky-followers.tester.js
@@ -1,0 +1,32 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Followers (live)')
+  .get('/chitvs.bsky.social.json')
+  .expectBadge({
+    label: 'followers',
+    message: Joi.string().regex(/^\d+(\.\d+)?[kM]?$/),
+  })
+
+t.create('User not found')
+  .get('/this-user-should-not-exist-xyz123.json')
+  .expectBadge({
+    label: 'followers',
+    message: Joi.allow('user not found', 'invalid'),
+  })
+
+t.create('Handles valid numeric response')
+  .get('/mocked-user.json')
+  .intercept(nock =>
+    nock('https://public.api.bsky.app')
+      .get('/xrpc/app.bsky.actor.getProfile')
+      .query({ actor: 'mocked-user' })
+      .reply(200, { followersCount: 9876 }),
+  )
+  .expectBadge({
+    label: 'followers',
+    message: '9.9k',
+    color: 'blue',
+  })

--- a/services/bluesky/bluesky-followers.tester.js
+++ b/services/bluesky/bluesky-followers.tester.js
@@ -1,20 +1,19 @@
 import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
-t.create('Followers (live)')
-  .get('/chitvs.bsky.social.json')
-  .expectBadge({
-    label: 'followers',
-    message: Joi.string().regex(/^\d+(\.\d+)?[kM]?$/),
-  })
+t.create('Followers (live)').get('/chitvs.bsky.social.json').expectBadge({
+  label: 'followers',
+  message: isMetric,
+})
 
 t.create('User not found')
   .get('/this-user-should-not-exist-xyz123.json')
   .expectBadge({
     label: 'followers',
-    message: Joi.allow('user not found', 'invalid'),
+    message: Joi.allow('user not found'),
   })
 
 t.create('Handles valid numeric response')

--- a/services/bluesky/bluesky-followers.tester.js
+++ b/services/bluesky/bluesky-followers.tester.js
@@ -1,4 +1,3 @@
-import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
 import { isMetric } from '../test-validators.js'
 
@@ -13,7 +12,7 @@ t.create('User not found')
   .get('/this-user-should-not-exist-xyz123.json')
   .expectBadge({
     label: 'followers',
-    message: Joi.allow('user not found'),
+    message: 'user not found',
   })
 
 t.create('Handles valid numeric response')

--- a/services/bluesky/bluesky-posts.service.js
+++ b/services/bluesky/bluesky-posts.service.js
@@ -1,29 +1,30 @@
 import Joi from 'joi'
 import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
-import { BaseJsonService } from '../index.js'
+import { BaseJsonService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   postsCount: nonNegativeInteger,
 }).required()
 
-const documentation = `
-Displays the number of Bluesky posts for a given handle.
-Example: https://img.shields.io/bluesky/posts/chitvs.bsky.social
-`
-
 export default class BlueskyPosts extends BaseJsonService {
   static category = 'social'
   static route = { base: 'bluesky/posts', pattern: ':actor' }
 
-  static examples = [
-    {
-      title: 'Bluesky posts',
-      namedParams: { actor: 'chitvs.bsky.social' },
-      staticPreview: this.render({ posts: 0 }),
-      documentation,
+  static openApi = {
+    '/bluesky/posts/{actor}': {
+      get: {
+        summary: 'Bluesky posts',
+        description:
+          'Displays the number of Bluesky posts for a given handle using the public Bluesky API.',
+        parameters: pathParams({
+          name: 'actor',
+          description: 'Bluesky handle (user ID)',
+          example: 'chitvs.bsky.social',
+        }),
+      },
     },
-  ]
+  }
 
   static defaultBadgeData = { label: 'posts', namedLogo: 'bluesky' }
 
@@ -38,9 +39,8 @@ export default class BlueskyPosts extends BaseJsonService {
   async fetch({ actor }) {
     return this._requestJson({
       schema,
+      url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
       options: {
-        method: 'GET',
-        url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
         searchParams: { actor },
       },
       httpErrors: {

--- a/services/bluesky/bluesky-posts.service.js
+++ b/services/bluesky/bluesky-posts.service.js
@@ -1,0 +1,57 @@
+import Joi from 'joi'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
+import { BaseJsonService } from '../index.js'
+
+const schema = Joi.object({
+  postsCount: nonNegativeInteger,
+}).required()
+
+const documentation = `
+Displays the number of Bluesky posts for a given handle.
+Example: https://img.shields.io/bluesky/posts/chitvs.bsky.social
+`
+
+export default class BlueskyPosts extends BaseJsonService {
+  static category = 'social'
+  static route = { base: 'bluesky/posts', pattern: ':actor' }
+
+  static examples = [
+    {
+      title: 'Bluesky posts',
+      namedParams: { actor: 'chitvs.bsky.social' },
+      staticPreview: this.render({ posts: 0 }),
+      documentation,
+    },
+  ]
+
+  static defaultBadgeData = { label: 'posts', namedLogo: 'bluesky' }
+
+  static render({ posts }) {
+    return {
+      message: metric(posts),
+      color: 'blue',
+      style: 'social',
+    }
+  }
+
+  async fetch({ actor }) {
+    return this._requestJson({
+      schema,
+      options: {
+        method: 'GET',
+        url: 'https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile',
+        searchParams: { actor },
+      },
+      httpErrors: {
+        400: 'invalid',
+        404: 'user not found',
+      },
+    })
+  }
+
+  async handle({ actor }) {
+    const data = await this.fetch({ actor })
+    return this.constructor.render({ posts: data.postsCount })
+  }
+}

--- a/services/bluesky/bluesky-posts.service.js
+++ b/services/bluesky/bluesky-posts.service.js
@@ -44,8 +44,7 @@ export default class BlueskyPosts extends BaseJsonService {
         searchParams: { actor },
       },
       httpErrors: {
-        400: 'invalid',
-        404: 'user not found',
+        400: 'user not found',
       },
     })
   }

--- a/services/bluesky/bluesky-posts.tester.js
+++ b/services/bluesky/bluesky-posts.tester.js
@@ -15,7 +15,7 @@ t.create('User not found')
   .get('/this-user-should-not-exist-xyz123.json')
   .expectBadge({
     label: 'posts',
-    message: Joi.allow('user not found'),
+    message: 'user not found',
   })
 
 t.create('Handles valid numeric response')

--- a/services/bluesky/bluesky-posts.tester.js
+++ b/services/bluesky/bluesky-posts.tester.js
@@ -1,5 +1,6 @@
 import Joi from 'joi'
 import { createServiceTester } from '../tester.js'
+import { isMetric } from '../test-validators.js'
 
 export const t = await createServiceTester()
 
@@ -7,14 +8,14 @@ t.create('Posts (live)')
   .get('/chitvs.bsky.social.json')
   .expectBadge({
     label: 'posts',
-    message: Joi.string().regex(/^\d+(\.\d+)?[kM]?$/),
+    message: Joi.alternatives(isMetric, Joi.equal('0')),
   })
 
 t.create('User not found')
   .get('/this-user-should-not-exist-xyz123.json')
   .expectBadge({
     label: 'posts',
-    message: Joi.allow('user not found', 'invalid'),
+    message: Joi.allow('user not found'),
   })
 
 t.create('Handles valid numeric response')

--- a/services/bluesky/bluesky-posts.tester.js
+++ b/services/bluesky/bluesky-posts.tester.js
@@ -1,0 +1,32 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Posts (live)')
+  .get('/chitvs.bsky.social.json')
+  .expectBadge({
+    label: 'posts',
+    message: Joi.string().regex(/^\d+(\.\d+)?[kM]?$/),
+  })
+
+t.create('User not found')
+  .get('/this-user-should-not-exist-xyz123.json')
+  .expectBadge({
+    label: 'posts',
+    message: Joi.allow('user not found', 'invalid'),
+  })
+
+t.create('Handles valid numeric response')
+  .get('/mocked-user.json')
+  .intercept(nock =>
+    nock('https://public.api.bsky.app')
+      .get('/xrpc/app.bsky.actor.getProfile')
+      .query({ actor: 'mocked-user' })
+      .reply(200, { postsCount: 4321 }),
+  )
+  .expectBadge({
+    label: 'posts',
+    message: '4.3k',
+    color: 'blue',
+  })


### PR DESCRIPTION
This PR adds two new badges for the Bluesky social network:

- Followers badge: displays the number of followers a user has.
- Posts badge: displays the number of posts a user has made.

Both badges are implemented with proper schema validation and corresponding tests. This contributes to the social category of Shields.io badges.

Fixes #10788
