### PR TITLE
Separate GitHub token metrics and debug logging

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -272,6 +272,7 @@ class Server {
 
     this.githubConstellation = new GithubConstellation({
       service: publicConfig.services.github,
+      metricsIntervalSeconds: publicConfig.metrics.influx.intervalSeconds,
       private: privateConfig,
     })
 


### PR DESCRIPTION
Follow up to #11500.

We've resolved the main incident. However, it strikes me that whilst the debug logs can be pretty verbose and I'd not want to keep them running all the time, having the metrics always turned on so that they can easily be viewed in Grafana feels useful. This PR separates the two.