### PR TITLE
Increase [Gitlab] test timeouts

### DIFF
--- a/services/gitlab/gitlab-issues.tester.js
+++ b/services/gitlab/gitlab-issues.tester.js
@@ -56,6 +56,7 @@ t.create('Open issues by label (raw)')
   })
 
 t.create('Opened issues by Scoped labels')
+  .timeout(10000)
   .get('/open/gitlab-org%2Fgitlab.json?labels=test,failure::new')
   .expectBadge({
     label: 'test,failure::new issues',

--- a/services/gitlab/gitlab-last-commit.tester.js
+++ b/services/gitlab/gitlab-last-commit.tester.js
@@ -60,6 +60,7 @@ t.create('last commit (project not found)')
   })
 
 t.create('last commit (no commits found)')
+  .timeout(10000)
   .get('/gitlab-org/gitlab.json?path=not/a/dir')
   .expectBadge({
     label: 'last commit',


### PR DESCRIPTION
A couple of tests in our daily runs fail due to timeouts ([example](https://github.com/badges/shields/actions/runs/23080283478)), let's see if increasing timeout helps.