### PR TITLE
Disable server SPDY pathway due to incompatibility with newer Node.js versions

### DIFF
--- a/core/server/server.js
+++ b/core/server/server.js
@@ -541,6 +541,7 @@ class Server {
       port,
       hostname,
       secure,
+      spdy: false,
       staticMaxAge: 300,
       cert,
       key,


### PR DESCRIPTION
Fixes https://github.com/badges/shields/issues/12106.

Unless specified otherwise, an SPDY-based Scoutcamp server is created when opting for HTTPS
https://github.com/badges/sc/blob/4f6e44522638392465ac093fa3354eec312d49ff/lib/camp.js#L1047-L1051

This change explicitly passes argument to disable SPDY, sidestepping the broken HTTP/2 response path in Camp/SPDY exposed by recent shift to newer Node.js release.

It should only affect Shields instances configured with `HTTPS=true` as an already non-working combination.