### PR TITLE
Return 200 status code for not found badges

### DIFF
--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -37,12 +37,17 @@ export default class PrometheusMetrics {
     })
   }
 
-  async registerMetricsEndpoint(server) {
+  async registerMetricsEndpoint(server, enabled = true) {
     const { register } = this
 
     server.route(/^\/metrics$/, async (data, match, end, ask) => {
-      ask.res.setHeader('Content-Type', register.contentType)
-      ask.res.end(await register.metrics())
+      if (enabled) {
+        ask.res.setHeader('Content-Type', register.contentType)
+        ask.res.end(await register.metrics())
+      } else {
+        ask.res.statusCode = 404
+        ask.res.end()
+      }
     })
   }
 

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -399,6 +399,8 @@ class Server {
       const [, extension] = match
       const format = (extension || '.svg').replace(/^\./, '')
 
+      request.res.statusCode = 200
+
       makeSend(
         format,
         request.res,
@@ -537,9 +539,10 @@ class Server {
     const { githubConstellation, metricInstance } = this
     await githubConstellation.initialize(camp)
     if (metricInstance) {
-      if (this.config.public.metrics.prometheus.endpointEnabled) {
-        metricInstance.registerMetricsEndpoint(camp)
-      }
+      metricInstance.registerMetricsEndpoint(
+        camp,
+        this.config.public.metrics.prometheus.endpointEnabled,
+      )
       if (this.influxMetrics) {
         this.influxMetrics.startPushingMetrics()
       }

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -207,21 +207,21 @@ describe('The server', function () {
           throwHttpErrors: false,
         },
       )
-      expect(statusCode).to.equal(404)
+      expect(statusCode).to.equal(200)
       expect(body)
         .to.satisfy(isSvg)
         .and.to.include('404')
         .and.to.include('badge not found')
     })
 
-    it('should return the 404 badge page for rando links', async function () {
+    it('should return the 404 badge page for random links', async function () {
       const { statusCode, body } = await got(
         `${baseUrl}this/is/most/definitely/not/a/badge.js`,
         {
           throwHttpErrors: false,
         },
       )
-      expect(statusCode).to.equal(404)
+      expect(statusCode).to.equal(200)
       expect(body)
         .to.satisfy(isSvg)
         .and.to.include('404')
@@ -245,7 +245,6 @@ describe('The server', function () {
           throwHttpErrors: false,
         },
       )
-      // TODO It would be nice if this were 404 or 410.
       expect(statusCode).to.equal(200)
       expect(body)
         .to.satisfy(isSvg)


### PR DESCRIPTION
Whilst browsing some READMEs, I noticed that broken images were sometimes displayed:
<img width="953" height="243" alt="Screenshot 2025-11-02 at 13 09 03" src="https://github.com/user-attachments/assets/12bef665-dfca-41ed-853b-055c1a3915ee" />

I first assumed that the badges were rendered by a non-Shield.io service, but turns out, they're ours.

Let's take https://img.shields.io/does-not-exist/my-badge as an example.
* Try opening it in a separate tab. You'll see a `404 | badge not found` badge.
* Try embedding it in markdown/HTML for example with `![](https://img.shields.io/does-not-exist/my-badge)`. This is what you'll get: ![](https://img.shields.io/does-not-exist/my-badge.svg)
* Try adding an alternative text for example with `![Shields.io](https://img.shields.io/does-not-exist/my-badge)`. This is what you'll get: ![Shields.io](https://img.shields.io/does-not-exist/my-badge.svg)

The two last cases arguably aren't great: either the badge will silently disappear from the README, or it will render the broken image placeholder. In both cases, the `404 | badge not found` output we produce is invisible to the user. In particular this will affect all badges we [deleted over the years](https://github.com/badges/shields/blob/master/doc/deprecating-badges.md#what-happens-next).

The reason why this is happening is that the `404 | badge not found` badge is accompanied by a 404 status code, which causes browsers to not render the response in HTML contexts.

This behaviour is arguably not intentional:
* In [our documentation](https://github.com/badges/shields/blob/master/doc/deprecating-badges.md#what-happens-next), we say:
  > Past that point, all related code will be deleted, and a not found error will be rendered instead:
![](https://img.shields.io/badge/404-badge%20not%20found-critical)
* This is also something we've explained to users in the past, for example: https://github.com/badges/shields/issues/8764#issuecomment-1368097001

I suggest we change things so that whenever we render a badge, it it accompanied by a 200 status code, even for the special not found badge cases.