### PR TITLE
Migrate [Jenkins] tests and examples from Eclipse to FreeBSD

### DIFF
--- a/services/jenkins/jenkins-build.service.js
+++ b/services/jenkins/jenkins-build.service.js
@@ -48,7 +48,7 @@ export default class JenkinsBuild extends JenkinsBase {
         parameters: [
           queryParam({
             name: 'jobUrl',
-            example: 'https://ci.eclipse.org/jgit/job/jgit',
+            example: 'https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
             required: true,
           }),
         ],

--- a/services/jenkins/jenkins-build.spec.js
+++ b/services/jenkins/jenkins-build.spec.js
@@ -7,7 +7,7 @@ const authConfigOverride = {
   public: {
     services: {
       jenkins: {
-        authorizedOrigins: ['https://ci.eclipse.org'],
+        authorizedOrigins: ['https://ci.freebsd.org'],
       },
     },
   },

--- a/services/jenkins/jenkins-build.tester.js
+++ b/services/jenkins/jenkins-build.tester.js
@@ -3,13 +3,15 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('build job not found')
-  .get('/build.json?jobUrl=https://ci.eclipse.org/jgit/job/does-not-exist')
+  .get('/build.json?jobUrl=https://ci.freebsd.org/job/does-not-exist')
   .expectBadge({ label: 'build', message: 'instance or job not found' })
 
 t.create('build found (view)')
-  .get('/build.json?jobUrl=https://ci.eclipse.org/jgit/view/all/job/jgit')
+  .get(
+    '/build.json?jobUrl=https://ci.freebsd.org/view/all/job/FreeBSD-main-amd64-test',
+  )
   .expectBadge({ label: 'build', message: isBuildStatus })
 
 t.create('build found (job)')
-  .get('/build.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit')
+  .get('/build.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-test')
   .expectBadge({ label: 'build', message: isBuildStatus })

--- a/services/jenkins/jenkins-common.spec.js
+++ b/services/jenkins/jenkins-common.spec.js
@@ -5,33 +5,33 @@ describe('jenkins-common', function () {
   describe('buildUrl', function () {
     it('returns the json api url', function () {
       const actualResult = buildUrl({
-        jobUrl: 'https://ci.eclipse.org/jgit/job/jgit',
+        jobUrl: 'https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
       })
 
       expect(actualResult).to.equal(
-        'https://ci.eclipse.org/jgit/job/jgit/lastCompletedBuild/api/json',
+        'https://ci.freebsd.org/job/FreeBSD-main-amd64-test/lastCompletedBuild/api/json',
       )
     })
 
     it('returns the json api url including a plugin name', function () {
       const actualResult = buildUrl({
-        jobUrl: 'https://ci.eclipse.org/jgit/job/jgit',
+        jobUrl: 'https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
         plugin: 'cobertura',
       })
 
       expect(actualResult).to.equal(
-        'https://ci.eclipse.org/jgit/job/jgit/lastCompletedBuild/cobertura/api/json',
+        'https://ci.freebsd.org/job/FreeBSD-main-amd64-test/lastCompletedBuild/cobertura/api/json',
       )
     })
 
     it('returns the json api url without the lastCompletedBuild element', function () {
       const actualResult = buildUrl({
-        jobUrl: 'https://ci.eclipse.org/jgit/job/jgit',
+        jobUrl: 'https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
         lastCompletedBuild: false,
       })
 
       expect(actualResult).to.equal(
-        'https://ci.eclipse.org/jgit/job/jgit/api/json',
+        'https://ci.freebsd.org/job/FreeBSD-main-amd64-test/api/json',
       )
     })
   })

--- a/services/jenkins/jenkins-tests.service.js
+++ b/services/jenkins/jenkins-tests.service.js
@@ -50,7 +50,7 @@ export default class JenkinsTests extends JenkinsBase {
         parameters: [
           queryParam({
             name: 'jobUrl',
-            example: 'https://ci.eclipse.org/jgit/job/jgit',
+            example: 'https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
             required: true,
           }),
           ...testResultOpenApiQueryParams,

--- a/services/jenkins/jenkins-tests.spec.js
+++ b/services/jenkins/jenkins-tests.spec.js
@@ -5,7 +5,7 @@ const authConfigOverride = {
   public: {
     services: {
       jenkins: {
-        authorizedOrigins: ['https://ci.eclipse.org'],
+        authorizedOrigins: ['https://ci.freebsd.org'],
       },
     },
   },

--- a/services/jenkins/jenkins-tests.tester.js
+++ b/services/jenkins/jenkins-tests.tester.js
@@ -13,43 +13,52 @@ export const t = await createServiceTester()
 // https://wiki.jenkins.io/pages/viewpage.action?pageId=58001258
 
 t.create('Test status')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit')
+  .get('/tests.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-test')
   .expectBadge({ label: 'tests', message: isDefaultTestTotals })
 
 t.create('Test status with compact message')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
-    qs: { compact_message: null },
-  })
+  .get(
+    '/tests.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
+    {
+      qs: { compact_message: null },
+    },
+  )
   .expectBadge({ label: 'tests', message: isDefaultCompactTestTotals })
 
 t.create('Test status with custom labels')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
-    qs: {
-      passed_label: 'good',
-      failed_label: 'bad',
-      skipped_label: 'n/a',
+  .get(
+    '/tests.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
+    {
+      qs: {
+        passed_label: 'good',
+        failed_label: 'bad',
+        skipped_label: 'n/a',
+      },
     },
-  })
+  )
   .expectBadge({ label: 'tests', message: isCustomTestTotals })
 
 t.create('Test status with compact message and custom labels')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/jgit/job/jgit', {
-    qs: {
-      compact_message: null,
-      passed_label: '💃',
-      failed_label: '🤦‍♀️',
-      skipped_label: '🤷',
+  .get(
+    '/tests.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-test',
+    {
+      qs: {
+        compact_message: null,
+        passed_label: '💃',
+        failed_label: '🤦‍♀️',
+        skipped_label: '🤷',
+      },
     },
-  })
+  )
   .expectBadge({
     label: 'tests',
     message: isCustomCompactTestTotals,
   })
 
 t.create('Test status on job with no tests')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/orbit/job/orbit-shell')
+  .get('/tests.json?jobUrl=https://ci.freebsd.org/job/FreeBSD-main-amd64-build')
   .expectBadge({ label: 'tests', message: 'no tests found' })
 
 t.create('Test status on non-existent job')
-  .get('/tests.json?jobUrl=https://ci.eclipse.org/orbit/job/does-not-exist')
+  .get('/tests.json?jobUrl=https://ci.freebsd.org/job/does-not-exist')
   .expectBadge({ label: 'tests', message: 'instance or job not found' })


### PR DESCRIPTION
https://ci.eclipse.org now requires authentication, let's migrate all tests and examples to https://ci.freebsd.org.