### PR TITLE
docs: document category validation helpers

### DIFF
--- a/core/base-service/categories.js
+++ b/core/base-service/categories.js
@@ -1,12 +1,32 @@
+/**
+ * Helpers for validating service category identifiers.
+ *
+ * @module
+ */
+
 import Joi from 'joi'
 import categories from '../../services/categories.js'
 
 const isRealCategory = Joi.equal(...categories.map(({ id }) => id)).required()
 
+/**
+ * Joi validator for service categories registered by Shields, including the
+ * special `debug`, `dynamic`, and `static` categories.
+ *
+ * @type {Joi}
+ */
 const isValidCategory = Joi.alternatives()
   .try(isRealCategory, Joi.equal('debug', 'dynamic', 'static').required())
   .required()
 
+/**
+ * Assert that a value is a valid Shields service category.
+ *
+ * @param {string} category - Service category identifier to validate.
+ * @param {string} [message] - Optional prefix for the validation error.
+ * @throws {Error} When the category is not recognized.
+ * @returns {void}
+ */
 function assertValidCategory(category, message = undefined) {
   Joi.assert(category, isValidCategory, message)
 }


### PR DESCRIPTION
## Summary

- add a module overview for the service category validation helpers
- document the exported `isValidCategory` Joi validator and its special categories
- document `assertValidCategory` parameters, validation failure, and return type

## Why

`core/base-service/categories.js` exports core helpers without JSDoc. This contributes to #6038, which tracks complete generated API documentation for the core framework.

## Impact

There are no runtime behavior changes. Contributors using the generated API documentation can now see the accepted category semantics and the assertion helper's contract.

## Validation

- `npm run build-docs`
- `npm run lint`
- `prettier --check core/base-service/categories.js`
- `git diff --check`

Contributes to #6038
