### PR TITLE
Add [RwxBuild] build status badge

### DIFF
--- a/services/rwx/rwx-build.service.js
+++ b/services/rwx/rwx-build.service.js
@@ -1,0 +1,108 @@
+import Joi from 'joi'
+import { BaseJsonService, pathParam, queryParam } from '../index.js'
+
+const responseSchema = Joi.object({
+  schemaVersion: Joi.number().valid(1).required(),
+  label: Joi.string().required(),
+  message: Joi.string().required(),
+  color: Joi.string().required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  repo: Joi.string().required(),
+  branch: Joi.string().required(),
+  definition: Joi.string().required(),
+  token: Joi.string(),
+  label: Joi.string().max(100),
+}).required()
+
+const tokenDescription = `
+Optional org-scoped status badge token. Required for private repositories.
+
+Manage tokens in your [RWX Org Settings](https://cloud.rwx.com/org/deep_link/manage/mint/status_badge_tokens).
+<b>Status badge tokens are read-only and grant access only to badge data.</b>
+`
+
+export default class RwxBuild extends BaseJsonService {
+  static category = 'build'
+
+  static route = {
+    base: 'rwx/build',
+    pattern: ':organizationSlug',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/rwx/build/{organizationSlug}': {
+      get: {
+        summary: 'RWX Latest Run Status',
+        description:
+          '[RWX](https://www.rwx.com/) is a CI/CD platform. This badge reports the status of the most recent run for a given repository, branch, and run definition.',
+        parameters: [
+          pathParam({
+            name: 'organizationSlug',
+            example: 'rwx',
+            description: 'RWX organization slug',
+          }),
+          queryParam({
+            name: 'repo',
+            example: 'rwx',
+            required: true,
+            description: 'Repository, without the owner/org prefix.',
+          }),
+          queryParam({
+            name: 'branch',
+            example: 'main',
+            required: true,
+          }),
+          queryParam({
+            name: 'definition',
+            example: '.rwx/main.yml',
+            required: true,
+            description:
+              'Path to the RWX run definition file, relative to the repository root.',
+          }),
+          queryParam({
+            name: 'token',
+            example: '0123456789abcdef0123456789abcdef',
+            description: tokenDescription,
+          }),
+          queryParam({
+            name: 'label',
+            example: 'ci',
+            description: 'Override the default `build` label.',
+          }),
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'build' }
+
+  async handle(
+    { organizationSlug },
+    { repo, branch, definition, token, label },
+  ) {
+    const searchParams = { repo, branch, definition }
+    if (token) {
+      searchParams.token = token
+    }
+    if (label) {
+      searchParams.label = label
+    }
+
+    const {
+      label: respLabel,
+      message,
+      color,
+    } = await this._requestJson({
+      schema: responseSchema,
+      url: `https://cloud.rwx.com/status_badges/${encodeURIComponent(
+        organizationSlug,
+      )}.json`,
+      options: { searchParams },
+    })
+
+    return { label: respLabel, message, color }
+  }
+}

--- a/services/rwx/rwx-build.tester.js
+++ b/services/rwx/rwx-build.tester.js
@@ -1,0 +1,134 @@
+import Joi from 'joi'
+import { normalizeColor } from '../../badge-maker/lib/color.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+const isRwxStatus = Joi.string().valid(
+  'passing',
+  'failing',
+  'running',
+  'queued',
+  'timed out',
+  'cancelled',
+  'error',
+  'debugging',
+  'sandboxed',
+  'unknown',
+  'no runs',
+)
+
+const isShieldsColor = Joi.string().custom((value, helpers) => {
+  if (normalizeColor(value) === undefined) {
+    return helpers.error('any.invalid')
+  }
+  return value
+}, 'shields color')
+
+t.create('live endpoint returns a valid status payload')
+  .get('/rwx.json?repo=rwx&branch=main&definition=.rwx/main.yml', {
+    followRedirect: false,
+  })
+  .expectBadge({
+    label: 'build',
+    message: isRwxStatus,
+    color: isShieldsColor,
+  })
+
+t.create('passing run')
+  .get('/rwx.json?repo=cloud&branch=main&definition=.rwx/main.yml')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query({
+        repo: 'cloud',
+        branch: 'main',
+        definition: '.rwx/main.yml',
+      })
+      .reply(200, {
+        schemaVersion: 1,
+        label: 'build',
+        message: 'passing',
+        color: 'brightgreen',
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'passing', color: 'brightgreen' })
+
+t.create('failing run')
+  .get('/rwx.json?repo=cloud&branch=main&definition=.rwx/main.yml')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query(true)
+      .reply(200, {
+        schemaVersion: 1,
+        label: 'build',
+        message: 'failing',
+        color: 'red',
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'failing', color: 'red' })
+
+t.create('unknown payload (private repo without token)')
+  .get('/rwx.json?repo=private-repo&branch=main&definition=.rwx/main.yml')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query(true)
+      .reply(200, {
+        schemaVersion: 1,
+        label: 'build',
+        message: 'unknown',
+        color: 'lightgrey',
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'unknown', color: 'lightgrey' })
+
+t.create('label query param is forwarded and returned')
+  .get('/rwx.json?repo=cloud&branch=main&definition=.rwx/main.yml&label=ci')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query({
+        repo: 'cloud',
+        branch: 'main',
+        definition: '.rwx/main.yml',
+        label: 'ci',
+      })
+      .reply(200, {
+        schemaVersion: 1,
+        label: 'ci',
+        message: 'passing',
+        color: 'brightgreen',
+      }),
+  )
+  .expectBadge({ label: 'ci', message: 'passing', color: 'brightgreen' })
+
+t.create('token query param is forwarded')
+  .get('/rwx.json?repo=cloud&branch=main&definition=.rwx/main.yml&token=abc123')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query({
+        repo: 'cloud',
+        branch: 'main',
+        definition: '.rwx/main.yml',
+        token: 'abc123',
+      })
+      .reply(200, {
+        schemaVersion: 1,
+        label: 'build',
+        message: 'passing',
+        color: 'brightgreen',
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'passing', color: 'brightgreen' })
+
+t.create('malformed upstream response surfaces invalid response')
+  .get('/rwx.json?repo=cloud&branch=main&definition=.rwx/main.yml')
+  .intercept(nock =>
+    nock('https://cloud.rwx.com/')
+      .get('/status_badges/rwx.json')
+      .query(true)
+      .reply(200, { schemaVersion: 1, label: 'build', message: 'passing' }),
+  )
+  .expectBadge({ label: 'build', message: 'invalid response data' })


### PR DESCRIPTION
Hey there folks - I work with [RWX](https://www.rwx.com/), a CI/CD platform, and this PR adds a service badge in the "build" category for our service, using a public JSON endpoint that already returns this information.