### PR TITLE
Fix GitHub token pool debug logging and add metrics

### DIFF
--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -32,6 +32,38 @@ export default class PrometheusMetrics {
         registers: [this.register],
       }),
     }
+    this.gauges = {
+      githubTokenPoolStandard: new prometheus.Gauge({
+        name: 'github_token_pool_standard_requests_remaining',
+        help: 'Total GitHub API requests remaining in standard token pool',
+        registers: [this.register],
+      }),
+      githubTokenPoolSearch: new prometheus.Gauge({
+        name: 'github_token_pool_search_requests_remaining',
+        help: 'Total GitHub API requests remaining in search token pool',
+        registers: [this.register],
+      }),
+      githubTokenPoolGraphql: new prometheus.Gauge({
+        name: 'github_token_pool_graphql_requests_remaining',
+        help: 'Total GitHub API requests remaining in GraphQL token pool',
+        registers: [this.register],
+      }),
+      githubTokenPoolStandardCount: new prometheus.Gauge({
+        name: 'github_token_pool_standard_count',
+        help: 'Number of tokens in standard token pool',
+        registers: [this.register],
+      }),
+      githubTokenPoolSearchCount: new prometheus.Gauge({
+        name: 'github_token_pool_search_count',
+        help: 'Number of tokens in search token pool',
+        registers: [this.register],
+      }),
+      githubTokenPoolGraphqlCount: new prometheus.Gauge({
+        name: 'github_token_pool_graphql_count',
+        help: 'Number of tokens in GraphQL token pool',
+        registers: [this.register],
+      }),
+    }
     this.interval = prometheus.collectDefaultMetrics({
       register: this.register,
     })
@@ -85,6 +117,25 @@ export default class PrometheusMetrics {
       category,
       serviceFamily,
       service,
+    )
+  }
+
+  noteGithubTokenPoolMetrics(tokenDebugInfo) {
+    const { standardTokens, searchTokens, graphqlTokens } = tokenDebugInfo
+
+    this.gauges.githubTokenPoolStandard.set(standardTokens.totalUsesRemaining)
+    this.gauges.githubTokenPoolStandardCount.set(
+      standardTokens.allTokenDebugInfo.length,
+    )
+
+    this.gauges.githubTokenPoolSearch.set(searchTokens.totalUsesRemaining)
+    this.gauges.githubTokenPoolSearchCount.set(
+      searchTokens.allTokenDebugInfo.length,
+    )
+
+    this.gauges.githubTokenPoolGraphql.set(graphqlTokens.totalUsesRemaining)
+    this.gauges.githubTokenPoolGraphqlCount.set(
+      graphqlTokens.allTokenDebugInfo.length,
     )
   }
 }

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -536,7 +536,7 @@ class Server {
     }
 
     const { githubConstellation, metricInstance } = this
-    await githubConstellation.initialize(camp)
+    await githubConstellation.initialize(camp, metricInstance)
     if (metricInstance) {
       metricInstance.registerMetricsEndpoint(
         camp,

--- a/core/token-pooling/token-pool.js
+++ b/core/token-pooling/token-pool.js
@@ -332,6 +332,30 @@ class TokenPool {
     this.fifoQueue.forEach(visit)
     this.priorityQueue.forEach(visit)
   }
+
+  /**
+   * Serialize debug information about the token pool.
+   *
+   * @param {object} options Options object
+   * @param {boolean} options.sanitize Whether to sanitize token IDs (default: true)
+   * @returns {object} Debug information about the token pool
+   */
+  serializeDebugInfo({ sanitize = true } = {}) {
+    const allTokenDebugInfo = []
+    let totalUsesRemaining = 0
+
+    this.forEach(token => {
+      totalUsesRemaining += token.usesRemaining
+      allTokenDebugInfo.push(token.getDebugInfo({ sanitize }))
+    })
+
+    return {
+      utcEpochSeconds: getUtcEpochSeconds(),
+      totalUsesRemaining,
+      allTokenDebugInfo,
+      sanitized: sanitize,
+    }
+  }
 }
 
 export { sanitizeToken, Token, TokenPool }

--- a/core/token-pooling/token-pool.spec.js
+++ b/core/token-pooling/token-pool.spec.js
@@ -123,4 +123,53 @@ describe('The token pool', function () {
       expect(() => tokenPool.next()).to.throw('Token pool is exhausted')
     })
   })
+
+  context('serializeDebugInfo()', function () {
+    let clock
+    beforeEach(function () {
+      clock = sinon.useFakeTimers({ now: 1544307744484 })
+    })
+    afterEach(function () {
+      clock.restore()
+    })
+
+    it('should return sanitized debug info', function () {
+      const debugInfo = tokenPool.serializeDebugInfo()
+
+      expect(debugInfo.utcEpochSeconds).to.equal(1544307744)
+      expect(debugInfo.totalUsesRemaining).to.equal(ids.length * batchSize)
+      expect(debugInfo.allTokenDebugInfo).to.have.lengthOf(ids.length)
+      expect(debugInfo.sanitized).to.equal(true)
+      debugInfo.allTokenDebugInfo.forEach(tokenInfo => {
+        expect(tokenInfo.id).to.be.a('string')
+        expect(tokenInfo.id).to.have.lengthOf(64) // SHA-256 hex is 64 chars
+        expect(tokenInfo.data).to.equal('[redacted]')
+        expect(tokenInfo.usesRemaining).to.equal(batchSize)
+        expect(tokenInfo.nextReset).to.equal(Token.nextResetNever)
+        expect(tokenInfo.isValid).to.equal(true)
+        expect(tokenInfo.isFrozen).to.equal(false)
+      })
+    })
+
+    it('should return unsanitized debug info', function () {
+      const debugInfo = tokenPool.serializeDebugInfo({ sanitize: false })
+
+      expect(debugInfo.sanitized).to.equal(false)
+      debugInfo.allTokenDebugInfo.forEach((tokenInfo, index) => {
+        expect(tokenInfo.id).to.equal(ids[index])
+      })
+    })
+
+    it('should exclude invalidated tokens', function () {
+      const token = tokenPool.next()
+      token.invalidate()
+
+      const debugInfo = tokenPool.serializeDebugInfo()
+
+      expect(debugInfo.allTokenDebugInfo).to.have.lengthOf(ids.length - 1)
+      expect(debugInfo.totalUsesRemaining).to.equal(
+        (ids.length - 1) * batchSize,
+      )
+    })
+  })
 })

--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -75,6 +75,18 @@ class GithubApiProvider {
     }
   }
 
+  getTokenDebugInfo({ sanitize = true } = {}) {
+    if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
+      return {
+        standardTokens: this.standardTokens.serializeDebugInfo({ sanitize }),
+        searchTokens: this.searchTokens.serializeDebugInfo({ sanitize }),
+        graphqlTokens: this.graphqlTokens.serializeDebugInfo({ sanitize }),
+      }
+    } else {
+      return {}
+    }
+  }
+
   getV3RateLimitFromHeaders(headers) {
     const h = Joi.attempt(headers, headerSchema)
     return {

--- a/services/github/github-constellation.js
+++ b/services/github/github-constellation.js
@@ -55,15 +55,22 @@ class GithubConstellation {
   scheduleDebugLogging() {
     if (this._debugEnabled) {
       this.debugInterval = setInterval(() => {
-        log.log(this.apiProvider.getTokenDebugInfo())
+        const debugInfo = this.apiProvider.getTokenDebugInfo()
+        log.log(debugInfo)
+        // Update Prometheus metrics if enabled
+        if (this.metricInstance) {
+          this.metricInstance.noteGithubTokenPoolMetrics(debugInfo)
+        }
       }, 1000 * this._debugIntervalSeconds)
     }
   }
 
-  async initialize(server) {
+  async initialize(server, metricInstance) {
     if (this.apiProvider.authType !== GithubApiProvider.AUTH_TYPES.TOKEN_POOL) {
       return
     }
+
+    this.metricInstance = metricInstance
 
     this.scheduleDebugLogging()
 


### PR DESCRIPTION
#1205 was opened in October 2017. In the meantime, #1813 renamed the `getTokenDebugInfo` function  to `serializeDebugInfo` in July 2018. When #1205 got merged in 2019, it accidentally changed the call `log(githubAuth.serializeDebugInfo())` back to `log(githubAuth.getTokenDebugInfo())`; .

As a consequence, in #7105, the debug logging capability was removed, as `getTokenDebugInfo` was pointing to nothing and `serializeDebugInfo` appeared unused. Today, the following line of code would blow up if we tried to enable debugging in production:
https://github.com/badges/shields/blob/56b993f53d8276a3547a1bdae7b1b19ba48174c9/services/github/github-constellation.js#L58

This PR fixes that and reintroduces a flavour of debug logging, with the objective of helping us investigate #11496. I've additionally implemented some new Prometheus metrics.