### PR TITLE
Adapt [YouTube] channel not found handling

### DIFF
--- a/services/youtube/youtube-base.js
+++ b/services/youtube/youtube-base.js
@@ -75,6 +75,9 @@ class YouTubeBase extends BaseJsonService {
           options: {
             searchParams: { id, part: 'statistics' },
           },
+          httpErrors: {
+            400: `${this.constructor.type} not found`,
+          },
         },
       ),
     )

--- a/services/youtube/youtube-channel-views.tester.js
+++ b/services/youtube/youtube-channel-views.tester.js
@@ -21,5 +21,4 @@ t.create('channel not found')
   .expectBadge({
     label: 'youtube',
     message: 'channel not found',
-    color: 'red',
   })

--- a/services/youtube/youtube-subscribers.tester.js
+++ b/services/youtube/youtube-subscribers.tester.js
@@ -21,5 +21,4 @@ t.create('channel not found')
   .expectBadge({
     label: 'youtube',
     message: 'channel not found',
-    color: 'red',
   })


### PR DESCRIPTION
Unfortunately, YouTube messed up their API and are now returning a 400 response code with a weird error JSON when the channel ID is not found. Videos are unaffected and still return a 200 response with empty results. In addition to leveraging incorrect status codes, this means their API is now inconsistent between different object types.

The workaround is not too bad on our side, but annoyingly it does mean we lose the `red` color. I don't think there's an easy way to retain it, and I don't think it's worth investing much effort as this is an edge-case.