### PR TITLE
Increase [NpmDownloads] cache

### DIFF
--- a/services/npm/npm-downloads.service.js
+++ b/services/npm/npm-downloads.service.js
@@ -73,6 +73,8 @@ export default class NpmDownloads extends BaseJsonService {
     },
   }
 
+  static _cacheLength = 3600
+
   // For testing.
   static _intervalMap = intervalMap
 


### PR DESCRIPTION
We're getting rate limited by the upstream service, see #11487. The default cache duration for the downloads category is 30 minutes ([link](https://github.com/badges/shields/blob/e948cd54b9a92754fa24144cf4717be77d3a76db/core/base-service/base.js#L163)), let's double it. Given NpmDownloads badge look at downloads over longer periods of time (week, month, year), doing so will have limited impact on the user experience.