### PR TITLE
[OSSFScorecard] Read api.scorecard.dev, not the diverged legacy host

### DIFF
--- a/services/ossf-scorecard/ossf-scorecard.service.js
+++ b/services/ossf-scorecard/ossf-scorecard.service.js
@@ -50,7 +50,7 @@ export default class OSSFScorecard extends BaseJsonService {
   async fetch({ host, orgName, repoName }) {
     return this._requestJson({
       schema,
-      url: `https://api.securityscorecards.dev/projects/${host}/${orgName}/${repoName}`,
+      url: `https://api.scorecard.dev/projects/${host}/${orgName}/${repoName}`,
       httpErrors: {
         404: 'invalid repo path',
       },


### PR DESCRIPTION
Fixes #12117, where a Scorecard maintainer confirmed the divergence is a CDN
bug: purges reach `api.scorecard.dev` but not `api.securityscorecards.dev`.

Same repo, fetched just now:

| host | score | result date |
|---|---|---|
| `api.scorecard.dev` | 8.3 | 2026-09-01 |
| `api.securityscorecards.dev` | 7.3 | 2026-08-25 |

Response shape is unchanged, and both service-test fixtures behave identically
on the new host — `rohankh532/org-workflow-add` returns 200 with a score,
`invalid-user/invalid-repo` returns 404.

@rhalbersma had planned this PR; happy to close in favour of theirs.


