### PR TITLE
Set checking-in-out attribute to `text=auto`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Using `text=auto` is a better practice for handling binary files. The previous `.gitattributes` configuration sometimes cannot detect the PNG files correctly and warns with the error below:

```
warning: in the working copy of 'core/server/test-public/img/frontend-image.png', CRLF will be replaced by LF the next time Git touches it
```