### PR TITLE
[ChromeWebStoreUsers] Fix 1M+ counts rendering as "12000,000" not "12M"

### DIFF
--- a/services/chrome-web-store/chrome-web-store-users.service.js
+++ b/services/chrome-web-store/chrome-web-store-users.service.js
@@ -23,6 +23,10 @@ class ChromeWebStoreUsers extends BaseChromeWebStoreService {
 
   static defaultBadgeData = { label: 'users' }
 
+  static transform(users) {
+    return String(users.replace(/,/g, ''))
+  }
+
   async handle({ storeId }) {
     const chromeWebStore = await this.fetch({ storeId })
     const downloads = chromeWebStore.users()
@@ -30,7 +34,7 @@ class ChromeWebStoreUsers extends BaseChromeWebStoreService {
       throw new NotFound({ prettyMessage: 'not found' })
     }
     return renderDownloadsBadge({
-      downloads: String(downloads.replace(',', '')),
+      downloads: this.constructor.transform(downloads),
     })
   }
 }

--- a/services/chrome-web-store/chrome-web-store-users.service.js
+++ b/services/chrome-web-store/chrome-web-store-users.service.js
@@ -24,7 +24,7 @@ class ChromeWebStoreUsers extends BaseChromeWebStoreService {
   static defaultBadgeData = { label: 'users' }
 
   static transform(users) {
-    return String(users.replace(/,/g, ''))
+    return String(users.replaceAll(',', ''))
   }
 
   async handle({ storeId }) {

--- a/services/chrome-web-store/chrome-web-store-users.spec.js
+++ b/services/chrome-web-store/chrome-web-store-users.spec.js
@@ -1,5 +1,4 @@
 import { test, given } from 'sazerac'
-import { metric } from '../text-formatters.js'
 import { ChromeWebStoreUsers } from './chrome-web-store-users.service.js'
 
 describe('ChromeWebStoreUsers', function () {
@@ -10,19 +9,6 @@ describe('ChromeWebStoreUsers', function () {
         given('500,000').expect('500000')
         given('3,000,000').expect('3000000')
         given('12,000,000').expect('12000000')
-      })
-    })
-  })
-
-  describe('rendered message', function () {
-    it('renders counts of a million or more as a compact metric', function () {
-      const render = users => metric(ChromeWebStoreUsers.transform(users))
-      test(render, () => {
-        given('8,000').expect('8k')
-        given('500,000').expect('500k')
-        given('3,000,000').expect('3M')
-        given('12,000,000').expect('12M')
-        given('1,234,567').expect('1.2M')
       })
     })
   })

--- a/services/chrome-web-store/chrome-web-store-users.spec.js
+++ b/services/chrome-web-store/chrome-web-store-users.spec.js
@@ -1,0 +1,29 @@
+import { test, given } from 'sazerac'
+import { metric } from '../text-formatters.js'
+import { ChromeWebStoreUsers } from './chrome-web-store-users.service.js'
+
+describe('ChromeWebStoreUsers', function () {
+  describe('transform', function () {
+    it('strips every thousands separator, not just the first', function () {
+      test(ChromeWebStoreUsers.transform, () => {
+        given('8,000').expect('8000')
+        given('500,000').expect('500000')
+        given('3,000,000').expect('3000000')
+        given('12,000,000').expect('12000000')
+      })
+    })
+  })
+
+  describe('rendered message', function () {
+    it('renders counts of a million or more as a compact metric', function () {
+      const render = users => metric(ChromeWebStoreUsers.transform(users))
+      test(render, () => {
+        given('8,000').expect('8k')
+        given('500,000').expect('500k')
+        given('3,000,000').expect('3M')
+        given('12,000,000').expect('12M')
+        given('1,234,567').expect('1.2M')
+      })
+    })
+  })
+})


### PR DESCRIPTION
`chrome-web-store/users` renders counts of 1M or more wrong, e.g. `12000,000` instead of `12M`. Counts under 1M are unaffected.

The store returns the count as a separated string like `"12,000,000"`, stripped via `downloads.replace(',', '')`. A string first argument only replaces the *first* match, leaving `"12000,000"`, which `metric()` can't parse and prints verbatim. Below 1M there's a single separator, so it happened to work.

Switched to a global regex (`/,/g`) and moved it into a `static transform()` (matching the sibling `ChromeWebStoreSize`) so it's unit-testable without live data. Added `chrome-web-store-users.spec.js` covering the 1M+ cases plus sub-1M regressions.