### PR TITLE
Drop deprecated github-tagger

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,10 +29,17 @@ jobs:
           ref: 'master'
 
       - name: Tag release in GitHub
-        uses: tvdias/github-tagger@v0.0.2
+        uses: actions/github-script@v9
+        env:
+          TAG: server-${{ steps.date.outputs.date }}
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          tag: server-${{ steps.date.outputs.date }}
+          script: |
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/tags/${process.env.TAG}`,
+              sha: context.sha,
+            })
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
See the annotations section of https://github.com/badges/shields/actions/runs/30024476185?pr=12054.

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: tvdias/github-tagger@v0.0.2. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

The [`tvdias/github-tagger`](https://github.com/tvdias/github-tagger) lacks maintenance. We can consider replacing it with a simple script.