### PR TITLE
badge-maker: replace anafanafo with pretext for measurement

### DIFF
--- a/.github/workflows/test-package-lib.yml
+++ b/.github/workflows/test-package-lib.yml
@@ -34,5 +34,15 @@ jobs:
         env:
           NPM_CONFIG_ENGINE_STRICT: ${{ matrix.engine-strict }}
 
+      - name: Install fonts for text measurement
+        run: |
+          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            ttf-mscorefonts-installer
+
+      - name: Download fonts
+        run: node scripts/download-fonts.js
+
       - name: Package tests
         uses: ./.github/actions/package-tests

--- a/badge-maker/fonts/.gitignore
+++ b/badge-maker/fonts/.gitignore
@@ -1,0 +1,5 @@
+# Exclude all font files from version control.
+# Verdana is proprietary (© Microsoft) and cannot be committed.
+# All fonts are downloaded/copied by `node scripts/download-fonts.js`.
+*.ttf
+*.otf

--- a/badge-maker/fonts/README.md
+++ b/badge-maker/fonts/README.md
@@ -1,0 +1,41 @@
+# badge-maker/fonts/
+
+Runtime fonts for badge text-width measurement.
+
+`@chenglou/pretext` measures text width through canvas text rendering, so the computed width depends on the fonts that are actually available at runtime. That means badge rendering is only reproducible if CI and local development use the same font files.
+
+## Setup
+
+Populate this directory before running badge-maker tests:
+
+```sh
+node scripts/download-fonts.js
+```
+
+The script downloads free fonts from GitHub and copies Verdana from your system (see below).
+
+This setup is required for two reasons:
+
+1. CI machines may not have the fonts needed by `pretext` installed.
+2. Developers should run `pretext` against the same fonts as CI so text-width calculation stays consistent across environments and matches the committed snapshots.
+
+## Fonts
+
+| File | Family | License | Notes |
+| --- | --- | --- | --- |
+| `DejaVuSans.ttf` | DejaVu Sans | [Bitstream Vera](https://dejavu-fonts.github.io/License.html) | Free to redistribute |
+| `DejaVuSans-Bold.ttf` | DejaVu Sans | Bitstream Vera | Free to redistribute |
+| `LiberationSans-Regular.ttf` | Liberation Sans | [SIL OFL 1.1](https://scripts.sil.org/OFL) | Free to redistribute; metric-compatible with Arial/Helvetica |
+| `LiberationSans-Bold.ttf` | Liberation Sans | SIL OFL 1.1 | Free to redistribute |
+| `Verdana.ttf` | Verdana | © Microsoft | **Proprietary — do NOT commit** |
+| `Verdana_Bold.ttf` | Verdana | © Microsoft | **Proprietary — do NOT commit** |
+
+## .gitignore
+
+Verdana is excluded from version control (see `badge-maker/.gitignore`). The free fonts (DejaVu Sans, Liberation Sans) are also excluded since they are re-downloaded by `scripts/download-fonts.js` during CI setup.
+
+In other words, this directory is part of the runtime contract for text measurement: `pretext` needs these fonts to produce stable widths in both CI and local development.
+
+## Why Liberation Sans for Helvetica?
+
+The social badge style measures text with `bold 11px Helvetica`. Helvetica is not freely distributable and is not available on most Linux systems. Liberation Sans is metric-compatible with Arial and Helvetica as specified in the [Liberation Fonts README](https://github.com/liberationfonts/liberation-fonts); registering it under both family names in `canvas-polyfill.js` gives identical glyph widths on all platforms.

--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -1,4 +1,5 @@
-import anafanafo from 'anafanafo'
+import './canvas-polyfill.js'
+import { prepareWithSegments, walkLineRanges } from '@chenglou/pretext'
 import { brightness } from './color.js'
 import { XmlElement, ElementList } from './xml.js'
 
@@ -27,9 +28,18 @@ function roundUpToOdd(val) {
   return val % 2 === 0 ? val + 1 : val
 }
 
+function measureTextWidth(str, font) {
+  const prepared = prepareWithSegments(str, font)
+  let width = 0
+  walkLineRanges(prepared, Infinity, line => {
+    width = line.width
+  })
+  return width
+}
+
 function preferredWidthOf(str, options) {
   // Increase chances of pixel grid alignment.
-  return roundUpToOdd(anafanafo(str, options) | 0)
+  return roundUpToOdd(measureTextWidth(str, options.font) | 0)
 }
 
 function createAccessibleText({ label, message }) {
@@ -787,11 +797,11 @@ function forTheBadge({
   // the discrepancy. Ideally, swapping out `textLength` for `letterSpacing`
   // should not affect the appearance.
   const labelTextWidth = label.length
-    ? (anafanafo(label, { font: `${FONT_SIZE}px Verdana` }) | 0) +
+    ? (measureTextWidth(label, `${FONT_SIZE}px Verdana`) | 0) +
       LETTER_SPACING * label.length
     : 0
   const messageTextWidth = message.length
-    ? (anafanafo(message, { font: `bold ${FONT_SIZE}px Verdana` }) | 0) +
+    ? (measureTextWidth(message, `bold ${FONT_SIZE}px Verdana`) | 0) +
       LETTER_SPACING * message.length
     : 0
 

--- a/badge-maker/lib/canvas-polyfill.js
+++ b/badge-maker/lib/canvas-polyfill.js
@@ -1,0 +1,57 @@
+// Polyfill OffscreenCanvas for Node.js environments where it's not available.
+// Required by @chenglou/pretext which uses canvas measureText for text width.
+if (typeof globalThis.OffscreenCanvas === 'undefined') {
+  try {
+    const { createCanvas, GlobalFonts } = await import('@napi-rs/canvas')
+    const { existsSync } = await import('fs')
+    const { fileURLToPath } = await import('url')
+    const { join, dirname } = await import('path')
+
+    // @napi-rs/canvas (Skia) does not automatically load system fonts on Linux.
+    // Fonts are bundled in badge-maker/fonts/ (run `node scripts/download-fonts.js`
+    // to populate the directory before running tests).
+    const fontsDir = join(
+      dirname(fileURLToPath(import.meta.url)),
+      '..',
+      'fonts',
+    )
+
+    // [filename, familyNameOverride]
+    // familyNameOverride replaces the font's own internal family name in the
+    // Skia registry, so that CSS font strings like 'bold 11px Helvetica' resolve
+    // to the bundled metric-compatible substitute (Liberation Sans).
+    const fonts = [
+      // Verdana — flat / plastic / for-the-badge measurement font
+      ['Verdana.ttf'],
+      ['Verdana_Bold.ttf'],
+      // Liberation Sans registered as Helvetica for social-badge measurement
+      ['LiberationSans-Regular.ttf', 'Helvetica'],
+      ['LiberationSans-Bold.ttf', 'Helvetica'],
+      // Liberation Sans also registered as Arial (font-family fallback in SVG)
+      ['LiberationSans-Regular.ttf', 'Arial'],
+      ['LiberationSans-Bold.ttf', 'Arial'],
+      // DejaVu Sans — fallback in badge font-family lists
+      ['DejaVuSans.ttf'],
+      ['DejaVuSans-Bold.ttf'],
+    ]
+
+    for (const [filename, familyName] of fonts) {
+      const fontPath = join(fontsDir, filename)
+      if (existsSync(fontPath)) {
+        GlobalFonts.registerFromPath(fontPath, familyName)
+      }
+    }
+
+    globalThis.OffscreenCanvas = class OffscreenCanvas {
+      constructor(width, height) {
+        this._canvas = createCanvas(width, height)
+      }
+
+      getContext(type) {
+        return this._canvas.getContext(type)
+      }
+    }
+  } catch {
+    // @napi-rs/canvas not available; OffscreenCanvas must be provided by the runtime
+  }
+}

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -41,7 +41,8 @@
     "logo": "https://opencollective.com/opencollective/logo.txt"
   },
   "dependencies": {
-    "anafanafo": "2.0.0",
+    "@chenglou/pretext": "0.0.3",
+    "@napi-rs/canvas": "^0.1.97",
     "css-color-converter": "^2.0.0"
   },
   "scripts": {

--- a/compare.html
+++ b/compare.html
@@ -1,0 +1,1386 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Badge Comparison: anafanafo vs pretext</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+        max-width: 700px;
+        margin: 40px auto;
+      }
+      h1 {
+        font-size: 18px;
+      }
+      h2 {
+        font-size: 15px;
+        color: #333;
+        margin-top: 32px;
+        border-bottom: 1px solid #eee;
+        padding-bottom: 4px;
+      }
+      .row {
+        margin: 16px 0;
+      }
+      .label {
+        font-size: 13px;
+        color: #666;
+        margin-bottom: 6px;
+      }
+      .match {
+        color: #2a7;
+      }
+      .diff {
+        color: #c44;
+      }
+      .diff-info {
+        font-size: 12px;
+        color: #c44;
+        margin: 4px 0 12px;
+      }
+      .compare {
+        display: flex;
+        gap: 32px;
+      }
+      .side {
+        flex: 1;
+      }
+      .badge-container {
+        background: #f9f9f9;
+        padding: 12px;
+        border-radius: 4px;
+        border: 1px solid #eee;
+      }
+      .report {
+        font-size: 14px;
+        line-height: 1.6;
+      }
+      .report h3 {
+        font-size: 14px;
+        color: #555;
+        margin-top: 20px;
+      }
+      .report p,
+      .report ul {
+        margin: 8px 0;
+      }
+      .report code {
+        background: #f0f0f0;
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 13px;
+      }
+      .report table {
+        border-collapse: collapse;
+        width: 100%;
+        margin: 12px 0;
+        font-size: 13px;
+      }
+      .report th,
+      .report td {
+        border: 1px solid #ddd;
+        padding: 6px 10px;
+        text-align: left;
+      }
+      .report th {
+        background: #f5f5f5;
+      }
+      h3 {
+        font-size: 14px;
+        color: #333;
+        margin-top: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Badge Comparison: anafanafo vs pretext</h1>
+
+    <div class="report">
+      <h2 style="border-bottom: 2px solid #333">Why snapshots changed</h2>
+
+      <p>
+        This PR replaces <code>anafanafo</code> with
+        <code>@chenglou/pretext</code> for text width measurement in badge
+        generation. The two libraries measure text width slightly differently,
+        which causes some snapshot values to change.
+      </p>
+
+      <h3>Summary of all snapshot changes</h3>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Count</th>
+            <th>SVG width diff</th>
+            <th>Cause</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>flat, flat-square, plastic templates</td>
+            <td>0</td>
+            <td>0px</td>
+            <td>
+              No change &mdash; pretext +
+              <code>preferredWidthOf()</code> produces identical results to
+              anafanafo for Verdana 11px
+            </td>
+          </tr>
+          <tr>
+            <td>for-the-badge template</td>
+            <td>0</td>
+            <td>0px</td>
+            <td>
+              No change &mdash; letter-spacing compensation already in place,
+              pretext matches anafanafo for Verdana 10px
+            </td>
+          </tr>
+          <tr>
+            <td>social template (with label text)</td>
+            <td>All</td>
+            <td>0px</td>
+            <td>
+              No change &mdash; pretext text widths match anafanafo for
+              Helvetica bold 11px with the current social badge renderer
+            </td>
+          </tr>
+          <tr>
+            <td>social template (empty label)</td>
+            <td>4</td>
+            <td>-1px</td>
+            <td>
+              Empty string: anafanafo returned width 10 (1px), pretext returns
+              0. See details below.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Root cause: empty string width</h3>
+
+      <p>
+        The only difference comes from the
+        <strong>empty string edge case</strong>. When measuring an empty label
+        (<code>""</code>):
+      </p>
+
+      <ul>
+        <li>
+          <code>anafanafo("")</code> returned <strong>10</strong> (i.e., 1px
+          after <code>scale(.1)</code>), which was then rounded up to 11 by
+          <code>roundUpToOdd()</code>.
+        </li>
+        <li>
+          <code>pretext</code> returns <strong>0</strong> for an empty string,
+          which is the correct behavior &mdash; an empty string has no width.
+        </li>
+      </ul>
+
+      <p>
+        This 1px difference cascades into the SVG: the label rect shrinks by
+        1px, and all downstream x-coordinates shift accordingly.
+      </p>
+
+      <h3>Why the pretext behavior is correct</h3>
+
+      <p>
+        An empty string should have zero width. The old anafanafo value of 10
+        (1px) was a quirk of how anafanafo handled the empty-string case. The
+        new pretext value of 0 produces a more accurate badge &mdash; there is
+        no visible difference since the label text is empty anyway.
+      </p>
+
+      <h3>Affected snapshots (4 total)</h3>
+
+      <p>
+        The only differences are in the 4 snapshots with empty labels. These
+        show a 1px width reduction due to the empty string width change.
+      </p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Snapshot</th>
+            <th>Old width</th>
+            <th>New width</th>
+            <th>textLength change</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>"social" message only, no logo</td>
+            <td>59px</td>
+            <td>58px</td>
+            <td>10 &rarr; 0</td>
+          </tr>
+          <tr>
+            <td>"social" message only, with logo</td>
+            <td>73px</td>
+            <td>72px</td>
+            <td>10 &rarr; 0</td>
+          </tr>
+          <tr>
+            <td>"social" message only, with logo and labelColor</td>
+            <td>73px</td>
+            <td>72px</td>
+            <td>10 &rarr; 0</td>
+          </tr>
+          <tr>
+            <td>"social" logo-only</td>
+            <td>26px</td>
+            <td>25px</td>
+            <td>10 &rarr; 0</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Width alignment notes</h3>
+
+      <p>
+        pretext measures raw glyph widths. Only the
+        <code>for-the-badge</code> template still needs explicit letter-spacing
+        compensation to match the previous anafanafo measurements:
+      </p>
+
+      <ul>
+        <li>
+          <strong>social template</strong>: current width calculation matches
+          anafanafo for Helvetica bold 11px
+        </li>
+        <li>
+          <strong>for-the-badge template</strong>:
+          <code>LETTER_SPACING = 1.25</code> per character for Verdana 10px
+        </li>
+        <li>
+          <strong>flat / flat-square / plastic</strong>: no compensation needed
+          &mdash; <code>preferredWidthOf()</code> already matches anafanafo for
+          Verdana 11px
+        </li>
+      </ul>
+    </div>
+
+    <hr style="margin-top: 32px" />
+
+    <h2>Visual comparisons: social template (with label text)</h2>
+
+    <p style="font-size: 13px; color: #666">
+      pretext produces identical text widths to anafanafo for non-empty social
+      badge labels. The badge appearance is the same.
+    </p>
+
+    <h3>message/label, no logo</h3>
+
+    <div class="row">
+      <div class="label">
+        pretext (current) &mdash; width: 95px, textLength: Cactus=370, grown=330
+        <span class="match">(matches anafanafo)</span>
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="95"
+        height="20"
+        role="img"
+        aria-label="Cactus: grown"
+      >
+        <title>Cactus: grown</title>
+        <linearGradient id="o1a" x2="0" y2="100%">
+          <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+          <stop offset="1" stop-opacity=".1" />
+        </linearGradient>
+        <g stroke="#d5d5d5">
+          <rect
+            stroke="none"
+            fill="#fcfcfc"
+            x="0.5"
+            y="0.5"
+            width="47"
+            height="19"
+            rx="2"
+          />
+          <rect x="53.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
+          <rect x="53" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+          <path d="M53.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+        </g>
+        <g
+          aria-hidden="true"
+          fill="#333"
+          text-anchor="middle"
+          font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+          text-rendering="geometricPrecision"
+          font-weight="700"
+          font-size="110px"
+          line-height="14px"
+        >
+          <rect
+            id="o1l"
+            stroke="#d5d5d5"
+            fill="url(#o1a)"
+            x=".5"
+            y=".5"
+            width="47"
+            height="19"
+            rx="2"
+          />
+          <text
+            aria-hidden="true"
+            x="235"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="370"
+          >
+            Cactus
+          </text>
+          <text x="235" y="140" transform="scale(.1)" textLength="370">
+            Cactus
+          </text>
+          <text
+            aria-hidden="true"
+            x="735"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="330"
+          >
+            grown
+          </text>
+          <text x="735" y="140" transform="scale(.1)" textLength="330">
+            grown
+          </text>
+        </g>
+      </svg>
+    </div>
+
+    <h3>message only, no logo (empty label edge case)</h3>
+
+    <div class="row">
+      <div class="label">
+        anafanafo (old) &mdash; width: 59px, label rect width: 11, label
+        textLength: 10
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="59"
+        height="20"
+        role="img"
+        aria-label="grown"
+      >
+        <title>grown</title>
+        <linearGradient id="o2a" x2="0" y2="100%">
+          <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+          <stop offset="1" stop-opacity=".1" />
+        </linearGradient>
+        <g stroke="#d5d5d5">
+          <rect
+            stroke="none"
+            fill="#fcfcfc"
+            x="0.5"
+            y="0.5"
+            width="11"
+            height="19"
+            rx="2"
+          />
+          <rect x="17.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
+          <rect x="17" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+          <path d="M17.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+        </g>
+        <g
+          aria-hidden="true"
+          fill="#333"
+          text-anchor="middle"
+          font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+          text-rendering="geometricPrecision"
+          font-weight="700"
+          font-size="110px"
+          line-height="14px"
+        >
+          <rect
+            id="o2l"
+            stroke="#d5d5d5"
+            fill="url(#o2a)"
+            x=".5"
+            y=".5"
+            width="11"
+            height="19"
+            rx="2"
+          />
+          <text
+            aria-hidden="true"
+            x="55"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="10"
+          ></text>
+          <text x="55" y="140" transform="scale(.1)" textLength="10"></text>
+          <text
+            aria-hidden="true"
+            x="375"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="330"
+          >
+            grown
+          </text>
+          <text x="375" y="140" transform="scale(.1)" textLength="330">
+            grown
+          </text>
+        </g>
+      </svg>
+    </div>
+
+    <div class="row">
+      <div class="label">
+        pretext (current) &mdash;
+        <span class="diff"
+          >width: 58px, label rect width: 10, label textLength: 0 (1px diff from
+          anafanafo)</span
+        >
+      </div>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="58"
+        height="20"
+        role="img"
+        aria-label="grown"
+      >
+        <title>grown</title>
+        <linearGradient id="ls2a" x2="0" y2="100%">
+          <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+          <stop offset="1" stop-opacity=".1" />
+        </linearGradient>
+        <g stroke="#d5d5d5">
+          <rect
+            stroke="none"
+            fill="#fcfcfc"
+            x="0.5"
+            y="0.5"
+            width="10"
+            height="19"
+            rx="2"
+          />
+          <rect x="16.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
+          <rect x="16" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+          <path d="M16.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+        </g>
+        <g
+          aria-hidden="true"
+          fill="#333"
+          text-anchor="middle"
+          font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+          text-rendering="geometricPrecision"
+          font-weight="700"
+          font-size="110px"
+          line-height="14px"
+        >
+          <rect
+            id="ls2l"
+            stroke="#d5d5d5"
+            fill="url(#ls2a)"
+            x=".5"
+            y=".5"
+            width="10"
+            height="19"
+            rx="2"
+          />
+          <text
+            aria-hidden="true"
+            x="50"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="0"
+          ></text>
+          <text x="50" y="140" transform="scale(.1)" textLength="0"></text>
+          <text
+            aria-hidden="true"
+            x="365"
+            y="150"
+            fill="#fff"
+            transform="scale(.1)"
+            textLength="330"
+          >
+            grown
+          </text>
+          <text x="365" y="140" transform="scale(.1)" textLength="330">
+            grown
+          </text>
+        </g>
+      </svg>
+    </div>
+
+    <hr style="margin-top: 48px" />
+    <h2>
+      Visual comparisons: empty label snapshots (diff &gt; 1px in inner
+      attributes)
+    </h2>
+    <p style="font-size: 13px; color: #666">
+      These 4 snapshots are the only ones with any difference. The root cause is
+      that <code>anafanafo("")</code> returned 10 while
+      <code>pretext</code> correctly returns 0 for empty strings. This causes a
+      1px SVG width reduction and shifts internal x-coordinates by up to 10
+      units (1px at <code>scale(.1)</code>).
+    </p>
+
+    <h2>"social" template: message only, no logo</h2>
+    <p class="diff-info">
+      SVG width: 59 &rarr; 58 (-1px) | textLength[0]: 10 &rarr; 0 |
+      textLength[1]: 10 &rarr; 0
+    </p>
+
+    <div class="compare">
+      <div class="side">
+        <div class="label">
+          anafanafo (old) &mdash; width: 59px, textLengths: 10, 10, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="59"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_old0_llink {
+                fill: url(#diff_old0_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_old0_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_old0_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_old0_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="11"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="17.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="17" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M17.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_old0_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_old0_a)"
+                x=".5"
+                y=".5"
+                width="11"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="55"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text x="55" y="140" transform="scale(.1)" textLength="10"></text>
+              <text
+                aria-hidden="true"
+                x="375"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_old0_rlink"
+                x="375"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div class="side">
+        <div class="label">
+          pretext (current) &mdash; width: 58px, textLengths: 0, 0, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="58"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_new0_llink {
+                fill: url(#diff_new0_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_new0_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_new0_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_new0_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="10"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="16.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="16" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M16.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_new0_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_new0_a)"
+                x=".5"
+                y=".5"
+                width="10"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="50"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="0"
+              ></text>
+              <text x="50" y="140" transform="scale(.1)" textLength="0"></text>
+              <text
+                aria-hidden="true"
+                x="365"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_new0_rlink"
+                x="365"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <h2>"social" template: message only, with logo</h2>
+    <p class="diff-info">
+      SVG width: 73 &rarr; 72 (-1px) | textLength[0]: 10 &rarr; 0 |
+      textLength[1]: 10 &rarr; 0
+    </p>
+
+    <div class="compare">
+      <div class="side">
+        <div class="label">
+          anafanafo (old) &mdash; width: 73px, textLengths: 10, 10, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="73"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_old1_llink {
+                fill: url(#diff_old1_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_old1_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_old1_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_old1_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="31.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="31" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M31.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_old1_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_old1_a)"
+                x=".5"
+                y=".5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="195"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text
+                x="195"
+                y="140"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text
+                aria-hidden="true"
+                x="515"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_old1_rlink"
+                x="515"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div class="side">
+        <div class="label">
+          pretext (current) &mdash; width: 72px, textLengths: 0, 0, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="72"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_new1_llink {
+                fill: url(#diff_new1_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_new1_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_new1_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_new1_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="30.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="30" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M30.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_new1_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_new1_a)"
+                x=".5"
+                y=".5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="190"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="0"
+              ></text>
+              <text x="190" y="140" transform="scale(.1)" textLength="0"></text>
+              <text
+                aria-hidden="true"
+                x="505"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_new1_rlink"
+                x="505"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <h2>"social" template: message only, with logo and labelColor</h2>
+    <p class="diff-info">
+      SVG width: 73 &rarr; 72 (-1px) | textLength[0]: 10 &rarr; 0 |
+      textLength[1]: 10 &rarr; 0
+    </p>
+
+    <div class="compare">
+      <div class="side">
+        <div class="label">
+          anafanafo (old) &mdash; width: 73px, textLengths: 10, 10, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="73"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_old2_llink {
+                fill: url(#diff_old2_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_old2_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_old2_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_old2_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="31.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="31" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M31.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_old2_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_old2_a)"
+                x=".5"
+                y=".5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="195"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text
+                x="195"
+                y="140"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text
+                aria-hidden="true"
+                x="515"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_old2_rlink"
+                x="515"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div class="side">
+        <div class="label">
+          pretext (current) &mdash; width: 72px, textLengths: 0, 0, 330, 330
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="72"
+            height="20"
+            role="img"
+            aria-label="grown"
+          >
+            <title>grown</title>
+            <style>
+              a:hover #diff_new2_llink {
+                fill: url(#diff_new2_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_new2_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_new2_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_new2_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+              <rect
+                x="30.5"
+                y="0.5"
+                width="41"
+                height="19"
+                rx="2"
+                fill="#fafafa"
+              />
+              <rect x="30" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+              <path d="M30.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_new2_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_new2_a)"
+                x=".5"
+                y=".5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="190"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="0"
+              ></text>
+              <text x="190" y="140" transform="scale(.1)" textLength="0"></text>
+              <text
+                aria-hidden="true"
+                x="505"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+              <text
+                id="diff_new2_rlink"
+                x="505"
+                y="140"
+                transform="scale(.1)"
+                textLength="330"
+              >
+                grown
+              </text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+
+    <h2>social badge, logo-only</h2>
+    <p class="diff-info">
+      SVG width: 26 &rarr; 25 (-1px) | textLength[0]: 10 &rarr; 0 |
+      textLength[1]: 10 &rarr; 0
+    </p>
+
+    <div class="compare">
+      <div class="side">
+        <div class="label">
+          anafanafo (old) &mdash; width: 26px, textLengths: 10, 10
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="26"
+            height="20"
+            role="img"
+            aria-label=""
+          >
+            <title></title>
+            <style>
+              a:hover #diff_old3_llink {
+                fill: url(#diff_old3_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_old3_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_old3_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_old3_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_old3_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_old3_a)"
+                x=".5"
+                y=".5"
+                width="25"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="195"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+              <text
+                x="195"
+                y="140"
+                transform="scale(.1)"
+                textLength="10"
+              ></text>
+            </g>
+          </svg>
+        </div>
+      </div>
+      <div class="side">
+        <div class="label">
+          pretext (current) &mdash; width: 25px, textLengths: 0, 0
+        </div>
+        <div class="badge-container">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="25"
+            height="20"
+            role="img"
+            aria-label=""
+          >
+            <title></title>
+            <style>
+              a:hover #diff_new3_llink {
+                fill: url(#diff_new3_b);
+                stroke: #ccc;
+              }
+              a:hover #diff_new3_rlink {
+                fill: #4183c4;
+              }
+            </style>
+            <linearGradient id="diff_new3_a" x2="0" y2="100%">
+              <stop offset="0" stop-color="#fcfcfc" stop-opacity="0" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <linearGradient id="diff_new3_b" x2="0" y2="100%">
+              <stop offset="0" stop-color="#ccc" stop-opacity=".1" />
+              <stop offset="1" stop-opacity=".1" />
+            </linearGradient>
+            <g stroke="#d5d5d5">
+              <rect
+                stroke="none"
+                fill="#fcfcfc"
+                x="0.5"
+                y="0.5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+            </g>
+            <image
+              x="5"
+              y="3"
+              width="14"
+              height="14"
+              href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
+            />
+            <g
+              aria-hidden="true"
+              fill="#333"
+              text-anchor="middle"
+              font-family="Helvetica Neue,Helvetica,Arial,sans-serif"
+              text-rendering="geometricPrecision"
+              font-weight="700"
+              font-size="110px"
+              line-height="14px"
+            >
+              <rect
+                id="diff_new3_llink"
+                stroke="#d5d5d5"
+                fill="url(#diff_new3_a)"
+                x=".5"
+                y=".5"
+                width="24"
+                height="19"
+                rx="2"
+              />
+              <text
+                aria-hidden="true"
+                x="190"
+                y="150"
+                fill="#fff"
+                transform="scale(.1)"
+                textLength="0"
+              ></text>
+              <text x="190" y="140" transform="scale(.1)" textLength="0"></text>
+            </g>
+          </svg>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "@docusaurus/preset-classic": "^3.9.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.1.1",
+        "@napi-rs/canvas": "^0.1.97",
         "@typescript-eslint/parser": "^8.58.0",
         "c8": "^11.0.0",
         "caller": "^1.1.0",
@@ -123,7 +124,8 @@
       "version": "5.0.2",
       "license": "CC0-1.0",
       "dependencies": {
-        "anafanafo": "2.0.0",
+        "@chenglou/pretext": "0.0.3",
+        "@napi-rs/canvas": "^0.1.97",
         "css-color-converter": "^2.0.0"
       },
       "bin": {
@@ -2298,6 +2300,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.3.tgz",
+      "integrity": "sha512-RQmqMqUAPRCyv4R3LlRi/ao6KbNWYclqLA+V1HS7sWgyUUbjn3JmmlfXZSY/BjM4rbmIaMSyIVisYocYGYftiQ==",
+      "license": "MIT"
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -6198,6 +6206,270 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.1.1.tgz",
@@ -9025,14 +9297,6 @@
         "algoliasearch": ">= 3.1 < 6"
       }
     },
-    "node_modules/anafanafo": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anafanafo/-/anafanafo-2.0.0.tgz",
-      "integrity": "sha512-Nlfq7NC4AOkTJerWRIZcOAiMNtIDVIGWGvQ98O7Jl6Kr2Dk0dX5u4MqN778kSRTy5KRqchpLdF2RtLFEz9FVkQ==",
-      "dependencies": {
-        "char-width-table-consumer": "^1.0.0"
-      }
-    },
     "node_modules/ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -9754,11 +10018,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/binary-search": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
-      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
     },
     "node_modules/bintrees": {
       "version": "1.0.2",
@@ -10530,14 +10789,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/char-width-table-consumer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/char-width-table-consumer/-/char-width-table-consumer-1.0.0.tgz",
-      "integrity": "sha512-Fz4UD0LBpxPgL9i29CJ5O4KANwaMnX/OhhbxzvNa332h+9+nRKyeuLw4wA51lt/ex67+/AdsoBQJF3kgX2feYQ==",
-      "dependencies": {
-        "binary-search": "^1.3.5"
       }
     },
     "node_modules/character-entities": {

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@docusaurus/preset-classic": "^3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.1.1",
+    "@napi-rs/canvas": "^0.1.97",
     "@typescript-eslint/parser": "^8.58.0",
     "c8": "^11.0.0",
     "caller": "^1.1.0",

--- a/performance.html
+++ b/performance.html
@@ -1,0 +1,772 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Performance Report: anafanafo vs pretext</title>
+    <style>
+      :root {
+        --bg: #fff;
+        --fg: #1a1a2e;
+        --muted: #6b7280;
+        --border: #e5e7eb;
+        --accent: #3b82f6;
+        --accent2: #10b981;
+        --red: #ef4444;
+        --green: #22c55e;
+        --card-bg: #f9fafb;
+        --bar-anafanafo: #3b82f6;
+        --bar-pretext: #10b981;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        color: var(--fg);
+        background: var(--bg);
+        line-height: 1.6;
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 40px 24px 80px;
+      }
+      h1 {
+        font-size: 28px;
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      .subtitle {
+        color: var(--muted);
+        font-size: 15px;
+        margin-bottom: 32px;
+      }
+      h2 {
+        font-size: 20px;
+        font-weight: 600;
+        margin: 40px 0 16px;
+        padding-bottom: 8px;
+        border-bottom: 2px solid var(--border);
+      }
+      h3 {
+        font-size: 16px;
+        font-weight: 600;
+        margin: 28px 0 12px;
+        color: #374151;
+      }
+      p {
+        margin: 8px 0;
+        font-size: 15px;
+      }
+      code {
+        background: #f3f4f6;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 13px;
+        font-family: 'SF Mono', 'Fira Code', monospace;
+      }
+
+      /* Summary cards */
+      .summary-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 16px;
+        margin: 20px 0;
+      }
+      .summary-card {
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 10px;
+        padding: 20px;
+        text-align: center;
+      }
+      .summary-card .value {
+        font-size: 32px;
+        font-weight: 700;
+        color: var(--accent);
+      }
+      .summary-card .value.green {
+        color: var(--accent2);
+      }
+      .summary-card .label {
+        font-size: 13px;
+        color: var(--muted);
+        margin-top: 4px;
+      }
+
+      /* Bar chart */
+      .chart-container {
+        margin: 20px 0;
+      }
+      .chart-row {
+        display: flex;
+        align-items: center;
+        margin: 10px 0;
+        gap: 12px;
+      }
+      .chart-label {
+        width: 180px;
+        font-size: 13px;
+        text-align: right;
+        flex-shrink: 0;
+        color: #374151;
+      }
+      .chart-bars {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .bar-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .bar-tag {
+        width: 72px;
+        font-size: 11px;
+        color: var(--muted);
+        text-align: right;
+        flex-shrink: 0;
+      }
+      .bar {
+        height: 22px;
+        border-radius: 4px;
+        display: flex;
+        align-items: center;
+        padding: 0 8px;
+        font-size: 11px;
+        font-weight: 600;
+        color: #fff;
+        min-width: 40px;
+        transition: width 0.4s ease;
+      }
+      .bar.anafanafo {
+        background: var(--bar-anafanafo);
+      }
+      .bar.pretext {
+        background: var(--bar-pretext);
+      }
+
+      /* Table */
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 13px;
+        margin: 16px 0;
+      }
+      th {
+        background: #f3f4f6;
+        font-weight: 600;
+        text-align: left;
+        padding: 10px 12px;
+        border-bottom: 2px solid var(--border);
+        position: sticky;
+        top: 0;
+      }
+      td {
+        padding: 8px 12px;
+        border-bottom: 1px solid var(--border);
+      }
+      tr:hover td {
+        background: #f9fafb;
+      }
+      .num {
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+      }
+      .diff-pos {
+        color: var(--red);
+      }
+      .diff-neg {
+        color: var(--green);
+      }
+      .diff-zero {
+        color: var(--muted);
+      }
+
+      /* Legend */
+      .legend {
+        display: flex;
+        gap: 24px;
+        margin: 12px 0;
+        font-size: 13px;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+      }
+      .legend-dot {
+        width: 12px;
+        height: 12px;
+        border-radius: 3px;
+      }
+      .legend-dot.anafanafo {
+        background: var(--bar-anafanafo);
+      }
+      .legend-dot.pretext {
+        background: var(--bar-pretext);
+      }
+
+      /* Info box */
+      .info-box {
+        background: #eff6ff;
+        border: 1px solid #bfdbfe;
+        border-radius: 8px;
+        padding: 16px 20px;
+        margin: 20px 0;
+        font-size: 14px;
+        line-height: 1.7;
+      }
+      .info-box strong {
+        color: #1e40af;
+      }
+
+      /* Tabs */
+      .tab-container {
+        margin: 20px 0;
+      }
+      .tab-buttons {
+        display: flex;
+        gap: 0;
+        border-bottom: 2px solid var(--border);
+      }
+      .tab-btn {
+        padding: 8px 20px;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        border: none;
+        background: none;
+        color: var(--muted);
+        border-bottom: 2px solid transparent;
+        margin-bottom: -2px;
+        transition: all 0.2s;
+      }
+      .tab-btn.active {
+        color: var(--accent);
+        border-bottom-color: var(--accent);
+      }
+      .tab-btn:hover {
+        color: var(--fg);
+      }
+      .tab-panel {
+        display: none;
+        padding-top: 16px;
+      }
+      .tab-panel.active {
+        display: block;
+      }
+
+      .methodology {
+        background: var(--card-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 20px 24px;
+        margin: 20px 0;
+        font-size: 14px;
+      }
+      .methodology ul {
+        margin: 8px 0 8px 20px;
+      }
+      .methodology li {
+        margin: 4px 0;
+      }
+      footer {
+        margin-top: 60px;
+        padding-top: 20px;
+        border-top: 1px solid var(--border);
+        color: var(--muted);
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Performance Report: anafanafo vs pretext</h1>
+    <p class="subtitle">
+      Text width measurement benchmark for Shields.io badge rendering &mdash;
+      commit <code>0c49f70</code>
+    </p>
+
+    <!-- ============================================================= -->
+    <h2>Summary</h2>
+    <div class="summary-grid">
+      <div class="summary-card">
+        <div class="value">~2.2×</div>
+        <div class="label">anafanafo is faster (raw speed)</div>
+      </div>
+      <div class="summary-card">
+        <div class="value green">&lt; 1 px</div>
+        <div class="label">Average width difference (Verdana)</div>
+      </div>
+      <div class="summary-card">
+        <div class="value green">Sub-pixel</div>
+        <div class="label">pretext precision level</div>
+      </div>
+      <div class="summary-card">
+        <div class="value">5,000</div>
+        <div class="label">Iterations per font × 26 strings</div>
+      </div>
+    </div>
+
+    <div class="info-box">
+      <strong>Key Takeaway:</strong> anafanafo is approximately
+      <strong>2.2×&nbsp;faster</strong> than pretext in raw throughput. However,
+      pretext provides <strong>sub-pixel precise</strong>
+      measurements using real font metrics via canvas, resulting in more
+      accurate badge rendering. The absolute time difference (~0.003&nbsp;ms per
+      call) is negligible for Shields.io's use case where badges are rendered
+      server-side on demand.
+    </div>
+
+    <!-- ============================================================= -->
+    <h2>Speed Comparison</h2>
+
+    <div class="legend">
+      <div class="legend-item">
+        <div class="legend-dot anafanafo"></div>
+        anafanafo 2.0.0
+      </div>
+      <div class="legend-item">
+        <div class="legend-dot pretext"></div>
+        @chenglou/pretext 0.0.3
+      </div>
+    </div>
+
+    <div class="chart-container" id="speed-chart"></div>
+
+    <!-- ============================================================= -->
+    <h2>Width Accuracy Comparison</h2>
+    <p>
+      pretext measures text using actual font outlines via the Canvas API (<code
+        >@napi-rs/canvas</code
+      >
+      Skia backend), while anafanafo uses pre-computed character-width lookup
+      tables. The table below shows measured widths and their differences.
+    </p>
+
+    <div class="tab-container">
+      <div class="tab-buttons" id="tab-buttons"></div>
+      <div id="tab-panels"></div>
+    </div>
+
+    <!-- ============================================================= -->
+    <h2>Methodology</h2>
+    <div class="methodology">
+      <ul>
+        <li>
+          <strong>Environment:</strong> Node.js, macOS, single-threaded
+          benchmark
+        </li>
+        <li>
+          <strong>Iterations:</strong> 5,000 iterations per font, each iterating
+          over 26 representative badge strings
+        </li>
+        <li>
+          <strong>Warm-up:</strong> 1,000 warm-up iterations before timed runs
+          to allow JIT optimisation
+        </li>
+        <li>
+          <strong>Strings:</strong> 26 strings covering short labels
+          (<code>MIT</code>), typical badges, long sentences, full alphabet,
+          digits, and special characters
+        </li>
+        <li>
+          <strong>Fonts tested:</strong> <code>11px Verdana</code>,
+          <code>bold 10px Verdana</code>, <code>bold 11px Helvetica</code>
+        </li>
+        <li>
+          <strong>anafanafo</strong> (v2.0.0): lookup-table-based width
+          estimation — integer-only results
+        </li>
+        <li>
+          <strong>pretext</strong> (v0.0.3): canvas
+          <code>measureText()</code> via <code>@napi-rs/canvas</code> + Skia —
+          sub-pixel precision
+        </li>
+      </ul>
+    </div>
+
+    <!-- ============================================================= -->
+    <h2>How It Works</h2>
+
+    <h3>anafanafo</h3>
+    <p>
+      Uses pre-computed character-width data stored as JSON arrays, one per
+      supported font. Each character's width is looked up and summed to estimate
+      the total string width. Fast but limited to the bundled font set, and
+      returns rounded integer values.
+    </p>
+
+    <h3>@chenglou/pretext</h3>
+    <p>
+      A text layout library that delegates measurement to the Canvas API. In the
+      Shields.io server environment, <code>@napi-rs/canvas</code> provides an
+      <code>OffscreenCanvas</code> polyfill backed by Skia, giving access to
+      real font metrics. Returns floating-point widths with sub-pixel precision.
+    </p>
+
+    <!-- ============================================================= -->
+    <h2>Trade-offs</h2>
+    <table>
+      <thead>
+        <tr>
+          <th></th>
+          <th>anafanafo</th>
+          <th>pretext</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>Speed</strong></td>
+          <td>~350 ms / 130k calls</td>
+          <td>~800 ms / 130k calls</td>
+        </tr>
+        <tr>
+          <td><strong>Per-call cost</strong></td>
+          <td>~0.003 ms</td>
+          <td>~0.006 ms</td>
+        </tr>
+        <tr>
+          <td><strong>Precision</strong></td>
+          <td>Integer pixels (rounded)</td>
+          <td>Sub-pixel (float)</td>
+        </tr>
+        <tr>
+          <td><strong>Font support</strong></td>
+          <td>4 bundled font/size combos</td>
+          <td>Any system / loaded font</td>
+        </tr>
+        <tr>
+          <td><strong>Dependencies</strong></td>
+          <td>None (pure JS + data)</td>
+          <td><code>@napi-rs/canvas</code> (native addon)</td>
+        </tr>
+        <tr>
+          <td><strong>Accuracy</strong></td>
+          <td>Approximation from metrics tables</td>
+          <td>Real font shaping via Skia</td>
+        </tr>
+        <tr>
+          <td><strong>Bundle size</strong></td>
+          <td>~45 KB (data tables)</td>
+          <td>~15 KB (JS) + native binary</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <footer>
+      Generated for Shields.io &mdash; badge-maker text width measurement
+      benchmark
+    </footer>
+
+    <script>
+      // ================================================================
+      // Benchmark data (collected via scripts/benchmark-text-width.js)
+      // ================================================================
+      const DATA = {
+        iterations: 5000,
+        stringsCount: 26,
+        fonts: [
+          {
+            font: '11px Verdana',
+            anafanafo: { totalMs: 353.09 },
+            pretext: { totalMs: 773.17 },
+            speedup: 0.46,
+            widths: [
+              { text: 'build', anafanafo: 26, pretext: 26.71 },
+              { text: 'passing', anafanafo: 41, pretext: 41.75 },
+              { text: 'coverage', anafanafo: 50, pretext: 49.81 },
+              { text: '98%', anafanafo: 25, pretext: 25.82 },
+              { text: 'license', anafanafo: 37, pretext: 37.57 },
+              { text: 'MIT', anafanafo: 20, pretext: 20.68 },
+              { text: 'npm', anafanafo: 24, pretext: 24.51 },
+              { text: 'v3.2.1', anafanafo: 35, pretext: 35.49 },
+              { text: 'downloads', anafanafo: 58, pretext: 58.38 },
+              { text: '1.2M/month', anafanafo: 67, pretext: 67.89 },
+              { text: 'Hello, World!', anafanafo: 71, pretext: 71.15 },
+              { text: 'shields.io', anafanafo: 51, pretext: 51.56 },
+              { text: 'code quality', anafanafo: 66, pretext: 66.93 },
+              { text: 'A+', anafanafo: 16, pretext: 16.52 },
+              { text: 'dependencies', anafanafo: 75, pretext: 75.17 },
+              { text: 'up to date', anafanafo: 56, pretext: 56.91 },
+              { text: 'docker pulls', anafanafo: 66, pretext: 66.36 },
+              { text: '500M+', anafanafo: 39, pretext: 39.25 },
+              { text: 'GitHub Stars', anafanafo: 70, pretext: 70.72 },
+              { text: '★ 42.3k', anafanafo: 46, pretext: 46.36 },
+              {
+                text: 'continuous integration pipeline status',
+                anafanafo: 208,
+                pretext: 207.97,
+              },
+              {
+                text: 'The quick brown fox jumps over the lazy dog',
+                anafanafo: 250,
+                pretext: 249.89,
+              },
+              {
+                text: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                anafanafo: 196,
+                pretext: 196.35,
+              },
+              {
+                text: 'abcdefghijklmnopqrstuvwxyz',
+                anafanafo: 160,
+                pretext: 160.69,
+              },
+              { text: '0123456789', anafanafo: 69, pretext: 69.93 },
+              {
+                text: '!@#$%^&*()_+-=[]{}|;:,.<>?',
+                anafanafo: 178,
+                pretext: 178.07,
+              },
+            ],
+          },
+          {
+            font: 'bold 10px Verdana',
+            anafanafo: { totalMs: 346.2 },
+            pretext: { totalMs: 781.0 },
+            speedup: 0.44,
+            widths: [
+              { text: 'build', anafanafo: 27, pretext: 27.94 },
+              { text: 'passing', anafanafo: 43, pretext: 43.07 },
+              { text: 'coverage', anafanafo: 51, pretext: 51.17 },
+              { text: '98%', anafanafo: 26, pretext: 26.94 },
+              { text: 'license', anafanafo: 39, pretext: 39.06 },
+              { text: 'MIT', anafanafo: 21, pretext: 21.75 },
+              { text: 'npm', anafanafo: 24, pretext: 24.7 },
+              { text: 'v3.2.1', anafanafo: 35, pretext: 35.05 },
+              { text: 'downloads', anafanafo: 60, pretext: 60.66 },
+              { text: '1.2M/month', anafanafo: 70, pretext: 70.45 },
+              { text: 'Hello, World!', anafanafo: 73, pretext: 73.3 },
+              { text: 'shields.io', anafanafo: 53, pretext: 53.35 },
+              { text: 'code quality', anafanafo: 68, pretext: 68.5 },
+              { text: 'A+', anafanafo: 16, pretext: 16.43 },
+              { text: 'dependencies', anafanafo: 77, pretext: 77.02 },
+              { text: 'up to date', anafanafo: 57, pretext: 57.25 },
+              { text: 'docker pulls', anafanafo: 68, pretext: 68.36 },
+              { text: '500M+', anafanafo: 39, pretext: 39.48 },
+              { text: 'GitHub Stars', anafanafo: 71, pretext: 71.23 },
+              { text: '★ 42.3k', anafanafo: 45, pretext: 45.07 },
+              {
+                text: 'continuous integration pipeline status',
+                anafanafo: 214,
+                pretext: 214.04,
+              },
+              {
+                text: 'The quick brown fox jumps over the lazy dog',
+                anafanafo: 252,
+                pretext: 252.98,
+              },
+              {
+                text: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                anafanafo: 198,
+                pretext: 198.81,
+              },
+              {
+                text: 'abcdefghijklmnopqrstuvwxyz',
+                anafanafo: 165,
+                pretext: 165.7,
+              },
+              { text: '0123456789', anafanafo: 71, pretext: 71.09 },
+              {
+                text: '!@#$%^&*()_+-=[]{}|;:,.<>?',
+                anafanafo: 175,
+                pretext: 175.99,
+              },
+            ],
+          },
+          {
+            font: 'bold 11px Helvetica',
+            anafanafo: { totalMs: 364.61 },
+            pretext: { totalMs: 823.64 },
+            speedup: 0.44,
+            widths: [
+              { text: 'build', anafanafo: 25, pretext: 23.24 },
+              { text: 'passing', anafanafo: 40, pretext: 37.91 },
+              { text: 'coverage', anafanafo: 48, pretext: 45.25 },
+              { text: '98%', anafanafo: 23, pretext: 22.02 },
+              { text: 'license', anafanafo: 37, pretext: 34.24 },
+              { text: 'MIT', anafanafo: 19, pretext: 18.94 },
+              { text: 'npm', anafanafo: 23, pretext: 21.4 },
+              { text: 'v3.2.1', anafanafo: 30, pretext: 29.97 },
+              { text: 'downloads', anafanafo: 57, pretext: 52.59 },
+              { text: '1.2M/month', anafanafo: 62, pretext: 58.08 },
+              { text: 'Hello, World!', anafanafo: 66, pretext: 62.77 },
+              { text: 'shields.io', anafanafo: 49, pretext: 45.86 },
+              { text: 'code quality', anafanafo: 63, pretext: 58.71 },
+              { text: 'A+', anafanafo: 14, pretext: 13.76 },
+              { text: 'dependencies', anafanafo: 73, pretext: 68.5 },
+              { text: 'up to date', anafanafo: 53, pretext: 48.94 },
+              { text: 'docker pulls', anafanafo: 64, pretext: 58.7 },
+              { text: '500M+', anafanafo: 34, pretext: 33.94 },
+              { text: 'GitHub Stars', anafanafo: 67, pretext: 62.97 },
+              { text: '★ 42.3k', anafanafo: 41, pretext: 36.94 },
+              {
+                text: 'continuous integration pipeline status',
+                anafanafo: 197,
+                pretext: 181.03,
+              },
+              {
+                text: 'The quick brown fox jumps over the lazy dog',
+                anafanafo: 234,
+                pretext: 217.68,
+              },
+              {
+                text: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                anafanafo: 197,
+                pretext: 193.74,
+              },
+              {
+                text: 'abcdefghijklmnopqrstuvwxyz',
+                anafanafo: 153,
+                pretext: 140.01,
+              },
+              { text: '0123456789', anafanafo: 61, pretext: 61.18 },
+              {
+                text: '!@#$%^&*()_+-=[]{}|;:,.<>?',
+                anafanafo: 132,
+                pretext: 130.47,
+              },
+            ],
+          },
+        ],
+      }
+
+      // ================================================================
+      // Render speed chart
+      // ================================================================
+      ;(function renderSpeedChart() {
+        const container = document.getElementById('speed-chart')
+        const maxMs = Math.max(
+          ...DATA.fonts.flatMap(f => [f.anafanafo.totalMs, f.pretext.totalMs]),
+        )
+
+        for (const f of DATA.fonts) {
+          const row = document.createElement('div')
+          row.className = 'chart-row'
+
+          const label = document.createElement('div')
+          label.className = 'chart-label'
+          label.textContent = f.font
+
+          const bars = document.createElement('div')
+          bars.className = 'chart-bars'
+
+          for (const [lib, cls] of [
+            ['anafanafo', 'anafanafo'],
+            ['pretext', 'pretext'],
+          ]) {
+            const barRow = document.createElement('div')
+            barRow.className = 'bar-row'
+
+            const tag = document.createElement('div')
+            tag.className = 'bar-tag'
+            tag.textContent = lib
+
+            const bar = document.createElement('div')
+            bar.className = `bar ${cls}`
+            const pct = (f[lib].totalMs / maxMs) * 100
+            bar.style.width = `${pct}%`
+            bar.textContent = `${f[lib].totalMs.toFixed(1)} ms`
+
+            barRow.appendChild(tag)
+            barRow.appendChild(bar)
+            bars.appendChild(barRow)
+          }
+
+          row.appendChild(label)
+          row.appendChild(bars)
+          container.appendChild(row)
+        }
+      })()
+
+      // ================================================================
+      // Render width tables in tabs
+      // ================================================================
+      ;(function renderWidthTabs() {
+        const btnContainer = document.getElementById('tab-buttons')
+        const panelContainer = document.getElementById('tab-panels')
+
+        DATA.fonts.forEach((f, idx) => {
+          // Tab button
+          const btn = document.createElement('button')
+          btn.className = `tab-btn${idx === 0 ? ' active' : ''}`
+          btn.textContent = f.font
+          btn.dataset.idx = idx
+          btn.addEventListener('click', () => {
+            document
+              .querySelectorAll('.tab-btn')
+              .forEach(b => b.classList.remove('active'))
+            document
+              .querySelectorAll('.tab-panel')
+              .forEach(p => p.classList.remove('active'))
+            btn.classList.add('active')
+            document.getElementById(`panel-${idx}`).classList.add('active')
+          })
+          btnContainer.appendChild(btn)
+
+          // Panel
+          const panel = document.createElement('div')
+          panel.className = `tab-panel${idx === 0 ? ' active' : ''}`
+          panel.id = `panel-${idx}`
+
+          // Stats summary
+          const diffs = f.widths.map(w => Math.abs(w.pretext - w.anafanafo))
+          const avgDiff = diffs.reduce((a, b) => a + b, 0) / diffs.length
+          const maxDiff = Math.max(...diffs)
+
+          const stats = document.createElement('p')
+          stats.innerHTML = `
+            <strong>Average Δ:</strong> ${avgDiff.toFixed(2)} px &nbsp;|&nbsp;
+            <strong>Max Δ:</strong> ${maxDiff.toFixed(2)} px &nbsp;|&nbsp;
+            <strong>Speed ratio:</strong> anafanafo is ${(1 / f.speedup).toFixed(1)}× faster
+          `
+          panel.appendChild(stats)
+
+          // Table
+          const table = document.createElement('table')
+          table.innerHTML = `
+            <thead>
+              <tr>
+                <th>Text</th>
+                <th class="num">anafanafo (px)</th>
+                <th class="num">pretext (px)</th>
+                <th class="num">Δ (px)</th>
+              </tr>
+            </thead>
+          `
+          const tbody = document.createElement('tbody')
+          for (const w of f.widths) {
+            const diff = w.pretext - w.anafanafo
+            const absDiff = Math.abs(diff)
+            const cls =
+              absDiff < 0.01 ? 'diff-zero' : diff > 0 ? 'diff-pos' : 'diff-neg'
+            const sign = diff > 0 ? '+' : ''
+
+            const tr = document.createElement('tr')
+            tr.innerHTML = `
+              <td><code>${escapeHtml(w.text)}</code></td>
+              <td class="num">${w.anafanafo.toFixed(2)}</td>
+              <td class="num">${w.pretext.toFixed(2)}</td>
+              <td class="num ${cls}">${sign}${diff.toFixed(2)}</td>
+            `
+            tbody.appendChild(tr)
+          }
+          table.appendChild(tbody)
+          panel.appendChild(table)
+          panelContainer.appendChild(panel)
+        })
+      })()
+
+      function escapeHtml(str) {
+        const div = document.createElement('div')
+        div.appendChild(document.createTextNode(str))
+        return div.innerHTML
+      }
+    </script>
+  </body>
+</html>

--- a/scripts/download-fonts.js
+++ b/scripts/download-fonts.js
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * Populate badge-maker/fonts/ with fonts required for badge text-width measurement.
+ *
+ * Free fonts (DejaVu Sans and Liberation Sans) are downloaded from GitHub.
+ * Verdana (proprietary, © Microsoft) is copied from the system font directory;
+ * it must already be installed:
+ *   - Linux:  sudo apt-get install ttf-mscorefonts-installer
+ *   - macOS:  included in Microsoft Office or as a standalone download
+ *
+ * Run once before executing badge-maker tests:
+ *   node scripts/download-fonts.js
+ */
+
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  copyFileSync,
+  writeFileSync,
+} from 'fs'
+import { unlink } from 'fs/promises'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { pipeline } from 'stream/promises'
+import { Readable } from 'stream'
+import { execFileSync } from 'child_process'
+import { tmpdir } from 'os'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const fontsDir = join(__dirname, '..', 'badge-maker', 'fonts')
+mkdirSync(fontsDir, { recursive: true })
+
+let hasError = false
+
+/**
+ * Download a URL to a local file.
+ *
+ * @param {string} url The URL to download.
+ * @param {string} destPath The destination file path.
+ * @returns {Promise<void>}
+ */
+async function downloadFile(url, destPath) {
+  const resp = await fetch(url, {
+    redirect: 'follow',
+    headers: { 'User-Agent': 'shields.io/download-fonts' },
+  })
+  if (!resp.ok) throw new Error(`HTTP ${resp.status} fetching ${url}`)
+  await pipeline(Readable.fromWeb(resp.body), createWriteStream(destPath))
+}
+
+/**
+ * Convert an unknown thrown value to a printable message.
+ *
+ * @param {unknown} err The thrown value.
+ * @returns {string} The error message.
+ */
+function errorMessage(err) {
+  return err instanceof Error ? err.message : String(err)
+}
+
+/**
+ * Download a .tar.gz archive and extract specific TTF files from it.
+ * Uses the system `tar` binary available on both Linux and macOS.
+ *
+ * @param {string} url The archive URL.
+ * @param {string[]} filenames The font filenames to extract.
+ * @returns {Promise<void>}
+ */
+async function downloadFromTarball(url, filenames) {
+  const needed = filenames.filter(f => !existsSync(join(fontsDir, f)))
+  if (needed.length === 0) {
+    for (const f of filenames) console.log(`  skip (exists): ${f}`)
+    return
+  }
+
+  const tarPath = join(tmpdir(), `shields-fonts-${Date.now()}.tar.gz`)
+  process.stdout.write(
+    `  downloading:   ${filenames.join(', ')} (via tarball) ...`,
+  )
+  try {
+    await downloadFile(url, tarPath)
+    console.log(' downloaded, extracting...')
+
+    const listing = execFileSync('tar', ['-tzf', tarPath])
+      .toString()
+      .split('\n')
+
+    for (const filename of needed) {
+      const archivePath = listing.find(path => path.endsWith(`/${filename}`))
+      process.stdout.write(`  extracting:    ${filename} ...`)
+      if (!archivePath) {
+        console.log(' FAILED (not found in archive listing)')
+        hasError = true
+        continue
+      }
+      try {
+        const content = execFileSync(
+          'tar',
+          ['-xzf', tarPath, '--to-stdout', archivePath],
+          {
+            maxBuffer: 8 * 1024 * 1024,
+          },
+        )
+        writeFileSync(join(fontsDir, filename), content)
+        console.log(' done')
+      } catch {
+        console.log(` FAILED (${archivePath} could not be extracted)`)
+        hasError = true
+      }
+    }
+  } catch (err) {
+    console.log(` FAILED: ${errorMessage(err)}`)
+    hasError = true
+  } finally {
+    await unlink(tarPath).catch(() => {})
+  }
+}
+
+/**
+ * Copy a font file from the first existing candidate path into badge-maker/fonts/.
+ *
+ * @param {string[]} candidates Ordered source paths to try.
+ * @param {string} filename The output filename under badge-maker/fonts/.
+ * @returns {boolean} True if the font was copied or already exists.
+ */
+function copyFromSystem(candidates, filename) {
+  const dest = join(fontsDir, filename)
+  if (existsSync(dest)) {
+    console.log(`  skip (exists): ${filename}`)
+    return true
+  }
+  for (const src of candidates) {
+    if (existsSync(src)) {
+      copyFileSync(src, dest)
+      console.log(`  copied:        ${filename}  (from ${src})`)
+      return true
+    }
+  }
+  return false
+}
+
+// ── DejaVu Sans ──────────────────────────────────────────────────────────────
+// License: Bitstream Vera Fonts copyright (free to redistribute).
+// On ubuntu-latest this is provided by fonts-dejavu-core.
+console.log('DejaVu Sans:')
+const dejavuOk = copyFromSystem(
+  [
+    // Linux (fonts-dejavu-core)
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+    // Common macOS Homebrew path (if installed)
+    '/opt/homebrew/share/fonts/DejaVuSans.ttf',
+    '/usr/local/share/fonts/DejaVuSans.ttf',
+  ],
+  'DejaVuSans.ttf',
+)
+const dejavuBoldOk = copyFromSystem(
+  [
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+    '/opt/homebrew/share/fonts/DejaVuSans-Bold.ttf',
+    '/usr/local/share/fonts/DejaVuSans-Bold.ttf',
+  ],
+  'DejaVuSans-Bold.ttf',
+)
+
+if (!dejavuOk || !dejavuBoldOk) {
+  console.warn(
+    '  warning: DejaVu Sans not found on this host. Using Verdana/Liberation Sans only.',
+  )
+}
+
+// ── Liberation Sans ───────────────────────────────────────────────────────────
+// License: SIL Open Font Licence 1.1 (free to redistribute)
+// Source:  https://github.com/liberationfonts/liberation-fonts
+// Metric-compatible with Arial and Helvetica — registered under those family
+// names in canvas-polyfill.js so 'bold 11px Helvetica' resolves correctly.
+console.log('Liberation Sans:')
+await downloadFromTarball(
+  'https://github.com/liberationfonts/liberation-fonts/files/7261482/liberation-fonts-ttf-2.1.5.tar.gz',
+  ['LiberationSans-Regular.ttf', 'LiberationSans-Bold.ttf'],
+)
+
+// ── Verdana ───────────────────────────────────────────────────────────────────
+// License: © Microsoft Corporation — proprietary, do NOT commit to repository.
+// Must be installed on the host system before running this script.
+//   Linux:  sudo apt-get install ttf-mscorefonts-installer
+//   macOS:  pre-installed with Microsoft Office or certain system updates
+console.log('Verdana:')
+const verdanaOk = copyFromSystem(
+  [
+    // Linux (ttf-mscorefonts-installer)
+    '/usr/share/fonts/truetype/msttcorefonts/Verdana.ttf',
+    // macOS
+    '/System/Library/Fonts/Supplemental/Verdana.ttf',
+    '/Library/Fonts/Verdana.ttf',
+  ],
+  'Verdana.ttf',
+)
+const verdanaBoldOk = copyFromSystem(
+  [
+    '/usr/share/fonts/truetype/msttcorefonts/Verdana_Bold.ttf',
+    '/System/Library/Fonts/Supplemental/Verdana Bold.ttf',
+    '/Library/Fonts/Verdana Bold.ttf',
+  ],
+  'Verdana_Bold.ttf',
+)
+
+if (!verdanaOk || !verdanaBoldOk) {
+  console.warn(
+    '\nWARNING: Verdana not found on this system.\n' +
+      '  Badge widths may differ from the committed snapshots.\n' +
+      '  Linux:  sudo apt-get install ttf-mscorefonts-installer\n' +
+      '  macOS:  install Microsoft Office or download the web fonts package.\n',
+  )
+  hasError = true
+}
+
+if (hasError) {
+  console.error('\nSome fonts could not be obtained. See warnings above.')
+  process.exit(1)
+} else {
+  console.log('\nAll fonts ready in badge-maker/fonts/')
+}


### PR DESCRIPTION
Resolves #9728

I've generated [`compare.html`](https://refined-github-html-preview.kidonng.workers.dev/LitoMore/shields.io/raw/migrate-to-pretext/compare.html) and [`performance.html`](https://refined-github-html-preview.kidonng.workers.dev/LitoMore/shields.io/raw/migrate-to-pretext/performance.html) files in the project root that introduce its comparison and performance. I will remove these temporary files before merging.

There is a new workflow step for downloading fonts because `pretext` needs it for calculating, but the Verdana font license does not allow us to commit the font file to the repository. Here are some of my thoughts:

- We need to find a better workflow to download font files since it's not only needed from the CI, but developers need them as well.
- Or changing the Verdana font to an open-source-friendly font? So that we can commit the file directly to the repository. But it will be a huge visual change for users.