### PR TITLE
Update the changelog commit message

### DIFF
--- a/.github/actions/draft-release/entrypoint.sh
+++ b/.github/actions/draft-release/entrypoint.sh
@@ -46,12 +46,12 @@ BRANCH_NAME="$RELEASE_NAME"-$(uuidgen | head -c 8)
 git checkout -b "$BRANCH_NAME"
 
 # Commit + push changelog
+TITLE="Changelog for Release $RELEASE_NAME"
 git add CHANGELOG.md
-git commit -m "Update Changelog"
+git commit -m "$TITLE"
 git push origin "$BRANCH_NAME"
 
 # Submit a PR
-TITLE="Changelog for Release $RELEASE_NAME"
 PR_RESP=$(curl https://api.github.com/repos/"$REPO_NAME"/pulls \
     -X POST \
     -H "Authorization: token $GITHUB_TOKEN" \


### PR DESCRIPTION
It's related to the https://github.com/badges/shields/pull/12054.

The Merge Queue does not support for editing the merge commit message from the PR. And the github-merge-queue bot will pick the commit message if there is only one commit in the PR. So that #12054 happened.

I've changed the commit message to the same string as the PR title to avoid the "Update Changelog" commit message on the master branch.

In the meantime, I notice that other maintainers always review and revise the changelog content before merging. I will do the same.