### PR TITLE
Remove read-all-stdin-sync dependency

### DIFF
--- a/core/service-test-runner/cli.js
+++ b/core/service-test-runner/cli.js
@@ -54,9 +54,9 @@
 //    Relying on npm scripts is safer. Using "pre" makes it impossible to run
 //    the second step without the first.
 
+import fs from 'fs'
 import minimist from 'minimist'
 import envFlag from 'node-env-flag'
-import readAllStdinSync from 'read-all-stdin-sync'
 import { createTestServer } from '../server/in-process-server-test-helpers.js'
 import Runner from './runner.js'
 
@@ -73,7 +73,7 @@ let onlyServices
 if (stdinOption && onlyOption) {
   console.error('Do not use --only with --stdin')
 } else if (stdinOption) {
-  const allStdin = readAllStdinSync().trim()
+  const allStdin = fs.readFileSync(0, 'utf-8').trim()
   onlyServices = allStdin ? allStdin.split('\n') : []
 } else if (onlyOption) {
   onlyServices = onlyOption.split(',')

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.0",
         "react-dom": "^18.3.1",
-        "read-all-stdin-sync": "^1.0.5",
         "rimraf": "^6.0.1",
         "sazerac": "^2.0.0",
         "simple-git-hooks": "^2.13.1",
@@ -29256,12 +29255,6 @@
       "dependencies": {
         "isarray": "0.0.1"
       }
-    },
-    "node_modules/read-all-stdin-sync": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/read-all-stdin-sync/-/read-all-stdin-sync-1.0.5.tgz",
-      "integrity": "sha512-iRLSFzQqEhFCK/GFfVXoFxQycf3HefbUgDOh+TvhvjUmfMRzF5rZwm2JVlB4Deb/Jfn6uXsksGBfAH8sx5DdLw==",
-      "dev": true
     },
     "node_modules/read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.1",
-    "read-all-stdin-sync": "^1.0.5",
     "rimraf": "^6.0.1",
     "sazerac": "^2.0.0",
     "simple-git-hooks": "^2.13.1",


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

We should be able to replace the read-all-stdin-sync dependency with native Node functionality. There used to be problems with `readFileSync` years and years ago (e.g. https://github.com/nodejs/node/issues/19831), but those are no longer a thing nowadays. To test things out, you can use `echo "eclipse\ngerrit" | npm run test:services -- --stdin` or similar