### PR TITLE
Add Danger warning when badge does not follow URL conventions

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -160,3 +160,23 @@ affectedServices.forEach(service => {
     )
   }
 })
+
+allFiles
+  .filter(file => file.match(/^services\/(.+)\/.+\.service.js$/))
+  .forEach(file => {
+    // eslint-disable-next-line promise/prefer-await-to-then
+    danger.git.diffForFile(file).then(({ diff }) => {
+      if (
+        diff.match(/base: '.*(download|install|license|version|release).*'/) ||
+        diff.match(/pattern: '.*(download|install|license|version|release).*'/)
+      ) {
+        warn(
+          [
+            'Found badge URL that may not follow our standard route abbreviations. <br>',
+            "Please ensure you've reviewed our [conventions]",
+            '(https://github.com/badges/shields/blob/master/doc/badge-urls.md)',
+          ].join(''),
+        )
+      }
+    })
+  })


### PR DESCRIPTION
One thing we repeatedly need to point out in PR reviews is following our [URL conventions](https://github.com/badges/shields/blob/master/doc/badge-urls.md), in particular for downloads badge. #11443, #10745, and #8767 are three examples where I've had to raise this at review time, but there are many others.

I suggest we add a simple Danger check. As with most Danger rules, it won't have us 100% covered, but should flag the most common cases.