### PR TITLE
Fix [BundleJs] test

### DIFF
--- a/services/bundlejs/bundlejs-package.tester.js
+++ b/services/bundlejs/bundlejs-package.tester.js
@@ -23,7 +23,7 @@ t.create('bundlejs/package (select exports)')
   .expectBadge({ label: 'minified size (gzip)', message: isMetricFileSize })
 
 t.create('bundlejs/package (scoped version select exports)')
-  .get('/@ngneat/falso@6.4.0.json?exports=randEmail,randFullName')
+  .get('/@floating-ui/dom@1.6.0.json?exports=computePosition,autoUpdate')
   .expectBadge({ label: 'minified size (gzip)', message: isMetricFileSize })
 
 t.create('bundlejs/package (externals)')


### PR DESCRIPTION
Was failing in [daily tests](https://github.com/badges/shields/actions/runs/22791784114):
> BundlejsPackage [live] bundlejs/package (scoped version select exports)
> [ GET /@ngneat/[falso@6.4.0.json](mailto:falso@6.4.0.json)?exports=randEmail,randFullName ]
> 
> AssertionError: label mismatch: expected 'bundlejs' to equal 'minified size (gzip)'