### PR TITLE
Remove misleading TODO

### DIFF
--- a/core/base-service/base.spec.js
+++ b/core/base-service/base.spec.js
@@ -309,7 +309,6 @@ describe('BaseService', function () {
   })
 
   describe('ScoutCamp integration', function () {
-    // TODO Strangely, without the useless escape the regexes do not match in Node 12.
     // eslint-disable-next-line no-useless-escape
     const expectedRouteRegex = /^\/foo(?:\/([^\/#\?]+?))(|\.svg|\.json)$/
 


### PR DESCRIPTION
This is not a Node.js 12 or more recent quirk as far as I can tell. The regex is generated by `path-to-regexp`, which does output those additional escapes. The escapes aren't useless from the perspective of matching the library output; they're only "useless" from a regex semantics standpoint, but that's not what we're interested in here.