### PR TITLE
increase cache time for [crates] dependents badge

### DIFF
--- a/services/crates/crates-dependents.service.js
+++ b/services/crates/crates-dependents.service.js
@@ -27,6 +27,8 @@ export default class CratesDependents extends BaseCratesService {
     },
   }
 
+  static _cacheLength = 43200 // due to issue #11633 - cache for 12 hours - this value is not quick to change
+
   static render({ dependentCount }) {
     return {
       label: 'dependents',


### PR DESCRIPTION
due to #11633 increase cache time.
1. dependents is not updating often
2. existing cache in other category is default cache (120) which is very sort
3. upstream advised of long cache time
4. longer cache reduce chance of timeout from long requests.

for more info see #11633

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
