### PR TITLE
Add link to [GithubFollowers] badge

### DIFF
--- a/services/github/github-followers.service.js
+++ b/services/github/github-followers.service.js
@@ -24,11 +24,12 @@ export default class GithubFollowers extends GithubAuthV3Service {
 
   static defaultBadgeData = { label: 'followers', namedLogo: 'github' }
 
-  static render({ followers }) {
+  static render({ followers, user }) {
     return {
       message: metric(followers),
       style: 'social',
       color: 'blue',
+      link: [`https://github.com/${user}?tab=followers`],
     }
   }
 
@@ -38,6 +39,6 @@ export default class GithubFollowers extends GithubAuthV3Service {
       schema,
       httpErrors: httpErrorsFor('user not found'),
     })
-    return this.constructor.render({ followers })
+    return this.constructor.render({ followers, user })
   }
 }

--- a/services/github/github-followers.tester.js
+++ b/services/github/github-followers.tester.js
@@ -2,11 +2,14 @@ import { isMetric } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('Followers').get('/webcaetano.json').expectBadge({
-  label: 'followers',
-  message: isMetric,
-  color: 'blue',
-})
+t.create('Followers')
+  .get('/webcaetano.json')
+  .expectBadge({
+    label: 'followers',
+    message: isMetric,
+    color: 'blue',
+    link: ['https://github.com/webcaetano?tab=followers'],
+  })
 
 t.create('Followers (user not found)').get('/PyvesB2.json').expectBadge({
   label: 'followers',


### PR DESCRIPTION
This was the only GitHub badge with social style/category that was missing a link. Fixes #2271.