### PR TITLE
fix: replace [JenkinsPluginInstalls] endpoint to old.stats.jenkins.io

### DIFF
--- a/services/jenkins/jenkins-plugin-installs.service.js
+++ b/services/jenkins/jenkins-plugin-installs.service.js
@@ -40,7 +40,7 @@ export default class JenkinsPluginInstalls extends BaseJsonService {
 
   async fetch({ plugin }) {
     return this._requestJson({
-      url: `https://stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`,
+      url: `https://old.stats.jenkins.io/plugin-installation-trend/${plugin}.stats.json`,
       schema: schemaInstallations,
       httpErrors: {
         404: 'plugin not found',


### PR DESCRIPTION
old endpoint does not work for now for now.
revert this once `stats.jenkins.io` is back with tasty stats.

note to self: after merging, open an issue to revert when upstream is usable.
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
