### PR TITLE
Deprecate [BitComponents] service

### DIFF
--- a/services/bit/bit-components.service.js
+++ b/services/bit/bit-components.service.js
@@ -1,59 +1,11 @@
-import Joi from 'joi'
-import { metric } from '../text-formatters.js'
-import { nonNegativeInteger } from '../validators.js'
-import { downloadCount } from '../color-formatters.js'
-import { BaseJsonService, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const collectionSchema = Joi.object({
-  payload: Joi.object({
-    totalComponents: nonNegativeInteger,
-  }).required(),
-}).required()
-
-export default class BitComponents extends BaseJsonService {
-  static category = 'other'
-  static route = {
+export const BitComponents = deprecatedService({
+  category: 'other',
+  route: {
     base: 'bit/collection/total-components',
     pattern: ':owner/:collection',
-  }
-
-  static openApi = {
-    '/bit/collection/total-components/{owner}/{collection}': {
-      get: {
-        summary: 'Bit Components',
-        parameters: pathParams(
-          {
-            name: 'owner',
-            example: 'ramda',
-          },
-          {
-            name: 'collection',
-            example: 'ramda',
-          },
-        ),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'components' }
-
-  static render({ count }) {
-    return { message: metric(count), color: downloadCount(count) }
-  }
-
-  async fetch({ owner, collection }) {
-    const url = `https://api.bit.dev/scope/${owner}/${collection}/`
-    return this._requestJson({
-      url,
-      schema: collectionSchema,
-      httpErrors: {
-        404: 'collection not found',
-      },
-    })
-  }
-
-  async handle({ owner, collection }) {
-    const json = await this.fetch({ owner, collection })
-    return this.constructor.render({ count: json.payload.totalComponents })
-  }
-}
+  },
+  label: 'bitcomponents',
+  dateAdded: new Date('2025-11-01'),
+})

--- a/services/bit/bit-components.tester.js
+++ b/services/bit/bit-components.tester.js
@@ -1,12 +1,12 @@
-import { createServiceTester } from '../tester.js'
-import { isMetric } from '../test-validators.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
 
-t.create('collection (valid)').get('/ramda/ramda.json').expectBadge({
-  label: 'components',
-  message: isMetric,
+export const t = new ServiceTester({
+  id: 'bitcomponents',
+  title: 'BitComponents',
+  pathPrefix: '/bit/collection/total-components',
 })
 
-t.create('collection (valid)')
-  .get('/bit/no-collection-test.json')
-  .expectBadge({ label: 'components', message: 'collection not found' })
+t.create('collection').get('/ramda/ramda.json').expectBadge({
+  label: 'bitcomponents',
+  message: 'no longer available',
+})


### PR DESCRIPTION
Service tests for this badge have been failing for months. I reached out to the maintainers here: https://github.com/teambit/bit/issues/4281. As you can see, it's not the first time that the API has broken.

Given how [little these badges are used](https://github.com/search?q=img.shields.io%2Fbit%2Fcollection&type=code) and given that there doesn't seem to be much momentum from upstream to get the API fixed, I suggest we drop support for these badges.