### PR TITLE
Remove decamelize and humanize-string Dependabot exclusions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,12 +14,6 @@ updates:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
           - 'version-update:semver-patch'
-      # https://github.com/badges/shields/issues/7324
-      # https://github.com/badges/shields/issues/7447
-      # we're stuck with these versions until Safari is compatible with lookbehind regex syntax
-      # https://caniuse.com/js-regexp-lookbehind
-      - dependency-name: 'decamelize'
-      - dependency-name: 'humanize-string'
     groups:
       # All official @docusaurus/* packages should have the exact same version as @docusaurus/core.
       # From https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups:


### PR DESCRIPTION
These we introduced following #7324 and #7447. The frontend nowadays doesn't rely on `decamelize` or `humanize-string` anymore, and Safari is now compatible with lookbehind regex syntax anyway. Let's clean this up.