### PR TITLE
Remove react-dom dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,6 @@
         "prettier": "3.6.2",
         "prism-react-renderer": "^2.4.1",
         "react": "^18.3.0",
-        "react-dom": "^18.3.1",
         "rimraf": "^6.0.1",
         "sazerac": "^2.0.0",
         "simple-git-hooks": "^2.13.1",
@@ -29052,6 +29051,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -30389,6 +30389,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
     "prettier": "3.6.2",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.0",
-    "react-dom": "^18.3.1",
     "rimraf": "^6.0.1",
     "sazerac": "^2.0.0",
     "simple-git-hooks": "^2.13.1",


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

Underneath the hood the dependency is still leveraged, but we don't need to specify it explicitly in our _package.json_ as we don't use it directly.