### PR TITLE
Increase [Crates] caches

### DIFF
--- a/services/crates/crates-downloads.service.js
+++ b/services/crates/crates-downloads.service.js
@@ -58,6 +58,8 @@ export default class CratesDownloads extends BaseCratesService {
     },
   }
 
+  static _cacheLength = 3600 // We're hitting the API more frequently than requested by upstream maintainers (see https://github.com/badges/shields/issues/11879).
+
   static render({ variant, downloads, version }) {
     let labelOverride
     if (variant === 'dr') {

--- a/services/crates/crates-msrv.service.js
+++ b/services/crates/crates-msrv.service.js
@@ -49,6 +49,8 @@ export default class CratesMSRV extends BaseCratesService {
     },
   }
 
+  static _cacheLength = 3600 // We're hitting the API more frequently than requested by upstream maintainers (see https://github.com/badges/shields/issues/11879).
+
   static defaultBadgeData = { label: 'msrv', color: 'blue' }
 
   static transform(response) {

--- a/services/crates/crates-size.service.js
+++ b/services/crates/crates-size.service.js
@@ -38,6 +38,8 @@ export default class CratesSize extends BaseCratesService {
     },
   }
 
+  static _cacheLength = 3600 // We're hitting the API more frequently than requested by upstream maintainers (see https://github.com/badges/shields/issues/11879).
+
   async handle({ crate, version }) {
     const json = await this.fetch({ crate, version })
     const size = this.constructor.getVersionObj(json).crate_size

--- a/services/crates/crates-user-downloads.service.js
+++ b/services/crates/crates-user-downloads.service.js
@@ -24,6 +24,8 @@ export default class CratesUserDownloads extends BaseCratesUserService {
     },
   }
 
+  static _cacheLength = 3600 // We're hitting the API more frequently than requested by upstream maintainers (see https://github.com/badges/shields/issues/11879).
+
   async handle({ userId }) {
     const json = await this.fetch({ userId })
     const { total_downloads: downloads } = json

--- a/services/crates/crates-version.service.js
+++ b/services/crates/crates-version.service.js
@@ -19,6 +19,8 @@ export default class CratesVersion extends BaseCratesService {
     },
   }
 
+  static _cacheLength = 3600 // We're hitting the API more frequently than requested by upstream maintainers (see https://github.com/badges/shields/issues/11879).
+
   async handle({ crate }) {
     const json = await this.fetch({ crate })
     const version = this.constructor.getLatestVersion(json)


### PR DESCRIPTION
Increases all Crates.io caches to a minimum of one hour per badge URL, which should hopefully fix #11879.