### PR TITLE
fix(nuget): fix double URL encoding for non-ASCII package names; test [Nuget MyGet]

### DIFF
--- a/services/nuget/nuget-v3-service-family.js
+++ b/services/nuget/nuget-v3-service-family.js
@@ -79,7 +79,7 @@ async function fetch(
     url: await searchServiceUrl(baseUrl, 'SearchQueryService'),
     options: {
       searchParams: {
-        q: `packageid:${encodeURIComponent(packageName.toLowerCase())}`,
+        q: `packageid:${packageName.toLowerCase()}`,
         // Include prerelease versions.
         prerelease: 'true',
         // Include packages with SemVer 2 version numbers.

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -117,7 +117,7 @@ t.create('version (pre) (not found)')
   .get('/vpre/not-a-real-package.json')
   .expectBadge({ label: 'nuget', message: 'package not found' })
 
-// https://github.com/badges/shields/issues/7942
+// https://github.com/badges/shields/issues/11513
 t.create('version (special characters - encoded)')
   .get('/v/NC%C3%B2dexSDK.json')
   .intercept(nock =>

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -137,5 +137,5 @@ t.create('version (special characters - encoded)')
   .expectBadge({
     label: 'nuget',
     message: 'v0.0.1',
-    color: 'blue',
+    color: 'orange',
   })

--- a/services/nuget/nuget.tester.js
+++ b/services/nuget/nuget.tester.js
@@ -116,3 +116,26 @@ t.create('version (pre) (valid)')
 t.create('version (pre) (not found)')
   .get('/vpre/not-a-real-package.json')
   .expectBadge({ label: 'nuget', message: 'package not found' })
+
+// https://github.com/badges/shields/issues/7942
+t.create('version (special characters - encoded)')
+  .get('/v/NC%C3%B2dexSDK.json')
+  .intercept(nock =>
+    nock('https://api.nuget.org').get('/v3/index.json').reply(200, queryIndex),
+  )
+  .intercept(nock =>
+    nock('https://api-v2v3search-0.nuget.org')
+      .get('/query?q=packageid%3Anc%C3%B2dexsdk&prerelease=true&semVerLevel=2')
+      .reply(200, {
+        data: [
+          {
+            versions: [{ version: '0.0.1' }],
+          },
+        ],
+      }),
+  )
+  .expectBadge({
+    label: 'nuget',
+    message: 'v0.0.1',
+    color: 'blue',
+  })


### PR DESCRIPTION
packageName was passed through encodeURIComponent() before being added to searchParams. Since got also encodes searchParams values, characters like ò (%C3%B2) were double-encoded (%25C3%25B2), causing NuGet's search API to receive the literal percent-encoded string and return 0 hits.

Fixes #7942

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
