### PR TITLE
Drop eslint-config-prettier dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
         "deepmerge": "^4.3.1",
         "docusaurus-preset-openapi": "0.7.7",
         "eslint": "9.36.0",
-        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-chai-friendly": "1.1.0",
         "eslint-plugin-cypress": "5.1.1",
         "eslint-plugin-icedfrisby": "0.2.0",
@@ -14678,6 +14677,8 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "deepmerge": "^4.3.1",
     "docusaurus-preset-openapi": "0.7.7",
     "eslint": "9.36.0",
-    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-chai-friendly": "1.1.0",
     "eslint-plugin-cypress": "5.1.1",
     "eslint-plugin-icedfrisby": "0.2.0",


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

According to its README, eslint-config-prettier:
> Turns off all rules that are unnecessary or might conflict with [Prettier](https://github.com/prettier/prettier).

Sure, that sounds potentially useful on paper. But we're no actually using that plugin directly, it isn't added to our ESLint configuration file. We're leveraging `eslint-plugin-prettier/recommended`, that brings in a sane config. 