### PR TITLE
Optimise SVG badge sizes

### DIFF
--- a/__snapshots__/make-badge.spec.js
+++ b/__snapshots__/make-badge.spec.js
@@ -7,14 +7,12 @@ exports['The badge generator SVG should match snapshot 1'] = `
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="20" fill="#555" />
     <rect x="45" width="45" height="20" fill="#4b0" />
@@ -27,58 +25,36 @@ exports['The badge generator SVG should match snapshot 1'] = `
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="235"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="140" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="665"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -93,14 +69,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="20" fill="#0f0" />
     <rect x="45" width="45" height="20" fill="#b3e" />
@@ -113,58 +87,36 @@ exports['The badge generator "flat" template badge generation should match snaps
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="235"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="140" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="665"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -179,16 +131,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r">
-    <rect width="107" height="20" rx="3" fill="#fff" />
-  </clipPath>
+  <clipPath id="r"><rect width="107" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="62" height="20" fill="#0f0" />
     <rect x="62" width="45" height="20" fill="#b3e" />
@@ -208,58 +156,36 @@ exports['The badge generator "flat" template badge generation should match snaps
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="405" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="405" y="140" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="835"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="835" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="835" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -274,14 +200,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="45" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="45" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="20" fill="#b3e" />
     <rect x="0" width="45" height="20" fill="#b3e" />
@@ -294,32 +218,21 @@ exports['The badge generator "flat" template badge generation should match snaps
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="225"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="225"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="225" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="225"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="225" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="225" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -334,14 +247,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="63" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="63" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="20" fill="#555" />
     <rect x="0" width="63" height="20" fill="#b3e" />
@@ -361,32 +272,21 @@ exports['The badge generator "flat" template badge generation should match snaps
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="405" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="405" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -401,14 +301,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="69" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="69" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="24" height="20" fill="#0f0" />
     <rect x="24" width="45" height="20" fill="#b3e" />
@@ -428,32 +326,21 @@ exports['The badge generator "flat" template badge generation should match snaps
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="455"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="455"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="455" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="455"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="455" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="455" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -461,14 +348,12 @@ exports['The badge generator "flat" template badge generation should match snaps
 
 exports['The badge generator "flat" template badge generation should match snapshots: message/label, with links 1'] = `
 <svg xmlns="http://www.w3.org/2000/svg" width="90" height="20">
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="20" fill="#0f0" />
     <rect x="45" width="45" height="20" fill="#b3e" />
@@ -483,61 +368,39 @@ exports['The badge generator "flat" template badge generation should match snaps
   >
     <a target="_blank" href="https://shields.io/">
       <rect width="45" x="0" height="20" fill="rgba(0,0,0,0)" />
-      <text
-        aria-hidden="true"
-        x="235"
-        y="150"
-        fill="#010101"
-        fill-opacity=".80"
-        filter="url(#blur)"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        cactus
-      </text>
-      <text
-        aria-hidden="true"
-        x="235"
-        y="150"
-        fill="#010101"
-        fill-opacity=".3"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        cactus
-      </text>
-      <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-        cactus
-      </text>
+      <g transform="scale(.1)">
+        <g aria-hidden="true" fill="#010101">
+          <text
+            x="235"
+            y="150"
+            fill-opacity=".8"
+            filter="url(#blur)"
+            textLength="350"
+          >
+            cactus
+          </text>
+          <text x="235" y="150" fill-opacity=".3" textLength="350">cactus</text>
+        </g>
+        <text x="235" y="140" textLength="350">cactus</text>
+      </g>
     </a>
     <a target="_blank" href="https://www.google.co.uk/">
       <rect width="45" x="45" height="20" fill="rgba(0,0,0,0)" />
-      <text
-        aria-hidden="true"
-        x="665"
-        y="150"
-        fill="#010101"
-        fill-opacity=".80"
-        filter="url(#blur)"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        grown
-      </text>
-      <text
-        aria-hidden="true"
-        x="665"
-        y="150"
-        fill="#010101"
-        fill-opacity=".3"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        grown
-      </text>
-      <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-        grown
-      </text>
+      <g transform="scale(.1)">
+        <g aria-hidden="true" fill="#010101">
+          <text
+            x="665"
+            y="150"
+            fill-opacity=".8"
+            filter="url(#blur)"
+            textLength="350"
+          >
+            grown
+          </text>
+          <text x="665" y="150" fill-opacity=".3" textLength="350">grown</text>
+        </g>
+        <text x="665" y="140" textLength="350">grown</text>
+      </g>
     </a>
   </g>
 </svg>
@@ -553,14 +416,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="20" fill="#f3f3f3" />
     <rect x="45" width="45" height="20" fill="#000" />
@@ -573,58 +434,36 @@ exports['The badge generator "flat" template badge generation should match snaps
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#ccc"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#ccc"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="140" transform="scale(.1)" fill="#333" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#ccc">
+        <text
+          x="235"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="140" textLength="350" fill="#333">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="665"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -639,14 +478,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="20" fill="#000" />
     <rect x="45" width="45" height="20" fill="#e2ffe1" />
@@ -659,58 +496,36 @@ exports['The badge generator "flat" template badge generation should match snaps
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#ccc"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="150"
-      fill="#ccc"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#333" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="235"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="140" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#ccc">
+        <text
+          x="665"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="140" textLength="350" fill="#333">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -736,12 +551,8 @@ exports['The badge generator "flat-square" template badge generation should matc
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="235" y="140" textLength="350" transform="scale(.1)">cactus</text>
+    <text x="665" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -774,12 +585,8 @@ exports['The badge generator "flat-square" template badge generation should matc
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="405" y="140" textLength="350" transform="scale(.1)">cactus</text>
+    <text x="835" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -805,9 +612,7 @@ exports['The badge generator "flat-square" template badge generation should matc
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text x="225" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="225" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -840,9 +645,7 @@ exports['The badge generator "flat-square" template badge generation should matc
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="405" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -875,9 +678,7 @@ exports['The badge generator "flat-square" template badge generation should matc
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text x="455" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="455" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -898,15 +699,11 @@ exports['The badge generator "flat-square" template badge generation should matc
   >
     <a target="_blank" href="https://shields.io/">
       <rect width="45" x="0" height="20" fill="rgba(0,0,0,0)" />
-      <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-        cactus
-      </text>
+      <text x="235" y="140" textLength="350" transform="scale(.1)">cactus</text>
     </a>
     <a target="_blank" href="https://www.google.co.uk/">
       <rect width="45" x="45" height="20" fill="rgba(0,0,0,0)" />
-      <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-        grown
-      </text>
+      <text x="665" y="140" textLength="350" transform="scale(.1)">grown</text>
     </a>
   </g>
 </svg>
@@ -933,12 +730,10 @@ exports['The badge generator "flat-square" template badge generation should matc
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text x="235" y="140" transform="scale(.1)" fill="#333" textLength="350">
+    <text x="235" y="140" textLength="350" transform="scale(.1)" fill="#333">
       cactus
     </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="665" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -964,10 +759,8 @@ exports['The badge generator "flat-square" template badge generation should matc
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text x="235" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text x="665" y="140" transform="scale(.1)" fill="#333" textLength="350">
+    <text x="235" y="140" textLength="350" transform="scale(.1)">cactus</text>
+    <text x="665" y="140" textLength="350" transform="scale(.1)" fill="#333">
       grown
     </text>
   </g>
@@ -984,16 +777,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="18" fill="#0f0" />
     <rect x="45" width="45" height="18" fill="#b3e" />
@@ -1006,58 +797,36 @@ exports['The badge generator "plastic" template badge generation should match sn
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="235"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="140" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="130" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="665"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1072,18 +841,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r">
-    <rect width="107" height="18" rx="4" fill="#fff" />
-  </clipPath>
+  <clipPath id="r"><rect width="107" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="62" height="18" fill="#0f0" />
     <rect x="62" width="45" height="18" fill="#b3e" />
@@ -1103,58 +868,36 @@ exports['The badge generator "plastic" template badge generation should match sn
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="405" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="835" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="405" y="140" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="405" y="130" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="835"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="835" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="835" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1169,16 +912,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="45" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="45" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="18" fill="#b3e" />
     <rect x="0" width="45" height="18" fill="#b3e" />
@@ -1191,32 +932,21 @@ exports['The badge generator "plastic" template badge generation should match sn
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="225"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="225"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="225" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="225"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="225" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="225" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1231,16 +961,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="63" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="63" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="18" fill="#555" />
     <rect x="0" width="63" height="18" fill="#b3e" />
@@ -1260,32 +988,21 @@ exports['The badge generator "plastic" template badge generation should match sn
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="405" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="405" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="405" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1300,16 +1017,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="grown"
 >
   <title>grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="69" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="69" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="24" height="18" fill="#0f0" />
     <rect x="24" width="45" height="18" fill="#b3e" />
@@ -1329,32 +1044,21 @@ exports['The badge generator "plastic" template badge generation should match sn
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="455"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="455"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="455" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="455"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="455" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="455" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1362,16 +1066,14 @@ exports['The badge generator "plastic" template badge generation should match sn
 
 exports['The badge generator "plastic" template badge generation should match snapshots: message/label, with links 1'] = `
 <svg xmlns="http://www.w3.org/2000/svg" width="90" height="18">
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="18" fill="#0f0" />
     <rect x="45" width="45" height="18" fill="#b3e" />
@@ -1386,61 +1088,39 @@ exports['The badge generator "plastic" template badge generation should match sn
   >
     <a target="_blank" href="https://shields.io/">
       <rect width="45" x="0" height="18" fill="rgba(0,0,0,0)" />
-      <text
-        aria-hidden="true"
-        x="235"
-        y="140"
-        fill="#010101"
-        fill-opacity=".80"
-        filter="url(#blur)"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        cactus
-      </text>
-      <text
-        aria-hidden="true"
-        x="235"
-        y="140"
-        fill="#010101"
-        fill-opacity=".3"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        cactus
-      </text>
-      <text x="235" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-        cactus
-      </text>
+      <g transform="scale(.1)">
+        <g aria-hidden="true" fill="#010101">
+          <text
+            x="235"
+            y="140"
+            fill-opacity=".8"
+            filter="url(#blur)"
+            textLength="350"
+          >
+            cactus
+          </text>
+          <text x="235" y="140" fill-opacity=".3" textLength="350">cactus</text>
+        </g>
+        <text x="235" y="130" textLength="350">cactus</text>
+      </g>
     </a>
     <a target="_blank" href="https://www.google.co.uk/">
       <rect width="45" x="45" height="18" fill="rgba(0,0,0,0)" />
-      <text
-        aria-hidden="true"
-        x="665"
-        y="140"
-        fill="#010101"
-        fill-opacity=".80"
-        filter="url(#blur)"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        grown
-      </text>
-      <text
-        aria-hidden="true"
-        x="665"
-        y="140"
-        fill="#010101"
-        fill-opacity=".3"
-        transform="scale(.1)"
-        textLength="350"
-      >
-        grown
-      </text>
-      <text x="665" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-        grown
-      </text>
+      <g transform="scale(.1)">
+        <g aria-hidden="true" fill="#010101">
+          <text
+            x="665"
+            y="140"
+            fill-opacity=".8"
+            filter="url(#blur)"
+            textLength="350"
+          >
+            grown
+          </text>
+          <text x="665" y="140" fill-opacity=".3" textLength="350">grown</text>
+        </g>
+        <text x="665" y="130" textLength="350">grown</text>
+      </g>
     </a>
   </g>
 </svg>
@@ -1456,16 +1136,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="18" fill="#f3f3f3" />
     <rect x="45" width="45" height="18" fill="#000" />
@@ -1478,58 +1156,36 @@ exports['The badge generator "plastic" template badge generation should match sn
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#ccc"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#ccc"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="130" transform="scale(.1)" fill="#333" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#ccc">
+        <text
+          x="235"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="140" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="130" textLength="350" fill="#333">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="665"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1544,16 +1200,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="90" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="90" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="45" height="18" fill="#000" />
     <rect x="45" width="45" height="18" fill="#e2ffe1" />
@@ -1566,58 +1220,36 @@ exports['The badge generator "plastic" template badge generation should match sn
     text-rendering="geometricPrecision"
     font-size="110"
   >
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="235"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="235" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#ccc"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="665"
-      y="140"
-      fill="#ccc"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="665" y="130" transform="scale(.1)" fill="#333" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="235"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="235" y="140" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="235" y="130" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#ccc">
+        <text
+          x="665"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="665" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="665" y="130" textLength="350" fill="#333">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -1643,15 +1275,12 @@ exports['The badge generator "for-the-badge" template badge generation should ma
     text-rendering="geometricPrecision"
     font-size="100"
   >
-    <text transform="scale(.1)" x="362.5" y="175" textLength="485" fill="#fff">
-      CACTUS
-    </text>
+    <text transform="scale(.1)" x="362.5" y="175" textLength="485">CACTUS</text>
     <text
       transform="scale(.1)"
       x="1096.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1688,15 +1317,12 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text transform="scale(.1)" x="532.5" y="175" textLength="485" fill="#fff">
-      CACTUS
-    </text>
+    <text transform="scale(.1)" x="532.5" y="175" textLength="485">CACTUS</text>
     <text
       transform="scale(.1)"
       x="1266.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1730,7 +1356,6 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       x="371.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1771,7 +1396,6 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       x="571.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1813,7 +1437,6 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       x="691.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1838,13 +1461,7 @@ exports['The badge generator "for-the-badge" template badge generation should ma
   >
     <a target="_blank" href="https://shields.io/">
       <rect width="72.5" height="28" fill="rgba(0,0,0,0)" />
-      <text
-        transform="scale(.1)"
-        x="362.5"
-        y="175"
-        textLength="485"
-        fill="#fff"
-      >
+      <text transform="scale(.1)" x="362.5" y="175" textLength="485">
         CACTUS
       </text>
     </a>
@@ -1855,7 +1472,6 @@ exports['The badge generator "for-the-badge" template badge generation should ma
         x="1096.25"
         y="175"
         textLength="502.5"
-        fill="#fff"
         font-weight="bold"
       >
         GROWN
@@ -1894,7 +1510,6 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       x="1096.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -1924,16 +1539,14 @@ exports['The badge generator "for-the-badge" template badge generation should ma
     text-rendering="geometricPrecision"
     font-size="100"
   >
-    <text transform="scale(.1)" x="362.5" y="175" textLength="485" fill="#fff">
-      CACTUS
-    </text>
+    <text transform="scale(.1)" x="362.5" y="175" textLength="485">CACTUS</text>
     <text
       transform="scale(.1)"
       x="1096.25"
       y="175"
       textLength="502.5"
-      fill="#333"
       font-weight="bold"
+      fill="#333"
     >
       GROWN
     </text>
@@ -1972,14 +1585,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="47"
       height="19"
       rx="2"
     />
-    <rect x="53.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="53" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="53.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="53" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M53.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <g
@@ -2061,14 +1674,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="64"
       height="19"
       rx="2"
     />
-    <rect x="70.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="70" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="70.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="70" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M70.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <image
@@ -2157,14 +1770,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="11"
       height="19"
       rx="2"
     />
-    <rect x="17.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="17" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="17.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="17" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M17.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <g
@@ -2244,14 +1857,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="25"
       height="19"
       rx="2"
     />
-    <rect x="31.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="31" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="31.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="31" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M31.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <image
@@ -2338,14 +1951,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="25"
       height="19"
       rx="2"
     />
-    <rect x="31.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="31" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="31.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="31" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M31.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <image
@@ -2425,14 +2038,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="47"
       height="19"
       rx="2"
     />
-    <rect x="53.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="53" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="53.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="53" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M53.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <g
@@ -2498,16 +2111,12 @@ exports['The badge generator "flat" template badge generation should match snaps
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s1" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r1">
-    <rect width="107" height="20" rx="3" fill="#fff" />
-  </clipPath>
+  <clipPath id="r1"><rect width="107" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r1)">
     <rect width="62" height="20" fill="#0f0" />
     <rect x="62" width="45" height="20" fill="#b3e" />
@@ -2527,58 +2136,36 @@ exports['The badge generator "flat" template badge generation should match snaps
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="405" y="150" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="405" y="140" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="835"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="835" y="150" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="835" y="140" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -2611,12 +2198,8 @@ exports['The badge generator "flat-square" template badge generation should matc
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text x="405" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text x="835" y="140" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <text x="405" y="140" textLength="350" transform="scale(.1)">cactus</text>
+    <text x="835" y="140" textLength="350" transform="scale(.1)">grown</text>
   </g>
 </svg>
 
@@ -2631,18 +2214,14 @@ exports['The badge generator "plastic" template badge generation should match sn
   aria-label="cactus: grown"
 >
   <title>cactus: grown</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s1" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r1">
-    <rect width="107" height="18" rx="4" fill="#fff" />
-  </clipPath>
+  <clipPath id="r1"><rect width="107" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r1)">
     <rect width="62" height="18" fill="#0f0" />
     <rect x="62" width="45" height="18" fill="#b3e" />
@@ -2662,58 +2241,36 @@ exports['The badge generator "plastic" template badge generation should match sn
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="405"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      cactus
-    </text>
-    <text x="405" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      cactus
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="140"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text
-      aria-hidden="true"
-      x="835"
-      y="140"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="350"
-    >
-      grown
-    </text>
-    <text x="835" y="130" transform="scale(.1)" fill="#fff" textLength="350">
-      grown
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="405"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          cactus
+        </text>
+        <text x="405" y="140" fill-opacity=".3" textLength="350">cactus</text>
+      </g>
+      <text x="405" y="130" textLength="350">cactus</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="835"
+          y="140"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="350"
+        >
+          grown
+        </text>
+        <text x="835" y="140" fill-opacity=".3" textLength="350">grown</text>
+      </g>
+      <text x="835" y="130" textLength="350">grown</text>
+    </g>
   </g>
 </svg>
 
@@ -2746,15 +2303,12 @@ exports['The badge generator "for-the-badge" template badge generation should ma
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text transform="scale(.1)" x="532.5" y="175" textLength="485" fill="#fff">
-      CACTUS
-    </text>
+    <text transform="scale(.1)" x="532.5" y="175" textLength="485">CACTUS</text>
     <text
       transform="scale(.1)"
       x="1266.25"
       y="175"
       textLength="502.5"
-      fill="#fff"
       font-weight="bold"
     >
       GROWN
@@ -2794,14 +2348,14 @@ exports['The badge generator "social" template badge generation should match sna
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="64"
       height="19"
       rx="2"
     />
-    <rect x="70.5" y="0.5" width="41" height="19" rx="2" fill="#fafafa" />
-    <rect x="70" y="7.5" width="0.5" height="5" stroke="#fafafa" />
+    <rect x="70.5" y=".5" width="41" height="19" rx="2" fill="#fafafa" />
+    <rect x="70" y="7.5" width=".5" height="5" stroke="#fafafa" />
     <path d="M70.5 6.5 l-3 3v1 l3 3" fill="#fafafa" />
   </g>
   <image
@@ -2869,16 +2423,12 @@ exports['The badge generator badges with logos should always produce the same ba
   aria-label="label: message"
 >
   <title>label: message</title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r">
-    <rect width="113" height="20" rx="3" fill="#fff" />
-  </clipPath>
+  <clipPath id="r"><rect width="113" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="54" height="20" fill="#555" />
     <rect x="54" width="59" height="20" fill="#4b0" />
@@ -2898,58 +2448,36 @@ exports['The badge generator badges with logos should always produce the same ba
       height="14"
       href="data:image/svg+xml;base64,PHN2ZyB4bWxu"
     />
-    <text
-      aria-hidden="true"
-      x="365"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="270"
-    >
-      label
-    </text>
-    <text
-      aria-hidden="true"
-      x="365"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="270"
-    >
-      label
-    </text>
-    <text x="365" y="140" transform="scale(.1)" fill="#fff" textLength="270">
-      label
-    </text>
-    <text
-      aria-hidden="true"
-      x="825"
-      y="150"
-      fill="#010101"
-      fill-opacity=".80"
-      filter="url(#blur)"
-      transform="scale(.1)"
-      textLength="490"
-    >
-      message
-    </text>
-    <text
-      aria-hidden="true"
-      x="825"
-      y="150"
-      fill="#010101"
-      fill-opacity=".3"
-      transform="scale(.1)"
-      textLength="490"
-    >
-      message
-    </text>
-    <text x="825" y="140" transform="scale(.1)" fill="#fff" textLength="490">
-      message
-    </text>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="365"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="270"
+        >
+          label
+        </text>
+        <text x="365" y="150" fill-opacity=".3" textLength="270">label</text>
+      </g>
+      <text x="365" y="140" textLength="270">label</text>
+    </g>
+    <g transform="scale(.1)">
+      <g aria-hidden="true" fill="#010101">
+        <text
+          x="825"
+          y="150"
+          fill-opacity=".8"
+          filter="url(#blur)"
+          textLength="490"
+        >
+          message
+        </text>
+        <text x="825" y="150" fill-opacity=".3" textLength="490">message</text>
+      </g>
+      <text x="825" y="140" textLength="490">message</text>
+    </g>
   </g>
 </svg>
 
@@ -2964,14 +2492,12 @@ exports['The badge generator badges with logo-only should always produce the sam
   aria-label=""
 >
   <title></title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1" />
     <stop offset="1" stop-opacity=".1" />
   </linearGradient>
-  <clipPath id="r"><rect width="25" height="20" rx="3" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="25" height="20" rx="3" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="20" fill="#555" />
     <rect x="0" width="25" height="20" fill="#4b0" />
@@ -3058,8 +2584,8 @@ exports['The badge generator badges with logo-only should always produce the sam
     <rect
       stroke="none"
       fill="#fcfcfc"
-      x="0.5"
-      y="0.5"
+      x=".5"
+      y=".5"
       width="25"
       height="19"
       rx="2"
@@ -3115,16 +2641,14 @@ exports['The badge generator badges with logo-only should always produce the sam
   aria-label=""
 >
   <title></title>
-  <filter id="blur">
-    <feGaussianBlur in="SourceGraphic" stdDeviation="16" />
-  </filter>
+  <filter id="blur"><feGaussianBlur stdDeviation="16" /></filter>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7" />
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1" />
     <stop offset=".9" stop-color="#000" stop-opacity=".3" />
     <stop offset="1" stop-color="#000" stop-opacity=".5" />
   </linearGradient>
-  <clipPath id="r"><rect width="25" height="18" rx="4" fill="#fff" /></clipPath>
+  <clipPath id="r"><rect width="25" height="18" rx="4" /></clipPath>
   <g clip-path="url(#r)">
     <rect width="0" height="18" fill="#555" />
     <rect x="0" width="25" height="18" fill="#4b0" />
@@ -3180,7 +2704,6 @@ exports['The badge generator badges with logo-only should always produce the sam
       x="230"
       y="175"
       textLength="0"
-      fill="#fff"
       font-weight="bold"
     ></text>
   </g>

--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -10,6 +10,8 @@ const FONT_FAMILY = 'Verdana,Geneva,DejaVu Sans,sans-serif'
 const WIDTH_FONT = '11px Verdana'
 const SOCIAL_FONT_FAMILY = 'Helvetica Neue,Helvetica,Arial,sans-serif'
 
+const DEFAULT_TEXT_FILL = '#fff'
+
 function capitalize(s) {
   return `${s.charAt(0).toUpperCase()}${s.slice(1)}`
 }
@@ -17,10 +19,16 @@ function capitalize(s) {
 function colorsForBackground(color) {
   const brightnessThreshold = 0.69
   if (brightness(color) <= brightnessThreshold) {
-    return { textColor: '#fff', shadowColor: '#010101' }
+    return { textColor: DEFAULT_TEXT_FILL, shadowColor: '#010101' }
   } else {
     return { textColor: '#333', shadowColor: '#ccc' }
   }
+}
+
+function withTextFill(attrs, textColor) {
+  // For non-social badges, parent text groups set fill="#fff", so child text fill
+  // attributes that match can be omitted to shrink the SVG.
+  return textColor === DEFAULT_TEXT_FILL ? attrs : { ...attrs, fill: textColor }
 }
 
 function roundUpToOdd(val) {
@@ -197,53 +205,56 @@ class Badge {
     const { textColor, shadowColor } = colorsForBackground(color)
     const x =
       FONT_SCALE_UP_FACTOR * (leftMargin + 0.5 * textWidth + this.horizPadding)
+    const y = 140 + this.constructor.verticalMargin
+    const textLength = FONT_SCALE_UP_FACTOR * textWidth
 
-    const text = new XmlElement({
-      name: 'text',
-      content: [content],
-      attrs: {
-        x,
-        y: 140 + this.constructor.verticalMargin,
-        transform: FONT_SCALE_DOWN_VALUE,
-        fill: textColor,
-        textLength: FONT_SCALE_UP_FACTOR * textWidth,
-      },
-    })
-
-    const shadowText = new XmlElement({
-      name: 'text',
-      content: [content],
-      attrs: {
-        'aria-hidden': 'true',
-        x,
-        y: 150 + this.constructor.verticalMargin,
-        fill: shadowColor,
-        'fill-opacity': '.3',
-        transform: FONT_SCALE_DOWN_VALUE,
-        textLength: FONT_SCALE_UP_FACTOR * textWidth,
-      },
-    })
-    const shadowBlur = new XmlElement({
-      name: 'text',
-      content: [content],
-      attrs: {
-        'aria-hidden': 'true',
-        x,
-        y: 150 + this.constructor.verticalMargin,
-        fill: shadowColor,
-        'fill-opacity': '.80',
-        filter: 'url(#blur)',
-        transform: FONT_SCALE_DOWN_VALUE,
-        textLength: FONT_SCALE_UP_FACTOR * textWidth,
-      },
-    })
-
-    const shadow = this.constructor.shadow
-      ? new ElementList({ content: [shadowBlur, shadowText] })
-      : ''
+    let element
+    if (this.constructor.shadow) {
+      const text = new XmlElement({
+        name: 'text',
+        content: [content],
+        attrs: withTextFill({ x, y, textLength }, textColor),
+      })
+      const shadowY = 150 + this.constructor.verticalMargin
+      const shadowText = new XmlElement({
+        name: 'text',
+        content: [content],
+        attrs: { x, y: shadowY, 'fill-opacity': '.3', textLength },
+      })
+      const shadowBlur = new XmlElement({
+        name: 'text',
+        content: [content],
+        attrs: {
+          x,
+          y: shadowY,
+          'fill-opacity': '.8',
+          filter: 'url(#blur)',
+          textLength,
+        },
+      })
+      const shadowGroup = new XmlElement({
+        name: 'g',
+        content: [shadowBlur, shadowText],
+        attrs: { 'aria-hidden': 'true', fill: shadowColor },
+      })
+      element = new XmlElement({
+        name: 'g',
+        content: [shadowGroup, text],
+        attrs: { transform: FONT_SCALE_DOWN_VALUE },
+      })
+    } else {
+      element = new XmlElement({
+        name: 'text',
+        content: [content],
+        attrs: withTextFill(
+          { x, y, textLength, transform: FONT_SCALE_DOWN_VALUE },
+          textColor,
+        ),
+      })
+    }
 
     if (!link) {
-      return new ElementList({ content: [shadow, text] })
+      return element
     }
 
     const rect = new XmlElement({
@@ -257,7 +268,7 @@ class Badge {
     })
     return new XmlElement({
       name: 'a',
-      content: [rect, shadow, text],
+      content: [rect, element],
       attrs: { target: '_blank', href: link },
     })
   }
@@ -298,7 +309,6 @@ class Badge {
             width: this.width,
             height: this.constructor.height,
             rx,
-            fill: '#fff',
           },
         }),
       ],
@@ -347,7 +357,7 @@ class Badge {
         this.getMessageElement(),
       ],
       attrs: {
-        fill: '#fff',
+        fill: DEFAULT_TEXT_FILL,
         'text-anchor': 'middle',
         'font-family': FONT_FAMILY,
         'text-rendering': 'geometricPrecision',
@@ -362,7 +372,7 @@ class Badge {
       content: [
         new XmlElement({
           name: 'feGaussianBlur',
-          attrs: { in: 'SourceGraphic', stdDeviation: '16' },
+          attrs: { stdDeviation: '16' },
         }),
       ],
       attrs: { id: 'blur' },
@@ -560,7 +570,7 @@ function social({
         name: 'rect',
         attrs: {
           x: messageBubbleMainX,
-          y: 0.5,
+          y: '.5',
           width: messageRectWidth,
           height: internalHeight,
           rx: 2,
@@ -572,7 +582,7 @@ function social({
         attrs: {
           x: messageBubbleNotchX,
           y: 7.5,
-          width: 0.5,
+          width: '.5',
           height: 5,
           stroke: '#fafafa',
         },
@@ -737,8 +747,8 @@ function social({
     attrs: {
       stroke: 'none',
       fill: '#fcfcfc',
-      x: 0.5,
-      y: 0.5,
+      x: '.5',
+      y: '.5',
       width: labelRectWidth,
       height: internalHeight,
       rx: 2,
@@ -876,13 +886,15 @@ function forTheBadge({
     const text = new XmlElement({
       name: 'text',
       content: [label],
-      attrs: {
-        transform: FONT_SCALE_DOWN_VALUE,
-        x: FONT_SCALE_UP_FACTOR * midX,
-        y: 175,
-        textLength: FONT_SCALE_UP_FACTOR * labelTextWidth,
-        fill: textColor,
-      },
+      attrs: withTextFill(
+        {
+          transform: FONT_SCALE_DOWN_VALUE,
+          x: FONT_SCALE_UP_FACTOR * midX,
+          y: 175,
+          textLength: FONT_SCALE_UP_FACTOR * labelTextWidth,
+        },
+        textColor,
+      ),
     })
 
     if (hasLeftLink && !shouldWrapBodyWithLink({ links })) {
@@ -913,14 +925,16 @@ function forTheBadge({
     const text = new XmlElement({
       name: 'text',
       content: [message],
-      attrs: {
-        transform: FONT_SCALE_DOWN_VALUE,
-        x: FONT_SCALE_UP_FACTOR * midX,
-        y: 175,
-        textLength: FONT_SCALE_UP_FACTOR * messageTextWidth,
-        fill: textColor,
-        'font-weight': 'bold',
-      },
+      attrs: withTextFill(
+        {
+          transform: FONT_SCALE_DOWN_VALUE,
+          x: FONT_SCALE_UP_FACTOR * midX,
+          y: 175,
+          textLength: FONT_SCALE_UP_FACTOR * messageTextWidth,
+          'font-weight': 'bold',
+        },
+        textColor,
+      ),
     })
 
     if (hasRightLink) {
@@ -995,7 +1009,7 @@ function forTheBadge({
       getMessageElement(),
     ],
     attrs: {
-      fill: '#fff',
+      fill: DEFAULT_TEXT_FILL,
       'text-anchor': 'middle',
       'font-family': FONT_FAMILY,
       'text-rendering': 'geometricPrecision',

--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -215,7 +215,7 @@ class Badge {
         content: [content],
         attrs: withTextFill({ x, y, textLength }, textColor),
       })
-      const shadowY = 150 + this.constructor.verticalMargin
+      const shadowY = y + 10
       const shadowText = new XmlElement({
         name: 'text',
         content: [content],

--- a/core/base-service/base-svg-scraping.js
+++ b/core/base-service/base-svg-scraping.js
@@ -8,7 +8,7 @@ import BaseService from './base.js'
 import trace from './trace.js'
 import { InvalidResponse } from './errors.js'
 
-const defaultValueMatcher = />([^<>]+)<\/text><\/g>/
+const defaultValueMatcher = /.*>([^<>]+)<\/text><\/g>/
 const leadingWhitespace = /(?:\r\n\s*|\r\s*|\n\s*)/g
 
 /**

--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -119,7 +119,7 @@ describe('The server', function () {
       )
       expect(statusCode).to.equal(200)
       expect(headers['content-type']).to.equal('image/svg+xml;charset=utf-8')
-      expect(headers['content-length']).to.equal('1460')
+      expect(headers['content-length']).to.equal('1275')
     })
 
     it('correctly calculates the content-length header for multi-byte unicode characters', async function () {

--- a/services/travis/travis-build.service.js
+++ b/services/travis/travis-build.service.js
@@ -66,7 +66,6 @@ export class TravisComBuild extends BaseSvgScrapingService {
       schema,
       url: `https://api.travis-ci.com/${user}/${repo}.svg`,
       options: { searchParams: { branch } },
-      valueMatcher: />([^<>]+)<\/text><\/g>/,
     })
 
     return this.constructor.render({ status })


### PR DESCRIPTION
Changes from #11783 increased the size of our badges, in particular the default flat style, by about a third. In this PR, I did a pass at trimming down the SVG sizes. I'll add some more explanations in inline PR comments.

I suggest deploying a review app, and checking that there are no visual changes compared to what's running in production today.