### PR TITLE
Streamline [JenkinsCoverage] support

### DIFF
--- a/services/jenkins/jenkins-coverage-redirector.service.js
+++ b/services/jenkins/jenkins-coverage-redirector.service.js
@@ -1,4 +1,4 @@
-import { retiredService } from '../index.js'
+import { redirector, retiredService } from '../index.js'
 
 const commonProps = {
   category: 'coverage',
@@ -29,5 +29,14 @@ export default [
       pattern: '',
     },
     ...commonProps,
+  }),
+  redirector({
+    category: 'coverage',
+    route: {
+      base: 'jenkins/coverage',
+      pattern: ':format(jacoco|cobertura|apiv1|apiv4)',
+    },
+    transformPath: () => '/jenkins/coverage',
+    dateAdded: new Date('2026-05-17'),
   }),
 ]

--- a/services/jenkins/jenkins-coverage-redirector.tester.js
+++ b/services/jenkins/jenkins-coverage-redirector.tester.js
@@ -57,3 +57,35 @@ t.create('old v1 api prefix to new prefix')
     label: 'jenkins',
     message: 'https://github.com/badges/shields/pull/11583',
   })
+
+t.create('jacoco format redirects to unique route')
+  .get(
+    `/coverage/jacoco.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+  .expectRedirect(
+    `/jenkins/coverage.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+
+t.create('cobertura format redirects to unique route')
+  .get(
+    `/coverage/cobertura.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+  .expectRedirect(
+    `/jenkins/coverage.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+
+t.create('apiv1 format redirects to unique route')
+  .get(
+    `/coverage/apiv1.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+  .expectRedirect(
+    `/jenkins/coverage.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+
+t.create('apiv4 format redirects to unique route')
+  .get(
+    `/coverage/apiv4.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )
+  .expectRedirect(
+    `/jenkins/coverage.svg?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master`,
+  )

--- a/services/jenkins/jenkins-coverage.service.js
+++ b/services/jenkins/jenkins-coverage.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { pathParam, queryParam } from '../index.js'
+import { queryParam } from '../index.js'
 import { coveragePercentage } from '../color-formatters.js'
 import JenkinsBase from './jenkins-base.js'
 import {
@@ -8,120 +8,35 @@ import {
   queryParamSchema,
 } from './jenkins-common.js'
 
-const formatMap = {
-  jacoco: {
-    schema: Joi.object({
-      instructionCoverage: Joi.object({
-        percentage: Joi.number().min(0).max(100).required(),
-      }).required(),
-    }).required(),
-    treeQueryParam: 'instructionCoverage[percentage]',
-    transform: json => ({ coverage: json.instructionCoverage.percentage }),
-    pluginSpecificPath: 'jacoco',
-  },
-  cobertura: {
-    schema: Joi.object({
-      results: Joi.object({
-        elements: Joi.array()
-          .items(
-            Joi.object({
-              name: Joi.string().required(),
-              ratio: Joi.number().min(0).max(100).required(),
-            }),
-          )
-          .has(Joi.object({ name: 'Lines' }))
-          .min(1)
-          .required(),
-      }).required(),
-    }).required(),
-    treeQueryParam: 'results[elements[name,ratio]]',
-    transform: json => {
-      const lineCoverage = json.results.elements.find(
-        element => element.name === 'Lines',
-      )
-      return { coverage: lineCoverage.ratio }
-    },
-    pluginSpecificPath: 'cobertura',
-  },
-  apiv1: {
-    schema: Joi.object({
-      results: Joi.object({
-        elements: Joi.array()
-          .items(
-            Joi.object({
-              name: Joi.string().required(),
-              ratio: Joi.number().min(0).max(100).required(),
-            }),
-          )
-          .has(Joi.object({ name: 'Line' }))
-          .min(1)
-          .required(),
-      }).required(),
-    }).required(),
-    treeQueryParam: 'results[elements[name,ratio]]',
-    transform: json => {
-      const lineCoverage = json.results.elements.find(
-        element => element.name === 'Line',
-      )
-      return { coverage: lineCoverage.ratio }
-    },
-    pluginSpecificPath: 'coverage/result',
-  },
-  apiv4: {
-    schema: Joi.object({
-      projectStatistics: Joi.object({
-        line: Joi.string()
-          .pattern(/\d+\.\d+%/)
-          .required(),
-      }).required(),
-    }).required(),
-    treeQueryParam: 'projectStatistics[line]',
-    transform: json => {
-      const lineCoverageStr = json.projectStatistics.line
-      const lineCoverage = lineCoverageStr.substring(
-        0,
-        lineCoverageStr.length - 1,
-      )
-      return { coverage: Number.parseFloat(lineCoverage) }
-    },
-    pluginSpecificPath: 'coverage',
-  },
-}
+const schemaCoverage = Joi.object({
+  projectStatistics: Joi.object({
+    line: Joi.string()
+      .pattern(/\d+\.\d+%/)
+      .required(),
+  }).required(),
+}).required()
 
-const description = `
-We support coverage metrics from a variety of Jenkins plugins:
-
-<ul>
-  <li><a href="https://plugins.jenkins.io/jacoco">JaCoCo</a></li>
-  <li><a href="https://plugins.jenkins.io/cobertura">Cobertura</a></li>
-  <li>Any plugin which integrates with version 1 or 4+ of the <a href="https://plugins.jenkins.io/code-coverage-api">Code Coverage API</a> (e.g. llvm-cov, Cobertura 1.13+, etc.)</li>
-</ul>
-`
+const description =
+  'We support coverage metrics from the <a href="https://github.com/jenkinsci/coverage-plugin">Jenkins Coverage Plugin</a>.'
 
 export default class JenkinsCoverage extends JenkinsBase {
   static category = 'coverage'
 
   static route = {
     base: 'jenkins/coverage',
-    pattern: ':format(jacoco|cobertura|apiv1|apiv4)',
+    pattern: '',
     queryParamSchema,
   }
 
   static openApi = {
-    '/jenkins/coverage/{format}': {
+    '/jenkins/coverage': {
       get: {
         summary: 'Jenkins Coverage',
         description,
         parameters: [
-          pathParam({
-            name: 'format',
-            example: 'jacoco',
-            schema: { type: 'string', enum: this.getEnum('format') },
-          }),
           queryParam({
             name: 'jobUrl',
-            example:
-              'https://jenkins-2.sse.uni-hildesheim.de/job/Teaching_SubmissionCheck',
+            example: 'https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master',
             required: true,
           }),
         ],
@@ -138,18 +53,23 @@ export default class JenkinsCoverage extends JenkinsBase {
     }
   }
 
-  async handle({ format }, { jobUrl }) {
-    const { schema, transform, treeQueryParam, pluginSpecificPath } =
-      formatMap[format]
+  async handle(_routeParams, { jobUrl }) {
     const json = await this.fetch({
-      url: buildUrl({ jobUrl, plugin: pluginSpecificPath }),
-      schema,
-      searchParams: buildTreeParamQueryString(treeQueryParam),
+      url: buildUrl({ jobUrl, plugin: 'coverage' }),
+      schema: schemaCoverage,
+      searchParams: buildTreeParamQueryString('projectStatistics[line]'),
       httpErrors: {
         404: 'job or coverage not found',
       },
     })
-    const { coverage } = transform(json)
-    return this.constructor.render({ coverage })
+    const lineCoverageStr = json.projectStatistics.line
+    const lineCoverage = lineCoverageStr.substring(
+      0,
+      lineCoverageStr.length - 1,
+    )
+
+    return this.constructor.render({
+      coverage: Number.parseFloat(lineCoverage),
+    })
   }
 }

--- a/services/jenkins/jenkins-coverage.spec.js
+++ b/services/jenkins/jenkins-coverage.spec.js
@@ -5,7 +5,7 @@ const authConfigOverride = {
   public: {
     services: {
       jenkins: {
-        authorizedOrigins: ['https://jenkins-2.sse.uni-hildesheim.de'],
+        authorizedOrigins: ['https://jenkins.mm12.xyz'],
       },
     },
   },
@@ -17,7 +17,7 @@ describe('JenkinsCoverage', function () {
       return testAuth(
         JenkinsCoverage,
         'BasicAuth',
-        { instructionCoverage: { percentage: 93 } },
+        { projectStatistics: { line: '93.0%' } },
         { configOverride: authConfigOverride },
       )
     })

--- a/services/jenkins/jenkins-coverage.tester.js
+++ b/services/jenkins/jenkins-coverage.tester.js
@@ -2,104 +2,10 @@ import { isIntegerPercentage } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-// The below page includes links to various publicly accessible Jenkins instances
-// although many of the links are dead, it is is still a helpful resource for finding
-// target Jenkins instances/jobs to use for testing.
-// https://wiki.jenkins.io/pages/viewpage.action?pageId=58001258
-
-t.create('jacoco: job found')
-  .get(
-    `/jacoco.json?jobUrl=${encodeURIComponent(
-      'https://jenkins-2.sse.uni-hildesheim.de/job/Teaching_SubmissionCheck',
-    )}`,
-  )
+t.create('code coverage API: job found')
+  .get('.json?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master')
   .expectBadge({ label: 'coverage', message: isIntegerPercentage })
 
-t.create('jacoco: job not found')
-  .get(
-    '/jacoco.json?jobUrl=https://jenkins-2.sse.uni-hildesheim.de/job/does-not-exist',
-  )
-  .expectBadge({ label: 'coverage', message: 'job or coverage not found' })
-
-const coverageCoberturaResponse = {
-  _class: 'io.jenkins.plugins.coverage.targets.CoverageResult',
-  results: {
-    elements: [
-      { name: 'Classes', ratio: 52.0 },
-      { name: 'Lines', ratio: 40.66363 },
-    ],
-  },
-}
-
-t.create('cobertura: job found')
-  .get(
-    '/cobertura.json?jobUrl=https://jenkins.sqlalchemy.org/job/dogpile_coverage',
-  )
-  .intercept(nock =>
-    nock(
-      'https://jenkins.sqlalchemy.org/job/dogpile_coverage/lastCompletedBuild',
-    )
-      .get('/cobertura/api/json')
-      .query(true)
-      .reply(200, coverageCoberturaResponse),
-  )
-  .expectBadge({ label: 'coverage', message: '41%' })
-
-t.create('cobertura: job not found')
-  .get(
-    '/cobertura.json?jobUrl=https://jenkins.sqlalchemy.org/job/does-not-exist',
-  )
-  .expectBadge({ label: 'coverage', message: 'job or coverage not found' })
-
-const coverageApiV1Response = {
-  _class: 'io.jenkins.plugins.coverage.targets.CoverageResult',
-  results: {
-    elements: [
-      { name: 'Report', ratio: 100.0 },
-      { name: 'Group', ratio: 100.0 },
-      { name: 'Package', ratio: 66.666664 },
-      { name: 'File', ratio: 52.0 },
-      { name: 'Class', ratio: 52.0 },
-      { name: 'Line', ratio: 40.66363 },
-      { name: 'Conditional', ratio: 29.91968 },
-    ],
-  },
-}
-
-t.create('code coverage API v1: job found')
-  .get(
-    '/apiv1.json?jobUrl=http://loneraver.duckdns.org:8082/job/github/job/VisVid/job/master',
-  )
-  .intercept(nock =>
-    nock(
-      'http://loneraver.duckdns.org:8082/job/github/job/VisVid/job/master/lastCompletedBuild',
-    )
-      .get('/coverage/result/api/json')
-      .query(true)
-      .reply(200, coverageApiV1Response),
-  )
-  .expectBadge({ label: 'coverage', message: isIntegerPercentage })
-
-t.create('code coverage API v1: job not found')
-  .get(
-    '/apiv1.json?jobUrl=http://loneraver.duckdns.org:8082/job/does-not-exist',
-  )
-  .intercept(nock =>
-    nock(
-      'http://loneraver.duckdns.org:8082/job/does-not-exist/lastCompletedBuild',
-    )
-      .get('/coverage/result/api/json')
-      .query(true)
-      .reply(404),
-  )
-  .expectBadge({ label: 'coverage', message: 'job or coverage not found' })
-
-t.create('code coverage API v4+: job found')
-  .get(
-    '/apiv4.json?jobUrl=https://jenkins.mm12.xyz/jenkins/job/nmfu/job/master',
-  )
-  .expectBadge({ label: 'coverage', message: isIntegerPercentage })
-
-t.create('code coverage API v4+: job not found')
-  .get('/apiv4.json?jobUrl=https://jenkins.mm12.xyz/jenkins/job/does-not-exist')
+t.create('code coverage API: job not found')
+  .get('.json?jobUrl=https://jenkins.mm12.xyz/jenkins/job/does-not-exist')
   .expectBadge({ label: 'coverage', message: 'job or coverage not found' })


### PR DESCRIPTION
We support four different Jenkins Coverage plugins. This adds code complexity, the corresponding tests have a tendency to break easily (#10372, #10217, #11736, #9918, etc.), and having all these different flavours contributes to users being confused (#11689, #11794). There's an opportunity to reduce our maintenance burden here.

* The first version of the [Code Coverage API is deprecated](https://plugins.jenkins.io/code-coverage-api/) (this is what we previously called apiv1), and I found [no usages of it across Github](https://github.com/search?q=img.shields.io%2Fjenkins%2Fcoverage%2Fapiv1&type=code).
* The [Cobertura plugin](https://github.com/jenkinsci/cobertura-plugin) has reached end of life. None of the [usages I looked at seem to work](https://github.com/search?q=img.shields.io%2Fjenkins%2Fcoverage%2Fcobertura&type=code).
* The [JaCoCo plugin](https://github.com/jenkinsci/jacoco-plugin) has reached end of life. Some [usages of it still seem to work](https://github.com/search?q=img.shields.io%2Fjenkins%2Fcoverage%2Fjacoco&type=code), but I'd argue Jenkins instances that still run this plugin should really update given it was deprecated in 2024. We're not contributing to a sain ecosystem by supporting EOL software forever.

We're left with the official [Coverage Plugin](https://github.com/jenkinsci/coverage-plugin) which has replaced all of the above (this is what we previously called apiv4). I've introduced a redirector that maps all the `jacoco|cobertura|apiv1|apiv4` routes to a new unique simplified route. Whenever a Jenkins instance updates to the new version of the plugin, this means whatever badge were using were start working again transparently, without them having to update the path.