### PR TITLE
[TRMNL] recipe badge service

### DIFF
--- a/services/trmnl/trmnl-base.js
+++ b/services/trmnl/trmnl-base.js
@@ -1,0 +1,17 @@
+import { BaseJsonService } from '../index.js'
+
+export default class TrmnlBase extends BaseJsonService {
+  async fetch({ recipeId, schema }) {
+    // This public proxy is maintained at:
+    // https://github.com/hossain-khan/trmnl-badges
+    // It provides caching and request deduplication in front of trmnl.com.
+    return this._requestJson({
+      schema,
+      url: 'https://trmnl-badges.gohk.xyz/api/stats',
+      options: { searchParams: { recipe: recipeId } },
+      httpErrors: {
+        404: 'recipe not found',
+      },
+    })
+  }
+}

--- a/services/trmnl/trmnl-connections.service.js
+++ b/services/trmnl/trmnl-connections.service.js
@@ -1,0 +1,58 @@
+import Joi from 'joi'
+import { pathParams } from '../index.js'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
+import TrmnlBase from './trmnl-base.js'
+
+const schema = Joi.object({
+  stats: Joi.object({
+    installs: nonNegativeInteger,
+    forks: nonNegativeInteger,
+  }).required(),
+}).required()
+
+const description =
+  'Total connections for a public [TRMNL Recipe](https://trmnl.com/recipes), calculated as installs plus forks. Data is fetched through the open-source [TRMNL Badges proxy](https://github.com/hossain-khan/trmnl-badges), which provides caching and request deduplication in front of the TRMNL API.'
+
+export default class TrmnlConnections extends TrmnlBase {
+  static category = 'social'
+
+  static route = {
+    base: 'trmnl/connections',
+    pattern: ':recipeId',
+  }
+
+  static openApi = {
+    '/trmnl/connections/{recipeId}': {
+      get: {
+        summary: 'TRMNL Recipe Connections',
+        description,
+        parameters: pathParams({
+          name: 'recipeId',
+          description: 'TRMNL Recipe ID',
+          example: '227153',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'connections', namedLogo: 'trmnl' }
+
+  static render({ recipeId, connections }) {
+    return {
+      message: metric(connections),
+      style: 'social',
+      color: 'blue',
+      link: [
+        `https://trmnl.com/recipes/${recipeId}`,
+        `https://trmnl.com/recipes/${recipeId}`,
+      ],
+    }
+  }
+
+  async handle({ recipeId }) {
+    const data = await this.fetch({ recipeId, schema })
+    const connections = data.stats.installs + data.stats.forks
+    return this.constructor.render({ recipeId, connections })
+  }
+}

--- a/services/trmnl/trmnl-connections.service.js
+++ b/services/trmnl/trmnl-connections.service.js
@@ -38,21 +38,16 @@ export default class TrmnlConnections extends TrmnlBase {
 
   static defaultBadgeData = { label: 'connections', namedLogo: 'trmnl' }
 
-  static render({ recipeId, connections }) {
+  static render({ connections }) {
     return {
       message: metric(connections),
-      style: 'social',
       color: 'blue',
-      link: [
-        `https://trmnl.com/recipes/${recipeId}`,
-        `https://trmnl.com/recipes/${recipeId}`,
-      ],
     }
   }
 
   async handle({ recipeId }) {
     const data = await this.fetch({ recipeId, schema })
     const connections = data.stats.installs + data.stats.forks
-    return this.constructor.render({ recipeId, connections })
+    return this.constructor.render({ connections })
   }
 }

--- a/services/trmnl/trmnl-connections.tester.js
+++ b/services/trmnl/trmnl-connections.tester.js
@@ -1,0 +1,43 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Recipe connections')
+  .get('/227153.json')
+  .expectBadge({
+    label: 'connections',
+    message: isMetric,
+    color: 'blue',
+    link: [
+      'https://trmnl.com/recipes/227153',
+      'https://trmnl.com/recipes/227153',
+    ],
+  })
+
+t.create('Calculates connections from installs and forks')
+  .get('/227153.json')
+  .intercept(nock =>
+    nock('https://trmnl-badges.gohk.xyz')
+      .get('/api/stats')
+      .query({ recipe: '227153' })
+      .reply(200, { stats: { installs: 6, forks: 188 } }),
+  )
+  .expectBadge({
+    label: 'connections',
+    message: '194',
+    color: 'blue',
+  })
+
+t.create('Recipe not found')
+  .get('/0.json')
+  .intercept(nock =>
+    nock('https://trmnl-badges.gohk.xyz')
+      .get('/api/stats')
+      .query({ recipe: '0' })
+      .reply(404, { error: 'Recipe not found' }),
+  )
+  .expectBadge({
+    label: 'connections',
+    message: 'recipe not found',
+  })

--- a/services/trmnl/trmnl-connections.tester.js
+++ b/services/trmnl/trmnl-connections.tester.js
@@ -23,15 +23,7 @@ t.create('Calculates connections from installs and forks')
     color: 'blue',
   })
 
-t.create('Recipe not found')
-  .get('/0.json')
-  .intercept(nock =>
-    nock('https://trmnl-badges.gohk.xyz')
-      .get('/api/stats')
-      .query({ recipe: '0' })
-      .reply(404, { error: 'Recipe not found' }),
-  )
-  .expectBadge({
-    label: 'connections',
-    message: 'recipe not found',
-  })
+t.create('Recipe not found').get('/0.json').expectBadge({
+  label: 'connections',
+  message: 'recipe not found',
+})

--- a/services/trmnl/trmnl-connections.tester.js
+++ b/services/trmnl/trmnl-connections.tester.js
@@ -3,17 +3,11 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('Recipe connections')
-  .get('/227153.json')
-  .expectBadge({
-    label: 'connections',
-    message: isMetric,
-    color: 'blue',
-    link: [
-      'https://trmnl.com/recipes/227153',
-      'https://trmnl.com/recipes/227153',
-    ],
-  })
+t.create('Recipe connections').get('/227153.json').expectBadge({
+  label: 'connections',
+  message: isMetric,
+  color: 'blue',
+})
 
 t.create('Calculates connections from installs and forks')
   .get('/227153.json')

--- a/services/trmnl/trmnl-forks.service.js
+++ b/services/trmnl/trmnl-forks.service.js
@@ -37,20 +37,15 @@ export default class TrmnlForks extends TrmnlBase {
 
   static defaultBadgeData = { label: 'forks', namedLogo: 'trmnl' }
 
-  static render({ recipeId, forks }) {
+  static render({ forks }) {
     return {
       message: metric(forks),
-      style: 'social',
       color: 'blue',
-      link: [
-        `https://trmnl.com/recipes/${recipeId}`,
-        `https://trmnl.com/recipes/${recipeId}`,
-      ],
     }
   }
 
   async handle({ recipeId }) {
     const data = await this.fetch({ recipeId, schema })
-    return this.constructor.render({ recipeId, forks: data.stats.forks })
+    return this.constructor.render({ forks: data.stats.forks })
   }
 }

--- a/services/trmnl/trmnl-forks.service.js
+++ b/services/trmnl/trmnl-forks.service.js
@@ -1,0 +1,56 @@
+import Joi from 'joi'
+import { pathParams } from '../index.js'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
+import TrmnlBase from './trmnl-base.js'
+
+const schema = Joi.object({
+  stats: Joi.object({
+    forks: nonNegativeInteger,
+  }).required(),
+}).required()
+
+const description =
+  'Number of forks for a public [TRMNL Recipe](https://trmnl.com/recipes). Data is fetched through the open-source [TRMNL Badges proxy](https://github.com/hossain-khan/trmnl-badges), which provides caching and request deduplication in front of the TRMNL API.'
+
+export default class TrmnlForks extends TrmnlBase {
+  static category = 'social'
+
+  static route = {
+    base: 'trmnl/forks',
+    pattern: ':recipeId',
+  }
+
+  static openApi = {
+    '/trmnl/forks/{recipeId}': {
+      get: {
+        summary: 'TRMNL Recipe Forks',
+        description,
+        parameters: pathParams({
+          name: 'recipeId',
+          description: 'TRMNL Recipe ID',
+          example: '227153',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'forks', namedLogo: 'trmnl' }
+
+  static render({ recipeId, forks }) {
+    return {
+      message: metric(forks),
+      style: 'social',
+      color: 'blue',
+      link: [
+        `https://trmnl.com/recipes/${recipeId}`,
+        `https://trmnl.com/recipes/${recipeId}`,
+      ],
+    }
+  }
+
+  async handle({ recipeId }) {
+    const data = await this.fetch({ recipeId, schema })
+    return this.constructor.render({ recipeId, forks: data.stats.forks })
+  }
+}

--- a/services/trmnl/trmnl-forks.tester.js
+++ b/services/trmnl/trmnl-forks.tester.js
@@ -3,17 +3,11 @@ import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
 
-t.create('Recipe forks')
-  .get('/227153.json')
-  .expectBadge({
-    label: 'forks',
-    message: isMetric,
-    color: 'blue',
-    link: [
-      'https://trmnl.com/recipes/227153',
-      'https://trmnl.com/recipes/227153',
-    ],
-  })
+t.create('Recipe forks').get('/227153.json').expectBadge({
+  label: 'forks',
+  message: isMetric,
+  color: 'blue',
+})
 
 t.create('Recipe not found')
   .get('/0.json')

--- a/services/trmnl/trmnl-forks.tester.js
+++ b/services/trmnl/trmnl-forks.tester.js
@@ -1,0 +1,29 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Recipe forks')
+  .get('/227153.json')
+  .expectBadge({
+    label: 'forks',
+    message: isMetric,
+    color: 'blue',
+    link: [
+      'https://trmnl.com/recipes/227153',
+      'https://trmnl.com/recipes/227153',
+    ],
+  })
+
+t.create('Recipe not found')
+  .get('/0.json')
+  .intercept(nock =>
+    nock('https://trmnl-badges.gohk.xyz')
+      .get('/api/stats')
+      .query({ recipe: '0' })
+      .reply(404, { error: 'Recipe not found' }),
+  )
+  .expectBadge({
+    label: 'forks',
+    message: 'recipe not found',
+  })

--- a/services/trmnl/trmnl-forks.tester.js
+++ b/services/trmnl/trmnl-forks.tester.js
@@ -9,15 +9,7 @@ t.create('Recipe forks').get('/227153.json').expectBadge({
   color: 'blue',
 })
 
-t.create('Recipe not found')
-  .get('/0.json')
-  .intercept(nock =>
-    nock('https://trmnl-badges.gohk.xyz')
-      .get('/api/stats')
-      .query({ recipe: '0' })
-      .reply(404, { error: 'Recipe not found' }),
-  )
-  .expectBadge({
-    label: 'forks',
-    message: 'recipe not found',
-  })
+t.create('Recipe not found').get('/0.json').expectBadge({
+  label: 'forks',
+  message: 'recipe not found',
+})

--- a/services/trmnl/trmnl-installs.service.js
+++ b/services/trmnl/trmnl-installs.service.js
@@ -1,0 +1,48 @@
+import Joi from 'joi'
+import { pathParams } from '../index.js'
+import { renderDownloadsBadge } from '../downloads.js'
+import { nonNegativeInteger } from '../validators.js'
+import TrmnlBase from './trmnl-base.js'
+
+const schema = Joi.object({
+  stats: Joi.object({
+    installs: nonNegativeInteger,
+  }).required(),
+}).required()
+
+const description =
+  'Number of installs for a public [TRMNL Recipe](https://trmnl.com/recipes). Data is fetched through the open-source [TRMNL Badges proxy](https://github.com/hossain-khan/trmnl-badges), which provides caching and request deduplication in front of the TRMNL API.'
+
+export default class TrmnlInstalls extends TrmnlBase {
+  static category = 'downloads'
+
+  static route = {
+    base: 'trmnl/installs',
+    pattern: ':recipeId',
+  }
+
+  static openApi = {
+    '/trmnl/installs/{recipeId}': {
+      get: {
+        summary: 'TRMNL Recipe Installs',
+        description,
+        parameters: pathParams({
+          name: 'recipeId',
+          description: 'TRMNL Recipe ID',
+          example: '227153',
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'installs' }
+
+  static render({ installs }) {
+    return renderDownloadsBadge({ downloads: installs })
+  }
+
+  async handle({ recipeId }) {
+    const data = await this.fetch({ recipeId, schema })
+    return this.constructor.render({ installs: data.stats.installs })
+  }
+}

--- a/services/trmnl/trmnl-installs.service.js
+++ b/services/trmnl/trmnl-installs.service.js
@@ -17,12 +17,12 @@ export default class TrmnlInstalls extends TrmnlBase {
   static category = 'downloads'
 
   static route = {
-    base: 'trmnl/installs',
+    base: 'trmnl/dt',
     pattern: ':recipeId',
   }
 
   static openApi = {
-    '/trmnl/installs/{recipeId}': {
+    '/trmnl/dt/{recipeId}': {
       get: {
         summary: 'TRMNL Recipe Installs',
         description,

--- a/services/trmnl/trmnl-installs.tester.js
+++ b/services/trmnl/trmnl-installs.tester.js
@@ -1,0 +1,35 @@
+import { isMetric } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('Recipe installs').get('/227153.json').expectBadge({
+  label: 'installs',
+  message: isMetric,
+})
+
+t.create('Recipe not found')
+  .get('/0.json')
+  .intercept(nock =>
+    nock('https://trmnl-badges.gohk.xyz')
+      .get('/api/stats')
+      .query({ recipe: '0' })
+      .reply(404, { error: 'Recipe not found' }),
+  )
+  .expectBadge({
+    label: 'installs',
+    message: 'recipe not found',
+  })
+
+t.create('Invalid response')
+  .get('/227153.json')
+  .intercept(nock =>
+    nock('https://trmnl-badges.gohk.xyz')
+      .get('/api/stats')
+      .query({ recipe: '227153' })
+      .reply(200, { stats: { installs: 'many', forks: 1 } }),
+  )
+  .expectBadge({
+    label: 'installs',
+    message: 'invalid response data',
+  })

--- a/services/trmnl/trmnl-installs.tester.js
+++ b/services/trmnl/trmnl-installs.tester.js
@@ -8,18 +8,10 @@ t.create('Recipe installs').get('/227153.json').expectBadge({
   message: isMetric,
 })
 
-t.create('Recipe not found')
-  .get('/0.json')
-  .intercept(nock =>
-    nock('https://trmnl-badges.gohk.xyz')
-      .get('/api/stats')
-      .query({ recipe: '0' })
-      .reply(404, { error: 'Recipe not found' }),
-  )
-  .expectBadge({
-    label: 'installs',
-    message: 'recipe not found',
-  })
+t.create('Recipe not found').get('/0.json').expectBadge({
+  label: 'installs',
+  message: 'recipe not found',
+})
 
 t.create('Invalid response')
   .get('/227153.json')


### PR DESCRIPTION
<!--
    Be sure to review our Contributing guidelines to help streamline the merging of your PR!

    * PR title conventions - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#running-service-tests-in-pull-requests
    * Code formatting - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#prettier
    * Merge processes and reminders - https://github.com/badges/shields/blob/master/CONTRIBUTING.md#pull-requests
-->

## Summary
Adding trmnl.com recipe badge service so that it's natively supported by shields.io - this service will complement existing custom badge service located at https://github.com/hossain-khan/trmnl-badges

This PR is inspired by [community post at discord](https://discord.com/channels/1281055965508141100/1479537493249622208/1525972551887487087)

<img width="824" height="206" alt="Screenshot 2026-07-18 at 3 03 44 PM" src="https://github.com/user-attachments/assets/2e1b84fd-b94e-4135-b869-2f52c2af2efa" />


> https://img.shields.io/badge/TRMNL-F8654B?logo=trmnl&logoColor=fff&style=flat-square

* TRMNL icon was added via simple-icons at https://github.com/badges/shields/pull/11834


## Testing

Here are some local test results


<img width="2142" height="2690" alt="trmnl-badge-preview html" src="https://github.com/user-attachments/assets/94a99fe8-b421-4bc6-b8f4-2c257853c657" />

[trmnl-badge-preview.html](https://github.com/user-attachments/files/30156262/trmnl-badge-preview.html)

