### PR TITLE
Align [PyPI] service naming with other services

### DIFF
--- a/cypress/e2e/main-page.cy.js
+++ b/cypress/e2e/main-page.cy.js
@@ -16,7 +16,7 @@ describe('Frontend', function () {
 
     cy.get(SEARCH_INPUT).type('pypi')
 
-    cy.contains('PyPI - License')
+    cy.contains('PyPI License')
   })
 
   it('Shows badges from category', function () {

--- a/services/pypi/pypi-downloads.service.js
+++ b/services/pypi/pypi-downloads.service.js
@@ -40,7 +40,7 @@ export default class PypiDownloads extends BaseJsonService {
   static openApi = {
     '/pypi/{period}/{packageName}': {
       get: {
-        summary: 'PyPI - Downloads',
+        summary: 'PyPI Downloads',
         description:
           'Python package downloads from [pypistats](https://pypistats.org/)',
         parameters: [

--- a/services/pypi/pypi-format.service.js
+++ b/services/pypi/pypi-format.service.js
@@ -9,7 +9,7 @@ export default class PypiFormat extends PypiBase {
   static openApi = {
     '/pypi/format/{packageName}': {
       get: {
-        summary: 'PyPI - Format',
+        summary: 'PyPI Format',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-framework-versions.service.js
+++ b/services/pypi/pypi-framework-versions.service.js
@@ -54,7 +54,7 @@ export default class PypiFrameworkVersion extends PypiBase {
   static openApi = {
     '/pypi/frameworkversions/{frameworkName}/{packageName}': {
       get: {
-        summary: 'PyPI - Versions from Framework Classifiers',
+        summary: 'PyPI Versions from Framework Classifiers',
         description,
         parameters: pathParams(
           {

--- a/services/pypi/pypi-implementation.service.js
+++ b/services/pypi/pypi-implementation.service.js
@@ -9,7 +9,7 @@ export default class PypiImplementation extends PypiBase {
   static openApi = {
     '/pypi/implementation/{packageName}': {
       get: {
-        summary: 'PyPI - Implementation',
+        summary: 'PyPI Implementation',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-license.service.js
+++ b/services/pypi/pypi-license.service.js
@@ -10,7 +10,7 @@ export default class PypiLicense extends PypiBase {
   static openApi = {
     '/pypi/l/{packageName}': {
       get: {
-        summary: 'PyPI - License',
+        summary: 'PyPI License',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-python-versions.service.js
+++ b/services/pypi/pypi-python-versions.service.js
@@ -10,7 +10,7 @@ export default class PypiPythonVersions extends PypiBase {
   static openApi = {
     '/pypi/pyversions/{packageName}': {
       get: {
-        summary: 'PyPI - Python Version',
+        summary: 'PyPI Python Version',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-status.service.js
+++ b/services/pypi/pypi-status.service.js
@@ -9,7 +9,7 @@ export default class PypiStatus extends PypiBase {
   static openApi = {
     '/pypi/status/{packageName}': {
       get: {
-        summary: 'PyPI - Status',
+        summary: 'PyPI Status',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-types.service.js
+++ b/services/pypi/pypi-types.service.js
@@ -8,7 +8,7 @@ export default class PypiTypes extends PypiBase {
   static openApi = {
     '/pypi/types/{packageName}': {
       get: {
-        summary: 'PyPI - Types',
+        summary: 'PyPI Types',
         description:
           'Type information provided by the package, as indicated by the presence of the `Typing :: Typed` and `Typing :: Stubs Only` classifiers in the package metadata',
         parameters: pypiGeneralParams,

--- a/services/pypi/pypi-version.service.js
+++ b/services/pypi/pypi-version.service.js
@@ -10,7 +10,7 @@ export default class PypiVersion extends PypiBase {
   static openApi = {
     '/pypi/v/{packageName}': {
       get: {
-        summary: 'PyPI - Version',
+        summary: 'PyPI Version',
         parameters: pypiGeneralParams,
       },
     },

--- a/services/pypi/pypi-wheel.service.js
+++ b/services/pypi/pypi-wheel.service.js
@@ -9,7 +9,7 @@ export default class PypiWheel extends PypiBase {
   static openApi = {
     '/pypi/wheel/{packageName}': {
       get: {
-        summary: 'PyPI - Wheel',
+        summary: 'PyPI Wheel',
         parameters: pypiGeneralParams,
       },
     },


### PR DESCRIPTION
Remove dashes in PyPI service names to align with other names. No code change.

New names (`-` after PyPI removed):
- PyPI License
- PyPI Downloads
- PyPI Format
- PyPI Versions from Framework Classifiers
- PyPI Implementation
- PyPI Python Version
- PyPI Status
- PyPI Types
- PyPI Version
- PyPI Wheel