### PR TITLE
Increase [GithubTotalStar] test timeout

### DIFF
--- a/services/github/github-total-star.tester.js
+++ b/services/github/github-total-star.tester.js
@@ -51,6 +51,7 @@ t.create('Stars (Org)')
   })
 
 t.create('Stars (Org) Lots of repo')
+  .timeout(15000)
   .get('/github.json')
   .expectBadge({
     label: 'stars',


### PR DESCRIPTION
The test `GithubTotalStarService [live] Stars (Org) Lots of repo` is regularly timing out, let's see if this helps.