### PR TITLE
Drop support for fetchLimit config

### DIFF
--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -67,7 +67,6 @@ public:
   cacheHeaders:
     defaultCacheLengthSeconds: 'BADGE_MAX_AGE_SECONDS'
 
-  fetchLimit: 'FETCH_LIMIT'
   fetchLimitBytes: 'FETCH_LIMIT_BYTES'
   userAgentBase: 'USER_AGENT_BASE'
 

--- a/core/base-service/got-config.js
+++ b/core/base-service/got-config.js
@@ -1,21 +1,15 @@
-import bytes from 'bytes'
 import configModule from 'config'
 import Joi from 'joi'
-import { fileSize, fileSizeBytes } from '../../services/validators.js'
+import { fileSizeBytes } from '../../services/validators.js'
 
 const schema = Joi.object({
-  fetchLimit: fileSize,
   fetchLimitBytes: fileSizeBytes,
   userAgentBase: Joi.string().required(),
-})
-  .or('fetchLimit', 'fetchLimitBytes')
-  .required()
+}).required()
 const config = configModule.util.toObject()
 const publicConfig = Joi.attempt(config.public, schema, { allowUnknown: true })
 
-const fetchLimitBytes = publicConfig.fetchLimit
-  ? bytes(publicConfig.fetchLimit)
-  : publicConfig.fetchLimitBytes
+const fetchLimitBytes = publicConfig.fetchLimitBytes
 
 function getUserAgent(userAgentBase = publicConfig.userAgentBase) {
   let version = 'dev'

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -17,7 +17,6 @@ import { handleRequest } from '../base-service/legacy-request-handler.js'
 import { clearResourceCache } from '../base-service/resource-cache.js'
 import { rasterRedirectUrl } from '../badge-urls/make-badge-url.js'
 import {
-  fileSize,
   fileSizeBytes,
   nonNegativeInteger,
   optionalUrl,
@@ -153,7 +152,7 @@ const publicConfigSchema = Joi.object({
   }).required(),
   cacheHeaders: { defaultCacheLengthSeconds: nonNegativeInteger },
   handleInternalErrors: Joi.boolean().required(),
-  fetchLimit: fileSize,
+  fetchLimit: Joi.string(),
   fetchLimitBytes: fileSizeBytes,
   userAgentBase: Joi.string().required(),
   requestTimeoutSeconds: nonNegativeInteger,
@@ -168,9 +167,7 @@ const publicConfigSchema = Joi.object({
   ),
   allowUnsecuredEndpointRequests: Joi.boolean().required(),
   requireCloudflare: Joi.boolean().required(),
-})
-  .or('fetchLimit', 'fetchLimitBytes')
-  .required()
+}).required()
 
 const privateConfigSchema = Joi.object({
   azure_devops_token: Joi.string(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@xmldom/xmldom": "0.9.8",
         "badge-maker": "file:badge-maker",
         "byte-size": "^9.0.1",
-        "bytes": "^3.1.2",
         "camelcase": "^9.0.0",
         "chalk": "^5.6.2",
         "check-node-version": "^4.2.1",
@@ -10398,6 +10397,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@xmldom/xmldom": "0.9.8",
     "badge-maker": "file:badge-maker",
     "byte-size": "^9.0.1",
-    "bytes": "^3.1.2",
     "camelcase": "^9.0.0",
     "chalk": "^5.6.2",
     "check-node-version": "^4.2.1",

--- a/server.js
+++ b/server.js
@@ -33,7 +33,9 @@ console.log('Configuration:')
 console.dir(config.public, { depth: null })
 
 if (config.public.fetchLimit != null) {
-  console.warn('fetchLimit is deprecated, please use fetchLimitBytes instead')
+  console.error(
+    'fetchLimit is no longer supported, its value will be ignored. Please use fetchLimitBytes instead.',
+  )
 }
 
 export const server = new Server(config)

--- a/services/validators.js
+++ b/services/validators.js
@@ -78,19 +78,11 @@ export const optionalUrl = Joi.string().uri({ scheme: ['http', 'https'] })
 export const url = optionalUrl.required()
 
 /**
- * Joi validator for a file size we are going to pass to bytes.parse
- * see https://github.com/visionmedia/bytes.js#bytesparsestringnumber-value-numbernull
- *
- * @type {Joi}
- */
-export const fileSize = Joi.string().regex(/^[0-9]+(b|kb|mb|gb|tb)$/i)
-
-/**
  * Joi validator for a file size in bytes (direct numeric value)
  *
  * @type {Joi}
  */
-export const fileSizeBytes = Joi.number().integer().positive()
+export const fileSizeBytes = Joi.number().integer().positive().required()
 
 /**
  * Joi validator that checks if a value is a relative-only URI


### PR DESCRIPTION
Follow up to #11430. This is essentially step 3 listed in that PR, step 2 having been completed in #11558.