### PR TITLE
Add @LitoMore to maintainers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ Maintainers:
 
 - [calebcartwright](https://github.com/calebcartwright)
 - [jNullj](https://github.com/jnullj)
+- [LitoMore](https://github.com/LitoMore)
 - [paulmelnikow](https://github.com/paulmelnikow)
 - [PyvesB](https://github.com/PyvesB)
-- [LitoMore](https://github.com/LitoMore)
 
 Alumni:
 


### PR DESCRIPTION
Just noticed the readme has a section for showing maintainers.