### PR TITLE
[GitHubRelease] Prefer `published_at` in github-release-date service

### DIFF
--- a/services/github/github-release-date.service.js
+++ b/services/github/github-release-date.service.js
@@ -24,7 +24,7 @@ const displayDateEnum = ['created_at', 'published_at']
 const queryParamSchema = Joi.object({
   display_date: Joi.string()
     .valid(...displayDateEnum)
-    .default('created_at'),
+    .default('published_at'),
 }).required()
 
 export default class GithubReleaseDate extends GithubAuthV3Service {


### PR DESCRIPTION
`created_at` refers to the creation time of the tag which the release points to, 
while `published_at` refers to the release publish time itself. 

In cases where the same (old) tag is reused across multiple publishes, 
when using `created_at` the badge will show an outdated date, 
while `published_at` would show the correct release publish date.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
