### PR TITLE
Reduce duplicate Services CI runs

### DIFF
--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -6,10 +6,14 @@ on:
     branches:
       - 'gh-readonly-queue/**'
 
+concurrency:
+  group: services-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-services:
+    if: github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
This is a small CI workflow adjustment.

## Why

In #11915, repeated PR description edits triggered Services CI multiple times, and the GitHub service tests eventually hit a GitHub API 429: [failed job](https://github.com/badges/shields/actions/runs/27069134205/job/79895123671).

This PR makes description-only edits skip live service tests.

## What

- Cancel older Services runs for the same PR / ref when a newer run starts.
- Run `test-services` for `pull_request.edited` only when the PR title changes.
- Skip `test-services` when only the PR body changes.
