### PR TITLE
Encourage repository stars

### DIFF
--- a/frontend/src/components/homepage-features.js
+++ b/frontend/src/components/homepage-features.js
@@ -74,6 +74,17 @@ const FeatureList = [
     title: 'Spread the word',
     description: (
       <>
+        <a
+          href="https://github.com/badges/shields"
+          rel="noreferrer"
+          target="_blank"
+        >
+          <img
+            alt="Shields.io GitHub stars"
+            src="https://img.shields.io/github/stars/badges/shields"
+          />
+        </a>
+        <br />
         Increase the project's visibility by adding a star to its{' '}
         <a
           href="https://github.com/badges/shields"


### PR DESCRIPTION
Having more stars on the repository gives the project a bit more visibility and can help us attract new contributors or maintainers.

I added a mention about this to our homepage, which also has the nice side effect or harmoniously balancing the two columns with three entries on each side:
<img width="2557" height="1315" alt="Screenshot 2026-01-01 at 18 10 14" src="https://github.com/user-attachments/assets/f1f8dc9b-73c9-4693-92e6-3187240a4870" />
