### PR TITLE
Update editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,5 @@
+# The formatting for most files is handled by Prettier nowadays.
+# See https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier for more information.
 
 root = true
 
@@ -6,7 +8,3 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-
-[*.{js,json,html,css}]
-charset = utf-8
-indent_size = 2


### PR DESCRIPTION
By default, `.editorconfig` does nothing in most IDEs. For example, in VS Code, you need to install an [extra plugin](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig); same for Eclipse, with the caveat that [the plugin](https://marketplace.eclipse.org/content/editorconfig-eclipse) doesn't even work anymore on modern versions of the IDE.

This file was introduced a decade ago (see #558). Since then, we've added Prettier to the project (#1123), which is the source of truth when it comes to formatting decisions. Let's remove this competing legacy file.