### PR TITLE
docs(core): add JSDoc to core utility functions

### DIFF
--- a/core/badge-urls/make-badge-url.js
+++ b/core/badge-urls/make-badge-url.js
@@ -1,6 +1,15 @@
 // Avoid "Attempted import error: 'URL' is not exported from 'url'" in frontend.
 import url from 'url'
 
+/**
+ * Build a redirect URL for the raster (non-SVG) badge variant. Preserves the
+ * path and query string from the original badge request.
+ *
+ * @param {object} options - Options for the redirect.
+ * @param {string} options.rasterUrl - Base URL for raster badge rendering.
+ * @param {string} badgeUrl - The original badge request URL.
+ * @returns {string} Redirect URL pointing to the raster endpoint.
+ */
 function rasterRedirectUrl({ rasterUrl }, badgeUrl) {
   // Ensure we're always using the `rasterUrl` by using just the path from
   // the request URL.

--- a/core/badge-urls/path-helpers.js
+++ b/core/badge-urls/path-helpers.js
@@ -1,5 +1,14 @@
-// Escapes `t` using the format specified in
-// <https://github.com/espadrine/gh-badges/issues/12#issuecomment-31518129>
+/**
+ * Escape a string according to the badge format encoding scheme. Underscores
+ * and dashes in the input are decoded using the rules from
+ * https://github.com/espadrine/gh-badges/issues/12#issuecomment-31518129
+ *
+ * Single underscores become spaces, double underscores become single
+ * underscores, and double dashes become single dashes.
+ *
+ * @param {string} t - The format-encoded string to decode.
+ * @returns {string} The decoded string.
+ */
 function escapeFormat(t) {
   return (
     t

--- a/core/base-service/coalesce-badge.js
+++ b/core/base-service/coalesce-badge.js
@@ -7,28 +7,32 @@ import { DEFAULT_LOGO_HEIGHT } from '../../badge-maker/lib/constants.js'
 import coalesce from './coalesce.js'
 import toArray from './to-array.js'
 
-// Translate modern badge data to the legacy schema understood by the badge
-// maker. Allow the user to override the label, color, logo, etc. through the
-// query string. Provide support for most badge options via `serviceData` so
-// the Endpoint badge can specify logos and colors, though allow that the
-// user's logo or color to take precedence. A notable exception is the case of
-// errors. When the service specifies that an error has occurred, the user's
-// requested color does not override the error color.
-//
-// Logos are resolved in this manner:
-//
-// 1. When `?logo=` contains a simple-icons logo or contains a base64-encoded
-//    SVG, that logo is used. When a `&logoColor=` is specified, that color is
-//    used (except for the base64-encoded logos). Otherwise the default color
-//    is used.
-//    When `?logo=` is specified, any logo-related parameters specified
-//    dynamically by the service, or by default in the service, are ignored.
-// 2. The second precedence is the dynamic logo returned by a service. This is
-//    used only by the Endpoint badge. The `logoColor` can be overridden by the
-//    query string.
-// 3. In the case of the `social` style only, the last precedence is the
-//    service's default logo. The `logoColor` can be overridden by the query
-//    string.
+/**
+ * Translate modern badge data to the legacy schema understood by the badge
+ * maker. Allows the user to override label, color, logo, etc. through the
+ * query string. Provides support for most badge options via `serviceData` so
+ * the Endpoint badge can specify logos and colors, though the user's logo or
+ * color takes precedence. A notable exception: when the service specifies an
+ * error, the user's color override is disregarded.
+ *
+ * Logos are resolved in this precedence order:
+ *
+ * 1. `?logo=` query param (named simple-icons logo or base64-encoded SVG).
+ * 2. Dynamic logo returned by the service (Endpoint badge only).
+ * 3. Service's default logo (social style only).
+ *
+ * @param {object} overrides - Query-string override values (style, label,
+ *    logo, color, etc.).
+ * @param {object} serviceData - Badge data from the service (message, color,
+ *    logo, cache seconds, etc.).
+ * @param {object} defaultBadgeData - Default badge values (color, label,
+ *    named logo).
+ * @param {object} [context] - Optional context including category and cache
+ *    length.
+ * @param {string} [context.category] - Badge category for the default label.
+ * @param {number} [context._cacheLength] - Default cache duration in seconds.
+ * @returns {object} Normalized badge data object ready for rendering.
+ */
 export default function coalesceBadge(
   overrides,
   serviceData,

--- a/core/base-service/got-config.js
+++ b/core/base-service/got-config.js
@@ -11,6 +11,15 @@ const publicConfig = Joi.attempt(config.public, schema, { allowUnknown: true })
 
 const fetchLimitBytes = publicConfig.fetchLimitBytes
 
+/**
+ * Build the User-Agent string for outgoing HTTP requests. Incorporates the
+ * configured base name and, when available, a version from the deployment
+ * environment (Docker image version or Heroku slug commit).
+ *
+ * @param {string} [userAgentBase] - Base name for the user-agent. Defaults to
+ *    the configured `public.userAgentBase`.
+ * @returns {string} Formatted user-agent string (e.g. `shields/abc1234`).
+ */
 function getUserAgent(userAgentBase = publicConfig.userAgentBase) {
   let version = 'dev'
   if (process.env.DOCKER_SHIELDS_VERSION) {

--- a/core/base-service/json.js
+++ b/core/base-service/json.js
@@ -3,6 +3,13 @@ import emojic from 'emojic'
 import { InvalidResponse } from './errors.js'
 import trace from './trace.js'
 
+/**
+ * Parse a JSON response buffer. Throws an `InvalidResponse` error when the
+ * JSON is unparseable.
+ *
+ * @param {string|Buffer} buffer - The raw response body.
+ * @returns {object|Array} The parsed JSON value.
+ */
 function parseJson(buffer) {
   const logTrace = (...args) => trace.logTrace('fetch', ...args)
   let json

--- a/core/base-service/jsonl.js
+++ b/core/base-service/jsonl.js
@@ -3,6 +3,14 @@ import emojic from 'emojic'
 import { InvalidResponse } from './errors.js'
 import trace from './trace.js'
 
+/**
+ * Parse a JSONL (newline-delimited JSON) response buffer. Splits the buffer
+ * by newlines, trims each line, filters empty lines, and parses each line
+ * as JSON. Throws an `InvalidResponse` error when any line is unparseable.
+ *
+ * @param {string|Buffer} buffer - The raw response body.
+ * @returns {Array<object>} Array of parsed JSON values, one per line.
+ */
 function parseJsonl(buffer) {
   const logTrace = (...args) => trace.logTrace('fetch', ...args)
   let jsonl

--- a/core/server/instance-id-generator.js
+++ b/core/server/instance-id-generator.js
@@ -1,3 +1,8 @@
+/**
+ * Generate a random 9-character alphanumeric instance identifier.
+ *
+ * @returns {string} Random identifier (e.g. `a1b2c3d4e`).
+ */
 function generateInstanceId() {
   // from https://gist.github.com/gordonbrander/2230317
   return Math.random().toString(36).substr(2, 9)


### PR DESCRIPTION
Adds JSDoc documentation to a handful of core utility functions that were missing it. follows up on #6038, building on what #11909 started.

the functions documented are:
coalesceBadge (core/base-service/coalesce-badge.js) -- the existing inline comment was converted to proper JSDoc with parameter descriptions and a summary of the logo resolution order
parseJson (core/base-service/json.js)
parseJsonl (core/base-service/jsonl.js)
getUserAgent (core/base-service/got-config.js)
generateInstanceId (core/server/instance-id-generator.js)
rasterRedirectUrl (core/badge-urls/make-badge-url.js)
escapeFormat (core/badge-urls/path-helpers.js)

build-docs passes with --pedantic and lint is clean.