### PR TITLE
Fix [SwaggerValidator] badges by switching to HTTPS

### DIFF
--- a/services/swagger/swagger.service.js
+++ b/services/swagger/swagger.service.js
@@ -54,7 +54,7 @@ export default class SwaggerValidatorService extends BaseJsonService {
 
   async fetch({ specUrl }) {
     return this._requestJson({
-      url: 'http://validator.swagger.io/validator/debug',
+      url: 'https://validator.swagger.io/validator/debug',
       schema,
       options: {
         searchParams: {

--- a/services/swagger/swagger.tester.js
+++ b/services/swagger/swagger.tester.js
@@ -2,7 +2,7 @@ import { createServiceTester } from '../tester.js'
 
 const getURL = '/3.0.json?specUrl=https://example.com/example.json'
 const getURLBase = '/3.0.json?specUrl='
-const apiURL = 'http://validator.swagger.io'
+const apiURL = 'https://validator.swagger.io'
 const apiGetURL = '/validator/debug'
 const apiGetQueryParams = {
   url: 'https://example.com/example.json',


### PR DESCRIPTION
The Swagger API now requires HTTPS. When plain HTTP is used, a 302 response code is returned, but the redirect URL is malformed:

> \* Host validator.swagger.io:80 was resolved.
> \* IPv6: (none)
> \* IPv4: xxxxxx
> \*   Trying xxxxx
> \* Connected to validator.swagger.io (xxxxxx) port 80
> \> GET /validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2FOAI%2FOpenAPI-Specification%2Fc442afe06ec28443df0c69d01dc38c54968b246f%2Fexamples%2Fv2.0%2Fjson%2Fpetstore-expanded.json HTTP/1.1
> \> Host: validator.swagger.io
> \> User-Agent: curl/8.7.1
> \> Accept: */*
> \> 
> \* Request completely sent off
> < HTTP/1.1 302 Moved Temporarily
> < Date: Sat, 22 Nov 2025 10:25:41 GMT
> < Content-Type: text/html
> < Content-Length: 110
> < Connection: keep-alive
> < Location: https://validator.swagger.io:443/validator/debug?HTTPS://validator.swagger.io:443/validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2FOAI%2FOpenAPI-Specification%2Fc442afe06ec28443df0c69d01dc38c54968b246f%2Fexamples%2Fv2.0%2Fjson%2Fpetstore-expanded.json

Let's query the API using HTTPS directly.