### PR TITLE
fix: remove footer dark style to enable theme switching

### DIFF
--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -88,7 +88,6 @@ const config = {
         ],
       },
       footer: {
-        style: 'dark',
         links: [
           {
             title: 'Community',


### PR DESCRIPTION
Fixes #11417

## Description
This PR removes the hardcoded style: 'dark' from the footer configuration to enable automatic theme switching between light and dark modes.

## Problem
When switching between light and dark modes, the footer color remained dark even in light mode, creating visual inconsistency and breaking design harmony.

## Solution
As suggested by maintainer @PyvesB, simply removing the style: 'dark' line allows the footer to dynamically adapt its colors according to the selected theme.

## Changes Made
Removed style: 'dark' from frontend/docusaurus.config.cjs (line 91)

## Testing
The footer now automatically switches between light and dark themes, ensuring consistent UI experience across both modes.