### PR TITLE
Increase [NostrBandFollowers] test timeouts

### DIFF
--- a/services/nostr-band/nostr-band-followers.tester.js
+++ b/services/nostr-band/nostr-band-followers.tester.js
@@ -3,13 +3,17 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('fetch: valid npub')
+  .timeout(15000)
   .get('/npub18c556t7n8xa3df2q82rwxejfglw5przds7sqvefylzjh8tjne28qld0we7.json')
   .expectBadge({
     label: 'followers',
     message: isMetric,
   })
 
-t.create('fetch: invalid npub').get('/invalidnpub.json').expectBadge({
-  label: 'followers',
-  message: 'invalid pubkey',
-})
+t.create('fetch: invalid npub')
+  .timeout(15000)
+  .get('/invalidnpub.json')
+  .expectBadge({
+    label: 'followers',
+    message: 'invalid pubkey',
+  })


### PR DESCRIPTION
These tests regularly fail in CI due to timeouts. What's odd is that they seem to run pretty fast locally and in production. Perhaps the nostr.band API is scaled down at night when ou daily tests run, making API responses very slow? Honestly, I'm not too sure, I suggest we try increasing the test timeout and see what happens.