### PR TITLE
feat: add Bluesky followers badge

### DIFF
--- a/services/bluesky/bluesky-followers.service.js
+++ b/services/bluesky/bluesky-followers.service.js
@@ -32,7 +32,6 @@ export default class BlueskyFollowers extends BaseJsonService {
     return {
       message: metric(followers),
       color: 'blue',
-      style: 'social',
     }
   }
 

--- a/services/bluesky/bluesky-followers.service.spec.js
+++ b/services/bluesky/bluesky-followers.service.spec.js
@@ -1,0 +1,25 @@
+import { test, given } from 'sazerac'
+import BlueskyFollowers from './bluesky-followers.service.js'
+
+describe('BlueskyFollowers', function () {
+  test(BlueskyFollowers.render, () => {
+    given({ followers: 9876 }).expect({
+      message: '9.9k',
+      color: 'blue',
+    })
+  })
+
+  test(BlueskyFollowers.render, () => {
+    given({ followers: 0 }).expect({
+      message: '0',
+      color: 'blue',
+    })
+  })
+
+  test(BlueskyFollowers.render, () => {
+    given({ followers: 1234567 }).expect({
+      message: '1.2M',
+      color: 'blue',
+    })
+  })
+})


### PR DESCRIPTION
Closes #10788
Adds a Bluesky followers badge using the public Bluesky API (no auth required).
Endpoint: https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=HANDLE
Usage: /bluesky/followers/:actor
Example: ![Bluesky Followers](https://img.shields.io/bluesky/followers/bsky.app)