### PR TITLE
Replace query-string with qs, test [chocolatey powershellgallery resharper]

### DIFF
--- a/core/base-service/redirector.js
+++ b/core/base-service/redirector.js
@@ -1,7 +1,7 @@
 import camelcase from 'camelcase'
 import emojic from 'emojic'
 import Joi from 'joi'
-import queryString from 'query-string'
+import qs from 'qs'
 import BaseService from './base.js'
 import {
   serverHasBeenUpSinceResourceCached,
@@ -92,12 +92,16 @@ export default function redirector(attrs) {
         let urlSuffix = ask.uri.search || ''
 
         if (transformQueryParams) {
-          const specifiedParams = queryString.parse(urlSuffix)
+          const specifiedParams = qs.parse(urlSuffix, {
+            ignoreQueryPrefix: true,
+          })
           const transformedParams = transformQueryParams(namedParams)
           const redirectParams = overrideTransformedQueryParams
             ? Object.assign(transformedParams, specifiedParams)
             : Object.assign(specifiedParams, transformedParams)
-          const outQueryString = queryString.stringify(redirectParams)
+          const outQueryString = qs.stringify(redirectParams, {
+            strictNullHandling: true,
+          })
           urlSuffix = `?${outQueryString}`
         }
 

--- a/core/base-service/redirector.spec.js
+++ b/core/base-service/redirector.spec.js
@@ -216,7 +216,7 @@ describe('Redirector', function () {
 
         expect(statusCode).to.equal(301)
         expect(headers.location).to.equal(
-          '/new/service/hello-world.svg?style=flat-square&token=def456',
+          '/new/service/hello-world.svg?token=def456&style=flat-square',
         )
       })
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "priorityqueuejs": "^2.0.0",
         "prom-client": "^15.1.3",
         "qs": "^6.14.0",
-        "query-string": "^9.3.1",
         "re2": "^1.22.1",
         "semver": "~7.7.2",
         "simple-icons": "15.16.0",
@@ -387,7 +386,6 @@
       "integrity": "sha512-/IYpF10BpthGZEJQZMhMqV4AqWr5avcWfZm/SIKK1RvUDmzGqLoW/+xeJVX9C8ZnNkIC8hivbIQFaNaRw0BFZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.39.0",
         "@algolia/requester-browser-xhr": "5.39.0",
@@ -535,7 +533,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2423,7 +2420,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2447,7 +2443,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2562,7 +2557,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3000,7 +2994,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4235,7 +4228,6 @@
       "integrity": "sha512-DyLk9BIA6I9gPIuia8XIL+XIEbNnExam6AHzRsfrEq4zJr7k/DsWW7oi4aJMepDnL7jMRhpVcdsCxdjb0/A9xg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.9.1",
         "@docusaurus/logger": "3.9.1",
@@ -4515,7 +4507,6 @@
       "integrity": "sha512-j9adi961F+6Ps9d0jcb5BokMcbjXAAJqKkV43eo8nh4YgmDj7KUNDX4EnOh/MjTQeO06oPY5cxp3yUXdW/8Ggw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@docusaurus/mdx-loader": "3.9.1",
         "@docusaurus/module-type-aliases": "3.9.1",
@@ -5771,7 +5762,6 @@
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -6217,7 +6207,6 @@
       "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -6373,7 +6362,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -6395,7 +6383,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.1.0.tgz",
       "integrity": "sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -6408,7 +6395,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
       "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6424,7 +6410,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
       "integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.204.0",
         "import-in-the-middle": "^1.8.1",
@@ -6817,7 +6802,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
       "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -6834,7 +6818,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
       "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.1.0",
         "@opentelemetry/resources": "2.1.0",
@@ -6852,7 +6835,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
       "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -7499,7 +7481,6 @@
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -7900,7 +7881,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -8024,7 +8004,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.58.tgz",
       "integrity": "sha512-TaGvMNhxvG2Q0K0aYxiKfNDS5m5ZsoIBBbtfUorxdH4NGSXIlYvZxLJI+9Dd3KjeB3780bciLyAb7ylO8pLhPw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -9159,7 +9138,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9260,7 +9238,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -9326,7 +9303,6 @@
       "integrity": "sha512-DzTfhUxzg9QBNGzU/0kZkxEV72TeA4MmPJ7RVfLnQwHNhhliPo7ynglEWJS791rNlLFoTyrKvkapwr/P3EXV9A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@algolia/abtesting": "1.5.0",
         "@algolia/client-abtesting": "5.39.0",
@@ -10345,7 +10321,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -10927,7 +10902,6 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.0.tgz",
       "integrity": "sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11434,6 +11408,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
       "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -11445,6 +11420,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -11460,6 +11436,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -11471,19 +11448,22 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11493,6 +11473,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11507,6 +11488,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12467,7 +12449,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13290,14 +13271,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -13623,6 +13596,7 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
       "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -14321,7 +14295,6 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -14628,7 +14601,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -14706,7 +14678,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -15090,7 +15061,6 @@
       "integrity": "sha512-vPZZsiOKaBAIATpFE2uMI4w5IRwdv/FpQ+qZZMR4E+PeOcM4OeoEbqxRMnywdxP19TyB/3h6QBB0EWon7letSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/types": "^8.35.0",
         "comment-parser": "^1.4.1",
@@ -16375,17 +16345,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/finalhandler": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -17207,7 +17166,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -19604,7 +19562,6 @@
       "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.1.tgz",
       "integrity": "sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@hapi/address": "^5.1.1",
         "@hapi/formula": "^3.0.2",
@@ -19758,7 +19715,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -21150,7 +21106,6 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
       "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -23822,7 +23777,6 @@
       "integrity": "sha512-iorDKDzBKgVk/npVkW2S+b57ekA9+xKWijVvNpgPMl1odxeB4HavgiydLN54Lhyn/jpcM+Z/BohCzIvHmfaPCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -23882,6 +23836,7 @@
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -23892,6 +23847,7 @@
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -23911,6 +23867,7 @@
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -23931,6 +23888,7 @@
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -24005,7 +23963,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mocha-junit-reporter": {
       "version": "2.2.1",
@@ -24394,8 +24353,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
       "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
@@ -24593,7 +24551,6 @@
       "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
       "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.1.0",
         "json-stringify-safe": "^5.0.1",
@@ -25936,7 +25893,6 @@
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -26612,7 +26568,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -26943,7 +26898,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -27895,7 +27849,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -28601,7 +28554,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -28953,23 +28905,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/query-string": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
-      "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -29124,7 +29059,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -29137,7 +29071,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -29194,7 +29127,6 @@
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -29231,7 +29163,6 @@
       "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -29264,7 +29195,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -29464,7 +29394,6 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -30522,7 +30451,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -31815,17 +31743,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/split2": {
@@ -33196,7 +33113,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -33748,8 +33664,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -34893,7 +34808,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
       "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -35532,7 +35446,8 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
       "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
@@ -35821,6 +35736,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
       "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -35895,13 +35811,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -35911,6 +35829,7 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -35953,7 +35872,6 @@
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "priorityqueuejs": "^2.0.0",
     "prom-client": "^15.1.3",
     "qs": "^6.14.0",
-    "query-string": "^9.3.1",
     "re2": "^1.22.1",
     "semver": "~7.7.2",
     "simple-icons": "15.16.0",

--- a/services/dynamic/dynamic-xml.tester.js
+++ b/services/dynamic/dynamic-xml.tester.js
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+import qs from 'qs'
 import { createServiceTester } from '../tester.js'
 import { exampleXml } from './dynamic-response-fixtures.js'
 export const t = await createServiceTester()
@@ -25,7 +25,7 @@ t.create('No query specified')
 
 t.create('XML from url')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: "//book[@id='bk102']/title",
     })}`,
@@ -39,7 +39,7 @@ t.create('XML from url')
 
 t.create('uri query parameter alias')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       uri: exampleUrl,
       query: "//book[@id='bk102']/title",
     })}`,
@@ -53,7 +53,7 @@ t.create('uri query parameter alias')
 
 t.create('attribute')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//book[2]/@id',
     })}`,
@@ -66,7 +66,7 @@ t.create('attribute')
 
 t.create('multiple results')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//book/title',
     })}`,
@@ -81,7 +81,7 @@ t.create('multiple results')
 
 t.create('prefix and suffix')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: "//book[@id='bk102']/title",
       prefix: 'title is ',
@@ -95,7 +95,7 @@ t.create('prefix and suffix')
 
 t.create('query doesnt exist')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//does/not/exist',
     })}`,
@@ -109,7 +109,7 @@ t.create('query doesnt exist')
 
 t.create('query doesnt exist (attribute)')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//does/not/@exist',
     })}`,
@@ -123,7 +123,7 @@ t.create('query doesnt exist (attribute)')
 
 t.create('Cannot resolve QName')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//a:si',
     })}`,
@@ -137,7 +137,7 @@ t.create('Cannot resolve QName')
 
 t.create('XPath parse error')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//a[contains(@href, "foo"]',
     })}`,
@@ -161,7 +161,7 @@ t.create('XML from url | invalid url')
 
 t.create('request should set Accept header')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: "//book[@id='bk102']/title",
     })}`,
@@ -177,7 +177,7 @@ t.create('request should set Accept header')
 
 t.create('query with node function')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: '//book[1]/title/text()',
     })}`,
@@ -191,7 +191,7 @@ t.create('query with node function')
 
 t.create('query with type conversion to string')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: 'string(//book[1]/title)',
     })}`,
@@ -205,7 +205,7 @@ t.create('query with type conversion to string')
 
 t.create('query with type conversion to number')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: exampleUrl,
       query: 'number(//book[1]/price)',
     })}`,
@@ -219,7 +219,7 @@ t.create('query with type conversion to number')
 
 t.create('query HTML document')
   .get(
-    `.json?${queryString.stringify({
+    `.json?${qs.stringify({
       url: 'https://httpbin.org/html',
       query: '//h1[1]',
     })}`,

--- a/services/github/auth/acceptor.js
+++ b/services/github/auth/acceptor.js
@@ -1,4 +1,4 @@
-import queryString from 'query-string'
+import qs from 'qs'
 import { fetch } from '../../../core/base-service/got.js'
 import log from '../../../core/server/log.js'
 
@@ -7,7 +7,7 @@ function setRoutes({ server, authHelper, onTokenAccepted }) {
 
   server.route(/^\/github-auth$/, (data, match, end, ask) => {
     ask.res.statusCode = 302 // Found.
-    const query = queryString.stringify({
+    const query = qs.stringify({
       // TODO The `_user` property bypasses security checks in AuthHelper.
       // (e.g: enforceStrictSsl and shouldAuthenticateRequest).
       // Do not use it elsewhere. It would be better to clean this up so
@@ -53,7 +53,7 @@ function setRoutes({ server, authHelper, onTokenAccepted }) {
 
     let content
     try {
-      content = queryString.parse(resp.buffer)
+      content = qs.parse(resp.buffer)
     } catch (e) {
       return end('The GitHub OAuth token could not be parsed.')
     }

--- a/services/github/auth/acceptor.spec.js
+++ b/services/github/auth/acceptor.spec.js
@@ -3,7 +3,7 @@ import Camp from '@shields_io/camp'
 import FormData from 'form-data'
 import sinon from 'sinon'
 import portfinder from 'portfinder'
-import queryString from 'query-string'
+import qs from 'qs'
 import nock from 'nock'
 import got from '../../../core/got-test-client.js'
 import GithubConstellation from '../github-constellation.js'
@@ -50,11 +50,11 @@ describe('Github token acceptor', function () {
 
     expect(res.statusCode).to.equal(302)
 
-    const qs = queryString.stringify({
+    const queryString = qs.stringify({
       client_id: fakeClientId,
       redirect_uri: 'https://img.shields.io/github-auth/done',
     })
-    const expectedLocationHeader = `https://github.com/login/oauth/authorize?${qs}`
+    const expectedLocationHeader = `https://github.com/login/oauth/authorize?${queryString}`
     expect(res.headers.location).to.equal(expectedLocationHeader)
   })
 
@@ -79,14 +79,11 @@ describe('Github token acceptor', function () {
         scope = nock('https://github.com')
           .post('/login/oauth/access_token')
           .reply((url, requestBody) => {
-            const parsedBody = queryString.parse(requestBody)
+            const parsedBody = qs.parse(requestBody)
             expect(parsedBody.client_id).to.equal(fakeClientId)
             expect(parsedBody.client_secret).to.equal(fakeClientSecret)
             expect(parsedBody.code).to.equal(fakeCode)
-            return [
-              200,
-              queryString.stringify({ access_token: fakeAccessToken }),
-            ]
+            return [200, qs.stringify({ access_token: fakeAccessToken })]
           })
       })
 

--- a/services/nuget/nuget-v2-service-family.js
+++ b/services/nuget/nuget-v2-service-family.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import queryString from 'query-string'
+import qs from 'qs'
 import { nonNegativeInteger } from '../validators.js'
 import {
   BaseXmlService,
@@ -43,7 +43,7 @@ async function fetch(
   { baseUrl, packageName, includePrereleases = false },
 ) {
   const url = `${baseUrl}/Packages()`
-  const searchParams = queryString.stringify(
+  const searchParams = qs.stringify(
     {
       $filter: createFilter({ packageName, includePrereleases }),
     },


### PR DESCRIPTION
We've had several issues with dependency updates recently (see #11246, #11289, #11421, to name but a few). The fewer packages we depend on directly, the fewer headaches we risk having in the future.

One thing that struck me when going through our dependencies is that we have two separate dependencies to deal with query strings. We rely on `qs` to perform nested stringification needed for Wordpress badges, so I opted for attempting to port everything over from `query-string` to `qs`.