### PR TITLE
refactor: replace route format with pattern in [website] redirect service

### DIFF
--- a/services/website/website-redirect.service.js
+++ b/services/website/website-redirect.service.js
@@ -9,6 +9,31 @@ function escapeFormatSlashes(t) {
   )
 }
 
+function splitDashSeparatedOptionalParams(s) {
+  const parts = []
+  let cur = ''
+  for (let i = 0; i < s.length; ) {
+    const ch = s[i]
+    const next = s[i + 1]
+    if (ch === '-' && next === '-') {
+      cur += '-'
+      i += 2
+    } else if (ch === '/' && next === '/') {
+      cur += '/'
+      i += 2
+    } else if (ch === '-') {
+      parts.push(cur)
+      cur = ''
+      i += 1
+    } else {
+      cur += ch
+      i += 1
+    }
+  }
+  parts.push(cur)
+  return parts
+}
+
 /*
 Old documentation, for reference:
 
@@ -54,39 +79,23 @@ export default [
     category: 'monitoring',
     route: {
       base: '',
-      format:
-        'website-(([^-/]|--|//)+)-(([^-/]|--|//)+)(-(([^-/]|--|//)+)-(([^-/]|--|//)+))?/([^/]+)/(.+?)',
-      capture: [
-        // Some of these could be made into non-capturing groups so these unused
-        // params would not need to be declared.
-        'upMessage',
-        'unused2',
-        'downMessage',
-        'unused4',
-        'unused5',
-        'upColor',
-        'unused7',
-        'downColor',
-        'unused8',
-        'protocol',
-        'hostAndPath',
-      ],
+      pattern: 'website-:labels/:protocol/:hostAndPath+',
     },
     transformPath: () => '/website',
-    transformQueryParams: ({
-      upMessage,
-      downMessage,
-      upColor,
-      downColor,
-      protocol,
-      hostAndPath,
-    }) => ({
-      up_message: upMessage ? escapeFormatSlashes(upMessage) : undefined,
-      down_message: downMessage ? escapeFormatSlashes(downMessage) : undefined,
-      up_color: upColor,
-      down_color: downColor,
-      url: `${protocol}://${hostAndPath}`,
-    }),
+    transformQueryParams: ({ labels, protocol, hostAndPath }) => {
+      const parts = splitDashSeparatedOptionalParams(labels || '')
+      const [upMessage, downMessage, upColor, downColor] = parts
+
+      return {
+        up_message: upMessage ? escapeFormatSlashes(upMessage) : undefined,
+        down_message: downMessage
+          ? escapeFormatSlashes(downMessage)
+          : undefined,
+        up_color: upColor,
+        down_color: downColor,
+        url: `${protocol}://${hostAndPath}`,
+      }
+    },
     dateAdded: new Date('2019-03-08'),
   }),
   redirector({


### PR DESCRIPTION
replace `route`'s deprecated `format` with `pattern`

part of #3329
helps #11800

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
