### PR TITLE
Update CircleCI reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
+++ b/.github/ISSUE_TEMPLATE/2_Failing_service_test.md
@@ -21,7 +21,7 @@ labels: 'keep-service-tests-green'
 :lady_beetle: **Stack trace**
 
 ```
-<!-- Provide the complete stack trace from the CircleCI test summary. -->
+<!-- Provide the complete stack trace from the GitHub Actions test summary. -->
 ```
 
 :bulb: **Possible solution**


### PR DESCRIPTION
When opening #11522, I noticed we were still referring to our old CircleCI setup.