### PR TITLE
Run URL conventions Danger only on added lines

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -165,8 +165,9 @@ allFiles
     // eslint-disable-next-line promise/prefer-await-to-then
     danger.git.diffForFile(file).then(({ diff }) => {
       if (
-        diff.match(/base: '.*(download|install|license|version|release).*'/) ||
-        diff.match(/pattern: '.*(download|install|license|version|release).*'/)
+        diff.match(
+          /^\+.*(base|pattern): '.*(download|install|license|version|release).*'/m,
+        )
       ) {
         warn(
           [


### PR DESCRIPTION
Follow up to https://github.com/badges/shields/pull/11478. I noticed in https://github.com/badges/shields/pull/11536 that the warnings are emitted even if deleting an existing badge that does not follow URL conventions. This PR adds a `^\+[...]m` bit to the regex to only look for added lines, i.e. ones starting with `+`. I also combined the two regexes into one.

I've tested this with the following command which no longer produces the false positive:
```
DANGER_GITHUB_API_TOKEN=<token> npm run danger -- pr https://github.com/badges/shields/pull/11536

Danger: ✓ passed, found only messages.
## Messages
:sparkles: Thanks for your contribution to Shields, @PyvesB!
```

Other cases still trigger as expected:
```
DANGER_GITHUB_API_TOKEN=<token> npm run danger -- pr https://github.com/badges/shields/pull/11489

Danger: ✓ found only warnings, not failing the build
## Warnings
This PR modified service code. <br>Please run tests by [including affected services in the pull request title](https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests).
-
Found badge URL that may not follow our standard route abbreviations in `services/comfyui/comfyui-downloads.service.js`. <br>Please ensure you've reviewed our [conventions](https://github.com/badges/shields/blob/master/doc/badge-urls.md).
-
Found badge URL that may not follow our standard route abbreviations in `services/comfyui/comfyui-version.service.js`. <br>Please ensure you've reviewed our [conventions](https://github.com/badges/shields/blob/master/doc/badge-urls.md).
## Messages
:sparkles: Thanks for your contribution to Shields, @neverbiasu!
-
Thanks for contributing to our documentation. We :heart: our [documentarians](http://www.writethedocs.org/)!
```