### PR TITLE
Improve check runs documentation

### DIFF
--- a/services/github/github-checks-status.service.js
+++ b/services/github/github-checks-status.service.js
@@ -9,9 +9,10 @@ import {
 
 const description = `
 Displays the status of a tag, commit, or branch, as reported by the Commit Status API.
-Nowadays, GitHub Actions and many third party integrations report state via the
-Checks API. If this badge does not show expected values, please try out our
-corresponding Check Runs badge instead. You can read more about status checks in
+
+<b>Note:</b> Nowadays, GitHub Actions and many third party integrations report state via
+the Checks API. If this badge does not show expected values, please try out our
+corresponding [Check Runs badge][check-runs-link] instead. You can read more about status checks in
 the [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks).
 
 ${commonDocumentation}
@@ -32,7 +33,8 @@ export default class GithubChecksStatus extends GithubAuthV3Service {
     '/github/checks-status/{user}/{repo}/{branch}': {
       get: {
         summary: 'GitHub branch status',
-        description,
+        description: `${description}
+        [check-runs-link]: https://shields.io/badges/git-hub-branch-check-runs`,
         parameters: [
           pathParam({ name: 'user', example: 'badges' }),
           pathParam({ name: 'repo', example: 'shields' }),
@@ -43,7 +45,8 @@ export default class GithubChecksStatus extends GithubAuthV3Service {
     '/github/checks-status/{user}/{repo}/{commit}': {
       get: {
         summary: 'GitHub commit status',
-        description,
+        description: `${description}
+        [check-runs-link]: https://shields.io/badges/git-hub-commit-check-runs`,
         parameters: [
           pathParam({ name: 'user', example: 'badges' }),
           pathParam({ name: 'repo', example: 'shields' }),
@@ -57,7 +60,8 @@ export default class GithubChecksStatus extends GithubAuthV3Service {
     '/github/checks-status/{user}/{repo}/{tag}': {
       get: {
         summary: 'GitHub tag status',
-        description,
+        description: `${description}
+        [check-runs-link]: https://shields.io/badges/git-hub-tag-check-runs`,
         parameters: [
           pathParam({ name: 'user', example: 'badges' }),
           pathParam({ name: 'repo', example: 'shields' }),

--- a/services/github/github-pull-request-check-state.service.js
+++ b/services/github/github-pull-request-check-state.service.js
@@ -10,9 +10,10 @@ import {
 
 const description = `
 Displays the status of a pull request, as reported by the Commit Status API.
-Nowadays, GitHub Actions and many third party integrations report state via the
-Checks API. If this badge does not show expected values, please try out our
-corresponding Check Runs badge instead. You can read more about status checks in
+
+<b>Note:</b> Nowadays, GitHub Actions and many third party integrations report state via
+the Checks API. If this badge does not show expected values, please try out one of our
+[Check Runs badges](https://shields.io/search/?q=GitHub+check+runs) instead. You can read more about status checks in
 the [GitHub documentation](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks).
 
 ${commonDocumentation}


### PR DESCRIPTION
The difference between statuses and checks is a regular source of confusion for our users. Recent examples include https://github.com/badges/shields/issues/4755#issuecomment-3694693484 and https://github.com/badges/shields/issues/11499.

For those who are curious, there's a bit more historical context about this in #4364.

This PR aims at improving our existing documentation, by adding a direct link to the relevant check runs badge, and adding a bold `Note:` with a new paragraph breakline.

| **Before** | **After** |
| :---:   | :---: |
| <img width="759" height="276" alt="Screenshot 2026-01-01 at 17 36 23" src="https://github.com/user-attachments/assets/486b0a40-46ed-4e4c-9ec0-d6fabcda0b51" />  | <img width="761" height="289" alt="Screenshot 2026-01-01 at 17 49 12" src="https://github.com/user-attachments/assets/dabd1f87-b3f2-4302-b32e-da3898856d5e" /> |