### PR TITLE
Polish `TZ` variable format

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "prettier:check": "prettier --check \"**/*.@(cjs|mjs|js|ts|md|json|yml)\"",
     "danger": "danger",
     "test:e2e": "cypress run",
-    "test:core": "cross-env TZ='UTC' NODE_CONFIG_ENV=test mocha \"core/**/*.spec.js\" \"lib/**/*.spec.js\" \"services/**/*.spec.js\"",
+    "test:core": "cross-env TZ=UTC NODE_CONFIG_ENV=test mocha \"core/**/*.spec.js\" \"lib/**/*.spec.js\" \"services/**/*.spec.js\"",
     "test:package": "mocha \"badge-maker/**/*.spec.js\"",
     "test:entrypoint": "cross-env NODE_CONFIG_ENV=test mocha entrypoint.spec.js",
     "test:integration": "cross-env NODE_CONFIG_ENV=test mocha \"core/**/*.integration.js\" \"services/**/*.integration.js\"",


### PR DESCRIPTION
This `TZ` variable was added by me in:

- https://github.com/badges/shields/pull/10765

This change might be a bit of a nitpick. But every time I saw the variable, it prompted me to remove the single quote.

And it now has a consistent format as `NODE_CONFIG_ENV`.