### PR TITLE
Cache deprecated badges for a day

### DIFF
--- a/core/base-service/deprecated-service.js
+++ b/core/base-service/deprecated-service.js
@@ -30,6 +30,7 @@ function deprecatedService(attrs) {
     static category = category
     static isDeprecated = true
     static route = route
+    static _cacheLength = 86400
     static defaultBadgeData = {
       label,
       // When an issue URL is provided, render the badge in red to alert the user that an upgrade action is required.


### PR DESCRIPTION
One nice outcome from the refactoring done in #11534 is that it's now much easier to override the cache length of deprecated badges. Deprecated badges only change when we delete them (after a minimum of one deprecation year), or in the rare event when we decide to undeprecate a badge (e.g. #3533). Caching them for a day will reduce the number of requests hitting our servers (at the time of writing 200k-300k for deprecated services on a typical week day) whilst still ensuring a deletion or an undeprecation kicks in pretty fast.