### PR TITLE
Cache some badges for longer

### DIFF
--- a/services/bundlephobia/bundlephobia.service.js
+++ b/services/bundlephobia/bundlephobia.service.js
@@ -106,7 +106,7 @@ export default class Bundlephobia extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 900
+  static _cacheLength = 1800
 
   static defaultBadgeData = { label: 'bundlephobia', color: 'informational' }
 

--- a/services/docker/docker-automated.service.js
+++ b/services/docker/docker-automated.service.js
@@ -43,7 +43,7 @@ export default class DockerAutomatedBuild extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 14400
+  static _cacheLength = 21600
 
   static defaultBadgeData = { label: 'docker build' }
 

--- a/services/docker/docker-pulls.service.js
+++ b/services/docker/docker-pulls.service.js
@@ -42,7 +42,7 @@ export default class DockerPulls extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 14400
+  static _cacheLength = 21600
 
   static defaultBadgeData = { label: 'docker pulls' }
 

--- a/services/docker/docker-size.service.js
+++ b/services/docker/docker-size.service.js
@@ -120,7 +120,7 @@ export default class DockerSize extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 600
+  static _cacheLength = 900
 
   static defaultBadgeData = { label: 'image size', color: 'blue' }
 

--- a/services/docker/docker-stars.service.js
+++ b/services/docker/docker-stars.service.js
@@ -42,7 +42,7 @@ export default class DockerStars extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 14400
+  static _cacheLength = 21600
 
   static defaultBadgeData = { label: 'docker stars' }
 

--- a/services/docker/docker-version.service.js
+++ b/services/docker/docker-version.service.js
@@ -97,6 +97,8 @@ export default class DockerVersion extends BaseJsonService {
     },
   }
 
+  static _cacheLength = 900
+
   static defaultBadgeData = { label: 'version', color: 'blue' }
 
   static render({ version }) {

--- a/services/npm/npm-downloads.service.js
+++ b/services/npm/npm-downloads.service.js
@@ -73,7 +73,7 @@ export default class NpmDownloads extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 3600
+  static _cacheLength = 7200
 
   // For testing.
   static _intervalMap = intervalMap

--- a/services/pepy/pepy-downloads.service.js
+++ b/services/pepy/pepy-downloads.service.js
@@ -39,7 +39,7 @@ export default class PepyDownloads extends BaseJsonService {
     },
   }
 
-  static _cacheLength = 21600
+  static _cacheLength = 28800
 
   static defaultBadgeData = { label: 'downloads' }
 

--- a/services/visual-studio-marketplace/visual-studio-marketplace-base.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace-base.js
@@ -55,7 +55,7 @@ export default class VisualStudioMarketplaceBase extends BaseJsonService {
   static get _cacheLength() {
     // we reached rate limit, instead of fine tuning for each service
     // we add a multipler to the default category cache length
-    return Math.floor(super._cacheLength * 1.3)
+    return Math.floor(super._cacheLength * 1.5)
   }
 
   static defaultBadgeData = {


### PR DESCRIPTION
Similar to what was done in #9785 and others. All these badges are reporting regular 429 error codes from upstream APIs, let's cache them for longer to reduce the request frequency.
