### PR TITLE
refactor: replace 'format' with 'pattern' in deprecated example/test

### DIFF
--- a/core/base-service/deprecated-service.spec.js
+++ b/core/base-service/deprecated-service.spec.js
@@ -4,7 +4,7 @@ import deprecatedService from './deprecated-service.js'
 describe('DeprecatedService', function () {
   const route = {
     base: 'service/that/no/longer/exists',
-    format: '(?:.+)',
+    pattern: ':various+',
   }
   const category = 'analysis'
   const dateAdded = new Date()

--- a/doc/deprecating-badges.md
+++ b/doc/deprecating-badges.md
@@ -24,7 +24,7 @@ export default deprecatedService({
   category: 'size',
   route: {
     base: 'imagelayers',
-    format: '(?:.+?)',
+    pattern: ':various+',
   },
   label: 'imagelayers',
   dateAdded: new Date('2019-xx-xx'), // Be sure to update this with today's date!


### PR DESCRIPTION
replaced format with pattern in old example
as well as a test to avoid old usage of the to be removed `format` route option.
i picked this up as i want to make another 2 pr to remove format once and for all, this will help with #11800 and moving towards express.

part of issue #3329
helps unblock #11800 

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
