### PR TITLE
Fix [PythonVersionFromToml] test

### DIFF
--- a/services/python/python-version-from-toml.tester.js
+++ b/services/python/python-version-from-toml.tester.js
@@ -22,6 +22,6 @@ t.create(
   'python versions - valid toml with missing python-requires field (invalid)',
 )
   .get(
-    '/python/required-version-toml.json?tomlFilePath=https://raw.githubusercontent.com/psf/requests/main/pyproject.toml',
+    '/python/required-version-toml.json?tomlFilePath=https://raw.githubusercontent.com/psf/requests/v2.31.0/pyproject.toml',
   )
   .expectBadge({ label: 'python', message: 'invalid response data' })


### PR DESCRIPTION
Was failing in [daily tests](https://github.com/badges/shields/actions/runs/22791784114):
> PythonVersionFromToml [live] python versions - valid toml with missing python-requires field (invalid)
> [ GET /python/required-version-toml.json?tomlFilePath=https://raw.githubusercontent.com/psf/requests/main/pyproject.toml ]
> 
> AssertionError: message mismatch: expected '>=3.10' to equal 'invalid response data'