### PR TITLE
[BrowserCalendar] Add browser version compatibility badges

### DIFF
--- a/services/browsercalendar/browsercalendar.service.js
+++ b/services/browsercalendar/browsercalendar.service.js
@@ -28,7 +28,10 @@ export default class BrowserCalendar extends BaseJsonService {
             name: 'browser',
             example: 'chrome',
             description: 'Browser name',
-            schema: { type: 'string', enum: ['chrome', 'firefox', 'edge', 'safari'] },
+            schema: {
+              type: 'string',
+              enum: ['chrome', 'firefox', 'edge', 'safari'],
+            },
           },
           {
             name: 'version',

--- a/services/browsercalendar/browsercalendar.service.js
+++ b/services/browsercalendar/browsercalendar.service.js
@@ -35,9 +35,9 @@ export default class BrowserCalendar extends BaseJsonService {
           },
           {
             name: 'version',
-            example: '<=150.0.0',
+            example: '^130.0.0',
             description:
-              'Semver version requirement (e.g., <=150.0.0, >=130.0.0, ^140.0.0)',
+              'Semver version requirement (e.g., ^140.0.0, ~130.0.0)',
           },
         ),
       },

--- a/services/browsercalendar/browsercalendar.service.js
+++ b/services/browsercalendar/browsercalendar.service.js
@@ -1,0 +1,64 @@
+import Joi from 'joi'
+import { BaseJsonService, pathParams } from '../index.js'
+
+const schema = Joi.object({
+  schemaVersion: Joi.number().required(),
+  label: Joi.string().required(),
+  message: Joi.string().required(),
+  color: Joi.string().required(),
+  isError: Joi.boolean(),
+}).required()
+
+export default class BrowserCalendar extends BaseJsonService {
+  static category = 'platform-support'
+
+  static route = {
+    base: 'browsercalendar',
+    pattern: ':browser(chrome|firefox|edge|safari)/:version',
+  }
+
+  static openApi = {
+    '/browsercalendar/{browser}/{version}': {
+      get: {
+        summary: 'Browser Calendar Version Compatibility',
+        description:
+          '[Browser Calendar](https://browsercalendar.com) provides real-time browser version tracking. Use this badge to show compatibility with specific browser versions using semver requirements.',
+        parameters: pathParams(
+          {
+            name: 'browser',
+            example: 'chrome',
+            description: 'Browser name',
+            schema: { type: 'string', enum: ['chrome', 'firefox', 'edge', 'safari'] },
+          },
+          {
+            name: 'version',
+            example: '<=150.0.0',
+            description:
+              'Semver version requirement (e.g., <=150.0.0, >=130.0.0, ^140.0.0)',
+          },
+        ),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'browser' }
+
+  async fetch({ browser, version }) {
+    return this._requestJson({
+      schema,
+      url: 'https://browsercalendar.com/api/shields',
+      options: {
+        searchParams: { [browser]: version },
+      },
+      httpErrors: {
+        400: 'invalid version format',
+        404: 'browser not found',
+      },
+    })
+  }
+
+  async handle({ browser, version }) {
+    const { label, message, color } = await this.fetch({ browser, version })
+    return { label, message, color }
+  }
+}

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -20,12 +20,10 @@ t.create('Firefox compatibility check')
     message: isVersionStatus,
   })
 
-t.create('Edge compatibility check')
-  .get('/edge/<=200.0.0.json')
-  .expectBadge({
-    label: 'Edge',
-    message: isVersionStatus,
-  })
+t.create('Edge compatibility check').get('/edge/<=200.0.0.json').expectBadge({
+  label: 'Edge',
+  message: isVersionStatus,
+})
 
 t.create('Safari compatibility check')
   .get('/safari/>=17.0.0.json')

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -1,0 +1,34 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+const isBrowserStatus = Joi.string().regex(/^(Chrome|Firefox|Edge|Safari) [^\s]+$/)
+
+t.create('Chrome compatibility check')
+  .get('/chrome/<=200.0.0.json')
+  .expectBadge({
+    label: 'Chrome',
+    message: isBrowserStatus,
+  })
+
+t.create('Firefox compatibility check')
+  .get('/firefox/>=100.0.0.json')
+  .expectBadge({
+    label: 'Firefox',
+    message: isBrowserStatus,
+  })
+
+t.create('Edge compatibility check')
+  .get('/edge/<=200.0.0.json')
+  .expectBadge({
+    label: 'Edge',
+    message: isBrowserStatus,
+  })
+
+t.create('Safari compatibility check')
+  .get('/safari/>=17.0.0.json')
+  .expectBadge({
+    label: 'Safari',
+    message: isBrowserStatus,
+  })

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -7,26 +7,26 @@ export const t = await createServiceTester()
 const isVersionStatus = Joi.string().regex(/^\d+(\.\d+)+\s[✓✗]$/)
 
 t.create('Chrome compatibility check')
-  .get('/chrome/<=200.0.0.json')
+  .get('/chrome/^130.0.0.json')
   .expectBadge({
     label: 'Chrome',
     message: isVersionStatus,
   })
 
 t.create('Firefox compatibility check')
-  .get('/firefox/>=100.0.0.json')
+  .get('/firefox/^100.0.0.json')
   .expectBadge({
     label: 'Firefox',
     message: isVersionStatus,
   })
 
-t.create('Edge compatibility check').get('/edge/<=200.0.0.json').expectBadge({
+t.create('Edge compatibility check').get('/edge/^100.0.0.json').expectBadge({
   label: 'Edge',
   message: isVersionStatus,
 })
 
 t.create('Safari compatibility check')
-  .get('/safari/>=17.0.0.json')
+  .get('/safari/^17.0.0.json')
   .expectBadge({
     label: 'Safari',
     message: isVersionStatus,

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -3,8 +3,8 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-// Version format: "131.0.0 ✓" or "131.0.0 ✗"
-const isVersionStatus = Joi.string().regex(/^\d+\.\d+\.\d+ [✓✗]$/)
+// Version format: "131.0.0 ✓" or "26.1 ✓" (Safari may have 2 parts)
+const isVersionStatus = Joi.string().regex(/^\d+(\.\d+)+\s[✓✗]$/)
 
 t.create('Chrome compatibility check')
   .get('/chrome/<=200.0.0.json')

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -3,32 +3,33 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-const isBrowserStatus = Joi.string().regex(/^(Chrome|Firefox|Edge|Safari) [^\s]+$/)
+// Version format: "131.0.0 ✓" or "131.0.0 ✗"
+const isVersionStatus = Joi.string().regex(/^\d+\.\d+\.\d+ [✓✗]$/)
 
 t.create('Chrome compatibility check')
   .get('/chrome/<=200.0.0.json')
   .expectBadge({
     label: 'Chrome',
-    message: isBrowserStatus,
+    message: isVersionStatus,
   })
 
 t.create('Firefox compatibility check')
   .get('/firefox/>=100.0.0.json')
   .expectBadge({
     label: 'Firefox',
-    message: isBrowserStatus,
+    message: isVersionStatus,
   })
 
 t.create('Edge compatibility check')
   .get('/edge/<=200.0.0.json')
   .expectBadge({
     label: 'Edge',
-    message: isBrowserStatus,
+    message: isVersionStatus,
   })
 
 t.create('Safari compatibility check')
   .get('/safari/>=17.0.0.json')
   .expectBadge({
     label: 'Safari',
-    message: isBrowserStatus,
+    message: isVersionStatus,
   })

--- a/services/browsercalendar/browsercalendar.tester.js
+++ b/services/browsercalendar/browsercalendar.tester.js
@@ -25,9 +25,7 @@ t.create('Edge compatibility check').get('/edge/^100.0.0.json').expectBadge({
   message: isVersionStatus,
 })
 
-t.create('Safari compatibility check')
-  .get('/safari/^17.0.0.json')
-  .expectBadge({
-    label: 'Safari',
-    message: isVersionStatus,
-  })
+t.create('Safari compatibility check').get('/safari/^17.0.0.json').expectBadge({
+  label: 'Safari',
+  message: isVersionStatus,
+})


### PR DESCRIPTION
## Summary

Adds Browser Calendar badges for showing real-time browser version compatibility.

[Browser Calendar](https://browsercalendar.com) tracks current stable versions of Chrome, Firefox, Edge, and Safari. This badge allows developers to display whether their project supports specific browser versions using semver requirements.

## Badge Examples

| Badge | URL |
|-------|-----|
| ![Chrome](https://img.shields.io/endpoint?url=https%3A%2F%2Fbrowsercalendar.com%2Fapi%2Fshields%3Fchrome%3D%253C%253D150.0.0) | `/browsercalendar/chrome/<=150.0.0` |
| ![Firefox](https://img.shields.io/endpoint?url=https%3A%2F%2Fbrowsercalendar.com%2Fapi%2Fshields%3Ffirefox%3D%253E%253D130.0.0) | `/browsercalendar/firefox/>=130.0.0` |
| ![Edge](https://img.shields.io/endpoint?url=https%3A%2F%2Fbrowsercalendar.com%2Fapi%2Fshields%3Fedge%3D%253C%253D200.0.0) | `/browsercalendar/edge/<=200.0.0` |
| ![Safari](https://img.shields.io/endpoint?url=https%3A%2F%2Fbrowsercalendar.com%2Fapi%2Fshields%3Fsafari%3D%253E%253D17.0.0) | `/browsercalendar/safari/>=17.0.0` |

## API Documentation

- **Endpoint:** `https://browsercalendar.com/api/shields`
- **Documentation:** https://browsercalendar.com/badge
- **Response format:** Shields.io endpoint badge JSON schema

The API returns:
- `schemaVersion`: 1
- `label`: Browser name (e.g., "Chrome")
- `message`: Status with checkmark or X (e.g., "Chrome ✓")
- `color`: brightgreen (compatible), yellow (partial), red (incompatible)

## Checklist

- [x] Service implementation with Joi schema validation
- [x] OpenAPI documentation with examples
- [x] Live service tests for all supported browsers
- [x] Proper error handling for invalid inputs