### PR TITLE
Remove ignored Dependabot Friday config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-      day: friday
       time: '12:00'
     open-pull-requests-limit: 99
     rebase-strategy: disabled
@@ -36,7 +35,6 @@ updates:
     directory: '/badge-maker'
     schedule:
       interval: monthly
-      day: friday
       time: '12:00'
     open-pull-requests-limit: 99
     rebase-strategy: disabled
@@ -62,7 +60,6 @@ updates:
     directory: '/.github/actions/docusaurus-swizzled-warning'
     schedule:
       interval: monthly
-      day: friday
       time: '12:00'
     open-pull-requests-limit: 99
     rebase-strategy: disabled


### PR DESCRIPTION
Refs: #11351, https://github.com/badges/shields/pull/11533#issuecomment-3593138413.

According to the [Dependabot documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference):
> day | Specify the day to run for a weekly interval.
> Use monthly to run on the first day of each month.

Let's remove the ignored `day: friday` entries. Having Dependabot predictably kick in on the first day of the month feels reasonable.


