### PR TITLE
Revert "update [crates] dependents badge description to include timeout issue (#11635)"

### DIFF
--- a/services/crates/crates-dependents.service.js
+++ b/services/crates/crates-dependents.service.js
@@ -4,14 +4,6 @@ import { metric } from '../text-formatters.js'
 import { nonNegativeInteger } from '../validators.js'
 import { BaseCratesService, description } from './crates-base.js'
 
-const dependentsDescription = `
-${description}
-
-Due to upstream API timeouts, crates with a very large number of dependents may fail to retrieve data.
-
-See [#11633](https://github.com/badges/shields/issues/11633) for more info.
-`
-
 const dependentsResponseSchema = Joi.object({
   meta: Joi.object({
     total: nonNegativeInteger,
@@ -26,7 +18,7 @@ export default class CratesDependents extends BaseCratesService {
     '/crates/dependents/{crate}': {
       get: {
         summary: 'Crates.io Dependents',
-        description: dependentsDescription,
+        description,
         parameters: pathParams({
           name: 'crate',
           example: 'tokio',


### PR DESCRIPTION
This reverts commit b912666b27962ea9a7d13e2e21c53d01d495371d.

due to fix of the ongoing problem in #11633

tested api calls that used to take seconds now response in <0.5s

<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->
