### PR TITLE
fix: regex for triple dotted version validation [Cdnjs CondaVersion Cran Galaxytoolshed Homebrew Pub]

### DIFF
--- a/services/test-validators.js
+++ b/services/test-validators.js
@@ -23,7 +23,7 @@ const withRegex = re => Joi.string().regex(re)
  *
  * @type {Joi.StringSchema}
  */
-const isVPlusTripleDottedVersion = withRegex(/^v[0-9]+.[0-9]+.[0-9]+$/)
+const isVPlusTripleDottedVersion = withRegex(/^v[0-9]+\.[0-9]+\.[0-9]+$/)
 
 /**
  * Validates a version string prefixed by `v` with at least a major version


### PR DESCRIPTION
noticed this while working on another PR.
`isVPlusTripleDottedVersion` is allowing any char and not just `.` as the `.` is not escaped `\.`
so this regex would accept also `v1a2b3` for example.