### PR TITLE
feat: add Progress / Percentage Badge (fixes #11592)

### DIFF
--- a/services/progress/progress-gradient.js
+++ b/services/progress/progress-gradient.js
@@ -1,0 +1,129 @@
+/**
+ * Gradient color interpolation for progress/percentage badges.
+ * Maps a percentage (0-100) to a color along a predefined or custom gradient.
+ */
+
+const NAMED_HEX = {
+  red: '#e05d44',
+  brightgreen: '#44cc11',
+  green: '#97ca00',
+  yellow: '#dfb317',
+  yellowgreen: '#a4a61d',
+  orange: '#fe7d37',
+}
+
+const PREDEFINED_GRADIENTS = {
+  'red-green': ['red', 'brightgreen'],
+  'green-red': ['brightgreen', 'red'],
+  'red-yellow-green': ['red', 'yellow', 'brightgreen'],
+  'green-yellow-red': ['brightgreen', 'yellow', 'red'],
+}
+
+/**
+ * Parse hex or named color to [r, g, b].
+ *
+ * @param {string} color - Hex (#abc, #aabbcc) or named color
+ * @returns {number[]} RGB values 0-255
+ */
+function parseColor(color) {
+  const trimmed = color.trim().toLowerCase()
+  if (NAMED_HEX[trimmed]) {
+    return hexToRgb(NAMED_HEX[trimmed])
+  }
+  if (trimmed.startsWith('#')) {
+    return hexToRgb(trimmed)
+  }
+  return hexToRgb(`#${trimmed}`)
+}
+
+function hexToRgb(hex) {
+  hex = hex.replace(/^#/, '')
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+  }
+  const r = parseInt(hex.slice(0, 2), 16)
+  const g = parseInt(hex.slice(2, 4), 16)
+  const b = parseInt(hex.slice(4, 6), 16)
+  return [r, g, b]
+}
+
+function rgbToHex(r, g, b) {
+  return `#${[r, g, b]
+    .map(x => Math.round(Math.max(0, Math.min(255, x))))
+    .map(x => x.toString(16).padStart(2, '0'))
+    .join('')}`
+}
+
+/**
+ * Linearly interpolate between two RGB colors.
+ *
+ * @param {number[]} a - Start color
+ * @param {number[]} b - End color
+ * @param {number} t - Factor 0..1
+ * @returns {string} Hex color
+ */
+function lerpColor(a, b, t) {
+  const r = a[0] + (b[0] - a[0]) * t
+  const g = a[1] + (b[1] - a[1]) * t
+  const b_ = a[2] + (b[2] - a[2]) * t
+  return rgbToHex(r, g, b_)
+}
+
+/**
+ * Get color from gradient at position t (0-1).
+ *
+ * @param {string[]} colorStops - Array of color names or hex codes
+ * @param {number} t - Position 0..1
+ * @returns {string} Hex color
+ */
+function interpolateGradient(colorStops, t) {
+  if (colorStops.length === 0) return NAMED_HEX.red
+  if (colorStops.length === 1) return resolveToHex(colorStops[0])
+  if (t >= 1) return resolveToHex(colorStops[colorStops.length - 1])
+  if (t <= 0) return resolveToHex(colorStops[0])
+
+  const segments = colorStops.length - 1
+  const segmentIndex = Math.min(Math.floor(t * segments), segments - 1)
+  const localT = t * segments - segmentIndex
+
+  const start = parseColor(resolveToHex(colorStops[segmentIndex]))
+  const end = parseColor(resolveToHex(colorStops[segmentIndex + 1]))
+  return lerpColor(start, end, localT)
+}
+
+function resolveToHex(color) {
+  const t = color.trim().toLowerCase()
+  if (NAMED_HEX[t]) return NAMED_HEX[t]
+  if (t.startsWith('#')) return t.length >= 6 ? t : expandShortHex(t)
+  if (/^[0-9a-f]{6}$/i.test(t) || /^[0-9a-f]{3}$/i.test(t)) return `#${t}`
+  return NAMED_HEX.red
+}
+
+function expandShortHex(hex) {
+  if (hex.length !== 4) return hex
+  return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`
+}
+
+/**
+ * Get badge color for a percentage using the specified gradient.
+ *
+ * @param {number} percentage - 0..100
+ * @param {string} gradientKey - Predefined key or custom colors (e.g. 'red-green')
+ * @returns {string} Hex color for badge
+ */
+export function gradientColorForPercentage(percentage, gradientKey) {
+  const t = Math.max(0, Math.min(100, percentage)) / 100
+
+  let colorStops
+  if (PREDEFINED_GRADIENTS[gradientKey]) {
+    colorStops = PREDEFINED_GRADIENTS[gradientKey]
+  } else if (gradientKey && gradientKey.includes('-')) {
+    colorStops = gradientKey.split('-').filter(Boolean)
+  } else {
+    colorStops = PREDEFINED_GRADIENTS['red-green']
+  }
+
+  return interpolateGradient(colorStops, t)
+}
+
+export { PREDEFINED_GRADIENTS, NAMED_HEX }

--- a/services/progress/progress-gradient.spec.js
+++ b/services/progress/progress-gradient.spec.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai'
+import { gradientColorForPercentage, NAMED_HEX } from './progress-gradient.js'
+
+describe('gradientColorForPercentage', function () {
+  it('returns red for 0% with red-green gradient', function () {
+    expect(gradientColorForPercentage(0, 'red-green')).to.equal(NAMED_HEX.red)
+  })
+
+  it('returns brightgreen for 100% with red-green gradient', function () {
+    expect(gradientColorForPercentage(100, 'red-green')).to.equal(
+      NAMED_HEX.brightgreen,
+    )
+  })
+
+  it('returns interpolated color for 50%', function () {
+    const color = gradientColorForPercentage(50, 'red-green')
+    expect(color).to.match(/^#[0-9a-f]{6}$/i)
+    expect(color).not.to.equal(NAMED_HEX.red)
+    expect(color).not.to.equal(NAMED_HEX.brightgreen)
+  })
+
+  it('uses green-red gradient (reversed)', function () {
+    expect(gradientColorForPercentage(0, 'green-red')).to.equal(
+      NAMED_HEX.brightgreen,
+    )
+    expect(gradientColorForPercentage(100, 'green-red')).to.equal(NAMED_HEX.red)
+  })
+
+  it('supports red-yellow-green gradient', function () {
+    expect(gradientColorForPercentage(0, 'red-yellow-green')).to.equal(
+      NAMED_HEX.red,
+    )
+    expect(gradientColorForPercentage(100, 'red-yellow-green')).to.equal(
+      NAMED_HEX.brightgreen,
+    )
+  })
+
+  it('defaults to red-green when gradient unknown', function () {
+    expect(gradientColorForPercentage(0, 'unknown')).to.equal(NAMED_HEX.red)
+  })
+
+  it('clamps percentage to 0-100', function () {
+    expect(gradientColorForPercentage(-10, 'red-green')).to.equal(NAMED_HEX.red)
+    expect(gradientColorForPercentage(150, 'red-green')).to.equal(
+      NAMED_HEX.brightgreen,
+    )
+  })
+})

--- a/services/progress/progress.service.js
+++ b/services/progress/progress.service.js
@@ -1,0 +1,132 @@
+/**
+ * Progress / Percentage Badge
+ * Displays a percentage with gradient-based coloring.
+ * Data is provided via URL parameters (static/generic badge).
+ */
+
+import Joi from 'joi'
+import { BaseStaticService, InvalidParameter, queryParams } from '../index.js'
+import { gradientColorForPercentage } from './progress-gradient.js'
+
+const queryParamSchema = Joi.object({
+  label: Joi.string().allow('').optional(),
+  message: Joi.string().allow('').optional(),
+  percentage: Joi.alternatives()
+    .try(Joi.number().min(0).max(100), Joi.number().min(0).max(1))
+    .optional(),
+  numerator: Joi.number().integer().min(0).optional(),
+  denominator: Joi.number().integer().min(1).optional(),
+  gradient: Joi.string().optional(),
+}).required()
+
+const description = `
+Visualize progress or percentages with gradient-based coloring.
+
+**Percentage input** (one of):
+- <code>percentage</code>: 0-100 (integer) or 0.00-1.00 (decimal)
+- <code>numerator</code> + <code>denominator</code>: Computed as numerator/denominator × 100
+
+**Gradient options**:
+- <code>red-green</code>: 0% red → 100% green
+- <code>green-red</code>: 0% green → 100% red
+- <code>red-yellow-green</code>: red → yellow → green
+- <code>green-yellow-red</code>: green → yellow → red
+- Custom: <code>color1-color2-color3</code> (hex or CSS color names)
+
+**Examples**:
+- Development progress: <code>/badge/progress?label=Docs&percentage=75&gradient=red-green</code>
+- Quality rating: <code>/badge/progress?label=Quality&numerator=4&denominator=5&gradient=red-yellow-green</code>
+`
+
+export default class ProgressBadge extends BaseStaticService {
+  static category = 'other'
+
+  static route = {
+    base: 'badge/progress',
+    pattern: '',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/badge/progress': {
+      get: {
+        summary: 'Progress / Percentage Badge',
+        description,
+        parameters: queryParams(
+          {
+            name: 'label',
+            schema: { type: 'string' },
+            example: 'progress',
+          },
+          {
+            name: 'message',
+            schema: { type: 'string' },
+            description: 'Optional; if empty shows percentage with %',
+          },
+          {
+            name: 'percentage',
+            schema: { type: 'number' },
+            description: '0-100 or 0.00-1.00',
+          },
+          {
+            name: 'numerator',
+            schema: { type: 'integer' },
+          },
+          {
+            name: 'denominator',
+            schema: { type: 'integer' },
+          },
+          {
+            name: 'gradient',
+            schema: {
+              type: 'string',
+              enum: [
+                'red-green',
+                'green-red',
+                'red-yellow-green',
+                'green-yellow-red',
+              ],
+            },
+          },
+        ),
+      },
+    },
+  }
+
+  static defaultBadgeData = {
+    label: 'progress',
+  }
+
+  handle(namedParams, queryParams) {
+    const { label, message, percentage, numerator, denominator, gradient } =
+      queryParams
+
+    let value
+    if (percentage !== undefined) {
+      value = percentage <= 1 ? percentage * 100 : percentage
+    } else if (numerator !== undefined && denominator !== undefined) {
+      value = (numerator / denominator) * 100
+    } else if (numerator !== undefined || denominator !== undefined) {
+      throw new InvalidParameter({
+        prettyMessage: 'numerator and denominator required together',
+      })
+    } else {
+      throw new InvalidParameter({
+        prettyMessage: 'percentage or numerator+denominator required',
+      })
+    }
+
+    const pct = Math.max(0, Math.min(100, value))
+    const gradientKey = gradient || 'red-green'
+    const color = gradientColorForPercentage(pct, gradientKey)
+
+    const displayMessage =
+      message !== undefined && message !== '' ? message : `${pct.toFixed(0)}%`
+
+    return {
+      label: label ?? 'progress',
+      message: displayMessage,
+      color,
+    }
+  }
+}

--- a/services/progress/progress.tester.js
+++ b/services/progress/progress.tester.js
@@ -1,0 +1,66 @@
+import Joi from 'joi'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('percentage: integer 0-100')
+  .get('.json?percentage=75&gradient=red-green')
+  .expectBadge({
+    label: 'progress',
+    message: '75%',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('percentage: decimal 0-1')
+  .get('.json?percentage=0.75&gradient=red-green')
+  .expectBadge({
+    label: 'progress',
+    message: '75%',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('numerator and denominator')
+  .get('.json?numerator=4&denominator=5&gradient=red-yellow-green')
+  .expectBadge({
+    label: 'progress',
+    message: '80%',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('custom label and message')
+  .get('.json?label=Docs&message=Good&percentage=90&gradient=green-red')
+  .expectBadge({
+    label: 'Docs',
+    message: 'Good',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('0% - red in red-green gradient')
+  .get('.json?percentage=0&gradient=red-green')
+  .expectBadge({
+    label: 'progress',
+    message: '0%',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('100% - green in red-green gradient')
+  .get('.json?percentage=100&gradient=red-green')
+  .expectBadge({
+    label: 'progress',
+    message: '100%',
+    color: Joi.string().regex(/^#[0-9a-f]{3,6}$/i),
+  })
+
+t.create('missing percentage and numerator')
+  .get('.json?gradient=red-green')
+  .expectBadge({
+    label: 'progress',
+    message: 'percentage or numerator+denominator required',
+    color: 'red',
+  })
+
+t.create('numerator without denominator').get('.json?numerator=5').expectBadge({
+  label: 'progress',
+  message: 'numerator and denominator required together',
+  color: 'red',
+})


### PR DESCRIPTION
Fixes #11592

## Summary
Adds a static progress/percentage badge with gradient-based coloring. Data is provided via URL parameters.

## What it does
- **Percentage input:** `percentage` (0-100 or 0.00-1.00) or `numerator` + `denominator`
- **Gradients:** `red-green`, `green-red`, `red-yellow-green`, `green-yellow-red`, or custom
- **Optional:** `label`, `message`, `gradient` params

## Examples
- `/badge/progress?percentage=75&gradient=red-green`
- `/badge/progress?label=Docs&percentage=75&gradient=red-green`
- `/badge/progress?label=Quality&numerator=4&denominator=5&gradient=red-yellow-green`