### PR TITLE
fix/service-badge-troubleshooting-docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,3 +168,36 @@ For local development, ensure the following are set:
 - `BADGES_PORT` (optional, defaults to 3000)
 
 See `.env.example` for the full list of supported variables.
+
+## Troubleshooting Common Badge Failures
+
+### Upstream API Timeouts
+
+If badge requests timeout, check:
+
+- Is the upstream service (e.g., GitHub, npm) currently available?
+- Try running the badge locally with `npm run dev`
+- Check the [.shields.io status page](https://status.shields.io)
+
+### Token Pool Exhaustion
+
+When you see `401 Unauthorized` errors:
+
+- The GitHub token pool may be exhausted for your tier
+- Reduce request frequency or wait for rate limit reset
+- For local dev, set `GITHUB_TOKEN` in your `.env` file
+
+### Common Badge Rendering Failures
+
+- **Badge not loading:** Check browser console for CORS errors; badges must be served from allowed domains
+- **Wrong data shown:** Verify your GitHub token has correct scopes
+- **SVG malformed:** Ensure `Content-Type: image/svg+xml` header is set correctly
+
+### Running Service-Specific Tests
+
+Run tests for a specific badge service:
+
+```bash
+npm test -- --grep "GitHub"
+npm test -- --grep "npm"
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,3 +158,13 @@ Note that many services are part of a "family" of related services. Depending on
 For example, a PR title of **[GitHubForks] Foo** will only run the service tests specifically for the GitHub Forks badge, whereas a title of **[GitHub] Foo** will run the service tests for all of the GitHub badges.
 
 In the rare case when it's necessary to see the output of a full service-test run in a PR (all 2,000+ tests), include `[*****]` in the title. Unless all the tests pass, the build will fail, so likely it will be necessary to remove it and re-run the tests before merging.
+
+### Required Environment Variables
+
+For local development, ensure the following are set:
+
+- `NODE_ENV=development`
+- `DOMAIN` (defaults to `img.shields.io`)
+- `BADGES_PORT` (optional, defaults to 3000)
+
+See `.env.example` for the full list of supported variables.

--- a/doc/TUTORIAL.md
+++ b/doc/TUTORIAL.md
@@ -5,7 +5,7 @@ This tutorial should help you add a service to shields.io in form of a badge. Yo
 ## (1) Reading
 
 - [Contributing Guidance](../CONTRIBUTING.md)
-- [Documentation](https://contributing.shields.io/index.html) for the Shields Core API
+- [Documentation](https://contributing.shields.io/tutorial-TUTORIAL.html) for the Shields Core API
 - You can also read previous [merged pull-requests with the 'service-badge' label](https://github.com/badges/shields/pulls?utf8=%E2%9C%93&q=is%3Apr+label%3Aservice-badge+is%3Amerged) to see how other people implemented their badges.
 
 ## (2) Setup


### PR DESCRIPTION
## Summary
Add troubleshooting documentation for common service badge failures.