### PR TITLE
[GithubIssues GithubPullRequests] Add draft filters without changing unfiltered counts

### DIFF
--- a/services/github/github-issues.service.js
+++ b/services/github/github-issues.service.js
@@ -16,28 +16,9 @@ const issueCountSchema = Joi.object({
   }).required(),
 }).required()
 
-const pullRequestCountSchema = Joi.object({
-  data: Joi.object({
-    repository: Joi.object({
-      pullRequests: Joi.object({
-        totalCount: nonNegativeInteger,
-      }).required(),
-    }).required(),
-  }).required(),
-}).required()
-
-const isPRVariant = {
-  'issues-pr': true,
-  'issues-pr-raw': true,
-  'issues-pr-closed': true,
-  'issues-pr-closed-raw': true,
-}
-
 const isClosedVariant = {
   'issues-closed': true,
   'issues-closed-raw': true,
-  'issues-pr-closed': true,
-  'issues-pr-closed-raw': true,
 }
 
 export default class GithubIssues extends GithubAuthV4Service {
@@ -45,13 +26,13 @@ export default class GithubIssues extends GithubAuthV4Service {
   static route = {
     base: 'github',
     pattern:
-      ':variant(issues|issues-raw|issues-closed|issues-closed-raw|issues-pr|issues-pr-raw|issues-pr-closed|issues-pr-closed-raw)/:user/:repo/:label*',
+      ':variant(issues|issues-raw|issues-closed|issues-closed-raw)/:user/:repo/:label*',
   }
 
   static openApi = {
     '/github/{variant}/{user}/{repo}': {
       get: {
-        summary: 'GitHub Issues or Pull Requests',
+        summary: 'GitHub Issues',
         description: documentation,
         parameters: pathParams(
           {
@@ -66,7 +47,7 @@ export default class GithubIssues extends GithubAuthV4Service {
     },
     '/github/{variant}/{user}/{repo}/{label}': {
       get: {
-        summary: 'GitHub Issues or Pull Requests by label',
+        summary: 'GitHub Issues by label',
         description: documentation,
         parameters: pathParams(
           {
@@ -84,7 +65,7 @@ export default class GithubIssues extends GithubAuthV4Service {
 
   static defaultBadgeData = { label: 'issues', color: 'informational' }
 
-  static render({ isPR, isClosed, issueCount, raw, label }) {
+  static render({ isClosed, issueCount, raw, label }) {
     const state = isClosed ? 'closed' : 'open'
 
     let labelPrefix = ''
@@ -99,10 +80,8 @@ export default class GithubIssues extends GithubAuthV4Service {
     const labelText = label
       ? `${isGhLabelMultiWord ? `"${label}"` : label} `
       : ''
-    const labelSuffix = isPR ? 'pull requests' : 'issues'
-
     return {
-      label: `${labelPrefix}${labelText}${labelSuffix}`,
+      label: `${labelPrefix}${labelText}issues`,
       message: `${metric(issueCount)}${
         messageSuffix ? ' ' : ''
       }${messageSuffix}`,
@@ -110,88 +89,50 @@ export default class GithubIssues extends GithubAuthV4Service {
     }
   }
 
-  async fetch({ isPR, isClosed, user, repo, label }) {
-    const commonVariables = {
-      user,
-      repo,
-      labels: label ? [label] : undefined,
-    }
-    if (isPR) {
-      const {
-        data: {
-          repository: {
-            pullRequests: { totalCount },
-          },
+  async fetch({ isClosed, user, repo, label }) {
+    const {
+      data: {
+        repository: {
+          issues: { totalCount },
         },
-      } = await this._requestGraphql({
-        query: gql`
-          query (
-            $user: String!
-            $repo: String!
-            $states: [PullRequestState!]
-            $labels: [String!]
-          ) {
-            repository(owner: $user, name: $repo) {
-              pullRequests(states: $states, labels: $labels) {
-                totalCount
-              }
+      },
+    } = await this._requestGraphql({
+      query: gql`
+        query (
+          $user: String!
+          $repo: String!
+          $states: [IssueState!]
+          $labels: [String!]
+        ) {
+          repository(owner: $user, name: $repo) {
+            issues(states: $states, labels: $labels) {
+              totalCount
             }
           }
-        `,
-        variables: {
-          ...commonVariables,
-          states: isClosed ? ['MERGED', 'CLOSED'] : ['OPEN'],
-        },
-        schema: pullRequestCountSchema,
-        transformErrors,
-      })
-      return { issueCount: totalCount }
-    } else {
-      const {
-        data: {
-          repository: {
-            issues: { totalCount },
-          },
-        },
-      } = await this._requestGraphql({
-        query: gql`
-          query (
-            $user: String!
-            $repo: String!
-            $states: [IssueState!]
-            $labels: [String!]
-          ) {
-            repository(owner: $user, name: $repo) {
-              issues(states: $states, labels: $labels) {
-                totalCount
-              }
-            }
-          }
-        `,
-        variables: {
-          ...commonVariables,
-          states: isClosed ? ['CLOSED'] : ['OPEN'],
-        },
-        schema: issueCountSchema,
-        transformErrors,
-      })
-      return { issueCount: totalCount }
-    }
+        }
+      `,
+      variables: {
+        user,
+        repo,
+        labels: label ? [label] : undefined,
+        states: isClosed ? ['CLOSED'] : ['OPEN'],
+      },
+      schema: issueCountSchema,
+      transformErrors,
+    })
+    return { issueCount: totalCount }
   }
 
   async handle({ variant, user, repo, label }) {
     const raw = variant.endsWith('-raw')
-    const isPR = isPRVariant[variant]
     const isClosed = isClosedVariant[variant]
     const { issueCount } = await this.fetch({
-      isPR,
       isClosed,
       user,
       repo,
       label,
     })
     return this.constructor.render({
-      isPR,
       isClosed,
       issueCount,
       raw,

--- a/services/github/github-issues.tester.js
+++ b/services/github/github-issues.tester.js
@@ -3,36 +3,6 @@ import { isMetric, isMetricOpenIssues } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('GitHub closed pull requests')
-  .get('/issues-pr-closed/badges/shields.json')
-  .expectBadge({
-    label: 'pull requests',
-    message: Joi.string().regex(
-      /^([0-9]+[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) closed$/,
-    ),
-  })
-
-t.create('GitHub closed pull requests raw')
-  .get('/issues-pr-closed-raw/badges/shields.json')
-  .expectBadge({
-    label: 'closed pull requests',
-    message: isMetric,
-  })
-
-t.create('GitHub pull requests')
-  .get('/issues-pr/badges/shields.json')
-  .expectBadge({
-    label: 'pull requests',
-    message: isMetricOpenIssues,
-  })
-
-t.create('GitHub pull requests raw')
-  .get('/issues-pr-raw/badges/shields.json')
-  .expectBadge({
-    label: 'open pull requests',
-    message: isMetric,
-  })
-
 t.create('GitHub closed issues')
   .get('/issues-closed/badges/shields.json')
   .expectBadge({
@@ -93,18 +63,4 @@ t.create('GitHub open issues (repo not found)')
   .expectBadge({
     label: 'issues',
     message: 'repo not found',
-  })
-
-t.create('GitHub open pull requests by label')
-  .get('/issues-pr/badges/shields/service-badge.json')
-  .expectBadge({
-    label: 'service-badge pull requests',
-    message: isMetricOpenIssues,
-  })
-
-t.create('GitHub open pull requests by label (raw)')
-  .get('/issues-pr-raw/badges/shields/service-badge.json')
-  .expectBadge({
-    label: 'open service-badge pull requests',
-    message: isMetric,
   })

--- a/services/github/github-issues.tester.js
+++ b/services/github/github-issues.tester.js
@@ -3,6 +3,32 @@ import { isMetric, isMetricOpenIssues } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
+t.create('GitHub open issues remain on the repository query')
+  .get('/issues/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('repository(owner: $user, name: $repo)') &&
+          query.includes('issues(states: $states, labels: $labels)') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.[0] === 'OPEN'
+        )
+      })
+      .reply(200, {
+        data: { repository: { issues: { totalCount: 4 } } },
+      }),
+  )
+  .expectBadge({
+    label: 'issues',
+    message: '4 open',
+  })
+
 t.create('GitHub closed issues')
   .get('/issues-closed/badges/shields.json')
   .expectBadge({

--- a/services/github/github-issues.tester.js
+++ b/services/github/github-issues.tester.js
@@ -3,32 +3,6 @@ import { isMetric, isMetricOpenIssues } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('GitHub open issues remain on the repository query')
-  .get('/issues/example/project.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('repository(owner: $user, name: $repo)') &&
-          query.includes('issues(states: $states, labels: $labels)') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.[0] === 'OPEN'
-        )
-      })
-      .reply(200, {
-        data: { repository: { issues: { totalCount: 4 } } },
-      }),
-  )
-  .expectBadge({
-    label: 'issues',
-    message: '4 open',
-  })
-
 t.create('GitHub closed issues')
   .get('/issues-closed/badges/shields.json')
   .expectBadge({

--- a/services/github/github-pull-requests.service.js
+++ b/services/github/github-pull-requests.service.js
@@ -1,0 +1,182 @@
+import gql from 'graphql-tag'
+import Joi from 'joi'
+import { pathParams, queryParam } from '../index.js'
+import { metric } from '../text-formatters.js'
+import { nonNegativeInteger } from '../validators.js'
+import { GithubAuthV4Service } from './github-auth-service.js'
+import { documentation, transformErrors } from './github-helpers.js'
+
+const pullRequestCountSchema = Joi.object({
+  data: Joi.object({
+    repository: Joi.object({
+      id: Joi.string().required(),
+    }).required(),
+    search: Joi.object({
+      issueCount: nonNegativeInteger,
+    }).required(),
+  }).required(),
+}).required()
+
+const queryParamSchema = Joi.object({
+  excludeDrafts: Joi.equal(''),
+  onlyDrafts: Joi.equal(''),
+})
+  .oxor('excludeDrafts', 'onlyDrafts')
+  .required()
+
+const pullRequestVariants = [
+  'issues-pr',
+  'issues-pr-raw',
+  'issues-pr-closed',
+  'issues-pr-closed-raw',
+]
+
+const variantSummaries = {
+  'issues-pr': 'GitHub Pull Requests',
+  'issues-pr-raw': 'GitHub Pull Requests (raw)',
+  'issues-pr-closed': 'GitHub Closed Pull Requests',
+  'issues-pr-closed-raw': 'GitHub Closed Pull Requests (raw)',
+}
+
+function openApiRoute({ variant, label }) {
+  return {
+    get: {
+      summary: `${variantSummaries[variant]}${label ? ' by label' : ''}`,
+      description: documentation,
+      parameters: [
+        ...pathParams(
+          { name: 'user', example: 'badges' },
+          { name: 'repo', example: 'shields' },
+          ...(label ? [{ name: 'label', example: 'service-badge' }] : []),
+        ),
+        queryParam({
+          name: 'excludeDrafts',
+          description: 'Exclude draft pull requests',
+          example: null,
+          schema: { type: 'boolean' },
+        }),
+        queryParam({
+          name: 'onlyDrafts',
+          description: 'Only include draft pull requests',
+          example: null,
+          schema: { type: 'boolean' },
+        }),
+      ],
+    },
+  }
+}
+
+const openApi = Object.fromEntries(
+  pullRequestVariants.flatMap(variant => [
+    [
+      `/github/${variant}/{user}/{repo}`,
+      openApiRoute({ variant, label: false }),
+    ],
+    [
+      `/github/${variant}/{user}/{repo}/{label}`,
+      openApiRoute({ variant, label: true }),
+    ],
+  ]),
+)
+
+export default class GithubPullRequests extends GithubAuthV4Service {
+  static category = 'issue-tracking'
+  static route = {
+    base: 'github',
+    pattern:
+      ':variant(issues-pr|issues-pr-raw|issues-pr-closed|issues-pr-closed-raw)/:user/:repo/:label*',
+    queryParamSchema,
+  }
+
+  static openApi = openApi
+
+  static defaultBadgeData = {
+    label: 'pull requests',
+    color: 'informational',
+  }
+
+  static render({
+    issueCount,
+    label,
+    raw,
+    isClosed,
+    excludeDrafts,
+    onlyDrafts,
+  }) {
+    const state = isClosed ? 'closed' : 'open'
+    const isGhLabelMultiWord = label && label.includes(' ')
+    const labelText = label
+      ? `${isGhLabelMultiWord ? `"${label}"` : label} `
+      : ''
+    let draftText = ''
+    if (excludeDrafts) {
+      draftText = 'non-drafts '
+    } else if (onlyDrafts) {
+      draftText = 'drafts '
+    }
+
+    return {
+      label: `${raw ? `${state} ` : ''}${labelText}${draftText}pull requests`,
+      message: `${metric(issueCount)}${raw ? '' : ` ${state}`}`,
+      color: issueCount > 0 ? 'yellow' : 'brightgreen',
+    }
+  }
+
+  async fetch({ user, repo, label, isClosed, excludeDrafts, onlyDrafts }) {
+    const searchQualifiers = [
+      `repo:${user}/${repo}`,
+      'is:pr',
+      `is:${isClosed ? 'closed' : 'open'}`,
+    ]
+    if (label) {
+      searchQualifiers.push(`label:"${label}"`)
+    }
+    if (excludeDrafts) {
+      searchQualifiers.push('draft:false')
+    }
+    if (onlyDrafts) {
+      searchQualifiers.push('draft:true')
+    }
+
+    const data = await this._requestGraphql({
+      query: gql`
+        query ($query: String!, $user: String!, $repo: String!) {
+          repository(owner: $user, name: $repo) {
+            id
+          }
+          search(query: $query, type: ISSUE) {
+            issueCount
+          }
+        }
+      `,
+      variables: { query: searchQualifiers.join(' '), user, repo },
+      schema: pullRequestCountSchema,
+      transformErrors,
+    })
+
+    return data.data.search.issueCount
+  }
+
+  async handle({ variant, user, repo, label }, queryParams) {
+    const raw = variant.endsWith('-raw')
+    const isClosed = variant.includes('-closed')
+    const excludeDrafts = queryParams.excludeDrafts !== undefined
+    const onlyDrafts = queryParams.onlyDrafts !== undefined
+    const issueCount = await this.fetch({
+      user,
+      repo,
+      label,
+      isClosed,
+      excludeDrafts,
+      onlyDrafts,
+    })
+    return this.constructor.render({
+      issueCount,
+      label,
+      raw,
+      isClosed,
+      excludeDrafts,
+      onlyDrafts,
+    })
+  }
+}

--- a/services/github/github-pull-requests.service.js
+++ b/services/github/github-pull-requests.service.js
@@ -9,6 +9,16 @@ import { documentation, transformErrors } from './github-helpers.js'
 const pullRequestCountSchema = Joi.object({
   data: Joi.object({
     repository: Joi.object({
+      pullRequests: Joi.object({
+        totalCount: nonNegativeInteger,
+      }).required(),
+    }).required(),
+  }).required(),
+}).required()
+
+const pullRequestSearchSchema = Joi.object({
+  data: Joi.object({
+    repository: Joi.object({
       id: Joi.string().required(),
     }).required(),
     search: Joi.object({
@@ -110,9 +120,9 @@ export default class GithubPullRequests extends GithubAuthV4Service {
       : ''
     let draftText = ''
     if (excludeDrafts) {
-      draftText = 'non-drafts '
+      draftText = 'non-draft '
     } else if (onlyDrafts) {
-      draftText = 'drafts '
+      draftText = 'draft '
     }
 
     return {
@@ -123,6 +133,40 @@ export default class GithubPullRequests extends GithubAuthV4Service {
   }
 
   async fetch({ user, repo, label, isClosed, excludeDrafts, onlyDrafts }) {
+    if (!excludeDrafts && !onlyDrafts) {
+      const {
+        data: {
+          repository: {
+            pullRequests: { totalCount },
+          },
+        },
+      } = await this._requestGraphql({
+        query: gql`
+          query (
+            $user: String!
+            $repo: String!
+            $states: [PullRequestState!]
+            $labels: [String!]
+          ) {
+            repository(owner: $user, name: $repo) {
+              pullRequests(states: $states, labels: $labels) {
+                totalCount
+              }
+            }
+          }
+        `,
+        variables: {
+          user,
+          repo,
+          states: isClosed ? ['MERGED', 'CLOSED'] : ['OPEN'],
+          labels: label ? [label] : undefined,
+        },
+        schema: pullRequestCountSchema,
+        transformErrors,
+      })
+      return totalCount
+    }
+
     const searchQualifiers = [
       `repo:${user}/${repo}`,
       'is:pr',
@@ -150,7 +194,7 @@ export default class GithubPullRequests extends GithubAuthV4Service {
         }
       `,
       variables: { query: searchQualifiers.join(' '), user, repo },
-      schema: pullRequestCountSchema,
+      schema: pullRequestSearchSchema,
       transformErrors,
     })
 

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -21,12 +21,16 @@ t.create('GitHub pull requests without a draft filter')
             ? JSON.parse(requestBody)
             : requestBody
         return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:open'
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
+          !query.includes('search(') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.[0] === 'OPEN' &&
+          variables.labels === undefined
         )
       })
       .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 5 } },
+        data: { repository: { pullRequests: { totalCount: 5 } } },
       }),
   )
   .expectBadge({
@@ -44,12 +48,16 @@ t.create('GitHub pull requests raw without a draft filter')
             ? JSON.parse(requestBody)
             : requestBody
         return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:open'
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
+          !query.includes('search(') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.[0] === 'OPEN' &&
+          variables.labels === undefined
         )
       })
       .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 5 } },
+        data: { repository: { pullRequests: { totalCount: 5 } } },
       }),
   )
   .expectBadge({
@@ -74,12 +82,16 @@ t.create('GitHub closed pull requests without a draft filter')
             ? JSON.parse(requestBody)
             : requestBody
         return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:closed'
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
+          !query.includes('search(') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.join(',') === 'MERGED,CLOSED' &&
+          variables.labels === undefined
         )
       })
       .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 7 } },
+        data: { repository: { pullRequests: { totalCount: 7 } } },
       }),
   )
   .expectBadge({
@@ -106,12 +118,16 @@ t.create('GitHub closed pull requests raw without a draft filter')
             ? JSON.parse(requestBody)
             : requestBody
         return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:closed'
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
+          !query.includes('search(') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.join(',') === 'MERGED,CLOSED' &&
+          variables.labels === undefined
         )
       })
       .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 7 } },
+        data: { repository: { pullRequests: { totalCount: 7 } } },
       }),
   )
   .expectBadge({
@@ -145,7 +161,7 @@ t.create('GitHub closed pull requests raw with only drafts')
       }),
   )
   .expectBadge({
-    label: 'closed drafts pull requests',
+    label: 'closed draft pull requests',
     message: '1',
   })
 
@@ -168,7 +184,7 @@ t.create('GitHub pull requests excluding drafts')
       }),
   )
   .expectBadge({
-    label: 'non-drafts pull requests',
+    label: 'non-draft pull requests',
     message: '3 open',
   })
 
@@ -191,7 +207,7 @@ t.create('GitHub pull requests with only drafts')
       }),
   )
   .expectBadge({
-    label: 'drafts pull requests',
+    label: 'draft pull requests',
     message: '2 open',
   })
 
@@ -215,7 +231,7 @@ t.create('GitHub pull requests by multi-word label excluding drafts')
       }),
   )
   .expectBadge({
-    label: '"feature request" non-drafts pull requests',
+    label: '"feature request" non-draft pull requests',
     message: '2 open',
   })
 
@@ -245,14 +261,14 @@ t.create('GitHub pull requests (repo not found)')
             : requestBody
         return (
           query.includes('repository(owner: $user, name: $repo)') &&
-          query.includes('search(query: $query, type: ISSUE)') &&
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
           variables.user === 'example' &&
           variables.repo === 'missing' &&
-          variables.query === 'repo:example/missing is:pr is:open'
+          variables.states?.[0] === 'OPEN'
         )
       })
       .reply(200, {
-        data: { repository: null, search: { issueCount: 0 } },
+        data: { repository: null },
         errors: [
           { type: 'NOT_FOUND', message: 'Could not resolve repository' },
         ],
@@ -264,12 +280,12 @@ t.create('GitHub pull requests (repo not found)')
   })
 
 t.create('GitHub pull requests with malformed response data')
-  .get('/issues-pr/example/project.json')
+  .get('/issues-pr/example/project.json?excludeDrafts')
   .intercept(nock =>
     nock('https://api.github.com/')
       .post('/graphql')
       .reply(200, {
-        data: { repository: {}, search: { issueCount: 5 } },
+        data: { repository: { id: 'R_example' }, search: {} },
       }),
   )
   .expectBadge({
@@ -277,11 +293,31 @@ t.create('GitHub pull requests with malformed response data')
     message: 'invalid response data',
   })
 
-t.create('GitHub open pull requests by label')
-  .get('/issues-pr/badges/shields/service-badge.json')
+t.create('GitHub open pull requests by label without a draft filter')
+  .get('/issues-pr/example/project/service-badge.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('pullRequests(states: $states, labels: $labels)') &&
+          !query.includes('search(') &&
+          variables.user === 'example' &&
+          variables.repo === 'project' &&
+          variables.states?.[0] === 'OPEN' &&
+          variables.labels?.join(',') === 'service-badge'
+        )
+      })
+      .reply(200, {
+        data: { repository: { pullRequests: { totalCount: 4 } } },
+      }),
+  )
   .expectBadge({
     label: 'service-badge pull requests',
-    message: isMetricOpenIssues,
+    message: '4 open',
   })
 
 t.create('GitHub open pull requests by label (raw)')

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -11,11 +11,80 @@ t.create('GitHub pull requests')
     message: isMetricOpenIssues,
   })
 
+t.create('GitHub pull requests without a draft filter')
+  .get('/issues-pr/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:open'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 5 } },
+      }),
+  )
+  .expectBadge({
+    label: 'pull requests',
+    message: '5 open',
+  })
+
+t.create('GitHub pull requests raw without a draft filter')
+  .get('/issues-pr-raw/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:open'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 5 } },
+      }),
+  )
+  .expectBadge({
+    label: 'open pull requests',
+    message: '5',
+  })
+
 t.create('GitHub pull requests raw')
   .get('/issues-pr-raw/badges/shields.json')
   .expectBadge({
     label: 'open pull requests',
     message: isMetric,
+  })
+
+t.create('GitHub closed pull requests without a draft filter')
+  .get('/issues-pr-closed/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:closed'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 7 } },
+      }),
+  )
+  .expectBadge({
+    label: 'pull requests',
+    message: '7 closed',
   })
 
 t.create('GitHub closed pull requests')
@@ -25,6 +94,29 @@ t.create('GitHub closed pull requests')
     message: Joi.string().regex(
       /^([0-9]+[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) closed$/,
     ),
+  })
+
+t.create('GitHub closed pull requests raw without a draft filter')
+  .get('/issues-pr-closed-raw/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:closed'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 7 } },
+      }),
+  )
+  .expectBadge({
+    label: 'closed pull requests',
+    message: '7',
   })
 
 t.create('GitHub closed pull requests raw')

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -263,6 +263,20 @@ t.create('GitHub pull requests (repo not found)')
     message: 'repo not found',
   })
 
+t.create('GitHub pull requests with malformed response data')
+  .get('/issues-pr/example/project.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql')
+      .reply(200, {
+        data: { repository: {}, search: { issueCount: 5 } },
+      }),
+  )
+  .expectBadge({
+    label: 'pull requests',
+    message: 'invalid response data',
+  })
+
 t.create('GitHub open pull requests by label')
   .get('/issues-pr/badges/shields/service-badge.json')
   .expectBadge({

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -126,6 +126,99 @@ t.create('GitHub closed pull requests raw')
     message: isMetric,
   })
 
+t.create('GitHub closed pull requests raw with only drafts')
+  .get('/issues-pr-closed-raw/example/project.json?onlyDrafts')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:closed draft:true'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 1 } },
+      }),
+  )
+  .expectBadge({
+    label: 'closed drafts pull requests',
+    message: '1',
+  })
+
+t.create('GitHub pull requests excluding drafts')
+  .get('/issues-pr/example/project.json?excludeDrafts')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:open draft:false'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 3 } },
+      }),
+  )
+  .expectBadge({
+    label: 'non-drafts pull requests',
+    message: '3 open',
+  })
+
+t.create('GitHub pull requests with only drafts')
+  .get('/issues-pr/example/project.json?onlyDrafts')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query === 'repo:example/project is:pr is:open draft:true'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 2 } },
+      }),
+  )
+  .expectBadge({
+    label: 'drafts pull requests',
+    message: '2 open',
+  })
+
+t.create('GitHub pull requests by multi-word label excluding drafts')
+  .get('/issues-pr/example/project/feature%20request.json?excludeDrafts')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.query ===
+            'repo:example/project is:pr is:open label:"feature request" draft:false'
+        )
+      })
+      .reply(200, {
+        data: { repository: { id: 'R_example' }, search: { issueCount: 2 } },
+      }),
+  )
+  .expectBadge({
+    label: '"feature request" non-drafts pull requests',
+    message: '2 open',
+  })
+
 t.create('GitHub open pull requests by label')
   .get('/issues-pr/badges/shields/service-badge.json')
   .expectBadge({

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -1,5 +1,9 @@
 import Joi from 'joi'
-import { isMetric, isMetricOpenIssues } from '../test-validators.js'
+import {
+  isMetric,
+  isMetricClosedIssues,
+  isMetricOpenIssues,
+} from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 
 export const t = await createServiceTester()
@@ -11,58 +15,11 @@ t.create('GitHub pull requests')
     message: isMetricOpenIssues,
   })
 
-t.create('GitHub pull requests without a draft filter')
-  .get('/issues-pr/example/project.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          !query.includes('search(') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.[0] === 'OPEN' &&
-          variables.labels === undefined
-        )
-      })
-      .reply(200, {
-        data: { repository: { pullRequests: { totalCount: 5 } } },
-      }),
-  )
+t.create('GitHub pull requests preserve repository redirects')
+  .get('/issues-pr/facebook/react.json')
   .expectBadge({
     label: 'pull requests',
-    message: '5 open',
-  })
-
-t.create('GitHub pull requests raw without a draft filter')
-  .get('/issues-pr-raw/example/project.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          !query.includes('search(') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.[0] === 'OPEN' &&
-          variables.labels === undefined
-        )
-      })
-      .reply(200, {
-        data: { repository: { pullRequests: { totalCount: 5 } } },
-      }),
-  )
-  .expectBadge({
-    label: 'open pull requests',
-    message: '5',
+    message: isMetricOpenIssues,
   })
 
 t.create('GitHub pull requests raw')
@@ -72,67 +29,11 @@ t.create('GitHub pull requests raw')
     message: isMetric,
   })
 
-t.create('GitHub closed pull requests without a draft filter')
-  .get('/issues-pr-closed/example/project.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          !query.includes('search(') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.join(',') === 'MERGED,CLOSED' &&
-          variables.labels === undefined
-        )
-      })
-      .reply(200, {
-        data: { repository: { pullRequests: { totalCount: 7 } } },
-      }),
-  )
-  .expectBadge({
-    label: 'pull requests',
-    message: '7 closed',
-  })
-
 t.create('GitHub closed pull requests')
   .get('/issues-pr-closed/badges/shields.json')
   .expectBadge({
     label: 'pull requests',
-    message: Joi.string().regex(
-      /^([0-9]+[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) closed$/,
-    ),
-  })
-
-t.create('GitHub closed pull requests raw without a draft filter')
-  .get('/issues-pr-closed-raw/example/project.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          !query.includes('search(') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.join(',') === 'MERGED,CLOSED' &&
-          variables.labels === undefined
-        )
-      })
-      .reply(200, {
-        data: { repository: { pullRequests: { totalCount: 7 } } },
-      }),
-  )
-  .expectBadge({
-    label: 'closed pull requests',
-    message: '7',
+    message: isMetricClosedIssues,
   })
 
 t.create('GitHub closed pull requests raw')
@@ -143,181 +44,54 @@ t.create('GitHub closed pull requests raw')
   })
 
 t.create('GitHub closed pull requests raw with only drafts')
-  .get('/issues-pr-closed-raw/example/project.json?onlyDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:closed draft:true'
-        )
-      })
-      .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 1 } },
-      }),
-  )
+  .get('/issues-pr-closed-raw/badges/shields.json?onlyDrafts')
   .expectBadge({
     label: 'closed draft pull requests',
-    message: '1',
+    message: Joi.alternatives(isMetric, Joi.equal('0')),
   })
 
 t.create('GitHub pull requests excluding drafts')
-  .get('/issues-pr/example/project.json?excludeDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:open draft:false'
-        )
-      })
-      .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 3 } },
-      }),
-  )
+  .get('/issues-pr/badges/shields.json?excludeDrafts')
   .expectBadge({
     label: 'non-draft pull requests',
-    message: '3 open',
+    message: isMetricOpenIssues,
   })
 
 t.create('GitHub pull requests with only drafts')
-  .get('/issues-pr/example/project.json?onlyDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query === 'repo:example/project is:pr is:open draft:true'
-        )
-      })
-      .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 2 } },
-      }),
-  )
+  .get('/issues-pr/badges/shields.json?onlyDrafts')
   .expectBadge({
     label: 'draft pull requests',
-    message: '2 open',
+    message: Joi.alternatives(isMetricOpenIssues, Joi.equal('0 open')),
   })
 
-t.create('GitHub pull requests by multi-word label excluding drafts')
-  .get('/issues-pr/example/project/feature%20request.json?excludeDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('search(query: $query, type: ISSUE)') &&
-          variables.query ===
-            'repo:example/project is:pr is:open label:"feature request" draft:false'
-        )
-      })
-      .reply(200, {
-        data: { repository: { id: 'R_example' }, search: { issueCount: 2 } },
-      }),
+t.create('GitHub closed pull requests by multi-word label excluding drafts')
+  .get(
+    '/issues-pr-closed/badges/shields/good%20first%20issue.json?excludeDrafts',
   )
   .expectBadge({
-    label: '"feature request" non-draft pull requests',
-    message: '2 open',
+    label: '"good first issue" non-draft pull requests',
+    message: isMetricClosedIssues,
   })
 
 t.create('GitHub pull requests with conflicting draft filters')
-  .get('/issues-pr/example/project.json?excludeDrafts&onlyDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql')
-      .optionally()
-      .reply(() => {
-        throw new Error('GitHub should not be called for invalid query params')
-      }),
-  )
+  .get('/issues-pr/badges/shields.json?excludeDrafts&onlyDrafts')
   .expectBadge({
     label: 'pull requests',
     message: Joi.string().pattern(/^invalid query parameter/),
   })
 
 t.create('GitHub pull requests (repo not found)')
-  .get('/issues-pr/example/missing.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('repository(owner: $user, name: $repo)') &&
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          variables.user === 'example' &&
-          variables.repo === 'missing' &&
-          variables.states?.[0] === 'OPEN'
-        )
-      })
-      .reply(200, {
-        data: { repository: null },
-        errors: [
-          { type: 'NOT_FOUND', message: 'Could not resolve repository' },
-        ],
-      }),
-  )
+  .get('/issues-pr-raw/badges/helmets.json')
   .expectBadge({
     label: 'pull requests',
     message: 'repo not found',
   })
 
-t.create('GitHub pull requests with malformed response data')
-  .get('/issues-pr/example/project.json?excludeDrafts')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql')
-      .reply(200, {
-        data: { repository: { id: 'R_example' }, search: {} },
-      }),
-  )
-  .expectBadge({
-    label: 'pull requests',
-    message: 'invalid response data',
-  })
-
-t.create('GitHub open pull requests by label without a draft filter')
-  .get('/issues-pr/example/project/service-badge.json')
-  .intercept(nock =>
-    nock('https://api.github.com/')
-      .post('/graphql', requestBody => {
-        const { query, variables } =
-          typeof requestBody === 'string'
-            ? JSON.parse(requestBody)
-            : requestBody
-        return (
-          query.includes('pullRequests(states: $states, labels: $labels)') &&
-          !query.includes('search(') &&
-          variables.user === 'example' &&
-          variables.repo === 'project' &&
-          variables.states?.[0] === 'OPEN' &&
-          variables.labels?.join(',') === 'service-badge'
-        )
-      })
-      .reply(200, {
-        data: { repository: { pullRequests: { totalCount: 4 } } },
-      }),
-  )
+t.create('GitHub open pull requests by label')
+  .get('/issues-pr/badges/shields/service-badge.json')
   .expectBadge({
     label: 'service-badge pull requests',
-    message: '4 open',
+    message: isMetricOpenIssues,
   })
 
 t.create('GitHub open pull requests by label (raw)')

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -219,6 +219,50 @@ t.create('GitHub pull requests by multi-word label excluding drafts')
     message: '2 open',
   })
 
+t.create('GitHub pull requests with conflicting draft filters')
+  .get('/issues-pr/example/project.json?excludeDrafts&onlyDrafts')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql')
+      .optionally()
+      .reply(() => {
+        throw new Error('GitHub should not be called for invalid query params')
+      }),
+  )
+  .expectBadge({
+    label: 'pull requests',
+    message: Joi.string().pattern(/^invalid query parameter/),
+  })
+
+t.create('GitHub pull requests (repo not found)')
+  .get('/issues-pr/example/missing.json')
+  .intercept(nock =>
+    nock('https://api.github.com/')
+      .post('/graphql', requestBody => {
+        const { query, variables } =
+          typeof requestBody === 'string'
+            ? JSON.parse(requestBody)
+            : requestBody
+        return (
+          query.includes('repository(owner: $user, name: $repo)') &&
+          query.includes('search(query: $query, type: ISSUE)') &&
+          variables.user === 'example' &&
+          variables.repo === 'missing' &&
+          variables.query === 'repo:example/missing is:pr is:open'
+        )
+      })
+      .reply(200, {
+        data: { repository: null, search: { issueCount: 0 } },
+        errors: [
+          { type: 'NOT_FOUND', message: 'Could not resolve repository' },
+        ],
+      }),
+  )
+  .expectBadge({
+    label: 'pull requests',
+    message: 'repo not found',
+  })
+
 t.create('GitHub open pull requests by label')
   .get('/issues-pr/badges/shields/service-badge.json')
   .expectBadge({

--- a/services/github/github-pull-requests.tester.js
+++ b/services/github/github-pull-requests.tester.js
@@ -1,0 +1,49 @@
+import Joi from 'joi'
+import { isMetric, isMetricOpenIssues } from '../test-validators.js'
+import { createServiceTester } from '../tester.js'
+
+export const t = await createServiceTester()
+
+t.create('GitHub pull requests')
+  .get('/issues-pr/badges/shields.json')
+  .expectBadge({
+    label: 'pull requests',
+    message: isMetricOpenIssues,
+  })
+
+t.create('GitHub pull requests raw')
+  .get('/issues-pr-raw/badges/shields.json')
+  .expectBadge({
+    label: 'open pull requests',
+    message: isMetric,
+  })
+
+t.create('GitHub closed pull requests')
+  .get('/issues-pr-closed/badges/shields.json')
+  .expectBadge({
+    label: 'pull requests',
+    message: Joi.string().regex(
+      /^([0-9]+[kMGTPEZY]?|[1-9]\.[1-9][kMGTPEZY]) closed$/,
+    ),
+  })
+
+t.create('GitHub closed pull requests raw')
+  .get('/issues-pr-closed-raw/badges/shields.json')
+  .expectBadge({
+    label: 'closed pull requests',
+    message: isMetric,
+  })
+
+t.create('GitHub open pull requests by label')
+  .get('/issues-pr/badges/shields/service-badge.json')
+  .expectBadge({
+    label: 'service-badge pull requests',
+    message: isMetricOpenIssues,
+  })
+
+t.create('GitHub open pull requests by label (raw)')
+  .get('/issues-pr-raw/badges/shields/service-badge.json')
+  .expectBadge({
+    label: 'open service-badge pull requests',
+    message: isMetric,
+  })


### PR DESCRIPTION
GitHub's repository `pullRequests` connection cannot filter drafts, while GitHub search can. Unfiltered pull request badge variants therefore stay on `repository.pullRequests` to preserve redirects for renamed or transferred repositories. Variants using `excludeDrafts` or `onlyDrafts` use search for the draft filter, while issue badges remain on the repository issues query.

The new presence-only `excludeDrafts` and `onlyDrafts` parameters add `draft:false` or `draft:true` to the search. Supplying both is rejected before any request goes to GitHub. Existing open, closed, raw, and label URLs keep their current behavior. Repository existence is still validated, so a missing repository shows `repo not found` instead of `0 open`.

Closes #11286

## Verification

Before this change, `excludeDrafts` was ignored. The live service tests now cover both query paths through the public badge routes, including an old `facebook/react` path that GitHub redirects to `react/react`.

- [x] Covered open, closed, raw, label, `excludeDrafts`, and `onlyDrafts` behavior with live GitHub requests
- [x] Added live redirect coverage for backwards compatibility
- [x] Preserved the existing GitHub Issues behavior
- [x] Rejected conflicting draft filters before contacting GitHub
- [x] Preserved `repo not found` for missing repositories
- [x] Ran 13 live `GithubPullRequests` tests and 27 combined GitHub issue/PR service tests locally
- [x] Ran `npm run test:core` with 1,544 passing tests
- [x] Ran `npm run defs`, ESLint, Prettier, and `git diff --check`
- [x] Passed the targeted `GithubIssues` and `GithubPullRequests` CI suite on commit `936924ca1d`

The initial implementation direction came from @feloy's earlier work and is credited in the implementation commit.
