### PR TITLE
Upload daily tests report

### DIFF
--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -68,3 +68,12 @@ jobs:
         run: |
           echo '# Services' >> $GITHUB_STEP_SUMMARY
           node scripts/mocha2md.js Report reports/service-tests.json >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload Service Tests Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: service-tests-report
+          path: reports/service-tests.json
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
I'm trying to make the results from our daily test suites readable by machines. This PR does so by uploading a JSON report that can later be downloaded by agents or scripts. This will help us develop AI-assisted workflows that can make fixing failing tests easier.