### PR TITLE
Fix [Depfu] test and example

### DIFF
--- a/services/depfu/depfu.service.js
+++ b/services/depfu/depfu.service.js
@@ -30,7 +30,7 @@ class Depfu extends BaseJsonService {
           },
           {
             name: 'project',
-            example: 'depfu/example-ruby',
+            example: 'openSUSE/open-build-service',
           },
         ),
       },

--- a/services/depfu/depfu.tester.js
+++ b/services/depfu/depfu.tester.js
@@ -11,7 +11,7 @@ const isDependencyStatus = Joi.string().valid(
 export const t = new ServiceTester({ id: 'depfu', title: 'Depfu' })
 
 t.create('depfu Github dependencies (valid)')
-  .get('/dependencies/github/depfu/example-ruby.json')
+  .get('/dependencies/github/openSUSE/open-build-service.json')
   .expectBadge({
     label: 'dependencies',
     message: isDependencyStatus,


### PR DESCRIPTION
https://github.com/depfu/example-ruby has not been updated in years and years, and Depfu goes disabled there. Let's switch to an active project.