### PR TITLE
Allow setting [CurseForge] API key in dev environments

### DIFF
--- a/.github/actions/service-tests/action.yml
+++ b/.github/actions/service-tests/action.yml
@@ -4,6 +4,10 @@ inputs:
   github-token:
     description: 'The GITHUB_TOKEN secret'
     required: true
+  curseforge-api-key:
+    description: 'The SERVICETESTS_CURSEFORGE_API_KEY secret'
+    required: false
+    default: ''
   librariesio-tokens:
     description: 'The SERVICETESTS_LIBRARIESIO_TOKENS secret'
     required: false
@@ -67,6 +71,7 @@ runs:
       env:
         RETRY_COUNT: 3
         GH_TOKEN: '${{ inputs.github-token }}'
+        CURSEFORGE_API_KEY: '${{ inputs.curseforge-api-key }}'
         LIBRARIESIO_TOKENS: '${{ inputs.librariesio-tokens }}'
         OBS_USER: '${{ inputs.obs-user }}'
         OBS_PASS: '${{ inputs.obs-pass }}'

--- a/.github/workflows/coveralls-code-coverage.yml
+++ b/.github/workflows/coveralls-code-coverage.yml
@@ -54,6 +54,7 @@ jobs:
         env:
           RETRY_COUNT: 3
           GH_TOKEN: '${{ secrets.GH_PAT }}'
+          CURSEFORGE_API_KEY: '${{ secrets.SERVICETESTS_CURSEFORGE_API_KEY }}'
           LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
           OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
           OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -53,6 +53,7 @@ jobs:
         env:
           RETRY_COUNT: 3
           GH_TOKEN: '${{ secrets.GH_PAT }}'
+          CURSEFORGE_API_KEY: '${{ secrets.SERVICETESTS_CURSEFORGE_API_KEY }}'
           LIBRARIESIO_TOKENS: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
           OBS_USER: '${{ secrets.SERVICETESTS_OBS_USER }}'
           OBS_PASS: '${{ secrets.SERVICETESTS_OBS_PASS }}'

--- a/.github/workflows/deploy-review-app.yml
+++ b/.github/workflows/deploy-review-app.yml
@@ -32,6 +32,7 @@ jobs:
           # credentials to set when we create the review app
           SECRETS: |
             GH_TOKEN=${{ secrets.GH_PAT }}
+            CURSEFORGE_API_KEY=${{ secrets.SERVICETESTS_CURSEFORGE_API_KEY }}
             LIBRARIESIO_TOKENS=${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}
             OBS_USER=${{ secrets.SERVICETESTS_OBS_USER }}
             OBS_PASS=${{ secrets.SERVICETESTS_OBS_PASS }}

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -24,6 +24,7 @@ jobs:
         uses: ./.github/actions/service-tests
         with:
           github-token: '${{ secrets.GH_PAT }}'
+          curseforge-api-key: '${{ secrets.SERVICETESTS_CURSEFORGE_API_KEY }}'
           librariesio-tokens: '${{ secrets.SERVICETESTS_LIBRARIESIO_TOKENS }}'
           obs-user: '${{ secrets.SERVICETESTS_OBS_USER }}'
           obs-pass: '${{ secrets.SERVICETESTS_OBS_PASS }}'

--- a/doc/production-hosting.md
+++ b/doc/production-hosting.md
@@ -26,6 +26,7 @@ Production hosting is managed by the Shields ops team:
 | Twitch                        | OAuth app                   | @PyvesB                                                         |
 | Reddit                        | OAuth app                   | @chris48s, @PyvesB                                              |
 | Discord                       | OAuth app                   | @PyvesB                                                         |
+| CurseForge                    | OAuth app                   | @PyvesB                                                         |
 | YouTube                       | Account owner               | @PyvesB                                                         |
 | GitLab                        | Account owner               | @calebcartwright                                                |
 | GitLab                        | Account access              | @calebcartwright, @chris48s, @paulmelnikow, @PyvesB             |


### PR DESCRIPTION
Similar to #11441. The CurseForge tests are currently never run, let's fix that.