### PR TITLE
Discord: add apiBaseUrl

### DIFF
--- a/services/discord/discord.service.js
+++ b/services/discord/discord.service.js
@@ -59,8 +59,8 @@ export default class Discord extends BaseJsonService {
     }
   }
 
-  async fetch({ serverId }) {
-    const url = `https://discord.com/api/v6/guilds/${serverId}/widget.json`
+  async fetch({ apiBaseUrl, serverId }) {
+    const url = `${apiBaseUrl ?? "https://discord.com/api/v6"}/guilds/${serverId}/widget.json`
     return this._requestJson(
       this.authHelper.withBearerAuthHeader(
         {
@@ -76,8 +76,8 @@ export default class Discord extends BaseJsonService {
     )
   }
 
-  async handle({ serverId }) {
-    const data = await this.fetch({ serverId })
+  async handle({ apiBaseUrl, serverId }) {
+    const data = await this.fetch({ apiBaseUrl, serverId })
     return this.constructor.render({ members: data.presence_count })
   }
 }


### PR DESCRIPTION
I have no idea if I did this right, or whether I should be introducing a new badge type here.
Just quickly whipped this up in the web editor, as I wanted to have support for discord-compatible alternatives like Spacebar or Oldcord.

Example:
https://api.old.server.spacebar.chat/api/guilds/1006649183970562092/widget.json
