### PR TITLE
feat: add [SdkmanVersion] badge

### DIFF
--- a/services/sdkman/sdkman-version.service.js
+++ b/services/sdkman/sdkman-version.service.js
@@ -1,0 +1,40 @@
+import { renderVersionBadge } from '../version.js'
+import { BaseService, InvalidResponse, pathParams } from '../index.js'
+
+export default class SdkmanVersion extends BaseService {
+  static category = 'version'
+
+  static route = {
+    base: 'sdkman/v',
+    pattern: ':candidate',
+  }
+
+  static openApi = {
+    '/sdkman/v/{candidate}': {
+      get: {
+        summary: 'SDKMAN Version',
+        parameters: pathParams({
+          name: 'candidate',
+          example: 'java',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'sdkman' }
+
+  async fetch({ candidate }) {
+    return this._request({
+      url: `https://api.sdkman.io/2/candidates/default/${candidate}`,
+    })
+  }
+
+  async handle({ candidate }) {
+    const { buffer } = await this.fetch({ candidate })
+    const version = buffer.trim()
+    if (!version) {
+      throw new InvalidResponse({ prettyMessage: 'invalid response data' })
+    }
+    return renderVersionBadge({ version })
+  }
+}

--- a/services/sdkman/sdkman-version.service.js
+++ b/services/sdkman/sdkman-version.service.js
@@ -26,6 +26,7 @@ export default class SdkmanVersion extends BaseService {
   async fetch({ candidate }) {
     return this._request({
       url: `https://api.sdkman.io/2/candidates/default/${candidate}`,
+      httpErrors: { 400: 'not found' },
     })
   }
 

--- a/services/sdkman/sdkman-version.tester.js
+++ b/services/sdkman/sdkman-version.tester.js
@@ -3,25 +3,13 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('version (valid)')
-  .get('/java.json')
-  .intercept(nock =>
-    nock('https://api.sdkman.io')
-      .get('/2/candidates/default/java')
-      .reply(200, '21.0.2-tem'),
-  )
-  .expectBadge({
-    label: 'sdkman',
-    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
-  })
+t.create('version (valid)').get('/java.json').expectBadge({
+  label: 'sdkman',
+  message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+})
 
 t.create('version (not found)')
   .get('/not-a-real-sdk.json')
-  .intercept(nock =>
-    nock('https://api.sdkman.io')
-      .get('/2/candidates/default/not-a-real-sdk')
-      .reply(404),
-  )
   .expectBadge({ label: 'sdkman', message: 'not found' })
 
 t.create('version (empty response)')

--- a/services/sdkman/sdkman-version.tester.js
+++ b/services/sdkman/sdkman-version.tester.js
@@ -1,0 +1,34 @@
+import { isVPlusDottedVersionNClausesWithOptionalSuffix } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('version (valid)')
+  .get('/java.json')
+  .intercept(nock =>
+    nock('https://api.sdkman.io')
+      .get('/2/candidates/default/java')
+      .reply(200, '21.0.2-tem'),
+  )
+  .expectBadge({
+    label: 'sdkman',
+    message: isVPlusDottedVersionNClausesWithOptionalSuffix,
+  })
+
+t.create('version (not found)')
+  .get('/not-a-real-sdk.json')
+  .intercept(nock =>
+    nock('https://api.sdkman.io')
+      .get('/2/candidates/default/not-a-real-sdk')
+      .reply(404),
+  )
+  .expectBadge({ label: 'sdkman', message: 'not found' })
+
+t.create('version (empty response)')
+  .get('/java.json')
+  .intercept(nock =>
+    nock('https://api.sdkman.io')
+      .get('/2/candidates/default/java')
+      .reply(200, ''),
+  )
+  .expectBadge({ label: 'sdkman', message: 'invalid response data' })


### PR DESCRIPTION
Adds a version badge for SDKMAN! SDK candidates.

Fetches plain-text version from `https://api.sdkman.io/2/candidates/default/:candidate`.

Example: `/sdkman/v/java` → `v21.0.2-tem`

Closes #7581
