### PR TITLE
fix: [JenkinsBuild] live view test

### DIFF
--- a/services/jenkins/jenkins-build.tester.js
+++ b/services/jenkins/jenkins-build.tester.js
@@ -8,7 +8,7 @@ t.create('build job not found')
 
 t.create('build found (view)')
   .get(
-    '/build.json?jobUrl=https://ci.hibernate.org/view/Main/job/hibernate-search/job/main',
+    '/build.json?jobUrl=https://ci-builds.apache.org/view/all/job/RocketMQ/job/auto-check-and-push-to-dockerhub',
   )
   .expectBadge({ label: 'build', message: isBuildStatus })
 


### PR DESCRIPTION
old test blocks us with 403, daily tests fail.
the view is all, so it might be a bit like cheating, but it seems to support the same path structure.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
