### PR TITLE
docs(core): document metrics converter

### DIFF
--- a/core/server/metrics/format-converters.js
+++ b/core/server/metrics/format-converters.js
@@ -1,3 +1,13 @@
+/**
+ * Convert metrics from `prom-client` JSON to InfluxDB v2 line protocol.
+ *
+ * Samples with identical labels are grouped on one line. Labels and metric
+ * fields are sorted so the output is deterministic.
+ *
+ * @param {object[]} metrics Metrics returned by `Registry#getMetricsAsJSON()`.
+ * @param {object} [extraLabels={}] Labels appended to every metric.
+ * @returns {string} Metrics encoded as InfluxDB v2 line protocol.
+ */
 function promClientJsonToInfluxV2(metrics, extraLabels = {}) {
   return metrics
     .flatMap(metric => {


### PR DESCRIPTION
Refs #6038

Documents `promClientJsonToInfluxV2`, including its input source, grouping and deterministic ordering behavior, optional labels, and return format. This changes documentation only; runtime behavior is unchanged.

Validation:

- `NODE_CONFIG_ENV=test TZ=UTC ./node_modules/.bin/mocha core/server/metrics/format-converters.spec.js` (10 passing)
- `npm test` (1,700 passing; includes lint, type checks, and formatting)
- `npm run build-docs`
- `git diff --check`

AI disclosure: OpenAI Codex was used to prepare this contribution. The diff and validation results were checked in the local environment.
