### PR TITLE
Treat `img.shields.io/favicon.ico` as 404 resource

### DIFF
--- a/core/base-service/legacy-result-sender.js
+++ b/core/base-service/legacy-result-sender.js
@@ -22,11 +22,17 @@ function sendJSON(res, askres, end) {
   end(null, { template: streamFromString(res) })
 }
 
+function sendEmpty(end) {
+  end(null, { template: streamFromString('') })
+}
+
 function makeSend(format, askres, end) {
   if (format === 'svg') {
     return res => sendSVG(res, askres, end)
   } else if (format === 'json') {
     return res => sendJSON(res, askres, end)
+  } else if (format === 'empty') {
+    return () => sendEmpty(end)
   } else {
     throw Error(`Unrecognized format: ${format}`)
   }

--- a/core/server/server.js
+++ b/core/server/server.js
@@ -364,6 +364,15 @@ class Server {
       public: { rasterUrl },
     } = config
 
+    camp.route(/^\/favicon\.ico$/, (query, match, end, request) => {
+      request.res.statusCode = 404
+      request.res.setHeader(
+        'Cache-Control',
+        'public, max-age=31536000, s-maxage=31536000, immutable',
+      )
+      makeSend('empty', request.res, end)()
+    })
+
     camp.route(/\.(gif|jpg)$/, (query, match, end, request) => {
       const [, format] = match
       makeSend(

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -238,6 +238,17 @@ describe('The server', function () {
       expect(headers.location).to.equal('http://frontend.example.test')
     })
 
+    it('should return the 404 page with empty response for favicon.icon', async function () {
+      const { statusCode, body, headers } = await got(`${baseUrl}favicon.ico`, {
+        throwHttpErrors: false,
+      })
+      expect(statusCode).to.equal(404)
+      expect(body).to.equal('')
+      expect(headers['cache-control']).to.equal(
+        'public, max-age=31536000, s-maxage=31536000, immutable',
+      )
+    })
+
     it('should return the 410 badge for obsolete formats', async function () {
       const { statusCode, body } = await got(
         `${baseUrl}badge/foo-bar-blue.jpg`,


### PR DESCRIPTION
Related to the discussion in https://github.com/badges/shields/pull/11479#issuecomment-3618283976.