### PR TITLE
Fix server test failure

### DIFF
--- a/core/server/server.spec.js
+++ b/core/server/server.spec.js
@@ -480,6 +480,7 @@ describe('The server', function () {
     })
 
     it('should parse dynamicAndEndpointBadgesEnabled environment values as booleans', function () {
+      this.timeout(5000)
       const script = `
         import config from 'config'
         import Server from './core/server/server.js'


### PR DESCRIPTION
We occasionally get the following test failure in our Windows CI run:
> The server configuration validation should parse dynamicAndEndpointBadgesEnabled environment values as booleans

> Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (D:\a\shields\shields\core\server\server.spec.js)
    at process.processImmediate (node:internal/timers:504:21)

Let's increase the timeout to 5s to give ourselves more headroom.
