### PR TITLE
Preserve service test results across PR edits

### DIFF
--- a/.github/actions/service-tests/action.yml
+++ b/.github/actions/service-tests/action.yml
@@ -53,15 +53,23 @@ runs:
   using: 'composite'
   steps:
     - name: Derive list of service tests to run
-      # Note: In this step we are using an intermediate env var instead of
-      # passing github.event.pull_request.title as an argument
-      # to prevent a shell injection attack. Further reading:
+      # Fetch the current title so a rerun after a title edit selects the
+      # correct services. Pass it through a quoted shell variable to prevent
+      # shell injection. Further reading:
       # https://securitylab.github.com/research/github-actions-untrusted-input/#exploitability-and-impact
       # https://securitylab.github.com/research/github-actions-untrusted-input/#remediation
       if: always()
       env:
-        TITLE: ${{ github.event.pull_request.title }}
-      run: npm run test:services:pr:prepare "$TITLE"
+        EVENT_TITLE: ${{ github.event.pull_request.title }}
+        GH_TOKEN: '${{ inputs.github-token }}'
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        if test -n "$PR_NUMBER"; then
+          TITLE="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.title')"
+        else
+          TITLE="$EVENT_TITLE"
+        fi
+        npm run test:services:pr:prepare -- "$TITLE"
       shell: bash
 
     - name: Run service tests

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -8,22 +8,29 @@ on:
 
 jobs:
   test-services:
-    name: ${{ github.event.action == 'edited' && !github.event.changes.title && 'description-edit (service tests skipped)' || 'test-services' }}
-    if: github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title
+    name: ${{ github.event.action == 'edited' && !github.event.changes.title && 'description-edit (no service tests)' || 'test-services' }}
     concurrency:
       # Do not let an ignored description edit cancel an in-progress service test.
       group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
+    env:
+      RUN_SERVICE_TESTS: ${{ github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title }}
     steps:
+      - name: Skip service tests for description-only edit
+        if: env.RUN_SERVICE_TESTS != 'true'
+        run: echo 'The PR title did not change.'
+
       - name: Checkout
+        if: env.RUN_SERVICE_TESTS == 'true'
         uses: actions/checkout@v7
 
       - name: Setup
+        if: env.RUN_SERVICE_TESTS == 'true'
         uses: ./.github/actions/setup
 
       - name: Service tests (triggered from local branch)
-        if: github.event.pull_request.head.repo.full_name == github.repository
+        if: env.RUN_SERVICE_TESTS == 'true' && github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/service-tests
         with:
           github-token: '${{ secrets.GH_PAT }}'
@@ -42,7 +49,7 @@ jobs:
           youtube-api-key: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
 
       - name: Service tests (triggered from fork)
-        if: github.event.pull_request.head.repo.full_name != github.repository
+        if: env.RUN_SERVICE_TESTS == 'true' && github.event.pull_request.head.repo.full_name != github.repository
         uses: ./.github/actions/service-tests
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test-services:
-    name: ${{ github.event.action == 'edited' && !github.event.changes.title && 'description-edit (no service tests)' || 'test-services' }}
+    name: test-services
     concurrency:
       # Do not let an ignored description edit cancel an in-progress service test.
       group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
@@ -19,7 +19,9 @@ jobs:
     steps:
       - name: Skip service tests for description-only edit
         if: env.RUN_SERVICE_TESTS != 'true'
-        run: echo 'The PR title did not change.'
+        run: |
+          echo 'The PR title did not change.'
+          echo 'Service tests were not rerun for this description-only edit.' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Checkout
         if: env.RUN_SERVICE_TESTS == 'true'

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -1,19 +1,17 @@
 name: Services
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
   push:
     branches:
       - 'gh-readonly-queue/**'
 
 concurrency:
-  # Do not let an ignored description edit cancel an in-progress service test.
-  group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
+  group: services-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   test-services:
-    if: github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -6,33 +6,24 @@ on:
     branches:
       - 'gh-readonly-queue/**'
 
+concurrency:
+  # Do not let an ignored description edit cancel an in-progress service test.
+  group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-services:
-    name: test-services
-    concurrency:
-      # Do not let an ignored description edit cancel an in-progress service test.
-      group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
-      cancel-in-progress: true
+    if: github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title
     runs-on: ubuntu-latest
-    env:
-      RUN_SERVICE_TESTS: ${{ github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title }}
     steps:
-      - name: Skip service tests for description-only edit
-        if: env.RUN_SERVICE_TESTS != 'true'
-        run: |
-          echo 'The PR title did not change.'
-          echo 'Service tests were not rerun for this description-only edit.' >> "$GITHUB_STEP_SUMMARY"
-
       - name: Checkout
-        if: env.RUN_SERVICE_TESTS == 'true'
         uses: actions/checkout@v7
 
       - name: Setup
-        if: env.RUN_SERVICE_TESTS == 'true'
         uses: ./.github/actions/setup
 
       - name: Service tests (triggered from local branch)
-        if: env.RUN_SERVICE_TESTS == 'true' && github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: ./.github/actions/service-tests
         with:
           github-token: '${{ secrets.GH_PAT }}'
@@ -51,7 +42,7 @@ jobs:
           youtube-api-key: '${{ secrets.SERVICETESTS_YOUTUBE_API_KEY }}'
 
       - name: Service tests (triggered from fork)
-        if: env.RUN_SERVICE_TESTS == 'true' && github.event.pull_request.head.repo.full_name != github.repository
+        if: github.event.pull_request.head.repo.full_name != github.repository
         uses: ./.github/actions/service-tests
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/test-services.yml
+++ b/.github/workflows/test-services.yml
@@ -6,13 +6,14 @@ on:
     branches:
       - 'gh-readonly-queue/**'
 
-concurrency:
-  group: services-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   test-services:
+    name: ${{ github.event.action == 'edited' && !github.event.changes.title && 'description-edit (service tests skipped)' || 'test-services' }}
     if: github.event_name == 'push' || github.event.action != 'edited' || github.event.changes.title
+    concurrency:
+      # Do not let an ignored description edit cancel an in-progress service test.
+      group: services-${{ github.event.action == 'edited' && !github.event.changes.title && github.run_id || github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
### Why

The Services workflow currently listens to `pull_request.edited`. Description-only edits create a skipped `test-services` check, which replaces the previous real result in the PR UI. Giving the skipped job a different name can conflict with the required `test-services` check, while rerunning service tests on every edit can exhaust API rate limits.

### What

- Stop triggering Services for `pull_request.edited`
- Keep the existing opened, reopened, synchronize, and merge-queue behavior
- Fetch the current PR title from the GitHub API when selecting service tests
- Allow an existing Services run to be rerun after a title edit using the latest title

After changing a PR title, a maintainer can rerun the existing Services workflow. Description edits leave the previous real `test-services` result intact.