### PR TITLE
Fix broken redirector tests, test [GitHubTag GitLabTag GitLabPipeline GradlePluginPortal MavenCentral NexusRedirect Packagist SonarRedirect WebsiteRedirect] 

### DIFF
--- a/services/github/github-tag.tester.js
+++ b/services/github/github-tag.tester.js
@@ -36,7 +36,7 @@ t.create('Tag (legacy route: tag)')
 t.create('Tag (legacy route: tag-pre)')
   .get('/tag-pre/photonstorm/phaser.svg')
   .expectRedirect(
-    '/github/v/tag/photonstorm/phaser.svg?include_prereleases&sort=semver',
+    '/github/v/tag/photonstorm/phaser.svg?sort=semver&include_prereleases',
   )
 
 t.create('Tag (legacy route: tag-date)')

--- a/services/gitlab/gitlab-coverage-redirect.tester.js
+++ b/services/gitlab/gitlab-coverage-redirect.tester.js
@@ -10,7 +10,7 @@ t.create('Coverage redirect (with branch)')
 t.create('Coverage redirect (with branch and job_name)')
   .get('/gitlab-org/gitlab-runner/master.json?job_name=test coverage report')
   .expectRedirect(
-    '/gitlab/pipeline-coverage/gitlab-org/gitlab-runner.json?branch=master&job_name=test%20coverage%20report',
+    '/gitlab/pipeline-coverage/gitlab-org/gitlab-runner.json?job_name=test%20coverage%20report&branch=master',
   )
 
 t.create('Coverage redirect (with branch and gitlab_url)')
@@ -18,5 +18,5 @@ t.create('Coverage redirect (with branch and gitlab_url)')
     '/gitlab-org/gitlab-runner/master.json?gitlab_url=https://gitlab.gnome.org',
   )
   .expectRedirect(
-    '/gitlab/pipeline-coverage/gitlab-org/gitlab-runner.json?branch=master&gitlab_url=https%3a%2f%2fgitlab.gnome.org',
+    '/gitlab/pipeline-coverage/gitlab-org/gitlab-runner.json?gitlab_url=https%3a%2f%2fgitlab.gnome.org&branch=master',
   )

--- a/services/gitlab/gitlab-pipeline-status.tester.js
+++ b/services/gitlab/gitlab-pipeline-status.tester.js
@@ -7,7 +7,7 @@ export const t = new ServiceTester({
 })
 
 t.create('Pipeline status')
-  .get('/pipeline-status/gitlab-org/gitlab.json?branch=v10.7.6')
+  .get('/pipeline-status/gitlab-org/gitlab.json?branch=ruby-next')
   .expectBadge({
     label: 'build',
     message: isBuildStatus,
@@ -58,5 +58,5 @@ t.create('Pipeline no branch redirect')
 t.create('Pipeline legacy route with branch redirect')
   .get('/pipeline/gitlab-org/gitlab/v10.7.6?style=flat')
   .expectRedirect(
-    '/gitlab/pipeline-status/gitlab-org/gitlab.svg?branch=v10.7.6&style=flat',
+    '/gitlab/pipeline-status/gitlab-org/gitlab.svg?style=flat&branch=v10.7.6',
   )

--- a/services/gradle-plugin-portal/gradle-plugin-portal.tester.js
+++ b/services/gradle-plugin-portal/gradle-plugin-portal.tester.js
@@ -4,23 +4,23 @@ export const t = await createServiceTester()
 t.create('gradle plugin portal')
   .get('/com.gradle.plugin-publish')
   .expectRedirect(
-    `/maven-metadata/v.svg?label=plugin%20portal&metadataUrl=${encodeURIComponent(
+    `/maven-metadata/v.svg?metadataUrl=${encodeURIComponent(
       'https://plugins.gradle.org/m2/com/gradle/plugin-publish/com.gradle.plugin-publish.gradle.plugin/maven-metadata.xml',
-    )}`,
+    )}&label=plugin%20portal`,
   )
 
 t.create('gradle plugin portal with custom labels')
   .get('/com.gradle.plugin-publish?label=custom%20label')
   .expectRedirect(
-    `/maven-metadata/v.svg?label=custom%20label&metadataUrl=${encodeURIComponent(
+    `/maven-metadata/v.svg?metadataUrl=${encodeURIComponent(
       'https://plugins.gradle.org/m2/com/gradle/plugin-publish/com.gradle.plugin-publish.gradle.plugin/maven-metadata.xml',
-    )}`,
+    )}&label=custom%20label`,
   )
 
 t.create('gradle plugin portal with custom color')
   .get('/com.gradle.plugin-publish?color=gray')
   .expectRedirect(
-    `/maven-metadata/v.svg?color=gray&label=plugin%20portal&metadataUrl=${encodeURIComponent(
+    `/maven-metadata/v.svg?metadataUrl=${encodeURIComponent(
       'https://plugins.gradle.org/m2/com/gradle/plugin-publish/com.gradle.plugin-publish.gradle.plugin/maven-metadata.xml',
-    )}`,
+    )}&label=plugin%20portal&color=gray`,
   )

--- a/services/maven-central/maven-central.tester.js
+++ b/services/maven-central/maven-central.tester.js
@@ -4,15 +4,15 @@ export const t = await createServiceTester()
 t.create('latest version redirection')
   .get('/com.github.fabriziocucci/yacl4j.json') // http://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/
   .expectRedirect(
-    `/maven-metadata/v.json?label=maven-central&metadataUrl=${encodeURIComponent(
+    `/maven-metadata/v.json?metadataUrl=${encodeURIComponent(
       'https://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/maven-metadata.xml',
-    )}`,
+    )}&label=maven-central`,
   )
 
 t.create('latest 0.8 version redirection')
   .get('/com.github.fabriziocucci/yacl4j/0.8.json') // http://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/
   .expectRedirect(
-    `/maven-metadata/v.json?label=maven-central&metadataUrl=${encodeURIComponent(
+    `/maven-metadata/v.json?metadataUrl=${encodeURIComponent(
       'https://repo1.maven.org/maven2/com/github/fabriziocucci/yacl4j/maven-metadata.xml',
-    )}&versionPrefix=0.8`,
+    )}&label=maven-central&versionPrefix=0.8`,
   )

--- a/services/nexus/nexus-redirect.tester.js
+++ b/services/nexus/nexus-redirect.tester.js
@@ -27,7 +27,7 @@ t.create('Nexus repository with query opts')
     '/fs-public-snapshots/https/repository.jboss.org/nexus/com.progress.fuse/fusehq:p=tar.gz:c=agent-apple-osx.svg',
   )
   .expectRedirect(
-    `/nexus/fs-public-snapshots/com.progress.fuse/fusehq.svg?queryOpt=${encodeURIComponent(
+    `/nexus/fs-public-snapshots/com.progress.fuse/fusehq.svg?server=${encodeURIComponent('https://repository.jboss.org/nexus')}&queryOpt=${encodeURIComponent(
       ':p=tar.gz:c=agent-apple-osx',
-    )}&server=${encodeURIComponent('https://repository.jboss.org/nexus')}`,
+    )}`,
   )

--- a/services/packagist/packagist-php-version.tester.js
+++ b/services/packagist/packagist-php-version.tester.js
@@ -20,5 +20,5 @@ t.create(
 )
   .get('/symfony/symfony/v3.2.8.json?server=https://packagist.org')
   .expectRedirect(
-    '/packagist/dependency-v/symfony/symfony/php.json?server=https%3A%2F%2Fpackagist.org&version=v3.2.8',
+    '/packagist/dependency-v/symfony/symfony/php.json?version=v3.2.8&server=https%3A%2F%2Fpackagist.org',
   )

--- a/services/packagist/packagist-version.tester.js
+++ b/services/packagist/packagist-version.tester.js
@@ -56,5 +56,5 @@ t.create('version (legacy redirect: vpre)')
 t.create('version (legacy redirect: vpre) (custom server)')
   .get('/vpre/symfony/symfony.svg?server=https%3A%2F%2Fpackagist.org')
   .expectRedirect(
-    '/packagist/v/symfony/symfony.svg?include_prereleases&server=https%3A%2F%2Fpackagist.org',
+    '/packagist/v/symfony/symfony.svg?server=https%3A%2F%2Fpackagist.org&include_prereleases',
   )

--- a/services/sonar/sonar-redirector.tester.js
+++ b/services/sonar/sonar-redirector.tester.js
@@ -39,8 +39,8 @@ t.create('sonar host parameter with version')
   .expectRedirect(
     `/sonar/alert_status/org.ow2.petals:petals-se-ase.svg?${queryString.stringify(
       {
-        server: 'http://sonar.petalslink.com',
         sonarVersion: '4.2',
+        server: 'http://sonar.petalslink.com',
       },
     )}`,
   )

--- a/services/website/website-redirect.tester.js
+++ b/services/website/website-redirect.tester.js
@@ -9,7 +9,7 @@ export const t = new ServiceTester({
 t.create('Website with custom messages')
   .get('/website-up-down/https/www.google.com.svg')
   .expectRedirect(
-    `/website.svg?down_message=down&up_message=up&url=${encodeURIComponent(
+    `/website.svg?up_message=up&down_message=down&url=${encodeURIComponent(
       'https://www.google.com',
     )}`,
   )
@@ -17,7 +17,7 @@ t.create('Website with custom messages')
 t.create('Website with custom messages and colors')
   .get('/website-up-down-yellow-gray/https/www.google.com.svg')
   .expectRedirect(
-    `/website.svg?down_color=gray&down_message=down&up_color=yellow&up_message=up&url=${encodeURIComponent(
+    `/website.svg?up_message=up&down_message=down&up_color=yellow&down_color=gray&url=${encodeURIComponent(
       'https://www.google.com',
     )}`,
   )


### PR DESCRIPTION
I noticed that a bunch of daily tests had started failing with an error along the following lines:
> AssertionError: expected an element of [ Array(1) ] to equal '/github/v/tag/photonstorm/phaser.svg?…'

#11425 switched to a different package to perform query string manipulation. The way it orders parameters is a little different, I had not paid attention to the redirector tests which need to be updated accordingly.