### PR TITLE
Fix [JenkinsTests] tests and example

### DIFF
--- a/services/jenkins/jenkins-tests.service.js
+++ b/services/jenkins/jenkins-tests.service.js
@@ -50,7 +50,8 @@ export default class JenkinsTests extends JenkinsBase {
         parameters: [
           queryParam({
             name: 'jobUrl',
-            example: 'https://jenkins.sqlalchemy.org/job/alembic_gerrit',
+            example:
+              'https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
             required: true,
           }),
           ...testResultOpenApiQueryParams,

--- a/services/jenkins/jenkins-tests.tester.js
+++ b/services/jenkins/jenkins-tests.tester.js
@@ -13,41 +13,52 @@ export const t = await createServiceTester()
 // https://wiki.jenkins.io/pages/viewpage.action?pageId=58001258
 
 t.create('Test status')
-  .get('/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit')
+  .get(
+    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
+  )
   .expectBadge({ label: 'tests', message: isDefaultTestTotals })
 
 t.create('Test status with compact message')
-  .get('/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit', {
-    qs: { compact_message: null },
-  })
+  .get(
+    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
+    {
+      qs: { compact_message: null },
+    },
+  )
   .expectBadge({ label: 'tests', message: isDefaultCompactTestTotals })
 
 t.create('Test status with custom labels')
-  .get('/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit', {
-    qs: {
-      passed_label: 'good',
-      failed_label: 'bad',
-      skipped_label: 'n/a',
+  .get(
+    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
+    {
+      qs: {
+        passed_label: 'good',
+        failed_label: 'bad',
+        skipped_label: 'n/a',
+      },
     },
-  })
+  )
   .expectBadge({ label: 'tests', message: isCustomTestTotals })
 
 t.create('Test status with compact message and custom labels')
-  .get('/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit', {
-    qs: {
-      compact_message: null,
-      passed_label: '💃',
-      failed_label: '🤦‍♀️',
-      skipped_label: '🤷',
+  .get(
+    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
+    {
+      qs: {
+        compact_message: null,
+        passed_label: '💃',
+        failed_label: '🤦‍♀️',
+        skipped_label: '🤷',
+      },
     },
-  })
+  )
   .expectBadge({
     label: 'tests',
     message: isCustomCompactTestTotals,
   })
 
 t.create('Test status on job with no tests')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/orbit/job/orbit-recipes')
+  .get('/tests.json?jobUrl=https://ci.eclipse.org/orbit/job/orbit-shell')
   .expectBadge({ label: 'tests', message: 'no tests found' })
 
 t.create('Test status on non-existent job')


### PR DESCRIPTION
The jobs https://jenkins.sqlalchemy.org/job/alembic_gerrit/ and https://ci.eclipse.org/orbit/job/orbit-recipes were either disabled or deleted. Let's update them.