### PR TITLE
fix: update license at [CratesLicense] test

### DIFF
--- a/services/crates/crates-license.tester.js
+++ b/services/crates/crates-license.tester.js
@@ -16,7 +16,7 @@ t.create('license (not found)')
 // https://github.com/badges/shields/issues/7073
 t.create('license (null licenses in history)')
   .get('/stun.json')
-  .expectBadge({ label: 'license', message: 'MIT OR Apache-2.0' })
+  .expectBadge({ label: 'license', message: 'MIT/Apache-2.0' })
 
 t.create('license (version with null license)')
   .get('/stun/0.0.1.json')


### PR DESCRIPTION
stun update license name from `MIT OR Apache-2.0` to `MIT/Apache-2.0`
update test by replacing the message to the new license.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
