### PR TITLE
[GithubReleaseBranch] Add GitHub release by branch badge

### DIFF
--- a/services/github/github-release-branch.service.js
+++ b/services/github/github-release-branch.service.js
@@ -63,11 +63,6 @@ export default class GithubReleaseBranch extends GithubAuthV3Service {
     return undefined
   }
 
-  transform({ release, branch }) {
-    const { tag_name: version, prerelease: isPrerelease } = release
-    return { version, isPrerelease, branch }
-  }
-
   static render({ version, isPrerelease, branch }) {
     return renderVersionBadge({
       version,
@@ -75,6 +70,10 @@ export default class GithubReleaseBranch extends GithubAuthV3Service {
       defaultLabel: GithubReleaseBranch.defaultBadgeData.label,
       tag: branch,
     })
+  }
+  transform({ release, branch }) {
+    const { tag_name: version, prerelease: isPrerelease } = release
+    return { version, isPrerelease, branch }
   }
 
   async fetchPage({ user, repo, page }) {

--- a/services/github/github-release-branch.service.js
+++ b/services/github/github-release-branch.service.js
@@ -1,0 +1,121 @@
+import Joi from 'joi'
+import { NotFound, pathParam } from '../index.js'
+import { renderVersionBadge } from '../version.js'
+import { GithubAuthV3Service } from './github-auth-service.js'
+import {
+  openApiQueryParams,
+  queryParamSchema,
+} from './github-common-release.js'
+import { documentation, httpErrorsFor } from './github-helpers.js'
+
+const releaseSchema = Joi.object({
+  tag_name: Joi.string().required(),
+  target_commitish: Joi.string().required(),
+  prerelease: Joi.boolean().required(),
+  name: Joi.string().allow(null).allow(''),
+}).required()
+
+const releaseArraySchema = Joi.alternatives().try(
+  Joi.array().items(releaseSchema),
+  Joi.array().length(0),
+)
+
+const branchDescription = `
+Returns the latest release associated with the specified branch.
+Releases are matched using the \`target_commitish\` field from the GitHub API.
+`
+
+export default class GithubReleaseBranch extends GithubAuthV3Service {
+  static category = 'version'
+
+  static route = {
+    base: 'github/v/release',
+    pattern: ':user/:repo/:branch',
+    queryParamSchema,
+  }
+
+  static openApi = {
+    '/github/v/release/{user}/{repo}/{branch}': {
+      get: {
+        summary: 'GitHub Release (by branch)',
+        description: `${documentation}\n${branchDescription}`,
+        parameters: [
+          pathParam({ name: 'user', example: 'laravel' }),
+          pathParam({ name: 'repo', example: 'framework' }),
+          pathParam({ name: 'branch', example: '13.x' }),
+          ...openApiQueryParams,
+        ],
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'latest-release' }
+
+  findReleaseOnPage({ releases, branch, includePrereleases }) {
+    for (const release of releases) {
+      if (release.target_commitish === branch) {
+        if (!includePrereleases && release.prerelease) {
+          continue
+        }
+        return release
+      }
+    }
+    return undefined
+  }
+
+  transform({ release, branch }) {
+    const { tag_name: version, prerelease: isPrerelease } = release
+    return { version, isPrerelease, branch }
+  }
+
+  static render({ version, isPrerelease, branch }) {
+    return renderVersionBadge({
+      version,
+      isPrerelease,
+      defaultLabel: GithubReleaseBranch.defaultBadgeData.label,
+      tag: branch,
+    })
+  }
+
+  async fetchPage({ user, repo, page }) {
+    return this._requestJson({
+      url: `/repos/${user}/${repo}/releases`,
+      schema: releaseArraySchema,
+      httpErrors: httpErrorsFor('repo not found'),
+      options: { searchParams: { per_page: 100, page } },
+    })
+  }
+
+  async fetchLatestReleaseByBranch({ user, repo, branch, includePrereleases }) {
+    let page = 1
+    while (true) {
+      const releases = await this.fetchPage({ user, repo, page })
+      if (releases.length === 0) {
+        const prettyMessage =
+          page === 1 ? 'no releases found' : 'no release found for branch'
+        throw new NotFound({ prettyMessage })
+      }
+      const release = this.findReleaseOnPage({
+        releases,
+        branch,
+        includePrereleases,
+      })
+      if (release) {
+        return release
+      }
+      page++
+    }
+  }
+
+  async handle({ user, repo, branch }, queryParams) {
+    const includePrereleases = queryParams.include_prereleases !== undefined
+    const release = await this.fetchLatestReleaseByBranch({
+      user,
+      repo,
+      branch,
+      includePrereleases,
+    })
+    const result = this.transform({ release, branch })
+    return this.constructor.render(result)
+  }
+}

--- a/services/github/github-release-branch.service.js
+++ b/services/github/github-release-branch.service.js
@@ -1,11 +1,7 @@
 import Joi from 'joi'
-import { NotFound, pathParam } from '../index.js'
+import { NotFound, pathParam, queryParam } from '../index.js'
 import { renderVersionBadge } from '../version.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
-import {
-  openApiQueryParams,
-  queryParamSchema,
-} from './github-common-release.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
 
 const releaseSchema = Joi.object({
@@ -19,6 +15,10 @@ const releaseArraySchema = Joi.alternatives().try(
   Joi.array().items(releaseSchema),
   Joi.array().length(0),
 )
+
+const queryParamSchema = Joi.object({
+  include_prereleases: Joi.equal(''),
+}).required()
 
 const branchDescription = `
 Returns the latest release associated with the specified branch.
@@ -43,7 +43,11 @@ export default class GithubReleaseBranch extends GithubAuthV3Service {
           pathParam({ name: 'user', example: 'laravel' }),
           pathParam({ name: 'repo', example: 'framework' }),
           pathParam({ name: 'branch', example: '13.x' }),
-          ...openApiQueryParams,
+          queryParam({
+            name: 'include_prereleases',
+            example: null,
+            schema: { type: 'boolean' },
+          }),
         ],
       },
     },

--- a/services/github/github-release-branch.service.spec.js
+++ b/services/github/github-release-branch.service.spec.js
@@ -16,24 +16,20 @@ describe('GithubReleaseBranch service', function () {
     given({ releases, branch: '2.x', includePrereleases: false }).expect(
       undefined,
     )
-    given(
-      {
-        releases: [
-          { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
-        ],
-        branch: 'main',
-        includePrereleases: false,
-      },
-    ).expect(undefined)
-    given(
-      {
-        releases: [
-          { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
-        ],
-        branch: 'main',
-        includePrereleases: true,
-      },
-    ).expect({
+    given({
+      releases: [
+        { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
+      ],
+      branch: 'main',
+      includePrereleases: false,
+    }).expect(undefined)
+    given({
+      releases: [
+        { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
+      ],
+      branch: 'main',
+      includePrereleases: true,
+    }).expect({
       tag_name: 'v2.0.0-beta',
       target_commitish: 'main',
       prerelease: true,

--- a/services/github/github-release-branch.service.spec.js
+++ b/services/github/github-release-branch.service.spec.js
@@ -1,0 +1,90 @@
+import { test, given } from 'sazerac'
+import GithubReleaseBranch from './github-release-branch.service.js'
+
+describe('GithubReleaseBranch service', function () {
+  test(GithubReleaseBranch.prototype.findReleaseOnPage, () => {
+    const releases = [
+      { tag_name: 'v2.0.0', target_commitish: 'main', prerelease: false },
+      { tag_name: 'v1.0.0', target_commitish: '1.x', prerelease: false },
+    ]
+    given({ releases, branch: '1.x', includePrereleases: false }).expect(
+      releases[1],
+    )
+    given({ releases, branch: 'main', includePrereleases: false }).expect(
+      releases[0],
+    )
+    given({ releases, branch: '2.x', includePrereleases: false }).expect(
+      undefined,
+    )
+    given(
+      {
+        releases: [
+          { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
+        ],
+        branch: 'main',
+        includePrereleases: false,
+      },
+    ).expect(undefined)
+    given(
+      {
+        releases: [
+          { tag_name: 'v2.0.0-beta', target_commitish: 'main', prerelease: true },
+        ],
+        branch: 'main',
+        includePrereleases: true,
+      },
+    ).expect({
+      tag_name: 'v2.0.0-beta',
+      target_commitish: 'main',
+      prerelease: true,
+    })
+  })
+
+  test(GithubReleaseBranch.prototype.transform, () => {
+    given({
+      release: {
+        tag_name: 'v9.11.0',
+        target_commitish: '9.x',
+        prerelease: false,
+      },
+      branch: '9.x',
+    }).expect({
+      version: 'v9.11.0',
+      isPrerelease: false,
+      branch: '9.x',
+    })
+    given({
+      release: {
+        tag_name: 'v2.0.0-beta',
+        target_commitish: 'main',
+        prerelease: true,
+      },
+      branch: 'main',
+    }).expect({
+      version: 'v2.0.0-beta',
+      isPrerelease: true,
+      branch: 'main',
+    })
+  })
+
+  test(GithubReleaseBranch.render, () => {
+    given({
+      version: 'v9.11.0',
+      isPrerelease: false,
+      branch: '9.x',
+    }).expect({
+      label: 'latest-release@9.x',
+      message: 'v9.11.0',
+      color: 'blue',
+    })
+    given({
+      version: 'v2.0.0-beta',
+      isPrerelease: true,
+      branch: 'main',
+    }).expect({
+      label: 'latest-release@main',
+      message: 'v2.0.0-beta',
+      color: 'orange',
+    })
+  })
+})

--- a/services/github/github-release-branch.tester.js
+++ b/services/github/github-release-branch.tester.js
@@ -4,7 +4,7 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('Release by branch (valid)')
-  .get('/v/release/laravel/framework/13.x.json')
+  .get('/laravel/framework/13.x.json')
   .expectBadge({
     label: 'latest-release@13.x',
     message: isSemver,
@@ -12,7 +12,7 @@ t.create('Release by branch (valid)')
   })
 
 t.create('Release by branch (valid, mocked)')
-  .get('/v/release/user/repo/main.json')
+  .get('/user/repo/main.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -23,7 +23,6 @@ t.create('Release by branch (valid, mocked)')
           target_commitish: 'main',
           prerelease: false,
           name: '',
-          assets: [],
         },
       ]),
   )
@@ -34,7 +33,7 @@ t.create('Release by branch (valid, mocked)')
   })
 
 t.create('Release by branch (prerelease, mocked)')
-  .get('/v/release/user/repo/main.json?include_prereleases')
+  .get('/user/repo/main.json?include_prereleases')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -45,7 +44,6 @@ t.create('Release by branch (prerelease, mocked)')
           target_commitish: 'main',
           prerelease: true,
           name: '',
-          assets: [],
         },
       ]),
   )
@@ -56,7 +54,7 @@ t.create('Release by branch (prerelease, mocked)')
   })
 
 t.create('Release by branch (paginated, mocked)')
-  .get('/v/release/user/repo/1.x.json')
+  .get('/user/repo/1.x.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -67,7 +65,6 @@ t.create('Release by branch (paginated, mocked)')
           target_commitish: 'main',
           prerelease: false,
           name: '',
-          assets: [],
         },
       ])
       .get('/repos/user/repo/releases')
@@ -78,7 +75,6 @@ t.create('Release by branch (paginated, mocked)')
           target_commitish: '1.x',
           prerelease: false,
           name: '',
-          assets: [],
         },
       ]),
   )
@@ -89,7 +85,7 @@ t.create('Release by branch (paginated, mocked)')
   })
 
 t.create('Release by branch (no matching branch, mocked)')
-  .get('/v/release/user/repo/2.x.json')
+  .get('/user/repo/2.x.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -100,7 +96,6 @@ t.create('Release by branch (no matching branch, mocked)')
           target_commitish: '1.x',
           prerelease: false,
           name: '',
-          assets: [],
         },
       ])
       .get('/repos/user/repo/releases')
@@ -113,11 +108,11 @@ t.create('Release by branch (no matching branch, mocked)')
   })
 
 t.create('Release by branch (repo not found)')
-  .get('/v/release/badges/helmets/1.x.json')
+  .get('/badges/helmets/1.x.json')
   .expectBadge({ label: 'latest-release', message: 'repo not found' })
 
 t.create('Release by branch (no releases, mocked)')
-  .get('/v/release/user/repo/main.json')
+  .get('/user/repo/main.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -127,7 +122,7 @@ t.create('Release by branch (no releases, mocked)')
   .expectBadge({ label: 'latest-release', message: 'no releases found' })
 
 t.create('Release by branch (prerelease excluded, mocked)')
-  .get('/v/release/user/repo/main.json')
+  .get('/user/repo/main.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -138,7 +133,6 @@ t.create('Release by branch (prerelease excluded, mocked)')
           target_commitish: 'main',
           prerelease: true,
           name: '',
-          assets: [],
         },
       ])
       .get('/repos/user/repo/releases')
@@ -151,7 +145,7 @@ t.create('Release by branch (prerelease excluded, mocked)')
   })
 
 t.create('Release by branch (stable after prerelease, mocked)')
-  .get('/v/release/user/repo/main.json')
+  .get('/user/repo/main.json')
   .intercept(nock =>
     nock('https://api.github.com')
       .get('/repos/user/repo/releases')
@@ -162,14 +156,12 @@ t.create('Release by branch (stable after prerelease, mocked)')
           target_commitish: 'main',
           prerelease: true,
           name: '',
-          assets: [],
         },
         {
           tag_name: 'v2.0.0',
           target_commitish: 'main',
           prerelease: false,
           name: '',
-          assets: [],
         },
       ]),
   )
@@ -180,7 +172,7 @@ t.create('Release by branch (stable after prerelease, mocked)')
   })
 
 t.create('Release by branch (prerelease color)')
-  .get('/v/release/laravel/framework/13.x.json?include_prereleases')
+  .get('/laravel/framework/13.x.json?include_prereleases')
   .expectBadge({
     label: 'latest-release@13.x',
     message: isSemver,

--- a/services/github/github-release-branch.tester.js
+++ b/services/github/github-release-branch.tester.js
@@ -1,0 +1,188 @@
+import Joi from 'joi'
+import { isSemver } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+export const t = await createServiceTester()
+
+t.create('Release by branch (valid)')
+  .get('/v/release/laravel/framework/13.x.json')
+  .expectBadge({
+    label: 'latest-release@13.x',
+    message: isSemver,
+    color: 'blue',
+  })
+
+t.create('Release by branch (valid, mocked)')
+  .get('/v/release/user/repo/main.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v2.0.0',
+          target_commitish: 'main',
+          prerelease: false,
+          name: '',
+          assets: [],
+        },
+      ]),
+  )
+  .expectBadge({
+    label: 'latest-release@main',
+    message: 'v2.0.0',
+    color: 'blue',
+  })
+
+t.create('Release by branch (prerelease, mocked)')
+  .get('/v/release/user/repo/main.json?include_prereleases')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v2.0.0-beta',
+          target_commitish: 'main',
+          prerelease: true,
+          name: '',
+          assets: [],
+        },
+      ]),
+  )
+  .expectBadge({
+    label: 'latest-release@main',
+    message: 'v2.0.0-beta',
+    color: 'orange',
+  })
+
+t.create('Release by branch (paginated, mocked)')
+  .get('/v/release/user/repo/1.x.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v2.0.0',
+          target_commitish: 'main',
+          prerelease: false,
+          name: '',
+          assets: [],
+        },
+      ])
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 2 })
+      .reply(200, [
+        {
+          tag_name: 'v1.0.0',
+          target_commitish: '1.x',
+          prerelease: false,
+          name: '',
+          assets: [],
+        },
+      ]),
+  )
+  .expectBadge({
+    label: 'latest-release@1.x',
+    message: 'v1.0.0',
+    color: 'blue',
+  })
+
+t.create('Release by branch (no matching branch, mocked)')
+  .get('/v/release/user/repo/2.x.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v1.0.0',
+          target_commitish: '1.x',
+          prerelease: false,
+          name: '',
+          assets: [],
+        },
+      ])
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 2 })
+      .reply(200, []),
+  )
+  .expectBadge({
+    label: 'latest-release',
+    message: 'no release found for branch',
+  })
+
+t.create('Release by branch (repo not found)')
+  .get('/v/release/badges/helmets/1.x.json')
+  .expectBadge({ label: 'latest-release', message: 'repo not found' })
+
+t.create('Release by branch (no releases, mocked)')
+  .get('/v/release/user/repo/main.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, []),
+  )
+  .expectBadge({ label: 'latest-release', message: 'no releases found' })
+
+t.create('Release by branch (prerelease excluded, mocked)')
+  .get('/v/release/user/repo/main.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v2.0.0-beta',
+          target_commitish: 'main',
+          prerelease: true,
+          name: '',
+          assets: [],
+        },
+      ])
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 2 })
+      .reply(200, []),
+  )
+  .expectBadge({
+    label: 'latest-release',
+    message: 'no release found for branch',
+  })
+
+t.create('Release by branch (stable after prerelease, mocked)')
+  .get('/v/release/user/repo/main.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/user/repo/releases')
+      .query({ per_page: 100, page: 1 })
+      .reply(200, [
+        {
+          tag_name: 'v2.0.0-beta',
+          target_commitish: 'main',
+          prerelease: true,
+          name: '',
+          assets: [],
+        },
+        {
+          tag_name: 'v2.0.0',
+          target_commitish: 'main',
+          prerelease: false,
+          name: '',
+          assets: [],
+        },
+      ]),
+  )
+  .expectBadge({
+    label: 'latest-release@main',
+    message: 'v2.0.0',
+    color: 'blue',
+  })
+
+t.create('Release by branch (prerelease color)')
+  .get('/v/release/laravel/framework/13.x.json?include_prereleases')
+  .expectBadge({
+    label: 'latest-release@13.x',
+    message: isSemver,
+    color: Joi.equal('blue', 'orange').required(),
+  })


### PR DESCRIPTION
Closes #7929

## Summary

Adds a new version badge that shows the latest GitHub release for a specified branch. The badge matches releases using the `target_commitish` field from the GitHub releases API and paginates through release pages when needed.

## Example

```
https://img.shields.io/github/v/release/laravel/framework/13.x
```

Produces a badge labeled `latest-release@13.x` with the latest release version for that branch.

## API rate limits

This badge uses the [GitHub REST API](https://docs.github.com/en/rest/releases/releases) (`GET /repos/{owner}/{repo}/releases`). Unauthenticated requests are limited to 60 requests/hour per IP; authenticated requests allow 5,000 requests/hour per token. Shields.io uses configured GitHub tokens when available.

## Checklist

- [x] Service implementation (`services/github/github-release-branch.service.js`)
- [x] Unit tests (`services/github/github-release-branch.service.spec.js`)
- [x] Service tests (`services/github/github-release-branch.tester.js`)
- [x] Tests passing
- [x] `npm run lint` (0 errors)

## Testing

- `npm run test:core -- --grep GithubReleaseBranch` (9 passing)
- `npm run test:services -- --only=GithubReleaseBranch` (10 passing)
