### PR TITLE
Fix [Reuse] unregistered handling

### DIFF
--- a/services/reuse/reuse-compliance.service.js
+++ b/services/reuse/reuse-compliance.service.js
@@ -42,6 +42,7 @@ export default class Reuse extends BaseJsonService {
     return await this._requestJson({
       schema: responseSchema,
       url: `https://api.reuse.software/status/${remote}`,
+      httpErrors: { 404: 'unregistered' },
     })
   }
 


### PR DESCRIPTION
Was failing in [daily tests](https://github.com/badges/shields/actions/runs/22791784114):
> Reuse [live] valid repo -- unregistered
> [ GET /github.com/badges/shields.json ]
> 
> AssertionError: message mismatch: expected 'not found' to equal 'unregistered'

The API now seems to return a 404 response code for unregistered projects.