### PR TITLE
Change to use the registration service that includes SemVer2 versions

### DIFF
--- a/services/feedz/feedz.service.js
+++ b/services/feedz/feedz.service.js
@@ -71,7 +71,7 @@ class FeedzVersionService extends BaseJsonService {
   async fetch({ baseUrl, packageName }) {
     const registrationsBaseUrl = await searchServiceUrl(
       baseUrl,
-      'RegistrationsBaseUrl',
+      'RegistrationsBaseUrl/3.6.0',
     )
     return await this._requestJson({
       schema: packageSchema,


### PR DESCRIPTION
Fixes https://github.com/badges/shields/issues/11623

## Problem

Shields is using the default `RegistrationsBaseUrl` endpoint, which excludes SemVer2 packages. According to the [NuGet API documentation](https://learn.microsoft.com/en-us/nuget/api/registration-base-url-resource), the `RegistrationsBaseUrl` resource has different versions with varying SemVer2 support:

- **`RegistrationsBaseUrl`** (default): SemVer 2.0.0 packages are **excluded**
- **`RegistrationsBaseUrl/3.4.0`**: SemVer 2.0.0 packages are **excluded** (but responses are gzip-compressed)
- **`RegistrationsBaseUrl/3.6.0`**: SemVer 2.0.0 packages are **included** (and responses are gzip-compressed)

The Feedz.io service was calling `searchServiceUrl(baseUrl, 'RegistrationsBaseUrl')`, which returned the default endpoint that excludes SemVer2 versions.

## Solution

Changed the service to request `RegistrationsBaseUrl/3.6.0` instead of `RegistrationsBaseUrl`. This ensures that SemVer2 versions are included in the API response, allowing the service to properly display them in badges.

The modified method is only used by feedz.

The downside to this approach is that it takes quite a few requests and returns lots of extra data that is not needed, making it slower.



## Testing

Running `npm run badge -- /feedz/vpre/xunit/xunit/xunit.v3`:

**Before**
```
 Service data
 { label: 'feedz', message: 'v3.2.2', color: 'blue' }
 Rendered badge
 {
  label: 'feedz',
  message: 'v3.2.2',
  color: 'blue',
  link: [],
  name: 'feedz',
  value: 'v3.2.2'
}
```

**After**
```
 Service data
 { label: 'feedz', message: 'v4.0.0-pre.11', color: 'orange' }
 Rendered badge
 {
  label: 'feedz',
  message: 'v4.0.0-pre.11',
  color: 'orange',
  link: [],
  name: 'feedz',
  value: 'v4.0.0-pre.11'
}
````
