### PR TITLE
docs(core): add JSDoc to checkErrorResponse and test-results helpers

### DIFF
--- a/core/base-service/check-error-response.js
+++ b/core/base-service/check-error-response.js
@@ -1,3 +1,7 @@
+/**
+ * @module
+ */
+
 import log from '../server/log.js'
 import { NotFound, InvalidResponse, Inaccessible } from './errors.js'
 
@@ -8,6 +12,24 @@ const defaultErrorMessages = {
 
 const headersToInclude = ['cf-ray']
 
+/**
+ * Create a handler that validates HTTP status codes from upstream API responses.
+ *
+ * Used in the `got` response pipeline by {@link module:core/base-service/base~BaseService}
+ * and related helpers. On status 200 the handler returns the inputs unchanged.
+ * On other status codes it throws a {@link NotFound}, {@link InvalidResponse}, or
+ * {@link Inaccessible} exception. Thrown errors include `response` and `buffer`
+ * from the upstream call for debugging.
+ *
+ * @param {object} [httpErrors={}] Status-code-to-message map merged with defaults.
+ *   Keys are numeric HTTP status codes. Values set the `prettyMessage` shown on
+ *   the badge. Defaults include `404: 'not found'` and
+ *   `429: 'rate limited by upstream service'`.
+ * @param {number[]} [logErrors=[429]] Status codes to log when encountered.
+ *   Selected response headers (for example `cf-ray`) are attached as log tags.
+ * @returns {function({buffer: Buffer, res: object}): Promise<{buffer: Buffer, res: object}>}
+ *   Async handler. Resolves with `{ buffer, res }` on 200; otherwise throws.
+ */
 export default function checkErrorResponse(httpErrors = {}, logErrors = [429]) {
   return async function ({ buffer, res }) {
     let error

--- a/services/test-results.js
+++ b/services/test-results.js
@@ -1,3 +1,9 @@
+/**
+ * Helpers for formatting test-result badge messages and colors.
+ *
+ * @module
+ */
+
 import Joi from 'joi'
 import { queryParams } from './index.js'
 
@@ -19,6 +25,20 @@ const testResultOpenApiQueryParams = queryParams(
   { name: 'skipped_label', example: 'n/a' },
 )
 
+/**
+ * Format test counts into a badge message string.
+ *
+ * @param {object} attrs Refer to individual attrs
+ * @param {number} attrs.passed Number of passing tests.
+ * @param {number} attrs.failed Number of failing tests.
+ * @param {number} attrs.skipped Number of skipped tests.
+ * @param {number} attrs.total Total number of tests.
+ * @param {string} [attrs.passedLabel] Label for passing tests in verbose mode.
+ * @param {string} [attrs.failedLabel] Label for failing tests in verbose mode.
+ * @param {string} [attrs.skippedLabel] Label for skipped tests in verbose mode.
+ * @param {boolean} [attrs.isCompact] When true, use compact symbols separated by ` | `.
+ * @returns {string} Formatted message, or `no tests` when total is zero.
+ */
 function renderTestResultMessage({
   passed,
   failed,
@@ -57,6 +77,23 @@ function renderTestResultMessage({
   }
 }
 
+/**
+ * Render badge data for a test result summary.
+ *
+ * Chooses badge color from pass/fail/skip counts and delegates message formatting
+ * to {@link renderTestResultMessage}.
+ *
+ * @param {object} attrs Refer to individual attrs
+ * @param {number} attrs.passed Number of passing tests.
+ * @param {number} attrs.failed Number of failing tests.
+ * @param {number} attrs.skipped Number of skipped tests.
+ * @param {number} attrs.total Total number of tests.
+ * @param {string} [attrs.passedLabel] Label for passing tests in verbose mode.
+ * @param {string} [attrs.failedLabel] Label for failing tests in verbose mode.
+ * @param {string} [attrs.skippedLabel] Label for skipped tests in verbose mode.
+ * @param {boolean} [attrs.isCompact] When true, use compact symbols in the message.
+ * @returns {{message: string, color: string}} Badge message and shields color name.
+ */
 function renderTestResultBadge({
   passed,
   failed,


### PR DESCRIPTION
Contributes to #6038

Adds JSDoc to two undocumented areas:

- `checkErrorResponse` in `core/base-service/check-error-response.js`
- `renderTestResultMessage` and `renderTestResultBadge` in `services/test-results.js`

Verified with `npm run build-docs` (jsdoc --pedantic) and `npm run lint`.