### PR TITLE
Remove deprecated fetchLimit from configuration

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -150,7 +150,6 @@ const publicConfigSchema = Joi.object({
   }).required(),
   cacheHeaders: { defaultCacheLengthSeconds: nonNegativeInteger },
   handleInternalErrors: Joi.boolean().required(),
-  fetchLimit: Joi.string(),
   fetchLimitBytes: fileSizeBytes,
   userAgentBase: Joi.string().required(),
   requestTimeoutSeconds: nonNegativeInteger,

--- a/server.js
+++ b/server.js
@@ -32,12 +32,6 @@ if (process.argv[3]) {
 console.log('Configuration:')
 console.dir(config.public, { depth: null })
 
-if (config.public.fetchLimit != null) {
-  console.error(
-    'fetchLimit is no longer supported, its value will be ignored. Please remove it from your config and use fetchLimitBytes instead.',
-  )
-}
-
 if (config.public.cors != null) {
   console.error(
     'cors.allowedOrigin is no longer supported, its value will be ignored. Please remove it from your config.',


### PR DESCRIPTION
Follow-up for #11569
We [deprecated at the 2025-12-01 release](https://github.com/badges/shields/blob/bf2f5fbd1fe98f1fecf74cdc748aabc106b63bef/CHANGELOG.md?plain=1#L46), I think that's a reasonable time for users to drop `fetchLimit` from their config.

note: put a big note for anyone who missed the deprecation notice at 2025-12-01.
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
