### PR TITLE
[EdgeAddOns] Add Microsoft Edge Add-ons badges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "smol-toml": "1.6.1",
         "svg-path-bbox": "^2.1.0",
         "svgpath": "^2.6.0",
-        "webextension-store-meta": "^1.2.10",
+        "webextension-store-meta": "^1.3.0",
         "xpath": "~0.0.34"
       },
       "devDependencies": {
@@ -27297,12 +27297,12 @@
       }
     },
     "node_modules/pretty-bytes": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
-      "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
       "license": "MIT",
       "engines": {
-        "node": "^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -33209,14 +33209,14 @@
       }
     },
     "node_modules/webextension-store-meta": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.2.10.tgz",
-      "integrity": "sha512-i6YelIlbKejvbBQYk/SxyJ2c80lwkRD+E4C5MKPShLeYxpqC+rYoydD12PGgTwv8od+LXgLkXLSrk+fw8Omusw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webextension-store-meta/-/webextension-store-meta-1.3.0.tgz",
+      "integrity": "sha512-VQc5Wyvrndh+GmI20DUcVXWNfPH3f2t+XwXLGMnv/lgH6bdmFoahG1o3w55sr2Ct7+ngbOxMkSFdGRmG46UciA==",
       "license": "MIT",
       "dependencies": {
         "domhandler": "^4.0.0",
         "htmlparser2": "^6.1.0",
-        "pretty-bytes": "^6.1.1",
+        "pretty-bytes": "^7.1.0",
         "undici": "^6.11.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "smol-toml": "1.6.1",
     "svg-path-bbox": "^2.1.0",
     "svgpath": "^2.6.0",
-    "webextension-store-meta": "^1.2.10",
+    "webextension-store-meta": "^1.3.0",
     "xpath": "~0.0.34"
   },
   "scripts": {

--- a/services/edge-add-ons/edge-add-ons-base.js
+++ b/services/edge-add-ons/edge-add-ons-base.js
@@ -1,0 +1,14 @@
+import { EdgeAddons } from 'webextension-store-meta/lib/edge-addons/index.js'
+import { BaseService } from '../index.js'
+
+const description = `
+[Microsoft Edge Add-ons](https://microsoftedge.microsoft.com/addons/) publishes extensions for Microsoft Edge.
+`
+
+export { description }
+
+export default class BaseEdgeAddOnsService extends BaseService {
+  async fetch({ storeId }) {
+    return EdgeAddons.load({ id: storeId, qs: { hl: 'en-US' } })
+  }
+}

--- a/services/edge-add-ons/edge-add-ons-last-updated.service.js
+++ b/services/edge-add-ons/edge-add-ons-last-updated.service.js
@@ -1,0 +1,36 @@
+import { renderDateBadge } from '../date.js'
+import { NotFound, pathParams } from '../index.js'
+import BaseEdgeAddOnsService, { description } from './edge-add-ons-base.js'
+
+export default class EdgeAddOnsLastUpdated extends BaseEdgeAddOnsService {
+  static category = 'activity'
+  static route = { base: 'edge-add-ons/last-updated', pattern: ':storeId' }
+
+  static openApi = {
+    '/edge-add-ons/last-updated/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Last Updated',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = {
+    label: 'last updated',
+  }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const lastUpdated = edgeAddOns.lastUpdateDate()
+
+    if (lastUpdated == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+
+    return renderDateBadge(lastUpdated * 1000)
+  }
+}

--- a/services/edge-add-ons/edge-add-ons-last-updated.tester.js
+++ b/services/edge-add-ons/edge-add-ons-last-updated.tester.js
@@ -1,0 +1,18 @@
+import { isFormattedDate } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Last updated')
+  .get('/cnlefmmeadmemmdciolhbnfeacpdfbkd.json')
+  .expectBadge({
+    label: 'last updated',
+    message: isFormattedDate,
+  })
+
+t.create('Last updated (not found)')
+  .get('/invalid-name-of-addon.json')
+  .expectBadge({
+    label: 'last updated',
+    message: 'not found',
+  })

--- a/services/edge-add-ons/edge-add-ons-rating.service.js
+++ b/services/edge-add-ons/edge-add-ons-rating.service.js
@@ -1,0 +1,121 @@
+import { floorCount as floorCountColor } from '../color-formatters.js'
+import { metric, starRating } from '../text-formatters.js'
+import { NotFound, pathParams } from '../index.js'
+import BaseEdgeAddOnsService, { description } from './edge-add-ons-base.js'
+
+class BaseEdgeAddOnsRating extends BaseEdgeAddOnsService {
+  static category = 'rating'
+
+  static defaultBadgeData = { label: 'rating' }
+}
+
+class EdgeAddOnsRating extends BaseEdgeAddOnsRating {
+  static route = {
+    base: 'edge-add-ons/rating',
+    pattern: ':storeId',
+  }
+
+  static openApi = {
+    '/edge-add-ons/rating/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Rating',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static render({ rating }) {
+    rating = Math.round(rating * 100) / 100
+    return {
+      message: `${rating}/5`,
+      color: floorCountColor(rating, 2, 3, 4),
+    }
+  }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const rating = edgeAddOns.averageRating()
+    if (rating == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return this.constructor.render({ rating })
+  }
+}
+
+class EdgeAddOnsRatingCount extends BaseEdgeAddOnsRating {
+  static route = {
+    base: 'edge-add-ons/rating-count',
+    pattern: ':storeId',
+  }
+
+  static openApi = {
+    '/edge-add-ons/rating-count/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Rating Count',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static render({ ratingCount }) {
+    return {
+      message: `${metric(ratingCount)} total`,
+      color: floorCountColor(ratingCount, 5, 50, 500),
+    }
+  }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const ratingCount = edgeAddOns.ratingCount()
+    if (ratingCount == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return this.constructor.render({ ratingCount })
+  }
+}
+
+class EdgeAddOnsRatingStars extends BaseEdgeAddOnsRating {
+  static route = {
+    base: 'edge-add-ons/stars',
+    pattern: ':storeId',
+  }
+
+  static openApi = {
+    '/edge-add-ons/stars/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Stars',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static render({ rating }) {
+    return {
+      message: starRating(rating),
+      color: floorCountColor(rating, 2, 3, 4),
+    }
+  }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const rating = edgeAddOns.averageRating()
+    if (rating == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return this.constructor.render({ rating })
+  }
+}
+
+export { EdgeAddOnsRating, EdgeAddOnsRatingCount, EdgeAddOnsRatingStars }

--- a/services/edge-add-ons/edge-add-ons-rating.tester.js
+++ b/services/edge-add-ons/edge-add-ons-rating.tester.js
@@ -1,0 +1,39 @@
+import Joi from 'joi'
+import { isStarRating } from '../test-validators.js'
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'EdgeAddOnsRating',
+  title: 'Microsoft Edge Add-ons Rating',
+  pathPrefix: '/edge-add-ons',
+})
+
+t.create('Rating')
+  .get('/rating/cnlefmmeadmemmdciolhbnfeacpdfbkd.json')
+  .expectBadge({
+    label: 'rating',
+    message: Joi.string().regex(/^\d(?:\.\d{1,2})?\/5$/),
+  })
+
+t.create('Rating (not found)')
+  .get('/rating/invalid-name-of-addon.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('Rating Count')
+  .get('/rating-count/cnlefmmeadmemmdciolhbnfeacpdfbkd.json')
+  .expectBadge({
+    label: 'rating',
+    message: Joi.string().regex(/^\d+(\.\d)?[kMGTPEZY]? total$/),
+  })
+
+t.create('Rating Count (not found)')
+  .get('/rating-count/invalid-name-of-addon.json')
+  .expectBadge({ label: 'rating', message: 'not found' })
+
+t.create('Stars')
+  .get('/stars/cnlefmmeadmemmdciolhbnfeacpdfbkd.json')
+  .expectBadge({ label: 'rating', message: isStarRating })
+
+t.create('Stars (not found)')
+  .get('/stars/invalid-name-of-addon.json')
+  .expectBadge({ label: 'rating', message: 'not found' })

--- a/services/edge-add-ons/edge-add-ons-users.service.js
+++ b/services/edge-add-ons/edge-add-ons-users.service.js
@@ -1,0 +1,46 @@
+import { renderDownloadsBadge } from '../downloads.js'
+import { redirector, NotFound, pathParams } from '../index.js'
+import BaseEdgeAddOnsService, { description } from './edge-add-ons-base.js'
+
+class EdgeAddOnsUsers extends BaseEdgeAddOnsService {
+  static category = 'downloads'
+  static route = { base: 'edge-add-ons/users', pattern: ':storeId' }
+
+  static openApi = {
+    '/edge-add-ons/users/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Users',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'users' }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const downloads = edgeAddOns.activeInstallCount()
+    if (downloads == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return renderDownloadsBadge({
+      downloads,
+    })
+  }
+}
+
+const EdgeAddOnsDownloads = redirector({
+  category: 'downloads',
+  route: {
+    base: 'edge-add-ons/d',
+    pattern: ':storeId',
+  },
+  transformPath: ({ storeId }) => `/edge-add-ons/users/${storeId}`,
+  dateAdded: new Date('2026-05-18'),
+})
+
+export { EdgeAddOnsDownloads, EdgeAddOnsUsers }

--- a/services/edge-add-ons/edge-add-ons-users.tester.js
+++ b/services/edge-add-ons/edge-add-ons-users.tester.js
@@ -1,0 +1,20 @@
+import { isMetric } from '../test-validators.js'
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'EdgeAddOnsUsers',
+  title: 'Microsoft Edge Add-ons Users',
+  pathPrefix: '/edge-add-ons',
+})
+
+t.create('Downloads (redirect)')
+  .get('/d/cnlefmmeadmemmdciolhbnfeacpdfbkd.svg')
+  .expectRedirect('/edge-add-ons/users/cnlefmmeadmemmdciolhbnfeacpdfbkd.svg')
+
+t.create('Users')
+  .get('/users/cnlefmmeadmemmdciolhbnfeacpdfbkd.json')
+  .expectBadge({ label: 'users', message: isMetric })
+
+t.create('Users (not found)')
+  .get('/users/invalid-name-of-addon.json')
+  .expectBadge({ label: 'users', message: 'not found' })

--- a/services/edge-add-ons/edge-add-ons-version.service.js
+++ b/services/edge-add-ons/edge-add-ons-version.service.js
@@ -1,0 +1,32 @@
+import { renderVersionBadge } from '../version.js'
+import { NotFound, pathParams } from '../index.js'
+import BaseEdgeAddOnsService, { description } from './edge-add-ons-base.js'
+
+export default class EdgeAddOnsVersion extends BaseEdgeAddOnsService {
+  static category = 'version'
+  static route = { base: 'edge-add-ons/v', pattern: ':storeId' }
+
+  static openApi = {
+    '/edge-add-ons/v/{storeId}': {
+      get: {
+        summary: 'Microsoft Edge Add-ons Version',
+        description,
+        parameters: pathParams({
+          name: 'storeId',
+          example: 'cnlefmmeadmemmdciolhbnfeacpdfbkd',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'edge add-ons' }
+
+  async handle({ storeId }) {
+    const edgeAddOns = await this.fetch({ storeId })
+    const version = edgeAddOns.version()
+    if (version == null) {
+      throw new NotFound({ prettyMessage: 'not found' })
+    }
+    return renderVersionBadge({ version })
+  }
+}

--- a/services/edge-add-ons/edge-add-ons-version.tester.js
+++ b/services/edge-add-ons/edge-add-ons-version.tester.js
@@ -1,0 +1,13 @@
+import { isVPlusDottedVersionNClauses } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Version').get('/cnlefmmeadmemmdciolhbnfeacpdfbkd.json').expectBadge({
+  label: 'edge add-ons',
+  message: isVPlusDottedVersionNClauses,
+})
+
+t.create('Version (not found)')
+  .get('/invalid-name-of-addon.json')
+  .expectBadge({ label: 'edge add-ons', message: 'not found' })


### PR DESCRIPTION
Adds Microsoft Edge Add-ons badge support using [`webextension-store-meta`](https://github.com/awesome-webextension/webextension-store-meta).

New routes:

  - `/edge-add-ons/v/:storeId`
  - `/edge-add-ons/users/:storeId`
  - `/edge-add-ons/d/:storeId`
  - `/edge-add-ons/rating/:storeId`
  - `/edge-add-ons/rating-count/:storeId`
  - `/edge-add-ons/stars/:storeId`
  - `/edge-add-ons/last-updated/:storeId`