### PR TITLE
Fix [GitlabPipeline] custom URL tests

### DIFF
--- a/services/gitlab/gitlab-pipeline-coverage.tester.js
+++ b/services/gitlab/gitlab-pipeline-coverage.tester.js
@@ -57,9 +57,7 @@ t.create('Coverage (custom invalid job)')
   })
 
 t.create('Coverage (custom gitlab URL)')
-  .get(
-    '/GNOME/at-spi2-core.json?gitlab_url=https://gitlab.gnome.org&branch=master',
-  )
+  .get('/sdk/kde-builder.json?gitlab_url=https://invent.kde.org&branch=master')
   .expectBadge({
     label: 'coverage',
     message: isIntegerPercentage,
@@ -67,7 +65,7 @@ t.create('Coverage (custom gitlab URL)')
 
 t.create('Coverage (custom gitlab URL and job)')
   .get(
-    '/GNOME/libhandy.json?gitlab_url=https://gitlab.gnome.org&branch=master&job_name=unit-test',
+    '/sdk/kde-builder.json?gitlab_url=https://invent.kde.org&branch=master&job_name=unit_and_integration_tests',
   )
   .expectBadge({
     label: 'coverage',

--- a/services/gitlab/gitlab-pipeline-status.tester.js
+++ b/services/gitlab/gitlab-pipeline-status.tester.js
@@ -45,7 +45,9 @@ t.create('Pipeline status (nonexistent repo)')
   })
 
 t.create('Pipeline status (custom gitlab URL)')
-  .get('/pipeline-status/GNOME/pango.json?gitlab_url=https://gitlab.gnome.org')
+  .get(
+    '/pipeline-status/sdk/kde-builder.json?gitlab_url=https://invent.kde.org&branch=master',
+  )
   .expectBadge({
     label: 'build',
     message: isBuildStatus,


### PR DESCRIPTION
The GNOME GitLab instance now has some sort of bot protection:
<img width="497" height="476" alt="Screenshot 2026-01-31 at 17 42 33" src="https://github.com/user-attachments/assets/4eafe265-43b8-43e5-b46a-f5081e145e83" />

Unlike other GitLab badges which hit the API directly and aren't covered by this check, the pipeline ones do SVG scrapping and fail due to this. I'm updated the public GitLab instance used in our tests.