### PR TITLE
docs: Add tech stack section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ If you intend on reporting or contributing a fix related to security vulnerabili
 
 ## Development
 
+Tech stack used:
+
+![Stack Fingerprint](https://stackfingerprint.vercel.app/api/card?repo=badges/shields&theme=slate&layout=banner&size=md&icons=color&pills=round)
+
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/badges/shields?quickstart=1)
 
 1. Install Node 22. You can use the [package manager][] of your choice.


### PR DESCRIPTION
Added tech stack information and a Stack Fingerprint badge.

why: Because I think a developer who is new to the repository would be happy to have an instant overview about the tech stacks used.

how: Simply added a Stack Fingerprint card badge on the README

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
