### PR TITLE
Fix test:services:trace on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "test:entrypoint": "cross-env NODE_CONFIG_ENV=test mocha entrypoint.spec.js",
     "test:integration": "cross-env NODE_CONFIG_ENV=test mocha \"core/**/*.integration.js\" \"services/**/*.integration.js\"",
     "test:services": "cross-env NODE_CONFIG_ENV=test mocha core/service-test-runner/cli.js",
-    "test:services:trace": "cross-env NODE_CONFIG_ENV=test TRACE_SERVICES=true npm run test:services -- $*",
+    "test:services:trace": "cross-env NODE_CONFIG_ENV=test TRACE_SERVICES=true mocha core/service-test-runner/cli.js",
     "test:services:pr:prepare": "node core/service-test-runner/pull-request-services-cli.js > pull-request-services.log",
     "test:services:pr:run": "cross-env NODE_CONFIG_ENV=test mocha core/service-test-runner/cli.js --stdin < pull-request-services.log",
     "test:services:pr": "run-s --silent test:services:pr:prepare test:services:pr:run",


### PR DESCRIPTION
Closes #8437.

By removing the superfluous script nesting, we no longer need to rely on `$*`, getting rid of the error on Windows. Tested both on my macOS and Windows machines, `npm run test:services:trace -- --only=pub` works like a charm on both.