### PR TITLE
Leverage expectRedirect in all redirector tests, test [GitHub GitLab AppveyorBuildRedirect]

### DIFF
--- a/services/appveyor/appveyor-build-redirect.tester.js
+++ b/services/appveyor/appveyor-build-redirect.tester.js
@@ -7,15 +7,9 @@ export const t = new ServiceTester({
 })
 
 t.create('Appveyor CI')
-  .get('/gruntjs/grunt', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader('Location', '/appveyor/build/gruntjs/grunt.svg')
+  .get('/gruntjs/grunt')
+  .expectRedirect('/appveyor/build/gruntjs/grunt.svg')
 
 t.create('Appveyor CI (branch)')
-  .get('/gruntjs/grunt/develop', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader('Location', '/appveyor/build/gruntjs/grunt/develop.svg')
+  .get('/gruntjs/grunt/develop')
+  .expectRedirect('/appveyor/build/gruntjs/grunt/develop.svg')

--- a/services/github/gist/github-gist-last-commit-redirect.tester.js
+++ b/services/github/gist/github-gist-last-commit-redirect.tester.js
@@ -7,11 +7,7 @@ export const t = new ServiceTester({
 })
 
 t.create('Last Commit redirect')
-  .get('/last-commit/a8b8c979d200ffde13cc08505f7a6436', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader(
-    'Location',
+  .get('/last-commit/a8b8c979d200ffde13cc08505f7a6436')
+  .expectRedirect(
     '/github/gist/last-commit/a8b8c979d200ffde13cc08505f7a6436.svg',
   )

--- a/services/github/gist/github-gist-stars-redirect.tester.js
+++ b/services/github/gist/github-gist-stars-redirect.tester.js
@@ -6,11 +6,5 @@ export const t = new ServiceTester({
 })
 
 t.create('Stars redirect')
-  .get('/stars/gists/a8b8c979d200ffde13cc08505f7a6436', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader(
-    'Location',
-    '/github/gist/stars/a8b8c979d200ffde13cc08505f7a6436.svg',
-  )
+  .get('/stars/gists/a8b8c979d200ffde13cc08505f7a6436')
+  .expectRedirect('/github/gist/stars/a8b8c979d200ffde13cc08505f7a6436.svg')

--- a/services/gitlab/gitlab-contributors-redirect.tester.js
+++ b/services/gitlab/gitlab-contributors-redirect.tester.js
@@ -2,8 +2,5 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('Contributors redirect')
-  .get('/gitlab-org/gitlab', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader('Location', '/gitlab/contributors/gitlab-org/gitlab.svg')
+  .get('/gitlab-org/gitlab')
+  .expectRedirect('/gitlab/contributors/gitlab-org/gitlab.svg')

--- a/services/gitlab/gitlab-license-redirect.tester.js
+++ b/services/gitlab/gitlab-license-redirect.tester.js
@@ -2,8 +2,5 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('License redirect')
-  .get('/gitlab-org/gitlab', {
-    followRedirect: false,
-  })
-  .expectStatus(301)
-  .expectHeader('Location', '/gitlab/license/gitlab-org/gitlab.svg')
+  .get('/gitlab-org/gitlab')
+  .expectRedirect('/gitlab/license/gitlab-org/gitlab.svg')


### PR DESCRIPTION
Some old redirector tests were not using our `expectRedirect`, let's clean things up.