### PR TITLE
Remove minimist dependency

### DIFF
--- a/core/service-test-runner/cli.js
+++ b/core/service-test-runner/cli.js
@@ -55,7 +55,7 @@
 //    the second step without the first.
 
 import fs from 'fs'
-import minimist from 'minimist'
+import { parseArgs } from 'util'
 import envFlag from 'node-env-flag'
 import { createTestServer } from '../server/in-process-server-test-helpers.js'
 import Runner from './runner.js'
@@ -66,9 +66,11 @@ const retry = {}
 retry.count = parseInt(process.env.RETRY_COUNT) || 0
 retry.backoff = parseInt(process.env.RETRY_BACKOFF) || 0
 
-const args = minimist(process.argv.slice(3))
-const stdinOption = args.stdin
-const onlyOption = args.only
+const { stdin: stdinOption, only: onlyOption } = parseArgs({
+  args: process.argv.slice(3),
+  options: { stdin: { type: 'boolean' }, only: { type: 'string' } },
+  strict: false,
+}).values
 let onlyServices
 if (stdinOption && onlyOption) {
   console.error('Do not use --only with --stdin')

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,6 @@
         "is-svg": "^6.1.0",
         "jsdoc": "^4.0.4",
         "lint-staged": "^16.2.3",
-        "minimist": "^1.2.8",
         "mocha": "^11.7.3",
         "mocha-env-reporter": "^4.0.0",
         "mocha-junit-reporter": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,6 @@
     "is-svg": "^6.1.0",
     "jsdoc": "^4.0.4",
     "lint-staged": "^16.2.3",
-    "minimist": "^1.2.8",
     "mocha": "^11.7.3",
     "mocha-env-reporter": "^4.0.0",
     "mocha-junit-reporter": "^2.2.1",

--- a/scripts/benchmark-performance.js
+++ b/scripts/benchmark-performance.js
@@ -1,14 +1,15 @@
+import { parseArgs } from 'util'
 import config from 'config'
 import got from 'got'
-import minimist from 'minimist'
 import Server from '../core/server/server.js'
 
 async function main() {
   const server = new Server(config.util.toObject())
   await server.start()
-  const args = minimist(process.argv)
-  const iterations = parseInt(args.iterations) || 10000
-  for (let i = 0; i < iterations; ++i) {
+  const { iterations = '10000' } = parseArgs({
+    options: { iterations: { type: 'string' } },
+  }).values
+  for (let i = 0; i < parseInt(iterations); ++i) {
     await got(`${server.baseUrl}badge/coverage-${i}-green.svg`)
   }
   await server.stop()

--- a/scripts/capture-timings.js
+++ b/scripts/capture-timings.js
@@ -1,5 +1,5 @@
 import readline from 'readline'
-import minimist from 'minimist'
+import { parseArgs } from 'util'
 
 async function captureTimings(warmupIterations) {
   const rl = readline.createInterface({
@@ -43,8 +43,10 @@ function logResults({ times, iterations, warmupIterations }) {
 }
 
 async function main() {
-  const args = minimist(process.argv)
-  const warmupIterations = parseInt(args['warmup-iterations']) || 100
+  const { 'warmup-iterations': warmupIter = '100' } = parseArgs({
+    options: { 'warmup-iterations': { type: 'string' } },
+  }).values
+  const warmupIterations = parseInt(warmupIter)
   const { times, iterations } = await captureTimings(warmupIterations)
   logResults({ times, iterations, warmupIterations })
 }


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

We can replace `minimist` with the built-in `parseArgs`, which was recently introduced in Node.js 18.