### PR TITLE
docs: document legacy result sender

### DIFF
--- a/core/base-service/legacy-result-sender.js
+++ b/core/base-service/legacy-result-sender.js
@@ -1,3 +1,10 @@
+/**
+ * Helpers for returning rendered badge responses through the legacy request
+ * pipeline.
+ *
+ * @module
+ */
+
 import stream from 'stream'
 
 function streamFromString(str) {
@@ -26,6 +33,15 @@ function sendEmpty(end) {
   end(null, { template: streamFromString('') })
 }
 
+/**
+ * Create a sender for a rendered badge response in the requested format.
+ *
+ * @param {'svg'|'json'|'empty'} format - Response format to send.
+ * @param {object} askres - HTTP response used to set format-specific headers.
+ * @param {Function} end - Callback that completes the request.
+ * @throws {Error} When the response format is not recognized.
+ * @returns {Function} Function that sends the rendered response body.
+ */
 function makeSend(format, askres, end) {
   if (format === 'svg') {
     return res => sendSVG(res, askres, end)


### PR DESCRIPTION
## Summary

- add a module overview for the legacy rendered-response helpers
- document `makeSend` formats, response and callback parameters, failure behavior, and return value

## Why

This contributes a small, bounded core docstring improvement to #6038. It changes documentation only; runtime behavior is unchanged.

## Validation

- `npm run build-docs`
- `npm run lint`
- `npm run test:package` (171 passing)
- `npm run test:core` (1,528 passing)
- `npm run test:entrypoint` (1 passing)
- `npm run check-types:package`
- `npm run prettier:check`
- `git diff --check`

## AI disclosure

OpenAI Codex assisted with implementation, validation, and drafting this description.
