### PR TITLE
Fix [Swagger] tests

### DIFF
--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -34,7 +34,7 @@ export default class SwaggerValidatorService extends BaseJsonService {
           name: 'specUrl',
           required: true,
           example:
-            'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore-expanded.json',
+            'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/c442afe06ec28443df0c69d01dc38c54968b246f/examples/v2.0/json/petstore-expanded.json',
         }),
       },
     },

--- a/services/swagger/swagger.tester.js
+++ b/services/swagger/swagger.tester.js
@@ -32,7 +32,7 @@ t.create('Invalid')
 
 t.create('Valid json 2.0')
   .get(
-    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v2.0/json/petstore-expanded.json`,
+    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/c442afe06ec28443df0c69d01dc38c54968b246f/examples/v2.0/json/petstore-expanded.json`,
   )
   .expectBadge({
     label: 'swagger',
@@ -42,7 +42,7 @@ t.create('Valid json 2.0')
 
 t.create('Valid yaml 3.0')
   .get(
-    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml`,
+    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/c442afe06ec28443df0c69d01dc38c54968b246f/examples/v3.0/petstore.yaml`,
   )
   .expectBadge({
     label: 'swagger',
@@ -61,7 +61,7 @@ t.create('Valid with warnings')
 // Isn't a spec, but valid json
 t.create('Invalid')
   .get(
-    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v3.0/schema.json`,
+    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/c442afe06ec28443df0c69d01dc38c54968b246f/schemas/v3.0/schema.json`,
   )
   .expectBadge({
     label: 'swagger',
@@ -71,7 +71,7 @@ t.create('Invalid')
 
 t.create('Not found')
   .get(
-    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/notFound.yaml`,
+    `${getURLBase}https://raw.githubusercontent.com/OAI/OpenAPI-Specification/c442afe06ec28443df0c69d01dc38c54968b246f/examples/v3.0/notFound.yaml`,
   )
   .expectBadge({
     label: 'swagger',


### PR DESCRIPTION
The schema files were moved around in https://github.com/OAI/OpenAPI-Specification/pull/4435. To avoid this breaking again in the future if the OpenAPI team decides to move or delete the files, I pointed to a stable revision.
