### PR TITLE
Ensure Git converts line endings to lf on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Fixes #5644. Tested on a Windows machine where `core.autocrlf` is set to `true` (i.e. the default, which causes problematic behaviour). Previously, editing in an editor such as the built-in notepad would change all line endings by adding a CR. Now, Git changes things back to LF, preventing carriage returns from being accidentally pushed:
> warning: CRLF will be replaced by LF in ...
> The file will have its original line endings in your working directory