### PR TITLE
chore: update cron schedule for draft release to run on the 15th of each month

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,8 +1,8 @@
 name: Draft Release
 on:
   schedule:
-    - cron: '0 1 8 * *'
-    # At 01:00 on the 8th day of every month (one-week delay after dependabot)
+    - cron: '0 1 15 * *'
+    # At 01:00 on the 15th day of every month (~two-week delay after dependabot)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
delay to run a week after dependabot for some time to merge and make sure things are stable.

thank you @chris48s for the suggestion.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
