### PR TITLE
fix: update cache key to include Cypress files in `test-e2e.yml`

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -21,7 +21,7 @@ jobs:
           cache-name: cache-cypress
         with:
           path: ~/.cache/Cypress
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json', 'cypress/**') }}
 
       - name: Setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Fix issue where updating the test does not update cache see PR #11718 for example of old cache being used.
We used to name the cache based on hash for pacakge-lock, this change will also include all files in `/cypress` as part of the cache name hash.

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
