### PR TITLE
Fix Danger action by pinning Node.js version

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          # Pin below Node 22.23.0 which regressed node-fetch@2 (https://github.com/nodejs/node/issues/63989).
+          node-version: '22.22'
 
       - name: Danger
         run: npm run danger ci


### PR DESCRIPTION
Danger actions have been failing, related to https://github.com/nodejs/node/issues/63989. Let's temporarily pin the Node.js version.