### PR TITLE
Add links to endpoint badges directory

### DIFF
--- a/frontend/docusaurus.config.cjs
+++ b/frontend/docusaurus.config.cjs
@@ -110,6 +110,10 @@ const config = {
                 label: 'Awesome Badges',
                 href: 'https://github.com/badges/awesome-badges',
               },
+              {
+                label: 'Endpoint Badges Directory',
+                href: 'https://github.com/badges/endpoint-badges-directory',
+              },
             ],
           },
           {

--- a/services/endpoint/endpoint.service.js
+++ b/services/endpoint/endpoint.service.js
@@ -21,7 +21,9 @@ configurable, subject to the Shields minimum. The endpoint URL is
 provided to Shields through the query string. Shields fetches it and
 formats the badge.
 
-The endpoint badge takes a single required query param: <code>url</code>, which is the URL to your JSON endpoint
+The endpoint badge takes a single required query param: <code>url</code>, which is the URL to your JSON endpoint.
+
+A collection of APIs compatible with Shields.io's endpoint badge is available <a href="https://github.com/badges/endpoint-badges-directory">here</a>.
 
 <div>
   <h2>Example JSON Endpoint Response</h2>


### PR DESCRIPTION
Implements https://github.com/badges/shields/pull/11842#issuecomment-4491469084. Points to the new repository https://github.com/badges/endpoint-badges-directory.

Let's see whether this gets any traction, we can always tear down if it doesn't.