### PR TITLE
Allow to run on Node.js 24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "deepmerge": "^4.3.1",
         "docusaurus-preset-openapi": "0.7.7",
         "eslint": "9.39.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-chai-friendly": "1.1.0",
         "eslint-plugin-cypress": "5.2.0",
         "eslint-plugin-icedfrisby": "0.2.0",
@@ -14545,6 +14546,23 @@
       },
       "peerDependencies": {
         "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-formatter-pretty": {

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "deepmerge": "^4.3.1",
     "docusaurus-preset-openapi": "0.7.7",
     "eslint": "9.39.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-chai-friendly": "1.1.0",
     "eslint-plugin-cypress": "5.2.0",
     "eslint-plugin-icedfrisby": "0.2.0",


### PR DESCRIPTION
Resolves #11071

This PR adds Node.js 24 to the `engines` and `check-node-version` list. But we are still using Node.js 22 for running GitHub Actions. We can switch to Node.js by creating another PR when we feel ready.

This PR also reverted the `eslint-config-prettier` change from https://github.com/badges/shields/pull/11432. npm has fixed a peer dependencies issue since https://github.com/npm/cli/pull/8579. We need to bring the `eslint-config-prettier` back because the `eslint-config-prettier` is the peer dependency of `eslint-plugin-prettier`.

**Note:**\
We already have an issue to track the `npm run docusaurus:start` failing issue. And it should have nothing to do with the Node.js version:

- https://github.com/badges/shields/issues/11421