### PR TITLE
badge-maker 6.0.0 release

### DIFF
--- a/badge-maker/CHANGELOG.md
+++ b/badge-maker/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 6.0.0
+
+### Visual Changes
+
+- Generated badges have a new standard palette with higher text contrast. See [this PR](https://github.com/badges/shields/pull/11783) for more information.
+
+### Other Changes
+
+- badge-maker was switched from CC0 to MIT and Apache 2.0 licenses. See [this blog post](https://shields.io/blog/mit-apache-license) for more information.
+- The structure of the generated SVGs has been optimised.
+
 ## 5.0.2
 
 ### Bug Fixes

--- a/badge-maker/package.json
+++ b/badge-maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "badge-maker",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "type": "module",
   "exports": {
     ".": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,7 @@
       }
     },
     "badge-maker": {
-      "version": "5.0.2",
+      "version": "6.0.0",
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "anafanafo": "2.0.0",


### PR DESCRIPTION
Ships new styling/constrat, SVG optimisations, and new licenses. There aren't any "breakingæ changes per say, but it does feel like a major version bump is justified here. Closes #11868.