### PR TITLE
refactor: replace route format with pattern for [Travis]

### DIFF
--- a/services/travis/travis-build.service.js
+++ b/services/travis/travis-build.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseSvgScrapingService, pathParams } from '../index.js'
+import { BaseSvgScrapingService, pathParams, NotFound } from '../index.js'
 
 const schema = Joi.object({
   message: Joi.alternatives()
@@ -12,9 +12,8 @@ export class TravisComBuild extends BaseSvgScrapingService {
   static category = 'build'
 
   static route = {
-    base: 'travis',
-    format: 'com/(?!php-v)([^/]+/[^/]+?)(?:/(.+?))?',
-    capture: ['userRepo', 'branch'],
+    base: 'travis/com',
+    pattern: ':user/:repo/:branch*',
   }
 
   static openApi = {
@@ -62,10 +61,14 @@ export class TravisComBuild extends BaseSvgScrapingService {
     return renderBuildStatusBadge({ status })
   }
 
-  async handle({ userRepo, branch }) {
+  async handle({ user, repo, branch }) {
+    if (user.startsWith('php-v')) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+
     const { message: status } = await this._requestSvg({
       schema,
-      url: `https://api.travis-ci.com/${userRepo}.svg`,
+      url: `https://api.travis-ci.com/${user}/${repo}.svg`,
       options: { searchParams: { branch } },
       valueMatcher: />([^<>]+)<\/text><\/g>/,
     })

--- a/services/travis/travis-build.service.js
+++ b/services/travis/travis-build.service.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { isBuildStatus, renderBuildStatusBadge } from '../build-status.js'
-import { BaseSvgScrapingService, pathParams, NotFound } from '../index.js'
+import { BaseSvgScrapingService, pathParams } from '../index.js'
 
 const schema = Joi.object({
   message: Joi.alternatives()
@@ -62,10 +62,6 @@ export class TravisComBuild extends BaseSvgScrapingService {
   }
 
   async handle({ user, repo, branch }) {
-    if (user.startsWith('php-v')) {
-      throw new NotFound({ prettyMessage: 'not found' })
-    }
-
     const { message: status } = await this._requestSvg({
       schema,
       url: `https://api.travis-ci.com/${user}/${repo}.svg`,

--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -27,7 +27,3 @@ t.create('invalid svg response')
     nock('https://api.travis-ci.com').get('/foo/bar.svg').reply(200),
   )
   .expectBadge({ label: 'build', message: 'unparseable svg response' })
-
-t.create('php-v user is rejected')
-  .get('/php-v-starting/some-repo.json')
-  .expectBadge({ label: 'build', message: 'not found' })

--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -27,3 +27,7 @@ t.create('invalid svg response')
     nock('https://api.travis-ci.com').get('/foo/bar.svg').reply(200),
   )
   .expectBadge({ label: 'build', message: 'unparseable svg response' })
+
+t.create('php-v user is rejected')
+  .get('/com/php-v-starting/some-repo.json')
+  .expectBadge({ label: 'build', message: 'not found' })

--- a/services/travis/travis-build.tester.js
+++ b/services/travis/travis-build.tester.js
@@ -4,30 +4,30 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('build status on default branch')
-  .get('/com/ivandelabeldad/rackian-gateway.json')
+  .get('/ivandelabeldad/rackian-gateway.json')
   .expectBadge({
     label: 'build',
     message: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
   })
 
 t.create('build status on named branch')
-  .get('/com/ivandelabeldad/rackian-gateway.json')
+  .get('/ivandelabeldad/rackian-gateway.json')
   .expectBadge({
     label: 'build',
     message: Joi.alternatives().try(isBuildStatus, Joi.equal('unknown')),
   })
 
 t.create('unknown repo')
-  .get('/com/this-repo/does-not-exist.json')
+  .get('/this-repo/does-not-exist.json')
   .expectBadge({ label: 'build', message: 'unknown' })
 
 t.create('invalid svg response')
-  .get('/com/foo/bar.json')
+  .get('/foo/bar.json')
   .intercept(nock =>
     nock('https://api.travis-ci.com').get('/foo/bar.svg').reply(200),
   )
   .expectBadge({ label: 'build', message: 'unparseable svg response' })
 
 t.create('php-v user is rejected')
-  .get('/com/php-v-starting/some-repo.json')
+  .get('/php-v-starting/some-repo.json')
   .expectBadge({ label: 'build', message: 'not found' })


### PR DESCRIPTION
replace `route`'s `format` with `pattern`

part of issue #3329
helps unblock #11800

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
