### PR TITLE
fix: remove null allowance from schema in [GitLabIssues]

### DIFF
--- a/services/gitlab/gitlab-issues.service.js
+++ b/services/gitlab/gitlab-issues.service.js
@@ -12,7 +12,7 @@ const schema = Joi.object({
       closed: nonNegativeInteger,
       opened: nonNegativeInteger,
     }).required(),
-  }).allow(null),
+  }),
 }).required()
 
 const queryParamSchema = Joi.object({


### PR DESCRIPTION
The return of null for any field in the response for this API call is undocumented and should not be allowed.

I could see a few errors on production related to the `transform` function using `statistics.count` while statistics is null, resulting in `TypeError` due to the call of a field of undefined.

This fix both upstream API schema usage & avoids future issues for calling fields of an undefined value.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
