### PR TITLE
Fix [Codecov] tests

### DIFF
--- a/services/codecov/codecov.service.js
+++ b/services/codecov/codecov.service.js
@@ -79,7 +79,7 @@ export default class Codecov extends BaseSvgScrapingService {
             schema: { type: 'string', enum: this.getEnum('vcsName') },
           }),
           pathParam({ name: 'user', example: 'codecov' }),
-          pathParam({ name: 'repo', example: 'example-node' }),
+          pathParam({ name: 'repo', example: 'umbrella' }),
           queryParam({
             name: 'token',
             description: tokenDescription,

--- a/services/codecov/codecov.tester.js
+++ b/services/codecov/codecov.tester.js
@@ -10,7 +10,7 @@ t.create('gets coverage status')
   })
 
 t.create('gets coverage status with flag')
-  .get('/github/codecov/example-node.json?flag=istanbul_mocha')
+  .get('/github/codecov/umbrella.json?flag=workerunit')
   .expectBadge({
     label: 'coverage',
     message: isIntegerPercentage,
@@ -31,7 +31,7 @@ t.create('gets coverage status for branch')
   })
 
 t.create('gets coverage status for branch with flag')
-  .get('/github/codecov/example-node/master.json?flag=istanbul_mocha')
+  .get('/github/codecov/umbrella/main.json?flag=workerunit')
   .expectBadge({
     label: 'coverage',
     message: isIntegerPercentage,
@@ -70,14 +70,14 @@ t.create('handles unknown repository with component')
   })
 
 t.create('gets coverage status for unknown flag')
-  .get('/github/codecov/example-node.json?flag=unknown_flag')
+  .get('/github/codecov/umbrella.json?flag=unknown_flag')
   .expectBadge({
     label: 'coverage',
     message: 'unknown',
   })
 
 t.create('gets coverage status for unknown component')
-  .get('/github/codecov/example-node.json?component=unknown_component')
+  .get('/github/codecov/umbrella.json?component=unknown_component')
   .expectBadge({
     label: 'coverage',
     message: 'unknown',


### PR DESCRIPTION
Our previous example got completely restructured the other week: https://github.com/codecov/example-node/pull/53. Flag analysis is no longer enabled on the project. Let's switch to a different one.