### PR TITLE
fix(tests): update guest API compliance test for [matrix]

### DIFF
--- a/services/matrix/matrix.tester.js
+++ b/services/matrix/matrix.tester.js
@@ -562,7 +562,7 @@ t.create('test fetchMode=guest is ignored for matrix.org')
   })
 
 t.create('test on real matrix room for guest API compliance')
-  .get('/ndcube:openastronomy.org.json?server_fqdn=openastronomy.modular.im')
+  .get('/twim:matrix.org.json?fetchMode=guest')
   .expectBadge({
     label: 'chat',
     message: Joi.string().regex(/^[0-9]+ users$/),


### PR DESCRIPTION
old endpoint does not allow guests anymore.
new test endpoint is on matrix.org and default to summery mode, so explicit guest mode is required.

fixes failed daily tests for matrix

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
