### PR TITLE
fix(tests): update [crates] tests to use the base64 crate reduces timeouts

### DIFF
--- a/services/crates/crates-dependents.tester.js
+++ b/services/crates/crates-dependents.tester.js
@@ -2,7 +2,7 @@ import { isMetric } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('dependent count').get('/tokio.json').expectBadge({
+t.create('dependent count').get('/base64.json').expectBadge({
   label: 'dependents',
   message: isMetric,
 })


### PR DESCRIPTION
Due to ongoing issue with crates.io response time for some crates dependent count is too long. base64 is still very popular but with much smaller response times.

This commit updates the test so we reduce the chance of failure in tests due to upstream optimization issue.

Part of issue - Crates.io Dependents upstream timeouts #11633
