### PR TITLE
Add [ReactNativeDirectory] supported platforms badge

### DIFF
--- a/services/react-native-directory/react-native-directory-platforms.service.js
+++ b/services/react-native-directory/react-native-directory-platforms.service.js
@@ -22,13 +22,13 @@ const librarySchema = Joi.object({
 const schema = Joi.object().pattern(Joi.string(), librarySchema).required()
 
 const platforms = {
-  ios: 'iOS',
   android: 'Android',
+  ios: 'iOS',
   web: 'Web',
-  windows: 'Windows',
   macos: 'macOS',
   tvos: 'tvOS',
   visionos: 'visionOS',
+  windows: 'Windows',
   expoGo: 'Expo Go',
   fireos: 'Fire OS',
   harmony: 'Harmony',

--- a/services/react-native-directory/react-native-directory-platforms.service.js
+++ b/services/react-native-directory/react-native-directory-platforms.service.js
@@ -1,0 +1,90 @@
+import Joi from 'joi'
+import { BaseJsonService, NotFound, pathParams } from '../index.js'
+import { packageNameDescription } from '../npm/npm-base.js'
+
+const librarySchema = Joi.object({
+  ios: Joi.boolean(),
+  android: Joi.boolean(),
+  web: Joi.boolean(),
+  windows: Joi.boolean(),
+  macos: Joi.boolean(),
+  tvos: Joi.boolean(),
+  visionos: Joi.boolean(),
+  expoGo: Joi.boolean(),
+  fireos: Joi.boolean(),
+  harmony: Joi.alternatives().try(Joi.boolean(), Joi.string()),
+  horizon: Joi.boolean(),
+  vegaos: Joi.alternatives().try(Joi.boolean(), Joi.string()),
+})
+  .unknown(true)
+  .required()
+
+const schema = Joi.object().pattern(Joi.string(), librarySchema).required()
+
+const platforms = {
+  ios: 'iOS',
+  android: 'Android',
+  web: 'Web',
+  windows: 'Windows',
+  macos: 'macOS',
+  tvos: 'tvOS',
+  visionos: 'visionOS',
+  expoGo: 'Expo Go',
+  fireos: 'Fire OS',
+  harmony: 'Harmony',
+  horizon: 'Horizon',
+  vegaos: 'VegaOS',
+}
+
+export default class ReactNativeDirectory extends BaseJsonService {
+  static category = 'platform-support'
+
+  static route = {
+    base: 'react-native-directory',
+    pattern: ':scope(@[^/]+)?/:packageName',
+  }
+
+  static openApi = {
+    '/react-native-directory/{packageName}': {
+      get: {
+        summary: 'React Native Directory Supported Platforms',
+        parameters: pathParams({
+          name: 'packageName',
+          example: 'react-native-reanimated',
+          description: packageNameDescription,
+        }),
+      },
+    },
+  }
+
+  static defaultBadgeData = { label: 'platforms' }
+
+  static render(library) {
+    const supportedPlatforms = Object.entries(platforms)
+      .filter(([key]) => library[key])
+      .map(([, name]) => name)
+
+    return {
+      message:
+        supportedPlatforms.length > 0 ? supportedPlatforms.join(', ') : 'none',
+    }
+  }
+
+  async handle({ scope, packageName }) {
+    const name = scope ? `${scope}/${packageName}` : packageName
+    const response = await this._requestJson({
+      schema,
+      url: `https://reactnative.directory/api/library?name=${encodeURIComponent(
+        name,
+      )}`,
+      httpErrors: { 404: 'package not found' },
+    })
+
+    const library = response[name]
+    if (!library) {
+      throw new NotFound({ prettyMessage: 'package not found' })
+    }
+
+    return this.constructor.render(library)
+  }
+}

--- a/services/react-native-directory/react-native-directory-platforms.service.js
+++ b/services/react-native-directory/react-native-directory-platforms.service.js
@@ -66,7 +66,7 @@ export default class ReactNativeDirectory extends BaseJsonService {
 
     return {
       message:
-        supportedPlatforms.length > 0 ? supportedPlatforms.join(', ') : 'none',
+        supportedPlatforms.length > 0 ? supportedPlatforms.join(' | ') : 'none',
     }
   }
 

--- a/services/react-native-directory/react-native-directory-platforms.tester.js
+++ b/services/react-native-directory/react-native-directory-platforms.tester.js
@@ -7,12 +7,12 @@ t.create('supported platforms of react-native-reanimated')
   .expectBadge({
     label: 'platforms',
     message:
-      'Android, iOS, Web, macOS, tvOS, visionOS, Expo Go, Fire OS, Harmony, VegaOS',
+      'Android | iOS | Web | macOS | tvOS | visionOS | Expo Go | Fire OS | Harmony | VegaOS',
   })
 
 t.create('supported platforms of @react-native-menu/menu')
   .get('/@react-native-menu/menu.json')
-  .expectBadge({ label: 'platforms', message: 'Android, iOS, visionOS' })
+  .expectBadge({ label: 'platforms', message: 'Android | iOS | visionOS' })
 
 t.create('package not found').get('/not-a-package.json').expectBadge({
   label: 'platforms',

--- a/services/react-native-directory/react-native-directory-platforms.tester.js
+++ b/services/react-native-directory/react-native-directory-platforms.tester.js
@@ -1,0 +1,99 @@
+import { ServiceTester } from '../tester.js'
+
+export const t = new ServiceTester({
+  id: 'ReactNativeDirectory',
+  title: 'React Native Directory',
+  pathPrefix: '/react-native-directory',
+})
+
+t.create('supported platforms')
+  .intercept(nock =>
+    nock('https://reactnative.directory')
+      .get('/api/library')
+      .query({ name: 'react-native-example' })
+      .reply(200, {
+        'react-native-example': {
+          ios: true,
+          android: true,
+          web: true,
+          windows: true,
+          macos: true,
+          tvos: true,
+          visionos: true,
+          expoGo: true,
+          fireos: true,
+          harmony: true,
+          horizon: true,
+          vegaos: '@vega-os/react-native-example',
+        },
+      }),
+  )
+  .get('/react-native-example.json')
+  .expectBadge({
+    label: 'platforms',
+    message:
+      'iOS, Android, Web, Windows, macOS, tvOS, visionOS, Expo Go, Fire OS, Harmony, Horizon, VegaOS',
+  })
+
+t.create('omits unsupported platforms')
+  .intercept(nock =>
+    nock('https://reactnative.directory')
+      .get('/api/library')
+      .query({ name: 'react-native-partial' })
+      .reply(200, {
+        'react-native-partial': {
+          ios: true,
+          android: true,
+          web: true,
+          expoGo: true,
+          newArchitecture: true,
+          fireos: true,
+        },
+      }),
+  )
+  .get('/react-native-partial.json')
+  .expectBadge({
+    label: 'platforms',
+    message: 'iOS, Android, Web, Expo Go, Fire OS',
+  })
+
+t.create('no supported platforms')
+  .intercept(nock =>
+    nock('https://reactnative.directory')
+      .get('/api/library')
+      .query({ name: 'react-native-example' })
+      .reply(200, {
+        'react-native-example': {
+          ios: false,
+          android: false,
+          web: false,
+          windows: false,
+          macos: false,
+          tvos: false,
+          visionos: false,
+          expoGo: false,
+          fireos: false,
+          harmony: false,
+          horizon: false,
+          vegaos: false,
+        },
+      }),
+  )
+  .get('/react-native-example.json')
+  .expectBadge({
+    label: 'platforms',
+    message: 'none',
+  })
+
+t.create('package not found')
+  .intercept(nock =>
+    nock('https://reactnative.directory')
+      .get('/api/library')
+      .query({ name: 'not-a-package' })
+      .reply(200, {}),
+  )
+  .get('/not-a-package.json')
+  .expectBadge({
+    label: 'platforms',
+    message: 'package not found',
+  })

--- a/services/react-native-directory/react-native-directory-platforms.tester.js
+++ b/services/react-native-directory/react-native-directory-platforms.tester.js
@@ -1,99 +1,20 @@
-import { ServiceTester } from '../tester.js'
+import { createServiceTester } from '../tester.js'
 
-export const t = new ServiceTester({
-  id: 'ReactNativeDirectory',
-  title: 'React Native Directory',
-  pathPrefix: '/react-native-directory',
-})
+export const t = await createServiceTester()
 
-t.create('supported platforms')
-  .intercept(nock =>
-    nock('https://reactnative.directory')
-      .get('/api/library')
-      .query({ name: 'react-native-example' })
-      .reply(200, {
-        'react-native-example': {
-          ios: true,
-          android: true,
-          web: true,
-          windows: true,
-          macos: true,
-          tvos: true,
-          visionos: true,
-          expoGo: true,
-          fireos: true,
-          harmony: true,
-          horizon: true,
-          vegaos: '@vega-os/react-native-example',
-        },
-      }),
-  )
-  .get('/react-native-example.json')
+t.create('supported platforms of react-native-reanimated')
+  .get('/react-native-reanimated.json')
   .expectBadge({
     label: 'platforms',
     message:
-      'iOS, Android, Web, Windows, macOS, tvOS, visionOS, Expo Go, Fire OS, Harmony, Horizon, VegaOS',
+      'Android, iOS, Web, macOS, tvOS, visionOS, Expo Go, Fire OS, Harmony, VegaOS',
   })
 
-t.create('omits unsupported platforms')
-  .intercept(nock =>
-    nock('https://reactnative.directory')
-      .get('/api/library')
-      .query({ name: 'react-native-partial' })
-      .reply(200, {
-        'react-native-partial': {
-          ios: true,
-          android: true,
-          web: true,
-          expoGo: true,
-          newArchitecture: true,
-          fireos: true,
-        },
-      }),
-  )
-  .get('/react-native-partial.json')
-  .expectBadge({
-    label: 'platforms',
-    message: 'iOS, Android, Web, Expo Go, Fire OS',
-  })
+t.create('supported platforms of @react-native-menu/menu')
+  .get('/@react-native-menu/menu.json')
+  .expectBadge({ label: 'platforms', message: 'Android, iOS, visionOS' })
 
-t.create('no supported platforms')
-  .intercept(nock =>
-    nock('https://reactnative.directory')
-      .get('/api/library')
-      .query({ name: 'react-native-example' })
-      .reply(200, {
-        'react-native-example': {
-          ios: false,
-          android: false,
-          web: false,
-          windows: false,
-          macos: false,
-          tvos: false,
-          visionos: false,
-          expoGo: false,
-          fireos: false,
-          harmony: false,
-          horizon: false,
-          vegaos: false,
-        },
-      }),
-  )
-  .get('/react-native-example.json')
-  .expectBadge({
-    label: 'platforms',
-    message: 'none',
-  })
-
-t.create('package not found')
-  .intercept(nock =>
-    nock('https://reactnative.directory')
-      .get('/api/library')
-      .query({ name: 'not-a-package' })
-      .reply(200, {}),
-  )
-  .get('/not-a-package.json')
-  .expectBadge({
-    label: 'platforms',
-    message: 'package not found',
-  })
+t.create('package not found').get('/not-a-package.json').expectBadge({
+  label: 'platforms',
+  message: 'package not found',
+})


### PR DESCRIPTION
# Why

React Native Directory provides the additional data for all registered packages, including platform support, which is not defined in package metadata otherwise. So far packages had to create the badges manually (for each platform, or combined ones), and this service does that automatically based on API data.

API docs:
* https://github.com/react-native-community/directory/blob/main/API.md

# How

Add React Native Directory supported platforms badge service and tests.

# Preview

<img width="2132" height="975" alt="Screenshot 2026-07-28 150727" src="https://github.com/user-attachments/assets/3a27b937-8866-4238-99cb-d2e8db6f88e0" />
