### PR TITLE
[AzureDevOpsBuild] Use PAT auth for Azure DevOps build badges

### DIFF
--- a/services/azure-devops/azure-devops-build.service.js
+++ b/services/azure-devops/azure-devops-build.service.js
@@ -36,6 +36,12 @@ Navigate to \`https://dev.azure.com/ORGANIZATION/_apis/projects/PROJECT_NAME\`
 `
 
 export default class AzureDevOpsBuild extends BaseSvgScrapingService {
+  static auth = {
+    passKey: 'azure_devops_token',
+    authorizedOrigins: ['https://dev.azure.com'],
+    defaultToEmptyStringForUser: true,
+  }
+
   static category = 'build'
 
   static route = {

--- a/services/azure-devops/azure-devops-build.service.js
+++ b/services/azure-devops/azure-devops-build.service.js
@@ -36,18 +36,18 @@ Navigate to \`https://dev.azure.com/ORGANIZATION/_apis/projects/PROJECT_NAME\`
 `
 
 export default class AzureDevOpsBuild extends BaseSvgScrapingService {
-  static auth = {
-    passKey: 'azure_devops_token',
-    authorizedOrigins: ['https://dev.azure.com'],
-    defaultToEmptyStringForUser: true,
-  }
-
   static category = 'build'
 
   static route = {
     base: 'azure-devops/build',
     pattern: ':organization/:projectId/:definitionId/:branch*',
     queryParamSchema,
+  }
+
+  static auth = {
+    passKey: 'azure_devops_token',
+    authorizedOrigins: ['https://dev.azure.com'],
+    defaultToEmptyStringForUser: true,
   }
 
   static openApi = {

--- a/services/azure-devops/azure-devops-build.spec.js
+++ b/services/azure-devops/azure-devops-build.spec.js
@@ -1,0 +1,13 @@
+import { testAuth } from '../test-helpers.js'
+import AzureDevOpsBuild from './azure-devops-build.service.js'
+
+const passingSvg =
+  '<?xml version="1.0"?><svg xmlns="http://www.w3.org/2000/svg"><g><text>passing</text></g></svg>'
+
+describe('AzureDevOpsBuild', function () {
+  describe('auth', function () {
+    it('sends the auth information as configured', async function () {
+      return testAuth(AzureDevOpsBuild, 'BasicAuth', passingSvg)
+    })
+  })
+})

--- a/services/azure-devops/azure-devops-helpers.js
+++ b/services/azure-devops/azure-devops-helpers.js
@@ -15,12 +15,16 @@ const schema = Joi.object({
 
 async function fetch(serviceInstance, { url, searchParams = {}, httpErrors }) {
   // Microsoft documentation: https://docs.microsoft.com/en-us/rest/api/vsts/build/status/get
-  const { message: status } = await serviceInstance._requestSvg({
+  let requestParams = {
     schema,
     url,
     options: { searchParams },
     httpErrors,
-  })
+  }
+  if (serviceInstance.authHelper?.isConfigured) {
+    requestParams = serviceInstance.authHelper.withBasicAuth(requestParams)
+  }
+  const { message: status } = await serviceInstance._requestSvg(requestParams)
   return { status }
 }
 


### PR DESCRIPTION
Closes #10162

## Summary

Azure DevOps build badges scrape SVG status endpoints from dev.azure.com but previously did not pass the configured `azure_devops_token` PAT. Other Azure DevOps badges (tests, coverage) already use basic auth via `AzureDevOpsBase`.

This change adds the same auth configuration to `AzureDevOpsBuild` and updates the shared SVG fetch helper to include basic auth when a PAT is configured, enabling build badges for private projects.

## Example

```
https://img.shields.io/azure-devops/build/totodem/8cf3ec0e-d0c2-4fcd-8206-ad204f254a96/2
```

## API rate limits

The [Azure DevOps REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/) does not publish a single global rate limit; limits vary by organization and service tier. This badge issues one GET per render to the build status SVG endpoint.

## Changes

- Add `static auth` to `AzureDevOpsBuild` using `azure_devops_token`
- Update `azure-devops-helpers.js` to pass auth through `_requestSvg` when configured
- Add `azure-devops-build.spec.js` auth test

## Checklist

- [x] Service implementation updated
- [x] Unit tests added
- [x] Tests passing
- [x] `npm run lint` (0 errors)

## Testing

```
npm run test:services -- --only=AzureDevOpsBuild
NODE_CONFIG_ENV=test npx mocha services/azure-devops/azure-devops-build.spec.js
```
