### PR TITLE
fix: strip build metadata suffix from packageManager field (fixes #9514) [GithubPackageJson]

### DIFF
--- a/services/github/github-package-json.service.js
+++ b/services/github/github-package-json.service.js
@@ -289,7 +289,11 @@ class DynamicGithubPackageJson extends ConditionalGithubAuthV3Service {
       branch,
       filename: 'package.json',
     })
-    const value = transformAndValidate({ data, key })
+    let value = transformAndValidate({ data, key })
+    // Strip build metadata suffix from packageManager field (e.g. yarn@3.2.3+sha224.abc -> yarn@3.2.3)
+    if (key === 'packageManager' && typeof value === 'string') {
+      value = value.replace(/\+.*$/, '')
+    }
     return this.constructor.render({ key, value, branch })
   }
 }

--- a/services/github/github-package-json.tester.js
+++ b/services/github/github-package-json.tester.js
@@ -112,3 +112,17 @@ t.create('Unknown dependency')
     label: 'dependency',
     message: 'dev dependency not found',
   })
+
+t.create('Package manager (strips build metadata suffix)')
+  .get('/packageManager/nodejs/corepack.json')
+  .expectBadge({
+    label: 'packageManager',
+    message: Joi.string().regex(/^(npm|yarn|pnpm|bun)@[\d.]+$/),
+  })
+
+t.create('Package manager (repo not found)')
+  .get('/packageManager/badges/helmets.json')
+  .expectBadge({
+    label: 'package.json',
+    message: 'repo not found, branch not found, or package.json missing',
+  })


### PR DESCRIPTION
Fixes #9514

The `packageManager` field in `package.json` includes a build metadata suffix (e.g. `yarn@4.11.0+sha224.abc123...`) which makes the badge difficult to read.

## Changes
- Modified `DynamicGithubPackageJson` in `github-package-json.service.js` to strip the `+` suffix when `key === 'packageManager'`
- Added 2 tests in `github-package-json.tester.js`

## Before / After
**Before:** `yarn@4.11.0+sha224.209a3e277c6bbc03df6e4206fbfcb0c1621c27ecf0688f79a0c619f0`
**After:** `yarn@4.11.0`