### PR TITLE
[Copr] Add build status badge

### DIFF
--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -30,13 +30,10 @@ const queryParamSchema = Joi.object({
 }).required()
 
 const description = `
-[COPR](https://copr.fedorainfracloud.org/) is a build system for creating RPM packages.
+Shows the latest build status for a package on
+[COPR](https://copr.fedorainfracloud.org/).
 
 For group projects, prefix the owner with \`@\` (for example \`@copr\`).
-
-The [Copr API v3 documentation](https://copr.fedorainfracloud.org/api_3/docs/) does not
-document request rate limits for read-only endpoints. This badge issues one GET per
-render to \`/api_3/package\` with \`with_latest_build=True\`.
 `
 
 export default class Copr extends BaseJsonService {
@@ -58,8 +55,6 @@ export default class Copr extends BaseJsonService {
             {
               name: 'owner',
               example: 'msuchy',
-              description:
-                'Project owner. For group projects, prefix with `@`.',
             },
             {
               name: 'project',
@@ -73,8 +68,6 @@ export default class Copr extends BaseJsonService {
           queryParam({
             name: 'server',
             example: 'https://copr.fedorainfracloud.org',
-            description:
-              'Copr server URL. Defaults to `https://copr.fedorainfracloud.org`.',
           }),
         ],
       },
@@ -87,15 +80,11 @@ export default class Copr extends BaseJsonService {
     return renderBuildStatusBadge({ status })
   }
 
-  packageUrl({ server, owner, project, package: packageName }) {
-    const trimmedServer = server.replace(/\/$/, '')
-    return `${trimmedServer}/api_3/package`
-  }
-
   async fetch({ server, owner, project, package: packageName }) {
+    const trimmedServer = server.replace(/\/$/, '')
     return this._requestJson({
       schema,
-      url: this.packageUrl({ server, owner, project, package: packageName }),
+      url: `${trimmedServer}/api_3/package`,
       options: {
         searchParams: {
           ownername: owner,

--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -33,6 +33,10 @@ const description = `
 [COPR](https://copr.fedorainfracloud.org/) is a build system for creating RPM packages.
 
 For group projects, prefix the owner with \`@\` (for example \`@copr\`).
+
+The [Copr API v3 documentation](https://copr.fedorainfracloud.org/api_3/docs/) does not
+document request rate limits for read-only endpoints. This badge issues one GET per
+render to \`/api_3/package\` with \`with_latest_build=True\`.
 `
 
 export default class Copr extends BaseJsonService {

--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -88,15 +88,6 @@ export default class Copr extends BaseJsonService {
     return `${trimmedServer}/api_3/package`
   }
 
-  transform({ builds }) {
-    const { state } = builds.latest
-    const status = stateStatusMap[state]
-    if (!status) {
-      throw new NotFound({ prettyMessage: 'unknown build state' })
-    }
-    return { status }
-  }
-
   async fetch({ server, owner, project, package: packageName }) {
     return this._requestJson({
       schema,
@@ -113,6 +104,15 @@ export default class Copr extends BaseJsonService {
         404: 'project or package not found',
       },
     })
+  }
+
+  transform({ builds }) {
+    const { state } = builds.latest
+    const status = stateStatusMap[state]
+    if (!status) {
+      throw new NotFound({ prettyMessage: 'unknown build state' })
+    }
+    return { status }
   }
 
   async handle(

--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -1,0 +1,131 @@
+import Joi from 'joi'
+import { renderBuildStatusBadge } from '../build-status.js'
+import { BaseJsonService, NotFound, pathParams, queryParam } from '../index.js'
+
+const stateStatusMap = {
+  succeeded: 'passing',
+  failed: 'failing',
+  canceled: 'cancelled',
+  skipped: 'skipped',
+  importing: 'building',
+  pending: 'building',
+  starting: 'building',
+  running: 'building',
+  waiting: 'building',
+  forked: 'passing',
+}
+
+const schema = Joi.object({
+  builds: Joi.object({
+    latest: Joi.object({
+      state: Joi.string().required(),
+    }).required(),
+  }).required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  server: Joi.string()
+    .uri({ scheme: ['http', 'https'] })
+    .optional(),
+}).required()
+
+const description = `
+[COPR](https://copr.fedorainfracloud.org/) is a build system for creating RPM packages.
+
+For group projects, prefix the owner with \`@\` (for example \`@copr\`).
+`
+
+export default class Copr extends BaseJsonService {
+  static category = 'build'
+
+  static route = {
+    base: 'copr/build',
+    pattern: ':owner/:project/:package',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/copr/build/{owner}/{project}/{package}': {
+      get: {
+        summary: 'Copr Build',
+        description,
+        parameters: [
+          ...pathParams(
+            {
+              name: 'owner',
+              example: 'msuchy',
+              description:
+                'Project owner. For group projects, prefix with `@`.',
+            },
+            {
+              name: 'project',
+              example: 'nanoblogger',
+            },
+            {
+              name: 'package',
+              example: 'nanoblogger',
+            },
+          ),
+          queryParam({
+            name: 'server',
+            example: 'https://copr.fedorainfracloud.org',
+            description:
+              'Copr server URL. Defaults to `https://copr.fedorainfracloud.org`.',
+          }),
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'build' }
+
+  static render({ status }) {
+    return renderBuildStatusBadge({ status })
+  }
+
+  packageUrl({ server, owner, project, package: packageName }) {
+    const trimmedServer = server.replace(/\/$/, '')
+    return `${trimmedServer}/api_3/package`
+  }
+
+  transform({ builds }) {
+    const { state } = builds.latest
+    const status = stateStatusMap[state]
+    if (!status) {
+      throw new NotFound({ prettyMessage: 'unknown build state' })
+    }
+    return { status }
+  }
+
+  async fetch({ server, owner, project, package: packageName }) {
+    return this._requestJson({
+      schema,
+      url: this.packageUrl({ server, owner, project, package: packageName }),
+      options: {
+        searchParams: {
+          ownername: owner,
+          projectname: project,
+          packagename: packageName,
+          with_latest_build: 'True',
+        },
+      },
+      httpErrors: {
+        404: 'project or package not found',
+      },
+    })
+  }
+
+  async handle(
+    { owner, project, package: packageName },
+    { server = 'https://copr.fedorainfracloud.org' },
+  ) {
+    const json = await this.fetch({
+      server,
+      owner,
+      project,
+      package: packageName,
+    })
+    const { status } = this.transform(json)
+    return this.constructor.render({ status })
+  }
+}

--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -31,7 +31,7 @@ const queryParamSchema = Joi.object({
 
 const description = `
 Shows the latest build status for a package on
-[COPR](https://copr.fedorainfracloud.org/).
+a Copr instance, for example [Fedora Copr](https://copr.fedorainfracloud.org/).
 
 For group projects, prefix the owner with \`@\` (for example \`@copr\`).
 `

--- a/services/copr/copr.service.js
+++ b/services/copr/copr.service.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import { renderBuildStatusBadge } from '../build-status.js'
 import { BaseJsonService, NotFound, pathParams, queryParam } from '../index.js'
+import { optionalUrl } from '../validators.js'
 
 const stateStatusMap = {
   succeeded: 'passing',
@@ -24,9 +25,7 @@ const schema = Joi.object({
 }).required()
 
 const queryParamSchema = Joi.object({
-  server: Joi.string()
-    .uri({ scheme: ['http', 'https'] })
-    .optional(),
+  baseUrl: optionalUrl,
 }).required()
 
 const description = `
@@ -66,7 +65,7 @@ export default class Copr extends BaseJsonService {
             },
           ),
           queryParam({
-            name: 'server',
+            name: 'baseUrl',
             example: 'https://copr.fedorainfracloud.org',
           }),
         ],
@@ -80,11 +79,10 @@ export default class Copr extends BaseJsonService {
     return renderBuildStatusBadge({ status })
   }
 
-  async fetch({ server, owner, project, package: packageName }) {
-    const trimmedServer = server.replace(/\/$/, '')
+  async fetch({ baseUrl, owner, project, package: packageName }) {
     return this._requestJson({
       schema,
-      url: `${trimmedServer}/api_3/package`,
+      url: `${baseUrl}/api_3/package`,
       options: {
         searchParams: {
           ownername: owner,
@@ -110,10 +108,10 @@ export default class Copr extends BaseJsonService {
 
   async handle(
     { owner, project, package: packageName },
-    { server = 'https://copr.fedorainfracloud.org' },
+    { baseUrl = 'https://copr.fedorainfracloud.org' },
   ) {
     const json = await this.fetch({
-      server,
+      baseUrl,
       owner,
       project,
       package: packageName,

--- a/services/copr/copr.service.spec.js
+++ b/services/copr/copr.service.spec.js
@@ -1,23 +1,7 @@
 import { test, given } from 'sazerac'
-import { renderBuildStatusBadge } from '../build-status.js'
 import Copr from './copr.service.js'
 
 describe('Copr service', function () {
-  test(Copr.prototype.packageUrl, () => {
-    given({
-      server: 'https://copr.fedorainfracloud.org',
-      owner: 'msuchy',
-      project: 'nanoblogger',
-      package: 'nanoblogger',
-    }).expect('https://copr.fedorainfracloud.org/api_3/package')
-    given({
-      server: 'https://copr.fedorainfracloud.org/',
-      owner: '@copr',
-      project: 'copr',
-      package: 'copr-backend',
-    }).expect('https://copr.fedorainfracloud.org/api_3/package')
-  })
-
   test(Copr.prototype.transform, () => {
     given({ builds: { latest: { state: 'succeeded' } } }).expect({
       status: 'passing',
@@ -36,18 +20,6 @@ describe('Copr service', function () {
     })
     given({ builds: { latest: { state: 'unknown-state' } } }).expectError(
       'Not Found: unknown build state',
-    )
-  })
-
-  test(Copr.render, () => {
-    given({ status: 'passing' }).expect(
-      renderBuildStatusBadge({ status: 'passing' }),
-    )
-    given({ status: 'failing' }).expect(
-      renderBuildStatusBadge({ status: 'failing' }),
-    )
-    given({ status: 'building' }).expect(
-      renderBuildStatusBadge({ status: 'building' }),
     )
   })
 })

--- a/services/copr/copr.service.spec.js
+++ b/services/copr/copr.service.spec.js
@@ -1,0 +1,53 @@
+import { test, given } from 'sazerac'
+import { renderBuildStatusBadge } from '../build-status.js'
+import Copr from './copr.service.js'
+
+describe('Copr service', function () {
+  test(Copr.prototype.packageUrl, () => {
+    given({
+      server: 'https://copr.fedorainfracloud.org',
+      owner: 'msuchy',
+      project: 'nanoblogger',
+      package: 'nanoblogger',
+    }).expect('https://copr.fedorainfracloud.org/api_3/package')
+    given({
+      server: 'https://copr.fedorainfracloud.org/',
+      owner: '@copr',
+      project: 'copr',
+      package: 'copr-backend',
+    }).expect('https://copr.fedorainfracloud.org/api_3/package')
+  })
+
+  test(Copr.prototype.transform, () => {
+    given({ builds: { latest: { state: 'succeeded' } } }).expect({
+      status: 'passing',
+    })
+    given({ builds: { latest: { state: 'failed' } } }).expect({
+      status: 'failing',
+    })
+    given({ builds: { latest: { state: 'running' } } }).expect({
+      status: 'building',
+    })
+    given({ builds: { latest: { state: 'canceled' } } }).expect({
+      status: 'cancelled',
+    })
+    given({ builds: { latest: { state: 'skipped' } } }).expect({
+      status: 'skipped',
+    })
+    given({ builds: { latest: { state: 'unknown-state' } } }).expectError(
+      'Not Found: unknown build state',
+    )
+  })
+
+  test(Copr.render, () => {
+    given({ status: 'passing' }).expect(
+      renderBuildStatusBadge({ status: 'passing' }),
+    )
+    given({ status: 'failing' }).expect(
+      renderBuildStatusBadge({ status: 'failing' }),
+    )
+    given({ status: 'building' }).expect(
+      renderBuildStatusBadge({ status: 'building' }),
+    )
+  })
+})

--- a/services/copr/copr.tester.js
+++ b/services/copr/copr.tester.js
@@ -16,6 +16,15 @@ t.create('build (valid group project)')
     message: isBuildStatus,
   })
 
+t.create('build (openEuler server)')
+  .get(
+    '/mywaaagh_admin/i3wm/acpi.json?server=https://eur.openeuler.openatom.cn',
+  )
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })
+
 t.create('build (not found)')
   .get('/not-a-user/not-a-project/not-a-package.json')
   .expectBadge({ label: 'build', message: 'project or package not found' })

--- a/services/copr/copr.tester.js
+++ b/services/copr/copr.tester.js
@@ -1,0 +1,42 @@
+import { isBuildStatus } from '../build-status.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('build (valid user project)')
+  .get('/msuchy/nanoblogger/nanoblogger.json')
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })
+
+t.create('build (valid group project)')
+  .get('/%40copr/copr/copr-backend.json')
+  .expectBadge({
+    label: 'build',
+    message: isBuildStatus,
+  })
+
+t.create('build (valid, mocked)')
+  .get('/owner/project/package.json')
+  .intercept(nock =>
+    nock('https://copr.fedorainfracloud.org')
+      .get('/api_3/package')
+      .query({
+        ownername: 'owner',
+        projectname: 'project',
+        packagename: 'package',
+        with_latest_build: 'True',
+      })
+      .reply(200, {
+        builds: {
+          latest: {
+            state: 'succeeded',
+          },
+        },
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'passing' })
+
+t.create('build (not found)')
+  .get('/not-a-user/not-a-project/not-a-package.json')
+  .expectBadge({ label: 'build', message: 'project or package not found' })

--- a/services/copr/copr.tester.js
+++ b/services/copr/copr.tester.js
@@ -16,27 +16,6 @@ t.create('build (valid group project)')
     message: isBuildStatus,
   })
 
-t.create('build (valid, mocked)')
-  .get('/owner/project/package.json')
-  .intercept(nock =>
-    nock('https://copr.fedorainfracloud.org')
-      .get('/api_3/package')
-      .query({
-        ownername: 'owner',
-        projectname: 'project',
-        packagename: 'package',
-        with_latest_build: 'True',
-      })
-      .reply(200, {
-        builds: {
-          latest: {
-            state: 'succeeded',
-          },
-        },
-      }),
-  )
-  .expectBadge({ label: 'build', message: 'passing' })
-
 t.create('build (not found)')
   .get('/not-a-user/not-a-project/not-a-package.json')
   .expectBadge({ label: 'build', message: 'project or package not found' })

--- a/services/copr/copr.tester.js
+++ b/services/copr/copr.tester.js
@@ -16,9 +16,9 @@ t.create('build (valid group project)')
     message: isBuildStatus,
   })
 
-t.create('build (openEuler server)')
+t.create('build (openEuler baseUrl)')
   .get(
-    '/mywaaagh_admin/i3wm/acpi.json?server=https://eur.openeuler.openatom.cn',
+    '/mywaaagh_admin/i3wm/acpi.json?baseUrl=https://eur.openeuler.openatom.cn',
   )
   .expectBadge({
     label: 'build',


### PR DESCRIPTION
## Summary

Adds a new build status badge for the [Fedora Copr](https://copr.fedorainfracloud.org/) build system. The optional `baseUrl` query parameter also works against other public Copr instances.

Closes #6078

## Example

```
https://img.shields.io/copr/build/msuchy/nanoblogger/nanoblogger
https://img.shields.io/copr/build/@copr/copr/copr-backend
https://img.shields.io/copr/build/mywaaagh_admin/i3wm/acpi?baseUrl=https://eur.openeuler.openatom.cn
https://img.shields.io/copr/build/msuchy/nanoblogger/nanoblogger?baseUrl=https://copr.stg.fedoraproject.org
```

## Badge endpoint

`/copr/build/:owner/:project/:package`

Optional `baseUrl` query parameter defaults to `https://copr.fedorainfracloud.org`.

Public instances documented by Copr: [Fedora](https://copr.fedorainfracloud.org), [Fedora staging](https://copr.stg.fedoraproject.org) (data periodically deleted), and [openEuler](https://eur.openeuler.openatom.cn). See the [Copr user documentation](https://docs.copr.fedorainfracloud.org/user_documentation.html#public-copr-instances).

## API rate limits

The [Copr API v3 documentation](https://copr.fedorainfracloud.org/api_3/docs/) does not document request rate limits for read-only endpoints. This badge issues one GET per render to `/api_3/package` with `with_latest_build=True`.

## Implementation

- `services/copr/copr.service.js` — fetches latest build state from Copr API v3
- `services/copr/copr.service.spec.js` — unit tests for build-state transformation
- `services/copr/copr.tester.js` — live service tests (Fedora + openEuler)

## Checklist

- [x] Service implementation (`services/copr/copr.service.js`)
- [x] Unit tests (`services/copr/copr.service.spec.js`)
- [x] Service tests (`services/copr/copr.tester.js`)
- [x] `npm run test:core -- --grep Copr` (6 passing)
- [x] `npm run test:services -- --grep Copr` (4 passing)
- [x] `npm run lint` (0 errors)
