### PR TITLE
[BitbucketPipelines] Show halted status for halted pipelines

### DIFF
--- a/services/bitbucket/bitbucket-pipelines.service.js
+++ b/services/bitbucket/bitbucket-pipelines.service.js
@@ -22,6 +22,9 @@ const bitbucketPipelinesSchema = Joi.object({
               'EXPIRED',
             ),
           }),
+          stage: Joi.object({
+            name: Joi.string().required(),
+          }),
         }).required(),
       }),
     )
@@ -91,6 +94,14 @@ class BitbucketPipelines extends BaseJsonService {
         throw new InvalidResponse({ prettyMessage: 'invalid response data' })
       }
       return values[0].state.result.name
+    }
+    const inProgress = data.values.filter(
+      value => value.state && value.state.name === 'IN_PROGRESS',
+    )
+    if (inProgress.length > 0 && inProgress[0].state?.stage?.name) {
+      // e.g: a pipeline HALTED because the account ran out of build minutes
+      // https://github.com/badges/shields/issues/9096
+      return inProgress[0].state.stage.name.toLowerCase()
     }
     return 'never built'
   }

--- a/services/bitbucket/bitbucket-pipelines.tester.js
+++ b/services/bitbucket/bitbucket-pipelines.tester.js
@@ -129,6 +129,39 @@ t.create('build result (with manual build steps)')
   )
   .expectBadge({ label: 'build', message: 'passing' })
 
+// regression test for https://github.com/badges/shields/issues/9096
+t.create('build result (halted, no completed builds)')
+  .get('/shields-io/test-repo/main.json')
+  .intercept(nock =>
+    nock('https://api.bitbucket.org')
+      .get(/^\/2.0\/.*/)
+      .reply(200, {
+        values: [
+          {
+            state: {
+              name: 'IN_PROGRESS',
+              type: 'pipeline_state_in_progress',
+              stage: {
+                name: 'HALTED',
+                type: 'pipeline_state_in_progress_halted',
+              },
+            },
+          },
+          {
+            state: {
+              name: 'IN_PROGRESS',
+              type: 'pipeline_state_in_progress',
+              stage: {
+                name: 'HALTED',
+                type: 'pipeline_state_in_progress_halted',
+              },
+            },
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'build', message: 'halted', color: 'lightgrey' })
+
 t.create('build result no branch redirect')
   .get('/shields-io/test-repo.svg')
   .expectRedirect('/bitbucket/pipelines/shields-io/test-repo/master.svg')


### PR DESCRIPTION
Fixes #9096

## Problem

For repos whose pipelines are `IN_PROGRESS` with stage `HALTED` (typically free-plan accounts that ran out of build minutes) and no completed builds, the badge showed `never built`, which is misleading — the project does have pipelines, they are just halted.

(The original `invalid response data` error reported in the issue was already fixed by #10163; this PR addresses the remaining misleading state, as [suggested in the issue](https://github.com/badges/shields/issues/9096#issuecomment-1476011887): "better handled with a grey HALTED status rather than throwing an error".)

Live example of the misleading badge today: https://img.shields.io/bitbucket/pipelines/harisekhon/diagrams-as-code/master

## Change

In `BitbucketPipelines.transform()`, when there are no `COMPLETED` pipelines but there are `IN_PROGRESS` ones with a `stage`, fall back to the stage name (e.g. `halted`), which renders as a grey badge via `renderBuildStatusBadge()`. `COMPLETED` results still take precedence, so the existing behaviour for repos with completed builds (including the PAUSED-then-completed case from #10137) is unchanged. Also adds `state.stage.name` to the response schema.

## How tested

- Added a mocked regression test reproducing the exact API response from the issue (two `IN_PROGRESS`/`HALTED` pipelines) → expects `build | halted` (grey)
- `npm run test:services -- --only=bitbucketpipelines` — 13 passing, including the existing regression tests for #10137
- Verified the real Bitbucket Cloud API response for the repo from the issue with `curl` (documented `api.bitbucket.org/2.0` endpoint)
- ESLint + Prettier clean

Drafted with AI assistance; reviewed by me (KesleyDavid).
