### PR TITLE
Remove form-data dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,6 @@
         "eslint-plugin-promise": "7.2.1",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-sort-class-members": "1.21.0",
-        "form-data": "^4.0.4",
         "globals": "16.4.0",
         "icedfrisby": "4.0.0",
         "icedfrisby-nock": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-sort-class-members": "1.21.0",
-    "form-data": "^4.0.4",
     "globals": "16.4.0",
     "icedfrisby": "4.0.0",
     "icedfrisby-nock": "^2.1.0",

--- a/services/github/auth/acceptor.spec.js
+++ b/services/github/auth/acceptor.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai'
 import Camp from '@shields_io/camp'
-import FormData from 'form-data'
+import { FormData } from 'undici'
 import sinon from 'sinon'
 import portfinder from 'portfinder'
 import qs from 'qs'


### PR DESCRIPTION
Continuing the dependency audit started in https://github.com/badges/shields/pull/11425.

We can replace `form-data` with the built-in `undici`, which was recently introduced in Node.js 18. got support using native `FormData` objects since version 14.