### PR TITLE
Support multiple licenses in [NpmLicense]

### DIFF
--- a/services/npm/npm-license.service.js
+++ b/services/npm/npm-license.service.js
@@ -41,9 +41,12 @@ export default class NpmLicense extends NpmBase {
       packageName,
       registryUrl,
     })
-    const licenses = toArray(license).map(license =>
-      typeof license === 'string' ? license : license.type,
-    )
+    const licenses = toArray(license)
+      .map(license => (typeof license === 'string' ? license : license.type))
+      .flatMap(license => {
+        const match = license.match(/^\((.+)\)$/)
+        return match ? match[1].split(/\s+(?:OR|AND)\s+/) : [license]
+      })
     return this.constructor.render({ licenses })
   }
 }

--- a/services/npm/npm-license.tester.js
+++ b/services/npm/npm-license.tester.js
@@ -31,8 +31,8 @@ t.create(
   .get('/rho-cc-promise.json')
   .expectBadge({
     label: 'license',
-    message: '(MPL-2.0 OR MIT)',
-    color: 'lightgrey',
+    message: 'MPL-2.0, MIT',
+    color: 'green',
   })
 
 t.create('license for package without a license property')


### PR DESCRIPTION
The license badge we have been displaying since #11492 doesn't look nice:
<img width="433" height="264" alt="Screenshot 2026-06-27 at 16 32 50" src="https://github.com/user-attachments/assets/6d4580ec-986f-4b56-b60e-0bf08c98aa15" />

We've got the machinery in place to support multiple licenses, we just need to parse the [SPDX expression format](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license).