### PR TITLE
ci: pin setup-flyctl to a full commit SHA

### DIFF
--- a/.github/workflows/cleanup-review-apps.yml
+++ b/.github/workflows/cleanup-review-apps.yml
@@ -11,7 +11,7 @@ jobs:
     environment: 'Review Apps'
     steps:
       - uses: actions/checkout@v7
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: install jq
         run: |

--- a/.github/workflows/deploy-review-app.yml
+++ b/.github/workflows/deploy-review-app.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
 
       - name: install jq
         run: |


### PR DESCRIPTION
## What
Pin `superfly/flyctl-actions/setup-flyctl` in `deploy-review-app.yml` and `cleanup-review-apps.yml` from the mutable `@master` branch to the commit it resolves to.

## Why
Those jobs pass `FLY_API_TOKEN` — and `deploy-review-app` also exposes the `SERVICETESTS_*` credentials and `GH_PAT` — to this third-party action via the moving `@master` branch, so the code that runs with those secrets can change without any change here (the tj-actions/changed-files class of risk). Pinning to a full SHA closes that; behaviour unchanged (`ed8efb3` is the current tip).

I used AI assistance to identify this and draft the change; I verified it against the live workflows myself.