### PR TITLE
add a new service: [zed]

### DIFF
--- a/services/zed/zed-downloads.service.js
+++ b/services/zed/zed-downloads.service.js
@@ -7,9 +7,10 @@ const schema = Joi.object({
     .items(
       Joi.object({
         download_count: Joi.number().integer().required(),
-      }),
+      })
+        .min(1)
+        .required(),
     )
-    .min(1)
     .required(),
 }).required()
 

--- a/services/zed/zed-downloads.tester.js
+++ b/services/zed/zed-downloads.tester.js
@@ -1,0 +1,12 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Zed Downloads (valid)').get('/react-snippets-es7.json').expectBadge({
+  label: 'installs',
+  message: isMetric,
+})
+
+t.create('Flathub Downloads  (not found)')
+  .get('/extension.does.not.exist.json')
+  .expectBadge({ label: 'installs', message: 'invalid response data' })


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

Hi, added a new service for Zed editor extension downloads. The tests and service file is largely copied/modified from pre existing flathub service.

For some reason `npm start` doesn't work, hence I used `npm run debug:server`.

<img width="776" height="113" alt="image" src="https://github.com/user-attachments/assets/a72b3592-4ab2-424c-b618-90b076a82421" />

