### PR TITLE
Remove legacy configuration checks

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -101,7 +101,6 @@ private:
   npm_token: 'NPM_TOKEN'
   obs_user: 'OBS_USER'
   obs_pass: 'OBS_PASS'
-  redis_url: 'REDIS_URL'
   opencollective_token: 'OPENCOLLECTIVE_TOKEN'
   pepy_key: 'PEPY_KEY'
   postgres_url: 'POSTGRES_URL'

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -193,7 +193,6 @@ const privateConfigSchema = Joi.object({
   npm_token: Joi.string(),
   obs_user: Joi.string(),
   obs_pass: Joi.string(),
-  redis_url: Joi.string().uri({ scheme: ['redis', 'rediss'] }),
   opencollective_token: Joi.string(),
   pepy_key: Joi.string(),
   postgres_url: Joi.string().uri({ scheme: 'postgresql' }),

--- a/server.js
+++ b/server.js
@@ -1,6 +1,3 @@
-import fs from 'fs'
-import path from 'path'
-import { fileURLToPath } from 'url'
 import configModule from 'config'
 import * as Sentry from '@sentry/node'
 import Server from './core/server/server.js'
@@ -16,7 +13,7 @@ Sentry.init({
     )
     if (filtered.length !== integrations.length - disabledIntegrations.length) {
       throw Error(
-        `An error occurred while filtering integrations. The following inetgrations were found: ${integrations.map(
+        `An error occurred while filtering integrations. The following integrations were found: ${integrations.map(
           ({ name }) => name,
         )}`,
       )
@@ -35,31 +32,6 @@ if (process.argv[3]) {
 console.log('Configuration:')
 console.dir(config.public, { depth: null })
 
-if (fs.existsSync('.env')) {
-  console.error(
-    'Legacy .env file found. It should be deleted and replaced with environment variables or config/local.yml',
-  )
-  process.exit(1)
-}
-
-if (config.private.redis_url != null) {
-  console.error(
-    'RedisTokenPersistence has been removed. Migrate to SqlTokenPersistence',
-  )
-  process.exit(1)
-}
-
-const legacySecretsPath = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  'private',
-  'secret.json',
-)
-if (fs.existsSync(legacySecretsPath)) {
-  console.error(
-    `Legacy secrets file found at ${legacySecretsPath}. It should be deleted and secrets replaced with environment variables or config/local.yml`,
-  )
-  process.exit(1)
-}
 export const server = new Server(config)
 
 process.on('SIGTERM', async () => {


### PR DESCRIPTION
These checks were introduced years ago when we dropped support for some server configurations:
* #8922
* #5864
* #3652

Self-hosted users have had ample time to update, let's drop these legacy checks.