### PR TITLE
fix(tests): update color validation for version badge in [AUR] tests

### DIFF
--- a/services/aur/aur.tester.js
+++ b/services/aur/aur.tester.js
@@ -18,7 +18,7 @@ t.create('version (valid)')
   .expectBadge({
     label: 'aur',
     message: isVPlusDottedVersionNClausesWithOptionalSuffix,
-    color: 'blue',
+    color: Joi.string().valid('blue', 'orange').required(),
   })
 
 t.create('version (not found)')


### PR DESCRIPTION
color may be blue on up to date pacakge or orange when not up to date.
packages are expected to be out of date from time to time. as can be seen in our latest daily tests.
this is a valid result and should not fail the test.
the `visual-studio-code-bin` package in aur is still very popular and 'alive'.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
