### PR TITLE
[AzureDevOpsCoverage] Support branch coverage via metric query param

### DIFF
--- a/services/azure-devops/azure-devops-coverage.service.js
+++ b/services/azure-devops/azure-devops-coverage.service.js
@@ -1,5 +1,5 @@
 import Joi from 'joi'
-import { pathParams } from '../index.js'
+import { pathParams, queryParams } from '../index.js'
 import { coveragePercentage as coveragePercentageColor } from '../color-formatters.js'
 import AzureDevOpsBase from './azure-devops-base.js'
 
@@ -20,6 +20,10 @@ Your badge will then have the form:
 
 Optionally, you can specify a named branch:
 \`https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID/NAMED_BRANCH.svg\`.
+
+By default the badge shows line coverage. To show branch coverage instead,
+append the \`metric\` query parameter:
+\`https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID.svg?metric=branch\`.
 `
 
 const buildCodeCoverageSchema = Joi.object({
@@ -41,12 +45,32 @@ const buildCodeCoverageSchema = Joi.object({
     .required(),
 }).required()
 
+const metricEnum = ['line', 'branch']
+
+const metricLabels = {
+  line: ['Line', 'Lines'],
+  branch: ['Branch', 'Branches'],
+}
+
+const queryParamSchema = Joi.object({
+  metric: Joi.string()
+    .valid(...metricEnum)
+    .default('line'),
+}).required()
+
+const openApiQueryParams = queryParams({
+  name: 'metric',
+  example: 'branch',
+  schema: { type: 'string', enum: metricEnum },
+})
+
 export default class AzureDevOpsCoverage extends AzureDevOpsBase {
   static category = 'coverage'
 
   static route = {
     base: 'azure-devops/coverage',
     pattern: ':organization/:project/:definitionId/:branch*',
+    queryParamSchema,
   }
 
   static openApi = {
@@ -54,44 +78,50 @@ export default class AzureDevOpsCoverage extends AzureDevOpsBase {
       get: {
         summary: 'Azure DevOps coverage',
         description,
-        parameters: pathParams(
-          {
-            name: 'organization',
-            example: 'swellaby',
-          },
-          {
-            name: 'project',
-            example: 'opensource',
-          },
-          {
-            name: 'definitionId',
-            example: '25',
-          },
-        ),
+        parameters: [
+          ...pathParams(
+            {
+              name: 'organization',
+              example: 'swellaby',
+            },
+            {
+              name: 'project',
+              example: 'opensource',
+            },
+            {
+              name: 'definitionId',
+              example: '25',
+            },
+          ),
+          ...openApiQueryParams,
+        ],
       },
     },
     '/azure-devops/coverage/{organization}/{project}/{definitionId}/{branch}': {
       get: {
         summary: 'Azure DevOps coverage (branch)',
         description,
-        parameters: pathParams(
-          {
-            name: 'organization',
-            example: 'swellaby',
-          },
-          {
-            name: 'project',
-            example: 'opensource',
-          },
-          {
-            name: 'definitionId',
-            example: '25',
-          },
-          {
-            name: 'branch',
-            example: 'master',
-          },
-        ),
+        parameters: [
+          ...pathParams(
+            {
+              name: 'organization',
+              example: 'swellaby',
+            },
+            {
+              name: 'project',
+              example: 'opensource',
+            },
+            {
+              name: 'definitionId',
+              example: '25',
+            },
+            {
+              name: 'branch',
+              example: 'master',
+            },
+          ),
+          ...openApiQueryParams,
+        ],
       },
     },
   }
@@ -105,7 +135,10 @@ export default class AzureDevOpsCoverage extends AzureDevOpsBase {
     }
   }
 
-  async handle({ organization, project, definitionId, branch }) {
+  async handle(
+    { organization, project, definitionId, branch },
+    { metric = 'line' },
+  ) {
     const httpErrors = {
       404: 'build pipeline or coverage not found',
     }
@@ -135,7 +168,7 @@ export default class AzureDevOpsCoverage extends AzureDevOpsBase {
     let total = 0
     json.coverageData.forEach(cd => {
       cd.coverageStats.forEach(coverageStat => {
-        if (coverageStat.label === 'Line' || coverageStat.label === 'Lines') {
+        if (metricLabels[metric].includes(coverageStat.label)) {
           covered += coverageStat.covered
           total += coverageStat.total
         }

--- a/services/azure-devops/azure-devops-coverage.tester.js
+++ b/services/azure-devops/azure-devops-coverage.tester.js
@@ -43,6 +43,12 @@ const secondLineCovStat = {
   covered: 35,
 }
 
+const secondBranchCovStat = {
+  label: 'Branches',
+  total: 19,
+  covered: 13,
+}
+
 const secondLinesCovStat = {
   label: 'Lines',
   total: 47,
@@ -51,6 +57,8 @@ const secondLinesCovStat = {
 
 const expCoverageSingleReport = '83%'
 const expCoverageMultipleReports = '77%'
+const expCoverageSingleBranchReport = '64%'
+const expCoverageMultipleBranchReports = '67%'
 
 t.create('default branch coverage')
   .get(`${uriPrefix}/${linuxDefinitionId}.json`)
@@ -262,3 +270,82 @@ t.create('multiple JaCoCo style line coverage stat reports')
       }),
   )
   .expectBadge({ label: 'coverage', message: expCoverageMultipleReports })
+
+t.create('branch coverage with metric query param')
+  .get(`${uriPrefix}/${linuxDefinitionId}.json?metric=branch`)
+  .expectBadge({
+    label: 'coverage',
+    message: isIntegerPercentage,
+  })
+
+t.create('single branch coverage stats')
+  .get(`${mockBadgeUriPath}?metric=branch`)
+  .intercept(nock =>
+    nock(azureDevOpsApiBaseUri)
+      .get(mockLatestBuildApiUriPath)
+      .reply(200, latestBuildResponse)
+      .get(mockCodeCoverageApiUriPath)
+      .reply(200, {
+        coverageData: [
+          {
+            coverageStats: [branchCovStat],
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'coverage', message: expCoverageSingleBranchReport })
+
+t.create('mixed line and branch coverage stats with branch metric')
+  .get(`${mockBadgeUriPath}?metric=branch`)
+  .intercept(nock =>
+    nock(azureDevOpsApiBaseUri)
+      .get(mockLatestBuildApiUriPath)
+      .reply(200, latestBuildResponse)
+      .get(mockCodeCoverageApiUriPath)
+      .reply(200, {
+        coverageData: [
+          {
+            coverageStats: [firstLinesCovStat, branchCovStat],
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'coverage', message: expCoverageSingleBranchReport })
+
+t.create('multiple branch coverage stat reports')
+  .get(`${mockBadgeUriPath}?metric=branch`)
+  .intercept(nock =>
+    nock(azureDevOpsApiBaseUri)
+      .get(mockLatestBuildApiUriPath)
+      .reply(200, latestBuildResponse)
+      .get(mockCodeCoverageApiUriPath)
+      .reply(200, {
+        coverageData: [
+          {
+            coverageStats: [
+              firstLinesCovStat,
+              branchCovStat,
+              secondBranchCovStat,
+            ],
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'coverage', message: expCoverageMultipleBranchReports })
+
+t.create('no branch coverage stats')
+  .get(`${mockBadgeUriPath}?metric=branch`)
+  .intercept(nock =>
+    nock(azureDevOpsApiBaseUri)
+      .get(mockLatestBuildApiUriPath)
+      .reply(200, latestBuildResponse)
+      .get(mockCodeCoverageApiUriPath)
+      .reply(200, {
+        coverageData: [
+          {
+            coverageStats: [firstLinesCovStat],
+          },
+        ],
+      }),
+  )
+  .expectBadge({ label: 'coverage', message: '0%' })


### PR DESCRIPTION
Fixes #8750

## What

Adds a `metric` query parameter to the Azure DevOps coverage badge, following the approach outlined by @calebcartwright in the issue:

- `?metric=line` (default, unchanged behaviour) — line coverage, from `Line`/`Lines` coverage stats
- `?metric=branch` — branch coverage, from `Branch`/`Branches` coverage stats

Example: `https://img.shields.io/azure-devops/coverage/ORGANIZATION/PROJECT/DEFINITION_ID.svg?metric=branch`

The default remains `line`, so existing badges are unaffected. The parameter is validated by a query param schema, documented in the badge description and in the OpenAPI definitions, and works for both the default-branch and named-branch routes.

## How tested

- `npm run test:services -- --only=azuredevopscoverage` — 21 passing, including:
  - a live test with `?metric=branch` against the public `swellaby/opensource` AzDO project
  - new mocked tests: single branch stat report, mixed line+branch stats with `metric=branch` (line stats ignored), multiple branch reports aggregated, and no branch stats (`0%`)
  - all pre-existing tests unchanged and passing (default `line` behaviour preserved)
- `npx mocha services/azure-devops/azure-devops-coverage.spec.js` — passing
- `npm run defs` — OpenAPI export clean
- ESLint + Prettier clean

Drafted with AI assistance; reviewed by me (KesleyDavid).
