### PR TITLE
fix: move onBrokenMarkdownLinks configuration to hooks

### DIFF
--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -9,7 +9,6 @@ const config = {
   url: 'https://shields.io',
   baseUrl: '/',
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',
   organizationName: 'badges',
   projectName: 'shields',
@@ -30,6 +29,9 @@ const config = {
       comments: true,
       admonitions: true,
       headingIds: true,
+    },
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
     },
   },
 


### PR DESCRIPTION
The old path for this config option is deprecated and will be removed in docusaurus v4.
warning can be found in [build log](https://github.com/badges/shields/actions/runs/22644845739/job/65631184147?pr=11718#step:5:27)

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
