### PR TITLE
Fix [SonarViolations] test

### DIFF
--- a/services/sonar/sonar-violations.tester.js
+++ b/services/sonar/sonar-violations.tester.js
@@ -122,7 +122,7 @@ t.create('Violations Long Format (legacy API supported)')
 
 t.create('Blocker Violations')
   .timeout(10000)
-  .get('/blocker_violations/brave_brave-core.json?server=https://sonarcloud.io')
+  .get('/blocker_violations/apache_camel.json?server=https://sonarcloud.io')
   .expectBadge({
     label: 'blocker violations',
     message: isMetric,


### PR DESCRIPTION
Was failing in [daily tests](https://github.com/badges/shields/actions/runs/22791784114):
> SonarViolations [live] Blocker Violations
> [ GET /blocker_violations/brave_brave-core.json?server=https://sonarcloud.io ]
> 
> ValidationError: message mismatch: "value" with value "0" fails to match the required pattern: /^([1-9][0-9]*[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY])$/