### PR TITLE
Make github-actions commit author consistent

### DIFF
--- a/.github/actions/draft-release/entrypoint.sh
+++ b/.github/actions/draft-release/entrypoint.sh
@@ -10,8 +10,8 @@ git fetch --unshallow --tags
 LAST_TAG=$(git tag | grep server | tail -n 1)
 
 # Set up a git user
-git config user.name "release[bot]"
-git config user.email "actions@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
 
 # Find the marker in CHANGELOG.md
 INSERT_POINT=$(grep -n "^\-\-\-$" CHANGELOG.md | cut -f1 -d:)

--- a/.github/scripts/deploy-review-app.sh
+++ b/.github/scripts/deploy-review-app.sh
@@ -11,8 +11,8 @@ org="shields-io"
 pr_json=$(curl --fail "https://api.github.com/repos/badges/shields/pulls/$PR_NUMBER")
 
 # Checkout the PR branch
-git config user.name "actions[bot]"
-git config user.email "actions@users.noreply.github.com"
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
 git fetch origin "pull/$PR_NUMBER/head:pr-$PR_NUMBER"
 git checkout "pr-$PR_NUMBER"
 


### PR DESCRIPTION
Let's use the [`f9e814db6331fc397bc654d3258e59c456391289`](https://github.com/badges/shields/commit/f9e814db6331fc397bc654d3258e59c456391289) as an example. This commit has three authors (1 author and 2 co-authors):

- `github-actions[bot]` (author)
- `release[bot]` (co-author)
- `jNullj` (co-author)

We can consider merging the `github-actions[bot]` and `release[bot]` into one. So that the commit won't show an unassociated GitHub account with an empty avatar.