### PR TITLE
Fix [JenkinsTests JenkinsBuild] tests

### DIFF
--- a/services/jenkins/jenkins-build.tester.js
+++ b/services/jenkins/jenkins-build.tester.js
@@ -1,12 +1,6 @@
-import Joi from 'joi'
 import { isBuildStatus } from '../build-status.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
-
-const isJenkinsBuildStatus = Joi.alternatives(
-  isBuildStatus,
-  Joi.string().allow('unstable'),
-)
 
 t.create('build job not found')
   .get('/build.json?jobUrl=https://ci.eclipse.org/jgit/job/does-not-exist')
@@ -14,10 +8,10 @@ t.create('build job not found')
 
 t.create('build found (view)')
   .get(
-    '/build.json?jobUrl=https://jenkins.sqlalchemy.org/view/alembic/job/alembic_coverage/',
+    '/build.json?jobUrl=https://ci.hibernate.org/view/Main/job/hibernate-search/job/main',
   )
-  .expectBadge({ label: 'build', message: isJenkinsBuildStatus })
+  .expectBadge({ label: 'build', message: isBuildStatus })
 
 t.create('build found (job)')
   .get('/build.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit')
-  .expectBadge({ label: 'build', message: isJenkinsBuildStatus })
+  .expectBadge({ label: 'build', message: isBuildStatus })

--- a/services/jenkins/jenkins-tests.service.js
+++ b/services/jenkins/jenkins-tests.service.js
@@ -50,8 +50,7 @@ export default class JenkinsTests extends JenkinsBase {
         parameters: [
           queryParam({
             name: 'jobUrl',
-            example:
-              'https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
+            example: 'https://ci.eclipse.org/jgit/job/jgit',
             required: true,
           }),
           ...testResultOpenApiQueryParams,

--- a/services/jenkins/jenkins-tests.tester.js
+++ b/services/jenkins/jenkins-tests.tester.js
@@ -13,45 +13,34 @@ export const t = await createServiceTester()
 // https://wiki.jenkins.io/pages/viewpage.action?pageId=58001258
 
 t.create('Test status')
-  .get(
-    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
-  )
+  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit')
   .expectBadge({ label: 'tests', message: isDefaultTestTotals })
 
 t.create('Test status with compact message')
-  .get(
-    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
-    {
-      qs: { compact_message: null },
-    },
-  )
+  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
+    qs: { compact_message: null },
+  })
   .expectBadge({ label: 'tests', message: isDefaultCompactTestTotals })
 
 t.create('Test status with custom labels')
-  .get(
-    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
-    {
-      qs: {
-        passed_label: 'good',
-        failed_label: 'bad',
-        skipped_label: 'n/a',
-      },
+  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
+    qs: {
+      passed_label: 'good',
+      failed_label: 'bad',
+      skipped_label: 'n/a',
     },
-  )
+  })
   .expectBadge({ label: 'tests', message: isCustomTestTotals })
 
 t.create('Test status with compact message and custom labels')
-  .get(
-    '/tests.json?jobUrl=https://jenkins.sqlalchemy.org/job/alembic_gerrit_pipeline',
-    {
-      qs: {
-        compact_message: null,
-        passed_label: '💃',
-        failed_label: '🤦‍♀️',
-        skipped_label: '🤷',
-      },
+  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
+    qs: {
+      compact_message: null,
+      passed_label: '💃',
+      failed_label: '🤦‍♀️',
+      skipped_label: '🤷',
     },
-  )
+  })
   .expectBadge({
     label: 'tests',
     message: isCustomCompactTestTotals,


### PR DESCRIPTION
Well, https://github.com/badges/shields/pull/11447 didn't last very long. sqlalchemy seems to be changing a lot of things on their Jenkins instance, I've seen a lot of disabled and deleted jobs. Let's stop using it in tests for the time being.

Eclipse JGit has been stable for years (see this test which is 6 years old: https://github.com/badges/shields/blob/d3a8267c6c54361b51a4626ab903336a5e13a576/services/jenkins/jenkins-build.tester.js#L22), let's use that in more places.