### PR TITLE
[WinGet] feat: add WinGet release date badge

### DIFF
--- a/services/winget/winget-release-date.service.js
+++ b/services/winget/winget-release-date.service.js
@@ -1,0 +1,179 @@
+import Joi from 'joi'
+import gql from 'graphql-tag'
+import { renderDateBadge } from '../date.js'
+import { InvalidParameter, InvalidResponse, pathParam } from '../index.js'
+import { GithubAuthV4Service } from '../github/github-auth-service.js'
+import { transformErrors } from '../github/github-helpers.js'
+import { latest } from './version.js'
+
+// Schema for the first query: list version directories
+const versionListSchema = Joi.object({
+  data: Joi.object({
+    repository: Joi.object({
+      object: Joi.object({
+        entries: Joi.array().items(
+          Joi.object({
+            type: Joi.string().required(),
+            name: Joi.string().required(),
+            object: Joi.object({
+              entries: Joi.array().items(
+                Joi.object({
+                  type: Joi.string().required(),
+                  name: Joi.string().required(),
+                }),
+              ),
+            }).required(),
+          }),
+        ),
+      })
+        .allow(null)
+        .required(),
+    }).required(),
+  }).required(),
+}).required()
+
+// Schema for the second query: read installer YAML file content
+const fileContentSchema = Joi.object({
+  data: Joi.object({
+    repository: Joi.object({
+      object: Joi.object({
+        text: Joi.string().allow(null).required(),
+      })
+        .allow(null)
+        .required(),
+    }).required(),
+  }).required(),
+}).required()
+
+export default class WingetReleaseDate extends GithubAuthV4Service {
+  static category = 'activity'
+
+  static route = {
+    base: 'winget/release-date',
+    pattern: ':name',
+  }
+
+  static openApi = {
+    '/winget/release-date/{name}': {
+      get: {
+        summary: 'WinGet Package Release Date',
+        description:
+          'Displays the ReleaseDate of the latest version of a WinGet package. ReleaseDate is an optional field in the WinGet manifest and may not be present for all packages.',
+        parameters: [
+          pathParam({
+            name: 'name',
+            example: 'UPX.UPX',
+          }),
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = {
+    label: 'release date',
+  }
+
+  async fetchVersions({ name }) {
+    const nameFirstLower = name[0].toLowerCase()
+    const nameSlashed = name.replaceAll('.', '/')
+    const path = `manifests/${nameFirstLower}/${nameSlashed}`
+    const expression = `HEAD:${path}`
+    return this._requestGraphql({
+      query: gql`
+        query RepoFiles($expression: String!) {
+          repository(owner: "microsoft", name: "winget-pkgs") {
+            object(expression: $expression) {
+              ... on Tree {
+                entries {
+                  type
+                  name
+                  object {
+                    ... on Tree {
+                      entries {
+                        type
+                        name
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: { expression },
+      schema: versionListSchema,
+      transformErrors,
+    })
+  }
+
+  async fetchInstallerYaml({ name, version }) {
+    const nameFirstLower = name[0].toLowerCase()
+    const nameSlashed = name.replaceAll('.', '/')
+    const expression = `HEAD:manifests/${nameFirstLower}/${nameSlashed}/${version}/${name}.installer.yaml`
+    return this._requestGraphql({
+      query: gql`
+        query FileContent($expression: String!) {
+          repository(owner: "microsoft", name: "winget-pkgs") {
+            object(expression: $expression) {
+              ... on Blob {
+                text
+              }
+            }
+          }
+        }
+      `,
+      variables: { expression },
+      schema: fileContentSchema,
+      transformErrors,
+    })
+  }
+
+  async handle({ name }) {
+    // Step 1: find the latest version
+    const versionJson = await this.fetchVersions({ name })
+
+    if (versionJson.data.repository.object?.entries == null) {
+      throw new InvalidParameter({
+        prettyMessage: 'package not found',
+      })
+    }
+
+    const entries = versionJson.data.repository.object.entries
+    const directories = entries.filter(entry => entry.type === 'tree')
+    const versionDirs = directories.filter(dir =>
+      dir.object.entries.some(
+        file => file.type === 'blob' && file.name === `${name}.yaml`,
+      ),
+    )
+    const versions = versionDirs.map(dir => dir.name)
+    const version = latest(versions)
+
+    if (version == null) {
+      throw new InvalidParameter({
+        prettyMessage: 'no versions found',
+      })
+    }
+
+    // Step 2: fetch the installer YAML content and extract ReleaseDate
+    const fileJson = await this.fetchInstallerYaml({ name, version })
+    const text = fileJson.data.repository.object?.text
+
+    if (!text) {
+      throw new InvalidResponse({
+        prettyMessage: 'installer manifest not found',
+      })
+    }
+
+    // Parse ReleaseDate from YAML text (e.g., "ReleaseDate: 2025-07-20")
+    const match = text.match(/^ReleaseDate:\s*(\S+)/m)
+    if (!match) {
+      throw new InvalidResponse({
+        prettyMessage: 'release date not available',
+      })
+    }
+
+    const releaseDate = match[1]
+    return renderDateBadge(releaseDate, true)
+  }
+}

--- a/services/winget/winget-release-date.tester.js
+++ b/services/winget/winget-release-date.tester.js
@@ -1,0 +1,111 @@
+import { isFormattedDate } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+// live test: UPX.UPX has a known ReleaseDate in its installer manifest
+t.create('gets the release date of UPX')
+  .get('/UPX.UPX.json')
+  .expectBadge({ label: 'release date', message: isFormattedDate })
+
+// intercept test: ReleaseDate present in installer YAML
+t.create('returns formatted date when ReleaseDate is present')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      // First GraphQL call: list version directories
+      .post('/graphql')
+      .reply(200, {
+        data: {
+          repository: {
+            object: {
+              entries: [
+                {
+                  type: 'tree',
+                  name: '5.0.2',
+                  object: {
+                    entries: [
+                      { type: 'blob', name: 'UPX.UPX.installer.yaml' },
+                      { type: 'blob', name: 'UPX.UPX.locale.en-US.yaml' },
+                      { type: 'blob', name: 'UPX.UPX.yaml' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+      // Second GraphQL call: fetch installer YAML content
+      .post('/graphql')
+      .reply(200, {
+        data: {
+          repository: {
+            object: {
+              text: 'PackageIdentifier: UPX.UPX\nPackageVersion: 5.0.2\nReleaseDate: 2025-07-20\nManifestType: installer\nManifestVersion: 1.10.0\n',
+            },
+          },
+        },
+      }),
+  )
+  .get('/UPX.UPX.json')
+  .expectBadge({ label: 'release date', message: isFormattedDate })
+
+// intercept test: ReleaseDate not present in installer YAML
+t.create(
+  'returns "release date not available" when ReleaseDate field is missing',
+)
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql')
+      .reply(200, {
+        data: {
+          repository: {
+            object: {
+              entries: [
+                {
+                  type: 'tree',
+                  name: '1.0.0',
+                  object: {
+                    entries: [
+                      { type: 'blob', name: 'Some.Package.installer.yaml' },
+                      { type: 'blob', name: 'Some.Package.yaml' },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+      .post('/graphql')
+      .reply(200, {
+        data: {
+          repository: {
+            object: {
+              text: 'PackageIdentifier: Some.Package\nPackageVersion: 1.0.0\nManifestType: installer\nManifestVersion: 1.10.0\n',
+            },
+          },
+        },
+      }),
+  )
+  .get('/Some.Package.json')
+  .expectBadge({
+    label: 'release date',
+    message: 'release date not available',
+  })
+
+// intercept test: package not found
+t.create('returns "package not found" for unknown package')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql')
+      .reply(200, {
+        data: {
+          repository: {
+            object: null,
+          },
+        },
+      }),
+  )
+  .get('/Unknown.Package.json')
+  .expectBadge({ label: 'release date', message: 'package not found' })


### PR DESCRIPTION
Closes #11285

Adds a new `/winget/release-date/{name}` badge that displays the `ReleaseDate` field from a package's latest version installer manifest.

### How it works

1. Fetches the list of version directories (same GraphQL query as existing version badge).
2. Finds the latest version using the existing `latest()` helper.
3. Fetches the content of `{name}.installer.yaml` via a second GraphQL query.
4. Extracts the `ReleaseDate` YAML field from the manifest text.
5. Renders a formatted date badge using `renderDateBadge()`.

### Edge cases handled

- Package not found: `package not found`
- ReleaseDate field absent (it is optional per WinGet schema): `release date not available`
- Installer manifest missing: `installer manifest not found`

### Tests

Three mocked tests added and passing. Live test requires a GitHub token in `local.yml` (same as the existing WinGet version badge).