### PR TITLE
Fix [DockerVersion DockerSize] pagination

### DIFF
--- a/services/docker/docker-fixtures.js
+++ b/services/docker/docker-fixtures.js
@@ -32,62 +32,7 @@ const sizeDataNoTagSemVerSort = [
     ],
   },
 ]
-const versionDataNoTagDateSort = {
-  count: 4,
-  results: [
-    {
-      name: 'latest',
-      images: [
-        {
-          digest:
-            'sha256:6bdb610acd12a4446d6dd839ebf8c2927c8e6bbde8b7beb2562d1f7f7c4437fb',
-          architecture: 'arm64',
-        },
-        {
-          digest:
-            'sha256:4070dd02827ed3545acb745de3b567a42b87828bb842181e80a2b69f6e3b37b2',
-          architecture: 'amd64',
-        },
-        {
-          digest:
-            'sha256:6f21523ebe450faa23e688b7ea3556ddf4415032263a80ad1f1543463098a779',
-          architecture: 'arm',
-        },
-      ],
-    },
-    {
-      name: 'arm64v8-latest',
-      images: [
-        {
-          digest:
-            'sha256:6bdb610acd12a4446d6dd839ebf8c2927c8e6bbde8b7beb2562d1f7f7c4437fb',
-          architecture: 'amd64',
-        },
-      ],
-    },
-    {
-      name: 'arm32v7-latest',
-      images: [
-        {
-          digest:
-            'sha256:6f21523ebe450faa23e688b7ea3556ddf4415032263a80ad1f1543463098a779',
-          architecture: 'amd64',
-        },
-      ],
-    },
-    {
-      name: 'amd64-latest',
-      images: [
-        {
-          digest:
-            'sha256:4070dd02827ed3545acb745de3b567a42b87828bb842181e80a2b69f6e3b37b2',
-          architecture: 'amd64',
-        },
-      ],
-    },
-  ],
-}
-const versionPagedDataNoTagDateSort = [
+const versionDataNoTagDateSort = [
   {
     name: 'latest',
     images: [
@@ -3044,7 +2989,6 @@ const versionDataWithArchSpecificVersions = [
 export {
   sizeDataNoTagSemVerSort,
   versionDataNoTagDateSort,
-  versionPagedDataNoTagDateSort,
   versionDataNoTagSemVerSort,
   versionDataWithTag,
   versionDataWithVaryingArchitectures,

--- a/services/docker/docker-helpers.js
+++ b/services/docker/docker-helpers.js
@@ -2,6 +2,7 @@ import Joi from 'joi'
 // see https://github.com/badges/shields/pull/1690
 import { NotFound } from '../index.js'
 const dockerBlue = '066da5'
+const maxDockerHubAnonymousPages = 10
 
 const archEnum = [
   'amd64',
@@ -44,25 +45,35 @@ function getDockerHubUser(user) {
   return user === '_' ? 'library' : user
 }
 
-async function getMultiPageData({ user, repo, fetch }) {
-  const data = await fetch({ user, repo })
+async function getMultiPageData({
+  user,
+  repo,
+  fetch,
+  isAuthenticated = false,
+  shouldFetchRemainingPages = () => true,
+}) {
+  const firstPageData = await fetch({ user, repo })
 
-  if (data.count === 0) {
+  if (firstPageData.count === 0) {
     throw new NotFound({ prettyMessage: 'repository not found' })
   }
 
-  const numberOfPages = Math.ceil(data.count / 100) // Maximum of 100 results can be returned per page
-
-  if (numberOfPages === 1) {
-    return data.results
+  if (!shouldFetchRemainingPages(firstPageData.results)) {
+    return firstPageData.results
   }
 
+  // Maximum of 100 results can be returned per page. Docker Hub rejects
+  // anonymous requests for page 11 (offset 1,000) with the following error:
+  // "pagination offset too large for anonymous requests; sign in to page further".
+  const maxPages = isAuthenticated ? Infinity : maxDockerHubAnonymousPages
+  const numberOfPages = Math.min(Math.ceil(firstPageData.count / 100), maxPages)
+
   const pageData = await Promise.all(
-    [...Array(numberOfPages - 1).keys()].map((_, i) =>
-      fetch({ user, repo, page: ++i + 1 }),
+    Array.from({ length: numberOfPages - 1 }, (_, pageIndex) =>
+      fetch({ user, repo, page: pageIndex + 2 }),
     ),
   )
-  return [...data.results].concat(...pageData.map(p => p.results))
+  return [firstPageData, ...pageData].flatMap(({ results }) => results)
 }
 
 function getDigestSemVerMatches({ data, digest }) {

--- a/services/docker/docker-size.service.js
+++ b/services/docker/docker-size.service.js
@@ -223,6 +223,7 @@ export default class DockerSize extends BaseJsonService {
         user,
         repo,
         fetch: this.fetch.bind(this),
+        isAuthenticated: this.authHelper.isConfigured,
       })
     } else {
       data = await this.fetch({ user, repo, tag })

--- a/services/docker/docker-size.spec.js
+++ b/services/docker/docker-size.spec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
 import { test, given } from 'sazerac'
 import DockerSize from './docker-size.service.js'
 import { sizeDataNoTagSemVerSort } from './docker-fixtures.js'
@@ -97,5 +99,39 @@ describe('DockerSize', function () {
     given(sizeDataNoTagSemVerSort, 'nonexistentArch').expectError(
       'Not Found: architecture not found',
     )
+  })
+
+  it('fetches anonymous pages 1 through 10 exactly once for semver sorting', async function () {
+    const service = new DockerSize({ authHelper: { isConfigured: false } }, {})
+    service.fetch = sinon.stub().resolves({
+      count: 1001,
+      results: [{ name: '1.0.0', full_size: 1, images: [] }],
+    })
+
+    await service.handle(
+      { user: 'example', repo: 'repository' },
+      { sort: 'semver' },
+    )
+
+    expect(
+      service.fetch.getCalls().map(({ args: [params] }) => params.page),
+    ).to.deep.equal([undefined, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
+
+  it('fetches authenticated pages 1 through 11 exactly once for semver sorting', async function () {
+    const service = new DockerSize({ authHelper: { isConfigured: true } }, {})
+    service.fetch = sinon.stub().resolves({
+      count: 1001,
+      results: [{ name: '1.0.0', full_size: 1, images: [] }],
+    })
+
+    await service.handle(
+      { user: 'example', repo: 'repository' },
+      { sort: 'semver' },
+    )
+
+    expect(
+      service.fetch.getCalls().map(({ args: [params] }) => params.page),
+    ).to.deep.equal([undefined, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
   })
 })

--- a/services/docker/docker-size.tester.js
+++ b/services/docker/docker-size.tester.js
@@ -30,6 +30,13 @@ t.create('docker image size (valid, user)')
     message: isIecFileSize,
   })
 
+t.create('docker image size (valid, user, semver sort)')
+  .get('/jrottenberg/ffmpeg.json?sort=semver')
+  .expectBadge({
+    label: 'image size',
+    message: isIecFileSize,
+  })
+
 t.create('docker image size (valid, user with tag)')
   .get('/jrottenberg/ffmpeg/3.2-alpine.json')
   .expectBadge({

--- a/services/docker/docker-version.service.js
+++ b/services/docker/docker-version.service.js
@@ -116,22 +116,22 @@ export default class DockerVersion extends BaseJsonService {
     })
   }
 
-  transform({ tag, sort, data, pagedData, arch = 'amd64' }) {
+  transform({ tag, sort, data, arch = 'amd64' }) {
     let version
 
     if (!tag && sort === 'date') {
-      version = data.results[0].name
+      version = data[0].name
       if (version !== 'latest') {
         return { version }
       }
-      const imageTag = data.results[0].images.find(i => i.architecture === arch) // Digest is the unique field that we utilise to match images
+      const imageTag = data[0].images.find(i => i.architecture === arch) // Digest is the unique field that we utilise to match images
       if (!imageTag) {
         throw new InvalidResponse({
           prettyMessage: 'digest not found for latest tag',
         })
       }
       const { digest } = imageTag
-      return { version: getDigestSemVerMatches({ data: pagedData, digest }) }
+      return { version: getDigestSemVerMatches({ data, digest }) }
     } else if (!tag && sort === 'semver') {
       const matches = data
         .filter(d => d.images.some(image => image.architecture === arch))
@@ -162,35 +162,17 @@ export default class DockerVersion extends BaseJsonService {
   }
 
   async handle({ user, repo, tag }, { sort, arch }) {
-    let data, pagedData
-
-    if (!tag && sort === 'date') {
-      data = await this.fetch({ user, repo })
-      if (data.count === 0) {
-        throw new NotFound({ prettyMessage: 'repository not found' })
-      }
-      if (data.results[0].name === 'latest') {
-        pagedData = await getMultiPageData({
-          user,
-          repo,
-          fetch: this.fetch.bind(this),
-        })
-      }
-    } else {
-      data = await getMultiPageData({
-        user,
-        repo,
-        fetch: this.fetch.bind(this),
-      })
-    }
-
-    const { version } = this.transform({
-      tag,
-      sort,
-      data,
-      pagedData,
-      arch,
+    const isDateSort = !tag && sort === 'date'
+    const data = await getMultiPageData({
+      user,
+      repo,
+      fetch: this.fetch.bind(this),
+      isAuthenticated: this.authHelper.isConfigured,
+      shouldFetchRemainingPages: ([firstTag]) =>
+        !isDateSort || firstTag.name === 'latest',
     })
+
+    const { version } = this.transform({ tag, sort, data, arch })
     return this.constructor.render({ version })
   }
 }

--- a/services/docker/docker-version.spec.js
+++ b/services/docker/docker-version.spec.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai'
+import sinon from 'sinon'
 import { test, given } from 'sazerac'
 import { InvalidResponse } from '../index.js'
 import DockerVersion from './docker-version.service.js'
 import {
   versionDataNoTagDateSort,
-  versionPagedDataNoTagDateSort,
   versionDataNoTagSemVerSort,
   versionDataWithTag,
   versionDataWithVaryingArchitectures,
@@ -16,14 +16,14 @@ describe('DockerVersion', function () {
     given({
       tag: '',
       sort: 'date',
-      data: { results: [{ name: 'stable' }] },
+      data: [{ name: 'stable' }],
     }).expect({
       version: 'stable',
     })
     given({
       tag: '',
       sort: 'date',
-      data: { results: [{ name: '3.9.5' }] },
+      data: [{ name: '3.9.5' }],
     }).expect({
       version: '3.9.5',
     })
@@ -31,7 +31,6 @@ describe('DockerVersion', function () {
       tag: '',
       sort: 'date',
       data: versionDataNoTagDateSort,
-      pagedData: versionPagedDataNoTagDateSort,
     }).expect({
       version: 'amd64-latest',
     })
@@ -75,29 +74,109 @@ describe('DockerVersion', function () {
     })
   })
 
+  it('does not paginate date-sorted requests whose newest tag is not latest', async function () {
+    const service = new DockerVersion(
+      { authHelper: { isConfigured: false } },
+      {},
+    )
+    service.fetch = sinon.stub().resolves({
+      count: 1001,
+      results: [{ name: '1.0.0', images: [] }],
+    })
+
+    await service.handle(
+      { user: 'example', repo: 'repository' },
+      { sort: 'date', arch: 'amd64' },
+    )
+
+    expect(
+      service.fetch.getCalls().map(({ args: [params] }) => params.page),
+    ).to.deep.equal([undefined])
+  })
+
+  it('fetches anonymous pages 1 through 10 exactly once', async function () {
+    const service = new DockerVersion(
+      { authHelper: { isConfigured: false } },
+      {},
+    )
+    service.fetch = sinon.stub().resolves({
+      count: 1001,
+      results: [
+        {
+          name: 'latest',
+          images: [
+            {
+              architecture: 'amd64',
+              digest:
+                'sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31',
+            },
+          ],
+        },
+      ],
+    })
+
+    await service.handle(
+      { user: 'example', repo: 'repository' },
+      { sort: 'date', arch: 'amd64' },
+    )
+
+    expect(
+      service.fetch.getCalls().map(({ args: [params] }) => params.page),
+    ).to.deep.equal([undefined, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+  })
+
+  it('fetches authenticated pages 1 through 11 exactly once', async function () {
+    const service = new DockerVersion(
+      { authHelper: { isConfigured: true } },
+      {},
+    )
+    service.fetch = sinon.stub().resolves({
+      count: 1001,
+      results: [
+        {
+          name: 'latest',
+          images: [
+            {
+              architecture: 'amd64',
+              digest:
+                'sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31',
+            },
+          ],
+        },
+      ],
+    })
+
+    await service.handle(
+      { user: 'example', repo: 'repository' },
+      { sort: 'date', arch: 'amd64' },
+    )
+
+    expect(
+      service.fetch.getCalls().map(({ args: [params] }) => params.page),
+    ).to.deep.equal([undefined, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11])
+  })
+
   it('throws InvalidResponse error with latest tag and no amd64 architecture digests', function () {
     expect(() => {
       DockerVersion.prototype.transform({
         sort: 'date',
-        data: {
-          results: [
-            {
-              name: 'latest',
-              images: [
-                {
-                  architecture: 'arm64',
-                  digest:
-                    'sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31',
-                },
-                {
-                  architecture: 'arm',
-                  digest:
-                    'sha256:c5ea49127cd44d0f50eafda229a056bb83b6e691883c56fd863d42675fae3909',
-                },
-              ],
-            },
-          ],
-        },
+        data: [
+          {
+            name: 'latest',
+            images: [
+              {
+                architecture: 'arm64',
+                digest:
+                  'sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31',
+              },
+              {
+                architecture: 'arm',
+                digest:
+                  'sha256:c5ea49127cd44d0f50eafda229a056bb83b6e691883c56fd863d42675fae3909',
+              },
+            ],
+          },
+        ],
       })
     })
       .to.throw(InvalidResponse)


### PR DESCRIPTION
Some of our Docker tests that were using images with a lot of tags started failing recently. We were getting the following error back from the API:
> pagination offset too large for anonymous requests; sign in to page further

This caps the pagination to 10 pages for unauthenticated requests: in all likelihood the result we're looking for is in those 10 first pages anyway.

Additionally, our DockerSize badge was effectively fetching the first page twice, once towards the start of its `handle` function, and a second time in `getMultiPageData`. The larger refactor addresses this and saves an API call.