### PR TITLE
Fix [GithubPullRequestCheckState] tests and examples

### DIFF
--- a/services/github/github-pull-request-check-state.service.js
+++ b/services/github/github-pull-request-check-state.service.js
@@ -53,7 +53,7 @@ export default class GithubPullRequestCheckState extends GithubAuthV3Service {
           },
           {
             name: 'number',
-            example: '1110',
+            example: '12083',
           },
         ),
       },
@@ -73,7 +73,7 @@ export default class GithubPullRequestCheckState extends GithubAuthV3Service {
           },
           {
             name: 'number',
-            example: '1110',
+            example: '12083',
           },
         ),
       },

--- a/services/github/github-pull-request-check-state.tester.js
+++ b/services/github/github-pull-request-check-state.tester.js
@@ -2,7 +2,8 @@ import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
 t.create('github pull request check state')
-  .get('/s/pulls/badges/shields/11053.json')
+  // The GitHub API stops returning data for PRs than are more than ~15 months old. Update to the latest opened PR when this happens.
+  .get('/s/pulls/badges/shields/12083.json')
   .expectBadge({ label: 'checks', message: 'success' })
 
 t.create('github pull request check state (pull request not found)')
@@ -26,5 +27,6 @@ t.create(
   })
 
 t.create('github pull request check contexts')
-  .get('/contexts/pulls/badges/shields/11053.json')
+  // The GitHub API stops returning data for PRs than are more than ~15 months old. Update to the latest opened PR when this happens.
+  .get('/contexts/pulls/badges/shields/12083.json')
   .expectBadge({ label: 'checks', message: '1 success' })


### PR DESCRIPTION
Similar to #11054. It's not ideal, but updating every 15 months feels like reasonable toil.