### PR TITLE
Fix [GreasyForkInstalls] tests

### DIFF
--- a/services/greasyfork/greasyfork-downloads.service.js
+++ b/services/greasyfork/greasyfork-downloads.service.js
@@ -19,7 +19,7 @@ export default class GreasyForkInstalls extends BaseGreasyForkService {
           },
           {
             name: 'scriptId',
-            example: '407466',
+            example: '545651',
           },
         ),
       },

--- a/services/greasyfork/greasyfork-downloads.tester.js
+++ b/services/greasyfork/greasyfork-downloads.tester.js
@@ -3,7 +3,7 @@ import { isMetric, isMetricOverTimePeriod } from '../test-validators.js'
 export const t = await createServiceTester()
 
 t.create('Daily Installs')
-  .get('/dd/407466.json')
+  .get('/dd/545651.json')
   .expectBadge({ label: 'installs', message: isMetricOverTimePeriod })
 
 t.create('Daily Installs (not found)')


### PR DESCRIPTION
Replaced https://greasyfork.org/en/scripts/407466-unedit-and-undelete-for-reddit with https://greasyfork.org/en/scripts/545651-enhancer-for-youtube-new-layout-video-downloader-and-more-features. The former regularly has 0 daily installs, making the test fail.