### PR TITLE
Delete [Pub] invalid tests

### DIFF
--- a/services/pub/pub-downloads.tester.js
+++ b/services/pub/pub-downloads.tester.js
@@ -18,11 +18,3 @@ t.create('pub monthly downloads (not found)')
     message: 'not found',
     color: 'red',
   })
-
-t.create('pub monthly downloads (invalid)')
-  .get('/analysis-options.json')
-  .expectBadge({
-    label: 'downloads',
-    message: 'invalid',
-    color: 'lightgrey',
-  })

--- a/services/pub/pub-likes.tester.js
+++ b/services/pub/pub-likes.tester.js
@@ -14,9 +14,3 @@ t.create('pub likes (not found)').get('/analysisoptions.json').expectBadge({
   message: 'not found',
   color: 'red',
 })
-
-t.create('pub likes (invalid)').get('/analysis-options.json').expectBadge({
-  label: 'likes',
-  message: 'invalid',
-  color: 'lightgrey',
-})

--- a/services/pub/pub-points.tester.js
+++ b/services/pub/pub-points.tester.js
@@ -15,9 +15,3 @@ t.create('pub points (not found)').get('/analysisoptions.json').expectBadge({
   message: 'not found',
   color: 'red',
 })
-
-t.create('pub points (invalid)').get('/analysis-options.json').expectBadge({
-  label: 'points',
-  message: 'invalid',
-  color: 'lightgrey',
-})


### PR DESCRIPTION
The Pub service no longer performs strict validation on allowed characters in package names. For example, `-` is now valid, these tests were falling back to the existing `not found` tests. Let's delete them.