### PR TITLE
[GithubSize] Support file paths via query parameter

### DIFF
--- a/services/github/github-size.service.js
+++ b/services/github/github-size.service.js
@@ -1,12 +1,13 @@
 import Joi from 'joi'
 import { renderSizeBadge } from '../size.js'
 import { nonNegativeInteger } from '../validators.js'
-import { NotFound, pathParam, queryParam } from '../index.js'
+import { InvalidParameter, NotFound, pathParam, queryParam } from '../index.js'
 import { GithubAuthV3Service } from './github-auth-service.js'
 import { documentation, httpErrorsFor } from './github-helpers.js'
 
 const queryParamSchema = Joi.object({
   branch: Joi.string(),
+  path: Joi.string(),
 }).required()
 
 const schema = Joi.alternatives(
@@ -21,7 +22,7 @@ export default class GithubSize extends GithubAuthV3Service {
 
   static route = {
     base: 'github/size',
-    pattern: ':user/:repo/:path+',
+    pattern: ':user/:repo/:path*',
     queryParamSchema,
   }
 
@@ -34,6 +35,26 @@ export default class GithubSize extends GithubAuthV3Service {
           pathParam({ name: 'user', example: 'webcaetano' }),
           pathParam({ name: 'repo', example: 'craft' }),
           pathParam({ name: 'path', example: 'build/phaser-craft.min.js' }),
+          queryParam({
+            name: 'branch',
+            example: 'master',
+            description: 'Can be a branch, a tag or a commit hash.',
+          }),
+        ],
+      },
+    },
+    '/github/size/{user}/{repo}': {
+      get: {
+        summary: 'GitHub file size in bytes from a query path',
+        description: documentation,
+        parameters: [
+          pathParam({ name: 'user', example: 'webcaetano' }),
+          pathParam({ name: 'repo', example: 'craft' }),
+          queryParam({
+            name: 'path',
+            example: 'build/phaser-craft.min.js',
+            required: true,
+          }),
           queryParam({
             name: 'branch',
             example: 'master',
@@ -60,8 +81,12 @@ export default class GithubSize extends GithubAuthV3Service {
     }
   }
 
-  async handle({ user, repo, path }, queryParams) {
-    const branch = queryParams.branch
+  async handle({ user, repo, path: routePath }, queryParams) {
+    const { branch, path: queryPath } = queryParams
+    const path = routePath || queryPath
+    if (!path) {
+      throw new InvalidParameter({ prettyMessage: 'path is required' })
+    }
     const body = await this.fetch({ user, repo, path, branch })
     if (Array.isArray(body)) {
       throw new NotFound({ prettyMessage: 'not a regular file' })

--- a/services/github/github-size.tester.js
+++ b/services/github/github-size.tester.js
@@ -6,6 +6,19 @@ t.create('File size')
   .get('/webcaetano/craft/build/phaser-craft.min.js.json')
   .expectBadge({ label: 'size', message: isIecFileSize })
 
+t.create('File size for a filename matching a badge format')
+  .get('/badges/shields.json?path=package.json')
+  .intercept(nock =>
+    nock('https://api.github.com')
+      .get('/repos/badges/shields/contents/package.json')
+      .reply(200, { size: 1024 }),
+  )
+  .expectBadge({ label: 'size', message: '1 KiB' })
+
+t.create('File size without a path')
+  .get('/badges/shields.json')
+  .expectBadge({ label: 'size', message: 'path is required' })
+
 t.create('File size 404')
   .get('/webcaetano/craft/build/does-not-exist.min.js.json')
   .expectBadge({ label: 'size', message: 'repo or file not found' })


### PR DESCRIPTION
## Summary

Add a query-parameter form of the GitHub file-size badge so filenames that look like badge output formats can be requested without ambiguity:

`/github/size/badges/shields.json?path=package.json`

The existing path-based form remains supported for backward compatibility.

Fixes #10548.

## Root cause and approach

In `/github/size/badges/shields/package.json`, Shields interprets the final `.json` as the requested badge format. The service consequently receives `package` as the file path and asks GitHub for the wrong file.

The service route now permits the path segment to be omitted and accepts `path` in its validated query schema. `handle()` prefers the existing route path when present, otherwise uses the query path, and returns a clear `path is required` error if neither is supplied. A second OpenAPI route documents the query form. This adds an unambiguous entry point without breaking existing badge URLs.

## Verification

- `npm run test:services -- --only=GithubSize --fgrep='filename matching a badge format'` — 1 passing.
- `npm run test:services -- --only=GithubSize --fgrep='File size without a path'` — 1 passing.
- The success regression mocks GitHub's contents API, asserts the request reaches `/contents/package.json`, and verifies a `1 KiB` badge.
- `npx --no-install eslint services/github/github-size.service.js services/github/github-size.tester.js` — passed.
- `npx --no-install prettier --check services/github/github-size.service.js services/github/github-size.tester.js` — passed.
- `npm run defs` — passed.

## Scope

Only `GithubSize` routing/query validation, its OpenAPI definition, and two focused service tests change. Existing route-path and branch behavior are retained.

## AI assistance

OpenAI Codex (GPT-5) was used to inspect the route/format interaction, implement the minimal backward-compatible change, and run/review the tests and final diff. The repository does not prohibit AI-assisted contributions; this usage is disclosed explicitly.