### PR TITLE
feat: add [MacPortsVersion] badge

### DIFF
--- a/services/macports/macports-version.service.js
+++ b/services/macports/macports-version.service.js
@@ -1,0 +1,43 @@
+import Joi from 'joi'
+import { renderVersionBadge } from '../version.js'
+import { BaseJsonService, pathParams } from '../index.js'
+
+const schema = Joi.object({
+  version: Joi.string().required(),
+}).required()
+
+export default class MacportsVersion extends BaseJsonService {
+  static category = 'version'
+
+  static route = {
+    base: 'macports/v',
+    pattern: ':portName',
+  }
+
+  static openApi = {
+    '/macports/v/{portName}': {
+      get: {
+        summary: 'MacPorts Version',
+        parameters: pathParams({
+          name: 'portName',
+          example: 'git',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'macports' }
+
+  async fetch({ portName }) {
+    return this._requestJson({
+      schema,
+      url: `https://ports.macports.org/api/v1/ports/${portName}/`,
+      httpErrors: { 404: 'port not found' },
+    })
+  }
+
+  async handle({ portName }) {
+    const { version } = await this.fetch({ portName })
+    return renderVersionBadge({ version })
+  }
+}

--- a/services/macports/macports-version.tester.js
+++ b/services/macports/macports-version.tester.js
@@ -1,0 +1,25 @@
+import { isVPlusDottedVersionAtLeastOne } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('version (valid)')
+  .get('/git.json')
+  .intercept(nock =>
+    nock('https://ports.macports.org')
+      .get('/api/v1/ports/git/')
+      .reply(200, { version: '2.47.1' }),
+  )
+  .expectBadge({
+    label: 'macports',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
+
+t.create('version (not found)')
+  .get('/not-a-real-port.json')
+  .intercept(nock =>
+    nock('https://ports.macports.org')
+      .get('/api/v1/ports/not-a-real-port/')
+      .reply(404),
+  )
+  .expectBadge({ label: 'macports', message: 'port not found' })

--- a/services/macports/macports-version.tester.js
+++ b/services/macports/macports-version.tester.js
@@ -3,10 +3,17 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('version (valid)').get('/git.json').expectBadge({
-  label: 'macports',
-  message: isVPlusDottedVersionAtLeastOne,
-})
+t.create('version (valid)')
+  .get('/git.json')
+  .intercept(nock =>
+    nock('https://ports.macports.org')
+      .get('/api/v1/ports/git/')
+      .reply(200, { version: '2.47.1' }),
+  )
+  .expectBadge({
+    label: 'macports',
+    message: isVPlusDottedVersionAtLeastOne,
+  })
 
 t.create('version (not found)')
   .get('/not-a-real-port.json')

--- a/services/macports/macports-version.tester.js
+++ b/services/macports/macports-version.tester.js
@@ -10,4 +10,9 @@ t.create('version (valid)').get('/git.json').expectBadge({
 
 t.create('version (not found)')
   .get('/not-a-real-port.json')
+  .intercept(nock =>
+    nock('https://ports.macports.org')
+      .get('/api/v1/ports/not-a-real-port/')
+      .reply(404),
+  )
   .expectBadge({ label: 'macports', message: 'port not found' })

--- a/services/macports/macports-version.tester.js
+++ b/services/macports/macports-version.tester.js
@@ -3,23 +3,11 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('version (valid)')
-  .get('/git.json')
-  .intercept(nock =>
-    nock('https://ports.macports.org')
-      .get('/api/v1/ports/git/')
-      .reply(200, { version: '2.47.1' }),
-  )
-  .expectBadge({
-    label: 'macports',
-    message: isVPlusDottedVersionAtLeastOne,
-  })
+t.create('version (valid)').get('/git.json').expectBadge({
+  label: 'macports',
+  message: isVPlusDottedVersionAtLeastOne,
+})
 
 t.create('version (not found)')
   .get('/not-a-real-port.json')
-  .intercept(nock =>
-    nock('https://ports.macports.org')
-      .get('/api/v1/ports/not-a-real-port/')
-      .reply(404),
-  )
   .expectBadge({ label: 'macports', message: 'port not found' })


### PR DESCRIPTION
Adds a version badge for MacPorts ports.

Fetches JSON from `https://ports.macports.org/api/v1/ports/:portName/` and extracts the `version` field.

Example: `/macports/v/git` → `v2.47.1`

Closes #9588