### PR TITLE
change deprecated badge messages to 'retired badge' [Bit Codeclimate Codeship Coincap DockerCloud GithubWorkflowStatus Hackage NostrBand Pub Security-Headers VisualStudioAppCenter VisualStudioMarketplace Wikiapiary]

### DIFF
--- a/core/base-service/deprecated-service.js
+++ b/core/base-service/deprecated-service.js
@@ -45,7 +45,7 @@ function deprecatedService(attrs) {
         }
       }
       return {
-        message: 'no longer available',
+        message: 'retired badge',
       }
     }
   }

--- a/core/base-service/deprecated-service.spec.js
+++ b/core/base-service/deprecated-service.spec.js
@@ -39,7 +39,7 @@ describe('DeprecatedService', function () {
   it('sets default deprecation message', async function () {
     const service = deprecatedService({ ...commonAttrs })
     expect(await service.invoke()).to.deep.equal({
-      message: 'no longer available',
+      message: 'retired badge',
     })
   })
 

--- a/doc/deprecating-badges.md
+++ b/doc/deprecating-badges.md
@@ -46,18 +46,18 @@ export const t = new ServiceTester({
 })
 ```
 
-Next you will need to replace/refactor the existing tests to validate the new deprecated badge behavior for this service. Deprecated badges always return a message of `no longer available` (such as `imagelayers | no longer available`) so the tests need to be updated to reflect that message value. For example:
+Next you will need to replace/refactor the existing tests to validate the new deprecated badge behavior for this service. Deprecated badges always return a message of `retired badge` (such as `imagelayers | retired badge`) so the tests need to be updated to reflect that message value. For example:
 
 ```js
-t.create('no longer available (previously image size)')
+t.create('retired badge (previously image size)')
   .get('/image-size/_/ubuntu/latest.json')
   .expectBadge({
     label: 'imagelayers',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 ```
 
-Make sure to have a live (non-mocked) test for each badge the service provides that validates the each badge returns the `no longer available` message.
+Make sure to have a live (non-mocked) test for each badge the service provides that validates the each badge returns the `retired badge` message.
 
 Here is an example of what the final result would look like for a test file:
 
@@ -69,18 +69,18 @@ export const t = new ServiceTester({
   title: 'ImageLayers',
 })
 
-t.create('no longer available (previously image size)')
+t.create('retired badge (previously image size)')
   .get('/image-size/_/ubuntu/latest.json')
   .expectBadge({
     label: 'imagelayers',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
-t.create('no longer available (previously number of layers)')
+t.create('retired badge (previously number of layers)')
   .get('/layers/_/ubuntu/latest.json')
   .expectBadge({
     label: 'imagelayers',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 ```
 

--- a/services/bit/bit-components.tester.js
+++ b/services/bit/bit-components.tester.js
@@ -8,5 +8,5 @@ export const t = new ServiceTester({
 
 t.create('collection').get('/ramda/ramda.json').expectBadge({
   label: 'bitcomponents',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/codeclimate/codeclimate.tester.js
+++ b/services/codeclimate/codeclimate.tester.js
@@ -10,5 +10,5 @@ t.create('test coverage')
   .get('/coverage/codeclimate/codeclimate.json')
   .expectBadge({
     label: 'codeclimate',
-    message: 'no longer available',
+    message: 'retired badge',
   })

--- a/services/codeship/codeship.tester.js
+++ b/services/codeship/codeship.tester.js
@@ -5,6 +5,6 @@ export const t = new ServiceTester({
   title: 'Codeship',
 })
 
-t.create('codeship (no longer available)')
+t.create('codeship (retired badge)')
   .get('/30419df0-80ff-0135-f7fb-06994b6b032d.json')
-  .expectBadge({ label: 'codeship', message: 'no longer available' })
+  .expectBadge({ label: 'codeship', message: 'retired badge' })

--- a/services/coincap/coincap.tester.js
+++ b/services/coincap/coincap.tester.js
@@ -10,15 +10,15 @@ t.create('coincap change percent 24hr')
   .get('/change-percent-24hr/bitcoin.json')
   .expectBadge({
     label: 'coincap',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('coincap price USD').get('/price-usd/bitcoin.json').expectBadge({
   label: 'coincap',
-  message: 'no longer available',
+  message: 'retired badge',
 })
 
 t.create('coincap rank').get('/rank/bitcoin.json').expectBadge({
   label: 'coincap',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/docker/docker-cloud-automated.tester.js
+++ b/services/docker/docker-cloud-automated.tester.js
@@ -10,5 +10,5 @@ t.create('docker cloud automated build')
   .get('/pavics/magpie.json')
   .expectBadge({
     label: 'dockercloud',
-    message: 'no longer available',
+    message: 'retired badge',
   })

--- a/services/docker/docker-cloud-build.tester.js
+++ b/services/docker/docker-cloud-build.tester.js
@@ -8,5 +8,5 @@ export const t = new ServiceTester({
 
 t.create('docker cloud build status').get('/pavics/magpie.json').expectBadge({
   label: 'dockercloud',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/github/github-workflow-status.tester.js
+++ b/services/github/github-workflow-status.tester.js
@@ -13,22 +13,22 @@ const expectedDeprecatedResponse = {
   color: 'red',
 }
 
-t.create('no longer available (previously nonexistent repo)')
+t.create('retired badge (previously nonexistent repo)')
   .get('/badges/shields-fakeness/fake.json')
   .expectBadge(expectedDeprecatedResponse)
 
-t.create('no longer available (previously nonexistent workflow)')
+t.create('retired badge (previously nonexistent workflow)')
   .get('/actions/toolkit/not-a-real-workflow.json')
   .expectBadge(expectedDeprecatedResponse)
 
-t.create('no longer available (previously valid workflow)')
+t.create('retired badge (previously valid workflow)')
   .get('/actions/toolkit/toolkit-unit-tests.json')
   .expectBadge(expectedDeprecatedResponse)
 
-t.create('no longer available (previously valid workflow - branch)')
+t.create('retired badge (previously valid workflow - branch)')
   .get('/actions/toolkit/toolkit-unit-tests/master.json')
   .expectBadge(expectedDeprecatedResponse)
 
-t.create('no longer available (previously valid workflow - event)')
+t.create('retired badge (previously valid workflow - event)')
   .get('/actions/toolkit/toolkit-unit-tests.json?event=push')
   .expectBadge(expectedDeprecatedResponse)

--- a/services/hackage/hackage-deps.tester.js
+++ b/services/hackage/hackage-deps.tester.js
@@ -7,4 +7,4 @@ export const t = new ServiceTester({
 
 t.create('hackage deps (deprecated)')
   .get('/package.json')
-  .expectBadge({ label: 'hackagedeps', message: 'no longer available' })
+  .expectBadge({ label: 'hackagedeps', message: 'retired badge' })

--- a/services/nostr-band/nostr-band-followers.tester.js
+++ b/services/nostr-band/nostr-band-followers.tester.js
@@ -11,5 +11,5 @@ t.create('followers')
   )
   .expectBadge({
     label: 'nostrband',
-    message: 'no longer available',
+    message: 'retired badge',
   })

--- a/services/pub/pub-popularity.tester.js
+++ b/services/pub/pub-popularity.tester.js
@@ -8,5 +8,5 @@ export const t = new ServiceTester({
 
 t.create('pub popularity').get('/analysis_options.json').expectBadge({
   label: 'pubpopularity',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/security-headers/security-headers.tester.js
+++ b/services/security-headers/security-headers.tester.js
@@ -7,5 +7,5 @@ export const t = new ServiceTester({
 
 t.create('deprecated service').get('/security-headers.json').expectBadge({
   label: 'securityheaders',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/visual-studio-app-center/visual-studio-app-center-builds.tester.js
+++ b/services/visual-studio-app-center/visual-studio-app-center-builds.tester.js
@@ -8,19 +8,19 @@ export const t = new ServiceTester({
 
 t.create('Valid Build').get('/nock/nock/master/token.json').expectBadge({
   label: 'visualstudioappcenter',
-  message: 'no longer available',
+  message: 'retired badge',
 })
 
 t.create('Invalid Branch')
   .get('/jct/test-1/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid API Token')
   .get('/jct/test-1/master/invalid.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })

--- a/services/visual-studio-app-center/visual-studio-app-center-releases-osversion.tester.js
+++ b/services/visual-studio-app-center/visual-studio-app-center-releases-osversion.tester.js
@@ -12,24 +12,24 @@ t.create('[fixed] Example Release')
   )
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Valid user, invalid project, valid API token')
   .get('/jcx/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid user, invalid project, valid API token')
   .get('/invalid/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid API Token').get('/invalid/invalid/invalid.json').expectBadge({
   label: 'visualstudioappcenter',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/visual-studio-app-center/visual-studio-app-center-releases-size.tester.js
+++ b/services/visual-studio-app-center/visual-studio-app-center-releases-size.tester.js
@@ -10,7 +10,7 @@ t.create('8368844 bytes to 8.37 megabytes')
   .get('/nock/nock/nock.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Valid Release')
@@ -19,24 +19,24 @@ t.create('Valid Release')
   )
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Valid user, invalid project, valid API token')
   .get('/jcx/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid user, invalid project, valid API token')
   .get('/invalid/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid API Token').get('/invalid/invalid/invalid.json').expectBadge({
   label: 'visualstudioappcenter',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/visual-studio-app-center/visual-studio-app-center-releases-version.tester.js
+++ b/services/visual-studio-app-center/visual-studio-app-center-releases-version.tester.js
@@ -12,29 +12,29 @@ t.create('[fixed] Example Release')
   )
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Valid user, invalid project, valid API token')
   .get('/jcx/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Invalid user, invalid project, valid API token')
   .get('/invalid/invalid/8c9b519a0750095b9fea3d40b2645d8a0c24a2f3.json')
   .expectBadge({
     label: 'visualstudioappcenter',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 t.create('Missing Short Version').get('/nock/nock/nock.json').expectBadge({
   label: 'visualstudioappcenter',
-  message: 'no longer available',
+  message: 'retired badge',
 })
 
 t.create('Invalid API Token').get('/invalid/invalid/invalid.json').expectBadge({
   label: 'visualstudioappcenter',
-  message: 'no longer available',
+  message: 'retired badge',
 })

--- a/services/visual-studio-marketplace/visual-studio-marketplace.tester.js
+++ b/services/visual-studio-marketplace/visual-studio-marketplace.tester.js
@@ -13,122 +13,122 @@ export const tLegacy = new ServiceTester({
 })
 
 // Downloads / Installs (visual-studio-marketplace)
-t.create('no longer available (visual-studio-marketplace downloads)')
+t.create('retired badge (visual-studio-marketplace downloads)')
   .get('/d/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
-t.create('no longer available (visual-studio-marketplace installs)')
+t.create('retired badge (visual-studio-marketplace installs)')
   .get('/i/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Downloads / Installs (vscode-marketplace - legacy)
 tLegacy
-  .create('no longer available (vscode-marketplace downloads)')
+  .create('retired badge (vscode-marketplace downloads)')
   .get('/d/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 tLegacy
-  .create('no longer available (vscode-marketplace installs)')
+  .create('retired badge (vscode-marketplace installs)')
   .get('/i/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Version (visual-studio-marketplace)
-t.create('no longer available (version)')
+t.create('retired badge (version)')
   .get('/v/lextudio.restructuredtext.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Version (vscode-marketplace - legacy)
 tLegacy
-  .create('no longer available (version legacy)')
+  .create('retired badge (version legacy)')
   .get('/v/lextudio.restructuredtext.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Rating / Stars (visual-studio-marketplace)
-t.create('no longer available (rating)')
+t.create('retired badge (rating)')
   .get('/r/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
-t.create('no longer available (stars)')
+t.create('retired badge (stars)')
   .get('/stars/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Rating / Stars (vscode-marketplace - legacy)
 tLegacy
-  .create('no longer available (rating legacy)')
+  .create('retired badge (rating legacy)')
   .get('/r/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 tLegacy
-  .create('no longer available (stars legacy)')
+  .create('retired badge (stars legacy)')
   .get('/stars/ritwickdey.LiveServer.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Release date / Last updated (visual-studio-marketplace)
-t.create('no longer available (release date)')
+t.create('retired badge (release date)')
   .get('/release-date/yasht.terminal-all-in-one.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
-t.create('no longer available (last updated)')
+t.create('retired badge (last updated)')
   .get('/last-updated/yasht.terminal-all-in-one.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Release date / Last updated (vscode-marketplace - legacy)
 tLegacy
-  .create('no longer available (release date legacy)')
+  .create('retired badge (release date legacy)')
   .get('/release-date/yasht.terminal-all-in-one.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 tLegacy
-  .create('no longer available (last updated legacy)')
+  .create('retired badge (last updated legacy)')
   .get('/last-updated/yasht.terminal-all-in-one.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })
 
 // Azure DevOps installs (visual-studio-marketplace)
-t.create('no longer available (azure devops installs total)')
+t.create('retired badge (azure devops installs total)')
   .get('/azure-devops/installs/total/swellaby.mirror-git-repository.json')
   .expectBadge({
     label: 'visual-studio-marketplace',
-    message: 'no longer available',
+    message: 'retired badge',
   })

--- a/services/wikiapiary/wikiapiary-installs.tester.js
+++ b/services/wikiapiary/wikiapiary-installs.tester.js
@@ -7,8 +7,8 @@ export const t = new ServiceTester({
 
 t.create('Extension')
   .get('/extension/installs/ParserFunctions.json')
-  .expectBadge({ label: 'wikiapiary', message: 'no longer available' })
+  .expectBadge({ label: 'wikiapiary', message: 'retired badge' })
 
 t.create('Skins')
   .get('/skin/installs/Vector.json')
-  .expectBadge({ label: 'wikiapiary', message: 'no longer available' })
+  .expectBadge({ label: 'wikiapiary', message: 'retired badge' })


### PR DESCRIPTION
- reduce confusion over deprecated badge source (badge, shields, endpoint service, user's service)
- reduce length of message to reduce traffic

will update all deprecated services and base class code in a follow-up commit after discussion that this change is acceptable as presented in these updated docs.

see also https://github.com/badges/shields/pull/11792#issuecomment-4229267483 for context.

about why use `retired badge`?
- retired is shorter then deprecated or available while still indicate deprecation - improve performance/reduce traffic. (maybe we could find another word?)
- the word badge indicates clearly what is deprecated, i was thinking adding shields explicitly, like `shields: retired badge` but badges are already linked in association to shields.io and this message is presented clearly on a badge so it should be clear and easy to tell what and why is wrong. omitting the `shields` reduces traffic and badge size
- using a shorter message is also good from a UI standpoint, most badges show short text like `pass` or `v2.0.0`. today's depreciation message is very long and may unexpectedly cause a change in badge size. seems like a bonus for some cases.

let me know what you think before i finish the PR, are there any better texts? did you find any past discussions about this?

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
