### PR TITLE
[static querystring] Extract URL parsing into a reusable codec

### DIFF
--- a/core/badge-urls/path-helpers.js
+++ b/core/badge-urls/path-helpers.js
@@ -1,23 +1,8 @@
-/**
- * Escape a string according to the badge format encoding scheme. Underscores
- * and dashes in the input are decoded using the rules from
- * https://github.com/espadrine/gh-badges/issues/12#issuecomment-31518129
- *
- * Single underscores become spaces, double underscores become single
- * underscores, and double dashes become single dashes.
- *
- * @param {string} t - The format-encoded string to decode.
- * @returns {string} The decoded string.
- */
-function escapeFormat(t) {
-  return (
-    t
-      // Single underscore.
-      .replace(/(^|[^_])((?:__)*)_(?!_)/g, '$1$2 ')
-      // Double underscore and double dash.
-      .replace(/__/g, '_')
-      .replace(/--/g, '-')
-  )
+import { decodeBadgeText } from './static-badge-path.js'
+
+// Backwards-compatible name used by legacy redirectors.
+function escapeFormat(text) {
+  return decodeBadgeText(text)
 }
 
 export { escapeFormat }

--- a/core/badge-urls/static-badge-path.js
+++ b/core/badge-urls/static-badge-path.js
@@ -1,0 +1,211 @@
+const labelPattern = '(?:[^-]|--)*?'
+const messagePattern = '(?:[^-]|--)*'
+const colorPattern = '(?:[^-.]|--)+'
+
+// This pattern deliberately contains no capturing groups so it can be
+// embedded in a service route without changing the route's captures.
+const staticBadgeContentPattern = `${labelPattern}-?${messagePattern}-${colorPattern}`
+const staticBadgeRouteFormat = `(?::|badge/)${staticBadgeContentPattern}`
+
+const staticBadgePathRegex = new RegExp(
+  `^/(?::|badge/)(${labelPattern})-?(${messagePattern})-(${colorPattern})(?:\\.(svg|json))?$`,
+)
+
+/**
+ * @typedef {object} StaticBadgePath
+ * @property {string} label
+ * @property {string} message
+ * @property {string} color
+ * @property {string} format
+ * @property {object} [queryParams]
+ */
+
+/**
+ * Decode text using the static badge path encoding.
+ *
+ * @param {string} text Encoded label or message.
+ * @returns {string} Decoded badge text.
+ */
+function decodeBadgeText(text) {
+  return text
+    .replace(/(^|[^_])((?:__)*)_(?!_)/g, '$1$2 ')
+    .replace(/__/g, '_')
+    .replace(/--/g, '-')
+}
+
+/**
+ * Encode text using the static badge path encoding.
+ *
+ * @param {string} text Badge label or message.
+ * @returns {string} Encoded badge text.
+ */
+function encodeBadgeText(text) {
+  return encodeURIComponent(text.replace(/_/g, '__').replace(/-/g, '--'))
+}
+
+function queryParamsFromSearchParams(searchParams) {
+  const queryParams = {}
+  for (const [name, value] of searchParams) {
+    if (!Object.hasOwn(queryParams, name)) {
+      queryParams[name] = value
+    } else if (Array.isArray(queryParams[name])) {
+      queryParams[name].push(value)
+    } else {
+      queryParams[name] = [queryParams[name], value]
+    }
+  }
+  return queryParams
+}
+
+function searchParamsFromQueryParams(queryParams) {
+  if (queryParams instanceof URLSearchParams) {
+    return new URLSearchParams(queryParams)
+  }
+  if (queryParams === undefined) {
+    return new URLSearchParams()
+  }
+  if (queryParams === null || typeof queryParams !== 'object') {
+    throw new TypeError('queryParams must be an object or URLSearchParams')
+  }
+
+  const searchParams = new URLSearchParams()
+  for (const [name, value] of Object.entries(queryParams)) {
+    const values = Array.isArray(value) ? value : [value]
+    for (const item of values) {
+      if (item !== undefined && item !== null) {
+        searchParams.append(name, `${item}`)
+      }
+    }
+  }
+  return searchParams
+}
+
+function lastQueryParam(queryParams, name) {
+  const value = queryParams[name]
+  return Array.isArray(value) ? value.at(-1) : value
+}
+
+/**
+ * Parse an encoded static badge path, including an optional query string.
+ *
+ * The label and color query parameters are applied using the same precedence
+ * as the badge pipeline. Other query parameters are returned without applying
+ * rendering-specific behavior.
+ *
+ * @param {string} path Raw, percent-encoded URL path and optional query.
+ * @param {object} [options] Parsing options.
+ * @param {boolean} [options.isDecoded=false] Whether a router has already
+ *   percent-decoded the pathname. Decoded input must not contain a query.
+ * @returns {StaticBadgePath|undefined}
+ *   Parsed badge path, or undefined when the pathname is not a static badge.
+ */
+function parseStaticBadgePath(path, { isDecoded = false } = {}) {
+  let pathname = path
+  let search = ''
+  if (!isDecoded) {
+    const fragmentIndex = pathname.indexOf('#')
+    if (fragmentIndex !== -1) {
+      pathname = pathname.slice(0, fragmentIndex)
+    }
+    const queryIndex = pathname.indexOf('?')
+    if (queryIndex !== -1) {
+      search = pathname.slice(queryIndex + 1)
+      pathname = pathname.slice(0, queryIndex)
+    }
+  }
+
+  let decodedPathname = pathname
+  if (!isDecoded) {
+    try {
+      decodedPathname = decodeURIComponent(pathname)
+    } catch {
+      return undefined
+    }
+  }
+
+  const match = staticBadgePathRegex.exec(decodedPathname)
+  if (!match) {
+    return undefined
+  }
+
+  const [, label, message, color, format = 'svg'] = match
+  const queryParams = queryParamsFromSearchParams(new URLSearchParams(search))
+  const overrideLabel = lastQueryParam(queryParams, 'label')
+  const overrideColor = Object.hasOwn(queryParams, 'color')
+    ? lastQueryParam(queryParams, 'color')
+    : lastQueryParam(queryParams, 'colorB')
+
+  const result = {
+    label: overrideLabel ?? decodeBadgeText(label),
+    message: decodeBadgeText(message),
+    color: overrideColor ?? color,
+    format,
+  }
+  if (Object.keys(queryParams).length > 0) {
+    result.queryParams = queryParams
+  }
+  return result
+}
+
+/**
+ * Build a canonical static badge pathname.
+ *
+ * @param {object} badge Static badge path data.
+ * @param {string} [badge.label=''] Badge label.
+ * @param {string} badge.message Badge message.
+ * @param {string} badge.color Badge color as a name, hex value, or CSS color.
+ * @param {'svg'|'json'} [badge.format='svg'] Output format.
+ * @param {object|URLSearchParams} [badge.queryParams] Query parameters. Array
+ *   values are serialized as repeated parameters.
+ * @returns {string} Percent-encoded static badge path.
+ */
+function formatStaticBadgePath({
+  label = '',
+  message,
+  color,
+  format = 'svg',
+  queryParams,
+}) {
+  const searchParams = searchParamsFromQueryParams(queryParams)
+  const hasLabelOverride = searchParams.has('label')
+  const hasColorOverride =
+    searchParams.has('color') || searchParams.has('colorB')
+
+  if (typeof label !== 'string') {
+    throw new TypeError('label must be a string')
+  }
+  if (label.endsWith('-') && !hasLabelOverride) {
+    throw new TypeError('label cannot end with a dash in the static badge path')
+  }
+  if (typeof message !== 'string') {
+    throw new TypeError('message must be a string')
+  }
+  if (typeof color !== 'string' || color.length === 0) {
+    throw new TypeError('color must be a non-empty string')
+  }
+  if (/[.-]/.test(color) && !hasColorOverride) {
+    throw new TypeError('color cannot contain dots or dashes')
+  }
+  if (format !== 'svg' && format !== 'json') {
+    throw new TypeError("format must be either 'svg' or 'json'")
+  }
+
+  const pathLabel = label.endsWith('-') ? '' : label
+  const pathColor = /[.-]/.test(color) ? 'lightgrey' : color
+  const encodedLabel = encodeBadgeText(pathLabel)
+  const encodedMessage = encodeBadgeText(message)
+  const encodedColor = encodeURIComponent(pathColor)
+  const content = encodedLabel
+    ? `${encodedLabel}-${encodedMessage}`
+    : encodedMessage
+  const search = searchParams.toString()
+
+  return `/badge/${content}-${encodedColor}.${format}${search ? `?${search}` : ''}`
+}
+
+export {
+  decodeBadgeText,
+  formatStaticBadgePath,
+  parseStaticBadgePath,
+  staticBadgeRouteFormat,
+}

--- a/core/badge-urls/static-badge-path.spec.js
+++ b/core/badge-urls/static-badge-path.spec.js
@@ -1,0 +1,243 @@
+import { expect } from 'chai'
+import {
+  formatStaticBadgePath,
+  parseStaticBadgePath,
+} from './static-badge-path.js'
+
+describe('Static badge path', function () {
+  describe('parseStaticBadgePath', function () {
+    it('parses label, message, color, and format', function () {
+      expect(
+        parseStaticBadgePath('/badge/best--license-Apache--2.0-blue.json'),
+      ).to.deep.equal({
+        label: 'best-license',
+        message: 'Apache-2.0',
+        color: 'blue',
+        format: 'json',
+      })
+    })
+
+    it('defaults to SVG when the extension is omitted', function () {
+      expect(parseStaticBadgePath('/badge/build-passing-green')).to.deep.equal({
+        label: 'build',
+        message: 'passing',
+        color: 'green',
+        format: 'svg',
+      })
+    })
+
+    it('parses a badge without a label', function () {
+      expect(
+        parseStaticBadgePath('/badge/all%20one%20color-red.svg'),
+      ).to.deep.equal({
+        label: '',
+        message: 'all one color',
+        color: 'red',
+        format: 'svg',
+      })
+    })
+
+    it('parses a badge without a message', function () {
+      expect(parseStaticBadgePath('/badge/label--blue.svg')).to.deep.equal({
+        label: 'label',
+        message: '',
+        color: 'blue',
+        format: 'svg',
+      })
+    })
+
+    it('decodes underscores and percent-encoded path characters', function () {
+      expect(
+        parseStaticBadgePath('/badge/a__label-a%2Fb_c-%23123.svg'),
+      ).to.deep.equal({
+        label: 'a_label',
+        message: 'a/b c',
+        color: '#123',
+        format: 'svg',
+      })
+    })
+
+    it('supports the legacy colon syntax', function () {
+      expect(parseStaticBadgePath('/:label-message-blue.json')).to.deep.equal({
+        label: 'label',
+        message: 'message',
+        color: 'blue',
+        format: 'json',
+      })
+    })
+
+    it('does not decode a pathname twice when a router decoded it', function () {
+      expect(
+        parseStaticBadgePath('/badge/label-100%25-blue.svg', {
+          isDecoded: true,
+        }),
+      ).to.deep.equal({
+        label: 'label',
+        message: '100%25',
+        color: 'blue',
+        format: 'svg',
+      })
+    })
+
+    it('applies query-string overrides and preserves other parameters', function () {
+      expect(
+        parseStaticBadgePath(
+          '/badge/path--label-message-blue.svg?label=query+label&color=red&style=flat-square&link=https%3A%2F%2Fexample.com%2Fa&link=https%3A%2F%2Fexample.com%2Fb',
+        ),
+      ).to.deep.equal({
+        label: 'query label',
+        message: 'message',
+        color: 'red',
+        format: 'svg',
+        queryParams: {
+          label: 'query label',
+          color: 'red',
+          style: 'flat-square',
+          link: ['https://example.com/a', 'https://example.com/b'],
+        },
+      })
+    })
+
+    it('supports legacy color overrides with modern color taking precedence', function () {
+      expect(
+        parseStaticBadgePath(
+          '/badge/label-message-blue.json?colorB=yellow&color=orange',
+        ),
+      ).to.include({ color: 'orange' })
+      expect(
+        parseStaticBadgePath('/badge/label-message-blue.json?colorB=yellow'),
+      ).to.include({ color: 'yellow' })
+    })
+
+    it('does not treat encoded query delimiters as a query string', function () {
+      expect(
+        parseStaticBadgePath('/badge/label-what%3Fcolor%3Dred-blue.svg'),
+      ).to.deep.equal({
+        label: 'label',
+        message: 'what?color=red',
+        color: 'blue',
+        format: 'svg',
+      })
+    })
+
+    it('returns undefined for non-static and malformed paths', function () {
+      expect(parseStaticBadgePath('/github/stars/badges/shields')).to.be
+        .undefined
+      expect(parseStaticBadgePath('/badge/missingcolor')).to.be.undefined
+      expect(parseStaticBadgePath('/badge/label-message-blue.png')).to.be
+        .undefined
+      expect(parseStaticBadgePath('/badge/bad%escape-red.svg')).to.be.undefined
+    })
+  })
+
+  describe('formatStaticBadgePath', function () {
+    it('formats a canonical static badge pathname', function () {
+      expect(
+        formatStaticBadgePath({
+          label: 'best-license',
+          message: 'Apache-2.0',
+          color: '#123',
+          format: 'json',
+        }),
+      ).to.equal('/badge/best--license-Apache--2.0-%23123.json')
+    })
+
+    it('omits the label segment when the label is empty', function () {
+      expect(
+        formatStaticBadgePath({ message: 'all one color', color: 'red' }),
+      ).to.equal('/badge/all%20one%20color-red.svg')
+    })
+
+    it('round trips path-significant characters', function () {
+      const badge = {
+        label: 'a_label-value',
+        message: 'a/b 100%',
+        color: 'rgb(1, 2, 3)',
+        format: 'json',
+      }
+
+      expect(parseStaticBadgePath(formatStaticBadgePath(badge))).to.deep.equal(
+        badge,
+      )
+    })
+
+    it('round trips adjacent spaces and underscores without ambiguity', function () {
+      const badge = {
+        label: ' _',
+        message: 'a _b_ ',
+        color: 'blue',
+        format: 'svg',
+      }
+
+      expect(parseStaticBadgePath(formatStaticBadgePath(badge))).to.deep.equal(
+        badge,
+      )
+    })
+
+    it('formats and round trips query parameters', function () {
+      const badge = {
+        label: 'query label',
+        message: 'message',
+        color: 'red',
+        format: 'svg',
+        queryParams: {
+          label: 'query label',
+          color: 'red',
+          style: 'flat-square',
+          link: ['https://example.com/a', 'https://example.com/b'],
+        },
+      }
+
+      const path = formatStaticBadgePath(badge)
+      expect(path).to.equal(
+        '/badge/query%20label-message-red.svg?label=query+label&color=red&style=flat-square&link=https%3A%2F%2Fexample.com%2Fa&link=https%3A%2F%2Fexample.com%2Fb',
+      )
+      expect(parseStaticBadgePath(path)).to.deep.equal(badge)
+    })
+
+    it('uses query overrides for values the path grammar cannot represent', function () {
+      const badge = {
+        label: 'trailing-',
+        message: 'message',
+        color: 'rgb(.5 0 0)',
+        format: 'json',
+        queryParams: {
+          label: 'trailing-',
+          color: 'rgb(.5 0 0)',
+        },
+      }
+
+      const path = formatStaticBadgePath(badge)
+      expect(path).to.equal(
+        '/badge/message-lightgrey.json?label=trailing-&color=rgb%28.5+0+0%29',
+      )
+      expect(parseStaticBadgePath(path)).to.deep.equal(badge)
+    })
+
+    it('rejects invalid inputs', function () {
+      expect(() =>
+        formatStaticBadgePath({ message: 'message', color: '' }),
+      ).to.throw(TypeError, 'color must be a non-empty string')
+      expect(() =>
+        formatStaticBadgePath({ message: 'message', color: 'blue-green' }),
+      ).to.throw(TypeError, 'color cannot contain dots or dashes')
+      expect(() =>
+        formatStaticBadgePath({
+          label: 'trailing-',
+          message: 'message',
+          color: 'blue',
+        }),
+      ).to.throw(
+        TypeError,
+        'label cannot end with a dash in the static badge path',
+      )
+      expect(() =>
+        formatStaticBadgePath({
+          message: 'message',
+          color: 'blue',
+          format: 'png',
+        }),
+      ).to.throw(TypeError, "format must be either 'svg' or 'json'")
+    })
+  })
+})

--- a/core/base-service/base-static.js
+++ b/core/base-service/base-static.js
@@ -18,6 +18,14 @@ import { prepareRoute, namedParamsForMatch } from './route.js'
  * request metrics.
  */
 export default class BaseStaticService extends BaseService {
+  /**
+   * Optional parser for services which need the complete decoded pathname
+   * instead of individual route captures.
+   *
+   * @type {Function|undefined}
+   */
+  static parsePath
+
   static register({ camp, metricInstance }, serviceConfig) {
     const { regex, captureNames } = prepareRoute(this.route)
 
@@ -36,7 +44,12 @@ export default class BaseStaticService extends BaseService {
 
       const metricHandle = metricHelper.startRequest()
 
-      const namedParams = namedParamsForMatch(captureNames, match, this)
+      const namedParams = this.parsePath
+        ? this.parsePath(ask.req.path)
+        : namedParamsForMatch(captureNames, match, this)
+      if (!namedParams) {
+        throw new Error(`${this.name} could not parse its matched route`)
+      }
       const serviceData = await this.invoke(
         {},
         serviceConfig,

--- a/services/static-badge/static-badge.service.js
+++ b/services/static-badge/static-badge.service.js
@@ -1,4 +1,7 @@
-import { escapeFormat } from '../../core/badge-urls/path-helpers.js'
+import {
+  parseStaticBadgePath,
+  staticBadgeRouteFormat,
+} from '../../core/badge-urls/static-badge-path.js'
 import { BaseStaticService } from '../index.js'
 
 const description = `
@@ -61,8 +64,11 @@ export default class StaticBadge extends BaseStaticService {
   static category = 'static'
   static route = {
     base: '',
-    format: '(?::|badge/)((?:[^-]|--)*?)-?((?:[^-]|--)*)-((?:[^-.]|--)+)',
-    capture: ['label', 'message', 'color'],
+    format: staticBadgeRouteFormat,
+  }
+
+  static parsePath(pathname) {
+    return parseStaticBadgePath(pathname, { isDecoded: true })
   }
 
   static openApi = {
@@ -86,6 +92,6 @@ export default class StaticBadge extends BaseStaticService {
   }
 
   handle({ label, message, color }) {
-    return { label: escapeFormat(label), message: escapeFormat(message), color }
+    return { label, message, color }
   }
 }

--- a/services/static-badge/static-badge.tester.js
+++ b/services/static-badge/static-badge.tester.js
@@ -46,6 +46,10 @@ t.create('"Shields-encoded" dash')
   .get('/badge/best--license-Apache--2.0-blue.json')
   .expectBadge({ label: 'best-license', message: 'Apache-2.0', color: 'blue' })
 
+t.create('URL decoding happens once')
+  .get('/badge/label-100%2525-blue.json')
+  .expectBadge({ label: 'label', message: '100%25', color: 'blue' })
+
 t.create('Override color')
   .get('/badge/label-message-blue.json?color=yellow')
   .expectBadge({ label: 'label', message: 'message', color: 'yellow' })


### PR DESCRIPTION
Extract the static badge URL grammar into a reusable, side-effect-free codec.

This is a useful utility for other self-hosted services to use the same badge path logic. Maybe we can expose this through `badge-maker` in the future.

And it useful for our OpenAPI doc pages. Then we can break down `badgeContent` into label, message, and color, which will be more intuitive for users.

### Changes

- Adds `parseStaticBadgePath()` for parsing static badge paths and optional query strings.
- Adds `formatStaticBadgePath()` for generating equivalent static badge URLs.
- Supports label, message, color, output format, legacy colon syntax, and Shields path escaping.
- Applies `label`, `color`, and legacy `colorB` query overrides.
- Preserves other query parameters, including repeated parameters such as `link`.
- Moves the route grammar out of `StaticBadge` so the parser and service share the same definition.
- Adds an optional `parsePath` hook to `BaseStaticService`.
- Keeps `escapeFormat()` as a backwards-compatible alias for the extracted decoder.
- Preserves the existing single URL-decoding behavior.

Color normalization and rendering-specific query behavior remain in the existing badge pipeline.

### Compatibility

The existing static badge HTTP route continues to use the same path grammar and query override pipeline. The query-string static badge endpoint (`/static/v1`) is unchanged.

The formatter only rejects values that cannot be represented by the path grammar unless an appropriate query override is supplied.