### PR TITLE
Stop disallowing unknown keys; run [Endpoint]

### DIFF
--- a/core/base-service/base.js
+++ b/core/base-service/base.js
@@ -293,11 +293,7 @@ class BaseService {
   static _validate(
     data,
     schema,
-    {
-      prettyErrorMessage = 'invalid response data',
-      includeKeys = false,
-      allowAndStripUnknownKeys = true,
-    } = {},
+    { prettyErrorMessage = 'invalid response data', includeKeys = false } = {},
   ) {
     return validate(
       {
@@ -306,7 +302,6 @@ class BaseService {
         includeKeys,
         traceErrorMessage: 'Response did not match schema',
         traceSuccessMessage: 'Response after validation',
-        allowAndStripUnknownKeys,
       },
       data,
       schema,

--- a/core/base-service/validate.js
+++ b/core/base-service/validate.js
@@ -9,7 +9,6 @@ function validate(
     includeKeys = false,
     traceErrorMessage = 'Data did not match schema',
     traceSuccessMessage = 'Data after validation',
-    allowAndStripUnknownKeys = true,
   },
   data,
   schema,
@@ -17,11 +16,8 @@ function validate(
   if (!schema || !Joi.isSchema(schema)) {
     throw Error('A Joi schema is required')
   }
-  const options = { abortEarly: false }
-  if (allowAndStripUnknownKeys) {
-    options.allowUnknown = true
-    options.stripUnknown = true
-  }
+  const options = { abortEarly: false, allowUnknown: true, stripUnknown: true }
+
   const { error, value } = schema.validate(data, options)
   if (error) {
     trace.logTrace(

--- a/core/base-service/validate.spec.js
+++ b/core/base-service/validate.spec.js
@@ -102,20 +102,12 @@ describe('validate', function () {
     })
   })
 
-  it('allowAndStripUnknownKeys', function () {
-    try {
-      validate(
-        { ...options, allowAndStripUnknownKeys: false, includeKeys: true },
-        { requiredString: 'bar', extra: 'nonsense', more: 'bogus' },
-        schema,
-      )
-      expect.fail('Expected to throw')
-    } catch (e) {
-      expect(e).to.be.an.instanceof(InvalidParameter)
-      expect(e.message).to.equal(
-        'Invalid Parameter: "extra" is not allowed. "more" is not allowed',
-      )
-      expect(e.prettyMessage).to.equal(`${prettyErrorMessage}: extra, more`)
-    }
+  it('allows but strips unknown keys', function () {
+    const result = validate(
+      { ...options, includeKeys: true },
+      { requiredString: 'bar', extra: 'nonsense', more: 'bogus' },
+      schema,
+    )
+    expect(result).to.deep.equal({ requiredString: 'bar' })
   })
 })

--- a/services/endpoint-common.js
+++ b/services/endpoint-common.js
@@ -51,9 +51,7 @@ const endpointSchema = Joi.object({
   .required()
 
 /**
- * Strictly validate the data according to the endpoint schema.
- * This rejects unknown/invalid keys.
- * Optionally it prints those keys in the message to provide detailed feedback.
+ * Validate the data according to the endpoint schema.
  *
  * @param {object} data Object containing the data for validation
  * @param {object} attrs Refer to individual attributes
@@ -73,7 +71,6 @@ function validateEndpointData(
       includeKeys,
       traceErrorMessage: 'Response did not match schema',
       traceSuccessMessage: 'Response after validation',
-      allowAndStripUnknownKeys: false,
     },
     data,
     endpointSchema,

--- a/services/endpoint/endpoint.tester.js
+++ b/services/endpoint/endpoint.tester.js
@@ -166,7 +166,7 @@ t.create('Invalid schema')
     message: 'invalid properties: schemaVersion, label, message',
   })
 
-t.create('Invalid schema')
+t.create('Valid schema with extra keys')
   .get('.json?url=https://example.com/badge')
   .intercept(nock =>
     nock('https://example.com/').get('/badge').reply(200, {
@@ -178,8 +178,8 @@ t.create('Invalid schema')
     }),
   )
   .expectBadge({
-    label: 'custom badge',
-    message: 'invalid properties: extra, bogus',
+    label: 'hey',
+    message: 'yo',
   })
 
 t.create('User color overrides success color')


### PR DESCRIPTION
Fixes #11934. We didn't win much by disallowing unknown keys in the endpoint badge, let's simplify things a little and make some uses cases easier.