### PR TITLE
Remove child-process-promise dependency

### DIFF
--- a/badge-maker/lib/badge-cli.spec.js
+++ b/badge-maker/lib/badge-cli.spec.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { spawn } from 'child-process-promise'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { expect, use } from 'chai'
 import sinonChai from 'sinon-chai'
 use(sinonChai)
@@ -8,9 +9,10 @@ use(sinonChai)
 const dirName = path.dirname(fileURLToPath(import.meta.url))
 
 function runCli(args) {
-  return spawn('node', [path.join(dirName, 'badge-cli.js'), ...args], {
-    capture: ['stdout'],
-  })
+  return promisify(execFile)('node', [
+    path.join(dirName, 'badge-cli.js'),
+    ...args,
+  ])
 }
 
 describe('The CLI', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "chai": "6.2.0",
         "chai-as-promised": "^8.0.2",
         "chai-datetime": "^1.8.1",
-        "child-process-promise": "^2.2.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.2.1",
         "cypress": "^15.3.0",
@@ -11170,17 +11169,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/child-process-promise": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-2.2.1.tgz",
-      "integrity": "sha512-Fi4aNdqBsr0mv+jgWxcZ/7rAIC2mgihrptyVI4foh/rrjY/3BNjfP9+oaiFx/fzim+1ZyCNBae0DlyfQhSugog==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^4.0.2",
-        "node-version": "^1.0.0",
-        "promise-polyfill": "^6.0.1"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -12244,32 +12232,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/cross-spawn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-      "integrity": "sha512-yAXz/pA1tD8Gtg2S98Ekf/sewp3Lcp3YoFKJ4Hkp5h5yLWnKVTDU0kwjKJ8NDCYcfTLfyGkzTikst+jWypT1iA==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^4.0.1",
-        "which": "^1.2.9"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-      "dev": true,
-      "dependencies": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
-      }
-    },
-    "node_modules/cross-spawn/node_modules/yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-      "dev": true
     },
     "node_modules/crypt": {
       "version": "0.0.2",
@@ -24886,15 +24848,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-version": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/node-version/-/node-version-1.2.0.tgz",
-      "integrity": "sha512-ma6oU4Sk0qOoKEAymVoTvk8EdXEobdS7m/mAGhDJ8Rouugho48crHBORAmy5BoOcv8wraPM6xumapQp5hl4iIQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/nodemon": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
@@ -28698,12 +28651,6 @@
         "node": "^16 || ^18 || >=20"
       }
     },
-    "node_modules/promise-polyfill": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
-      "integrity": "sha512-g0LWaH0gFsxovsU7R5LrrhHhWAWiHRnh1GPrhXnPgYsDkIqjRYUYSZEsej/wtleDrz5xVSIDbeKfidztp2XHFQ==",
-      "dev": true
-    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -28810,12 +28757,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-      "dev": true
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
     "chai": "6.2.0",
     "chai-as-promised": "^8.0.2",
     "chai-datetime": "^1.8.1",
-    "child-process-promise": "^2.2.1",
     "clsx": "^2.1.1",
     "concurrently": "^9.2.1",
     "cypress": "^15.3.0",


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

Nowadays, this dependency can be replaced with simple built-in Node.js function.