### PR TITLE
Fix [PubDownloads] test

### DIFF
--- a/services/pub/pub-downloads.tester.js
+++ b/services/pub/pub-downloads.tester.js
@@ -8,7 +8,7 @@ t.create('pub monthly downloads (valid)')
   .expectBadge({
     label: 'downloads',
     message: isMetricOverTimePeriod,
-    color: 'green',
+    color: 'brightgreen',
   })
 
 t.create('pub monthly downloads (not found)')


### PR DESCRIPTION
The `PubDownloads` live test has been failing in the daily test runs.

The monthly download count for [`analysis_options`](https://pub.dev/packages/analysis_options) has grown past 1000, which is the top threshold in `downloadCount`:

```js
// services/color-formatters.js
function downloadCount(downloads) {
  return floorCount(downloads, 10, 100, 1000)
}
```

So the badge now renders `brightgreen` while the test still expected `green`. This updates the expected color to match. As `brightgreen` is the top bucket, this shouldn't drift again.

Verified locally with `npm run test:services -- --only=pub` (13 passing).