### PR TITLE
Preserve repeated spaces in badge text

### DIFF
--- a/badge-maker/lib/badge-renderers.js
+++ b/badge-maker/lib/badge-renderers.js
@@ -31,6 +31,14 @@ function withTextFill(attrs, textColor) {
   return textColor === DEFAULT_TEXT_FILL ? attrs : { ...attrs, fill: textColor }
 }
 
+function withPreservedSpacing(attrs, content) {
+  return /\s{2,}/.test(content) ? { ...attrs, 'xml:space': 'preserve' } : attrs
+}
+
+function withTextAttrs(attrs, textColor, content) {
+  return withPreservedSpacing(withTextFill(attrs, textColor), content)
+}
+
 function roundUpToOdd(val) {
   return val % 2 === 0 ? val + 1 : val
 }
@@ -213,24 +221,30 @@ class Badge {
       const text = new XmlElement({
         name: 'text',
         content: [content],
-        attrs: withTextFill({ x, y, textLength }, textColor),
+        attrs: withTextAttrs({ x, y, textLength }, textColor, content),
       })
       const shadowY = y + 10
       const shadowText = new XmlElement({
         name: 'text',
         content: [content],
-        attrs: { x, y: shadowY, 'fill-opacity': '.3', textLength },
+        attrs: withPreservedSpacing(
+          { x, y: shadowY, 'fill-opacity': '.3', textLength },
+          content,
+        ),
       })
       const shadowBlur = new XmlElement({
         name: 'text',
         content: [content],
-        attrs: {
-          x,
-          y: shadowY,
-          'fill-opacity': '.8',
-          filter: 'url(#blur)',
-          textLength,
-        },
+        attrs: withPreservedSpacing(
+          {
+            x,
+            y: shadowY,
+            'fill-opacity': '.8',
+            filter: 'url(#blur)',
+            textLength,
+          },
+          content,
+        ),
       })
       const shadowGroup = new XmlElement({
         name: 'g',
@@ -246,9 +260,10 @@ class Badge {
       element = new XmlElement({
         name: 'text',
         content: [content],
-        attrs: withTextFill(
+        attrs: withTextAttrs(
           { x, y, textLength, transform: FONT_SCALE_DOWN_VALUE },
           textColor,
+          content,
         ),
       })
     }

--- a/badge-maker/lib/make-badge.spec.js
+++ b/badge-maker/lib/make-badge.spec.js
@@ -85,6 +85,16 @@ describe('The badge generator', function () {
         .and.to.include('grown')
     })
 
+    it('should preserve consecutive spaces in SVG text', function () {
+      const svg = makeBadge({
+        label: 'foo    bar',
+        message: 'grown',
+        format: 'svg',
+      })
+
+      expect(svg).to.include('xml:space="preserve">foo    bar</text>')
+    })
+
     it('should match snapshot', async function () {
       await expectBadgeToMatchSnapshot({
         label: 'cactus',


### PR DESCRIPTION
## Summary
- Preserve consecutive whitespace in badge SVG text nodes by adding `xml:space="preserve"` only when the rendered text contains repeated whitespace.
- Add a regression test for labels like `foo    bar`, where width calculation already accounts for the spaces but browser SVG rendering collapsed them.

Fixes #6510

## Tests
- `npm_config_cache=/tmp/shields-6510-npm-cache npx mocha badge-maker/lib/make-badge.spec.js` (failed before the renderer change, passed after)
- `npm_config_cache=/tmp/shields-6510-npm-cache npx mocha --timeout 10000 "badge-maker/**/*.spec.js"`
- `npm_config_cache=/tmp/shields-6510-npm-cache npm run check-types:package`
- `npm_config_cache=/tmp/shields-6510-npm-cache npx prettier --check badge-maker/lib/badge-renderers.js badge-maker/lib/make-badge.spec.js`
- `npm_config_cache=/tmp/shields-6510-npm-cache npx eslint badge-maker/lib/badge-renderers.js badge-maker/lib/make-badge.spec.js`
- `git diff --check`
