### PR TITLE
Use `GITHUB_OUTPUT` instead of `set-output`

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date --rfc-3339=date)"
+        run: echo "date=$(date --rfc-3339=date)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout branch "master"
         uses: actions/checkout@v7


### PR DESCRIPTION
See the annotations section of https://github.com/badges/shields/actions/runs/30024476185?pr=12054.

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/