### PR TITLE
fix(test): await SQL token fixture inserts

### DIFF
--- a/core/token-pooling/sql-token-persistence.integration.js
+++ b/core/token-pooling/sql-token-persistence.integration.js
@@ -54,12 +54,12 @@ describe('SQL token persistence', function () {
     const initialTokens = ['a', 'b', 'c'].map(char => char.repeat(40))
 
     beforeEach(async function () {
-      initialTokens.forEach(async token => {
+      for (const token of initialTokens) {
         await pool.query(
           `INSERT INTO pg_temp.${tableName} (token) VALUES ($1::text);`,
           [token],
         )
-      })
+      }
     })
 
     it('loads the contents', async function () {

--- a/core/token-pooling/sql-token-persistence.integration.js
+++ b/core/token-pooling/sql-token-persistence.integration.js
@@ -54,12 +54,14 @@ describe('SQL token persistence', function () {
     const initialTokens = ['a', 'b', 'c'].map(char => char.repeat(40))
 
     beforeEach(async function () {
-      for (const token of initialTokens) {
-        await pool.query(
-          `INSERT INTO pg_temp.${tableName} (token) VALUES ($1::text);`,
-          [token],
-        )
-      }
+      await Promise.all(
+        initialTokens.map(token =>
+          pool.query(
+            `INSERT INTO pg_temp.${tableName} (token) VALUES ($1::text);`,
+            [token],
+          ),
+        ),
+      )
     })
 
     it('loads the contents', async function () {


### PR DESCRIPTION
Small cleanup in the SQL token persistence integration test.

The test was using `forEach(async ...)` while inserting fixture rows. That pattern starts the async callbacks, but does not wait for them. In this specific test it is unlikely to fail in practice because `pg.Pool({ max: 1 })` serializes queries, but the setup code is still relying on accidental ordering.

This changes the setup to collect the insert promises with `map(...)` and wait for them with `Promise.all(...)`. The inserts are still started together; the test just waits for the fixture setup to finish before continuing.

Runnable example: [OneCompiler](https://onecompiler.com/nodejs/44qzrfn2n)

<details>
<summary>Minimal async example and output</summary>

```js
const fakeInsertToken = async token => {
  await new Promise(resolve => setTimeout(resolve, 10))
}

async function setupWithForEach() {
  let inserted = false

  ;['token'].forEach(async token => {
    await fakeInsertToken(token)
    inserted = true
  })

  return inserted
}

async function setupWithPromiseAll() {
  let inserted = false

  await Promise.all(
    ['token'].map(async token => {
      await fakeInsertToken(token)
      inserted = true
    }),
  )

  return inserted
}

console.table([
  {
    case: 'forEach(async callback)',
    result: await setupWithForEach(),
  },
  {
    case: 'Promise.all(map(async callback))',
    result: await setupWithPromiseAll(),
  },
])
```

```console
┌─────────┬─────────────────────────────────────┬────────┐
│ (index) │ case                                │ result │
├─────────┼─────────────────────────────────────┼────────┤
│ 0       │ 'forEach(async callback)'           │ false  │
│ 1       │ 'Promise.all(map(async callback))'  │ true   │
└─────────┴─────────────────────────────────────┴────────┘
```

</details>

