### PR TITLE
[GithubCheckRuns] pass nameFilter as check_name to GitHub API

### DIFF
--- a/services/github/github-check-runs.service.js
+++ b/services/github/github-check-runs.service.js
@@ -182,6 +182,9 @@ export default class GithubCheckRuns extends GithubAuthV3Service {
     // https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference
     const json = await this._requestJson({
       url: `/repos/${user}/${repo}/commits/${ref}/check-runs`,
+      options: {
+        searchParams: nameFilter ? { check_name: nameFilter } : undefined,
+      },
       httpErrors: httpErrorsFor('ref or repo not found'),
       schema,
     })

--- a/services/github/github-check-runs.spec.js
+++ b/services/github/github-check-runs.spec.js
@@ -1,5 +1,76 @@
+import { expect } from 'chai'
+import sinon from 'sinon'
 import { test, given } from 'sazerac'
+import '../../core/register-chai-plugins.spec.js'
+import GithubApiProvider from './github-api-provider.js'
 import GithubCheckRuns from './github-check-runs.service.js'
+
+const mockCheckRunsResponse = {
+  total_count: 1,
+  check_runs: [
+    { name: 'test-lint', status: 'completed', conclusion: 'success' },
+  ],
+}
+
+const rateLimitHeaders = {
+  'x-ratelimit-limit': 5000,
+  'x-ratelimit-remaining': 4999,
+  'x-ratelimit-reset': 123456789,
+}
+
+async function invokeWithMockRequest(nameFilter) {
+  const requestFetcher = sinon.stub().returns(
+    Promise.resolve({
+      buffer: JSON.stringify(mockCheckRunsResponse),
+      res: {
+        statusCode: 200,
+        headers: rateLimitHeaders,
+      },
+    }),
+  )
+  const githubApiProvider = new GithubApiProvider({
+    baseUrl: 'https://github-api.example.com',
+    authType: GithubApiProvider.AUTH_TYPES.TOKEN_POOL,
+    restApiVersion: '2022-11-28',
+  })
+  const mockToken = {
+    update: sinon.mock(),
+    invalidate: sinon.mock(),
+    recordFailedAttempt: sinon.mock(),
+    resetFailedAttempts: sinon.mock(),
+  }
+  sinon.stub(githubApiProvider.standardTokens, 'next').returns(mockToken)
+
+  const queryParams = nameFilter ? { nameFilter } : {}
+  await GithubCheckRuns.invoke(
+    { requestFetcher, githubApiProvider },
+    { handleInternalErrors: false },
+    { user: 'badges', repo: 'shields', ref: 'master' },
+    queryParams,
+  )
+  return requestFetcher
+}
+
+describe('GithubCheckRuns handle', function () {
+  it('passes check_name to GitHub API when nameFilter is provided', async function () {
+    const requestFetcher = await invokeWithMockRequest('test-lint')
+
+    expect(requestFetcher).to.have.been.calledOnceWith(
+      'https://github-api.example.com/repos/badges/shields/commits/master/check-runs',
+      sinon.match({
+        searchParams: { check_name: 'test-lint' },
+      }),
+    )
+  })
+
+  it('does not pass check_name when nameFilter is omitted', async function () {
+    const requestFetcher = await invokeWithMockRequest()
+
+    expect(requestFetcher).to.have.been.calledOnce
+    const [, options] = requestFetcher.firstCall.args
+    expect(options.searchParams).to.be.undefined
+  })
+})
 
 describe('GithubCheckRuns.transform', function () {
   test(GithubCheckRuns.transform, () => {


### PR DESCRIPTION
### Summary
Fixes a bug where the GitHub Check Runs badge returns "no check runs" when using nameFilter, even though the check exists.

Previously, nameFilter only filtered the first page of results client-side. For repos with many check runs, the target check could be on page 2+ and was never fetched.

Now, when nameFilter is provided, it is passed to GitHub as the check_name query parameter, so filtering happens server-side and pagination is no longer an issue.

fixes #12149 

### Changes

1. Pass check_name in the List check runs API request when nameFilter is set
2. Add unit tests verifying the API request includes check_name when filtered, and omits it when not

### Test plan

- [x] npm run test:core -- --grep "GithubCheckRuns handle"
- [x] TZ=UTC NODE_CONFIG_ENV=test npx mocha services/github/github-check-runs.spec.js
