### PR TITLE
Add Danger warning when no bracketed services in PR title

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -180,3 +180,15 @@ allFiles
       }
     })
   })
+
+if (affectedServices.length > 0 || testedServices.length > 0) {
+  if (!/\[.+?\]/.test(danger.github.pr.title)) {
+    warn(
+      [
+        'This PR modified service code. <br>',
+        'Please run tests by [including affected services in the pull request title]',
+        '(https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests).',
+      ].join(''),
+    )
+  }
+}


### PR DESCRIPTION
Fixes #2545.

This simple check covers the most common case I've seen over the years, i.e. contributors are not even aware they should include service names within `[]` in the PR title. Latest examples in date: #11511 and #11489.