### PR TITLE
fix([GitHub] downloads): handle 'total' keyword for all releases

### DIFF
--- a/services/github/github-downloads.service.js
+++ b/services/github/github-downloads.service.js
@@ -163,6 +163,8 @@ export default class GithubDownloads extends GithubAuthV3Service {
     { sort, displayAssetName },
   ) {
     let releases
+    // "total" with no assetName means "all releases, all assets" (e.g. /github/downloads/user/repo/total)
+    const isTotalAllReleases = tag === 'total' && !assetName
     if (tag === 'latest') {
       const includePre = variant === 'downloads-pre' || undefined
       const latestRelease = await fetchLatestRelease(
@@ -171,7 +173,7 @@ export default class GithubDownloads extends GithubAuthV3Service {
         { sort, include_prereleases: includePre },
       )
       releases = [latestRelease]
-    } else if (tag) {
+    } else if (tag && !isTotalAllReleases) {
       const wantedRelease = await this._requestJson({
         schema: releaseSchema,
         url: `/repos/${user}/${repo}/releases/tags/${tag}`,

--- a/services/github/github-downloads.tester.js
+++ b/services/github/github-downloads.tester.js
@@ -13,6 +13,35 @@ const mockReleases = releases => nock =>
     .get('/repos/photonstorm/phaser/releases?per_page=100')
     .reply(200, releases)
 
+const mockAllReleases = releases => nock =>
+  nock('https://api.github.com')
+    .get('/repos/photonstorm/phaser/releases?per_page=500')
+    .reply(200, releases)
+
+t.create('Downloads all releases (total across all releases)')
+  .get('/downloads/photonstorm/phaser/total.json')
+  .intercept(
+    mockAllReleases([
+      {
+        assets: [
+          { name: 'phaser.js', download_count: 10 },
+          { name: 'phaser.min.js', download_count: 20 },
+        ],
+        tag_name: 'v3.15.0',
+        prerelease: false,
+      },
+      {
+        assets: [
+          { name: 'phaser.js', download_count: 5 },
+          { name: 'phaser.min.js', download_count: 15 },
+        ],
+        tag_name: 'v3.15.1',
+        prerelease: false,
+      },
+    ]),
+  )
+  .expectBadge({ label: 'downloads', message: '50' })
+
 t.create('Downloads all releases')
   .get('/downloads/photonstorm/phaser/total.json')
   .expectBadge({ label: 'downloads', message: isMetric })


### PR DESCRIPTION
Fixes #11216

## Problem
The GitHub downloads badge for "total" across all releases (`/github/downloads/{user}/{repo}/total`) was returning "invalid" because the route pattern `:variant/:user/:repo/:tag*/:assetName` matches it as `tag=total`, `assetName=undefined`. The handle function then tried to fetch a release with tag "total" (which doesn't exist) instead of fetching all releases.

## Solution
Added detection for `tag === 'total' && !assetName` in the handle function to treat it as "all releases, all assets" - fetching from `/repos/{user}/{repo}/releases` instead of `/repos/{user}/{repo}/releases/tags/total`.

## Testing
Added a test case that mocks the all-releases endpoint with multiple releases and verifies the total downloads are correctly summed (10+20+5+15=50).
