### PR TITLE
Remove [Reuse] 'Not a Git repository' handling

### DIFF
--- a/services/reuse/reuse-compliance.service.js
+++ b/services/reuse/reuse-compliance.service.js
@@ -42,9 +42,6 @@ export default class Reuse extends BaseJsonService {
     return await this._requestJson({
       schema: responseSchema,
       url: `https://api.reuse.software/status/${remote}`,
-      httpErrors: {
-        400: 'Not a Git repository',
-      },
     })
   }
 

--- a/services/reuse/reuse-compliance.tester.js
+++ b/services/reuse/reuse-compliance.tester.js
@@ -50,22 +50,9 @@ t.create('valid repo -- checking')
   })
 
 t.create('valid repo -- unregistered')
-  .get('/github.com/username/repo.json')
-  .intercept(nock =>
-    nock('https://api.reuse.software/status')
-      .get('/github.com/username/repo')
-      .reply(200, { status: 'unregistered' }),
-  )
+  .get('/github.com/badges/shields.json')
   .expectBadge({
     label: 'reuse',
     message: 'unregistered',
     color: COLOR_MAP.unregistered,
-  })
-
-t.create('invalid repo')
-  .timeout(15000)
-  .get('/github.com/repo/invalid-repo.json')
-  .expectBadge({
-    label: 'reuse',
-    message: 'Not a Git repository',
   })


### PR DESCRIPTION
When an invalid repository is specified, the API now returns the same response as for an unregistered one. Let's remove the special handling.
