### PR TITLE
Add telemetry when GitHub token is removed

### DIFF
--- a/core/server/prometheus-metrics.js
+++ b/core/server/prometheus-metrics.js
@@ -31,6 +31,12 @@ export default class PrometheusMetrics {
         buckets: prometheus.exponentialBuckets(64 * 1024, 2, 8),
         registers: [this.register],
       }),
+      githubTokenInvalidations: new prometheus.Counter({
+        name: 'github_token_invalidations_total',
+        help: 'Total GitHub tokens invalidated and removed from the pool',
+        labelNames: ['reason'],
+        registers: [this.register],
+      }),
     }
     this.gauges = {
       githubTokenPoolStandard: new prometheus.Gauge({
@@ -118,6 +124,17 @@ export default class PrometheusMetrics {
       serviceFamily,
       service,
     )
+  }
+
+  /**
+   * Record that a GitHub token was invalidated and removed from the pool.
+   *
+   * @param {object} attrs Attributes
+   * @param {string} attrs.reason Why the token was invalidated,
+   *   e.g: 'http_401' or 'account_suspended'
+   */
+  noteGithubTokenInvalidation({ reason }) {
+    this.counters.githubTokenInvalidations.labels(reason).inc()
   }
 
   noteGithubTokenPoolMetrics(tokenDebugInfo) {

--- a/services/github/github-api-provider.js
+++ b/services/github/github-api-provider.js
@@ -1,6 +1,9 @@
 import Joi from 'joi'
 import log from '../../core/server/log.js'
-import { TokenPool } from '../../core/token-pooling/token-pool.js'
+import {
+  TokenPool,
+  sanitizeToken,
+} from '../../core/token-pooling/token-pool.js'
 import { getUserAgent } from '../../core/base-service/got-config.js'
 import { nonNegativeInteger } from '../validators.js'
 import { ImproperlyConfigured } from '../index.js'
@@ -56,6 +59,8 @@ class GithubApiProvider {
       globalToken,
       reserveFraction,
     })
+
+    this.metricInstance = undefined
 
     if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       this.standardTokens = new TokenPool({ batchSize: 25 })
@@ -113,7 +118,7 @@ class GithubApiProvider {
 
         if ('message' in parsedBody && !('data' in parsedBody)) {
           if (parsedBody.message === 'Sorry. Your account was suspended.') {
-            this.invalidateToken(token)
+            this.invalidateToken(token, 'account_suspended')
             return
           }
         }
@@ -155,7 +160,15 @@ class GithubApiProvider {
     token.update(usesRemaining, nextReset)
   }
 
-  invalidateToken(token) {
+  invalidateToken(token, reason) {
+    log.log(
+      `GitHub token invalidated and removed from pool (reason: ${reason}, token: ${sanitizeToken(
+        token.id,
+      )})`,
+    )
+    if (this.metricInstance) {
+      this.metricInstance.noteGithubTokenInvalidation({ reason })
+    }
     token.invalidate()
     this.onTokenInvalidated(token.id)
   }
@@ -209,7 +222,7 @@ class GithubApiProvider {
     const response = await requestFetcher(`${baseUrl}${url}`, mergedOptions)
     if (this.authType === this.constructor.AUTH_TYPES.TOKEN_POOL) {
       if (response.res.statusCode === 401) {
-        this.invalidateToken(token)
+        this.invalidateToken(token, 'http_401')
       } else if (response.res.statusCode < 500) {
         this.updateToken({ token, url, res: response.res })
       }

--- a/services/github/github-api-provider.spec.js
+++ b/services/github/github-api-provider.spec.js
@@ -6,6 +6,12 @@ describe('Github API provider', function () {
   const baseUrl = 'https://github-api.example.com'
   const reserveFraction = 0.333
 
+  const makeMockToken = id => ({
+    id,
+    update: sinon.spy(),
+    invalidate: sinon.spy(),
+  })
+
   let mockStandardToken, mockSearchToken, mockGraphqlToken, provider
   beforeEach(function () {
     provider = new GithubApiProvider({
@@ -14,13 +20,13 @@ describe('Github API provider', function () {
       reserveFraction,
     })
 
-    mockStandardToken = { update: sinon.spy(), invalidate: sinon.spy() }
+    mockStandardToken = makeMockToken('standard-token')
     sinon.stub(provider.standardTokens, 'next').returns(mockStandardToken)
 
-    mockSearchToken = { update: sinon.spy(), invalidate: sinon.spy() }
+    mockSearchToken = makeMockToken('search-token')
     sinon.stub(provider.searchTokens, 'next').returns(mockSearchToken)
 
-    mockGraphqlToken = { update: sinon.spy(), invalidate: sinon.spy() }
+    mockGraphqlToken = makeMockToken('graphql-token')
     sinon.stub(provider.graphqlTokens, 'next').returns(mockGraphqlToken)
   })
 

--- a/services/github/github-constellation.js
+++ b/services/github/github-constellation.js
@@ -77,6 +77,7 @@ class GithubConstellation {
     }
 
     this.metricInstance = metricInstance
+    this.apiProvider.metricInstance = metricInstance
 
     this.scheduleDebugLogging()
     this.scheduleMetricsCollection()


### PR DESCRIPTION
Will help investigate #11912, or future recurrences of the issue. Adds a log and a metric when a GitHub token is removed from the pool.