### PR TITLE
[TeamCity] Add 'metric' query parameter to TeamCity coverage badge

### DIFF
--- a/services/teamcity/teamcity-coverage.service.js
+++ b/services/teamcity/teamcity-coverage.service.js
@@ -17,7 +17,19 @@ const buildStatisticsSchema = Joi.object({
 
 const queryParamSchema = Joi.object({
   server: optionalUrl,
+  metric: Joi.string()
+    .valid('statement', 'line', 'block', 'method', 'class', 'branch')
+    .default('statement'),
 }).required()
+
+const METRIC_CODE = {
+  statement: 'S',
+  line: 'L',
+  block: 'B',
+  method: 'M',
+  class: 'C',
+  branch: 'R',
+}
 
 export default class TeamCityCoverage extends TeamCityBase {
   static category = 'coverage'
@@ -38,6 +50,10 @@ export default class TeamCityCoverage extends TeamCityBase {
             name: 'server',
             example: 'https://teamcity.jetbrains.com',
           }),
+          queryParam({
+            name: 'metric',
+            example: 'statement',
+          }),
         ],
       },
     },
@@ -54,13 +70,16 @@ export default class TeamCityCoverage extends TeamCityBase {
     }
   }
 
-  transform({ data }) {
+  transform({ data, metric }) {
+    const code = METRIC_CODE[metric]
+    const coveredKey = `CodeCoverageAbs${code}Covered`
+    const totalKey = `CodeCoverageAbs${code}Total`
     let covered, total
 
     for (const p of data.property) {
-      if (p.name === 'CodeCoverageAbsSCovered') {
+      if (p.name === coveredKey) {
         covered = +p.value
-      } else if (p.name === 'CodeCoverageAbsSTotal') {
+      } else if (p.name === totalKey) {
         total = +p.value
       }
 
@@ -73,7 +92,10 @@ export default class TeamCityCoverage extends TeamCityBase {
     throw new InvalidResponse({ prettyMessage: 'no coverage data available' })
   }
 
-  async handle({ buildId }, { server = 'https://teamcity.jetbrains.com' }) {
+  async handle(
+    { buildId },
+    { server = 'https://teamcity.jetbrains.com', metric },
+  ) {
     // JetBrains Docs: https://confluence.jetbrains.com/display/TCD18/REST+API#RESTAPI-Statistics
     const buildLocator = `buildType:(id:${buildId})`
     const apiPath = `app/rest/builds/${encodeURIComponent(
@@ -84,7 +106,7 @@ export default class TeamCityCoverage extends TeamCityBase {
       schema: buildStatisticsSchema,
     })
 
-    const { coverage } = this.transform({ data })
+    const { coverage } = this.transform({ data, metric })
     return this.constructor.render({ coverage })
   }
 }

--- a/services/teamcity/teamcity-coverage.tester.js
+++ b/services/teamcity/teamcity-coverage.tester.js
@@ -17,6 +17,15 @@ t.create('specified instance valid buildId')
     message: isIntegerPercentage,
   })
 
+t.create('Coverage (with metric)')
+  .get(
+    '/FileHelpersStable.json?server=https://teamcity.jetbrains.com&metric=line',
+  )
+  .expectBadge({
+    label: 'coverage',
+    message: isIntegerPercentage,
+  })
+
 t.create('no coverage data for build')
   .get('/bt234.json')
   .intercept(nock =>
@@ -26,6 +35,24 @@ t.create('no coverage data for build')
       .reply(200, { property: [] }),
   )
   .expectBadge({ label: 'coverage', message: 'no coverage data available' })
+
+t.create('mocked: coverage with line metric')
+  .get('/MyFakeBuild.json?server=https://teamcity.jetbrains.com&metric=line')
+  .intercept(nock =>
+    nock('https://teamcity.jetbrains.com/app/rest/builds')
+      .get(`/${encodeURIComponent('buildType:(id:MyFakeBuild)')}/statistics`)
+      .query({ guest: 1 })
+      .reply(200, {
+        property: [
+          { name: 'CodeCoverageAbsLCovered', value: '85' },
+          { name: 'CodeCoverageAbsLTotal', value: '100' },
+        ],
+      }),
+  )
+  .expectBadge({
+    label: 'coverage',
+    message: '85%',
+  })
 
 t.create('zero lines covered')
   .get('/bt345.json')


### PR DESCRIPTION
Added a new `metric` query parameter to the TeamCity coverage badge to allow users to specify which coverage type to display (e.g., `line`, `block`, `method`, `class`, `branch`).

* Kept backward compatibility by setting the default metric to `statement` (which maps to `S`), so existing badge URLs will not break.
* The metric codes (`S`, `L`, `M`, `C`, `B`, `R`) map directly to TeamCity's internal `CodeCoverageAbs*` statistical values. Reference: [TeamCity Custom Chart Documentation](https://www.jetbrains.com/help/teamcity/custom-chart.html#Built-in+Statistic+Values).

**Testing & Mocking Details:**
I was unable to test against the live JetBrains TeamCity server (`https://teamcity.jetbrains.com`) because it now requires authentication to view statistics for the `FileHelpersStable` build (it returns a `401 Unauthorized` / inaccessible error for guests). 

Because I couldn't hit the actual API, I tested this logic entirely via the local mocked service tests in `teamcity-coverage.tester.js`. The tests intercept the outbound request and feed it mocked JSON responses to prove that the code correctly extracts the different `metric` values (like `CodeCoverageAbsLCovered`) and calculates the percentage accurately without needing a live, public TeamCity server.

Closes #<#3111>
