### PR TITLE
Deprecate [NostrBand] bagdes

### DIFF
--- a/services/nostr-band/nostr-band-followers.service.js
+++ b/services/nostr-band/nostr-band-followers.service.js
@@ -1,67 +1,11 @@
-import Joi from 'joi'
-import { metric } from '../text-formatters.js'
-import { BaseJsonService, pathParams } from '../index.js'
+import { deprecatedService } from '../index.js'
 
-const npubSchema = Joi.object({
-  followers_pubkey_count: Joi.number().required(),
-}).required()
-
-const mainSchema = Joi.object({
-  stats: Joi.object()
-    .pattern(Joi.string(), npubSchema)
-    .min(1)
-    .max(1)
-    .required(),
-}).required()
-
-export default class NostrBandFollowers extends BaseJsonService {
-  static category = 'social'
-
-  static route = {
-    base: 'nostr-band/followers',
+export default deprecatedService({
+  category: 'social',
+  route: {
+    base: 'nostrband/followers',
     pattern: ':npub',
-  }
-
-  static openApi = {
-    '/nostr-band/followers/{npub}': {
-      get: {
-        summary: 'Nostr.band Followers',
-        description:
-          'Returns the number of followers for a Nostr pubkey using the Nostr.band API.',
-        parameters: pathParams({
-          name: 'npub',
-          description: 'Nostr pubkey in (npub1...) format or hex.',
-          example:
-            'npub18c556t7n8xa3df2q82rwxejfglw5przds7sqvefylzjh8tjne28qld0we7',
-        }),
-      },
-    },
-  }
-
-  static defaultBadgeData = { label: 'followers' }
-
-  static render({ followers }) {
-    return {
-      message: metric(followers),
-      style: 'social',
-    }
-  }
-
-  async fetch({ npub }) {
-    const data = await this._requestJson({
-      url: `https://api.nostr.band/v0/stats/profile/${npub}`,
-      schema: mainSchema,
-      httpErrors: {
-        400: 'invalid pubkey',
-      },
-    })
-    const stats = data.stats
-    const firstKey = Object.keys(stats)[0]
-    return stats[firstKey].followers_pubkey_count
-  }
-
-  async handle({ npub }) {
-    const followers = await this.fetch({ npub })
-    return this.constructor.render({ followers })
-  }
-}
+  },
+  label: 'nostrband',
+  dateAdded: new Date('2025-11-22'),
+})

--- a/services/nostr-band/nostr-band-followers.tester.js
+++ b/services/nostr-band/nostr-band-followers.tester.js
@@ -1,19 +1,15 @@
-import { isMetric } from '../test-validators.js'
-import { createServiceTester } from '../tester.js'
-export const t = await createServiceTester()
+import { ServiceTester } from '../tester.js'
 
-t.create('fetch: valid npub')
-  .timeout(15000)
-  .get('/npub18c556t7n8xa3df2q82rwxejfglw5przds7sqvefylzjh8tjne28qld0we7.json')
-  .expectBadge({
-    label: 'followers',
-    message: isMetric,
-  })
+export const t = new ServiceTester({
+  id: 'nostrband',
+  title: 'Nostr.band',
+})
 
-t.create('fetch: invalid npub')
-  .timeout(15000)
-  .get('/invalidnpub.json')
+t.create('followers')
+  .get(
+    '/followers/npub18c556t7n8xa3df2q82rwxejfglw5przds7sqvefylzjh8tjne28qld0we7.json',
+  )
   .expectBadge({
-    label: 'followers',
-    message: 'invalid pubkey',
+    label: 'nostrband',
+    message: 'no longer available',
   })


### PR DESCRIPTION
The API has been pretty unreliable for some time (see #11494), and has been completely down for the past ~5 days, returning 502 status codes. The website no longer loads data either: https://nostr.band/

This is one of our least popular badges, with only 7 requests in the past 24 hours:
<img width="1273" height="341" alt="Screenshot 2025-11-22 at 11 44 34" src="https://github.com/user-attachments/assets/420a81fd-c619-474e-8c1d-85ecd285ee05" />

I'm a little concerned that other sites from the same org apparently got their domains acquired (https://github.com/nostrband/nostr-universe/issues/163), but there has been no response from the author. This badge could become a liability if the same happens for the nostr.band domain.

I suggest we deprecate it.
