### PR TITLE
Cache defaultpypiBaseUrl [PyPI] value

### DIFF
--- a/services/pypi/pypi-base.js
+++ b/services/pypi/pypi-base.js
@@ -38,6 +38,12 @@ export const pypiBaseUrlParam = queryParam({
 export const pypiGeneralParams = [pypiPackageParam, pypiBaseUrlParam]
 
 export default class PypiBase extends BaseJsonService {
+  constructor(...args) {
+    super(...args)
+    this._defaultPypiBaseUrl =
+      config.util.toObject().public.services.pypi.baseUri
+  }
+
   static buildRoute(base) {
     return {
       base,
@@ -46,10 +52,7 @@ export default class PypiBase extends BaseJsonService {
     }
   }
 
-  async fetch({ egg, pypiBaseUrl = null }) {
-    const defaultpypiBaseUrl =
-      config.util.toObject().public.services.pypi.baseUri
-    pypiBaseUrl = pypiBaseUrl || defaultpypiBaseUrl
+  async fetch({ egg, pypiBaseUrl = this._defaultPypiBaseUrl }) {
     return this._requestJson({
       schema,
       url: `${pypiBaseUrl}/pypi/${egg}/json`,

--- a/services/pypi/pypi-format.tester.js
+++ b/services/pypi/pypi-format.tester.js
@@ -20,3 +20,22 @@ t.create('format (egg)')
 t.create('format (invalid)')
   .get('/not-a-package.json')
   .expectBadge({ label: 'format', message: 'package or version not found' })
+
+t.create('format (explicit pypi base url)')
+  .get('/requests/2.18.4.json?pypiBaseUrl=https://some-other-pypi.org')
+  .intercept(nock =>
+    nock('https://some-other-pypi.org')
+      .get('/pypi/requests/2.18.4/json')
+      .reply(200, {
+        info: {
+          version: '2.18.4',
+          classifiers: [],
+        },
+        urls: [
+          {
+            packagetype: 'bdist_wheel',
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'format', message: 'wheel' })


### PR DESCRIPTION
Whilst reviewing #11530, I noticed that we were calling `config.util.toObject().public.services.pypi.baseUri` on every single PyPI badge request. Let's cache it when initialising the PyPI services. None of the tests were exercising the `pypiBaseUrl` parameter, I've added a mocked test with a non-default value.