### PR TITLE
Improve [ChromeWebStore] rating count handling and fix all examples

### DIFF
--- a/services/chrome-web-store/chrome-web-store-rating.service.js
+++ b/services/chrome-web-store/chrome-web-store-rating.service.js
@@ -1,6 +1,6 @@
 import { floorCount as floorCountColor } from '../color-formatters.js'
 import { metric, starRating } from '../text-formatters.js'
-import { NotFound, pathParams } from '../index.js'
+import { InvalidResponse, NotFound, pathParams } from '../index.js'
 import BaseChromeWebStoreService, {
   description,
 } from './chrome-web-store-base.js'
@@ -24,7 +24,7 @@ class ChromeWebStoreRating extends BaseChromeWebStoreRating {
         description,
         parameters: pathParams({
           name: 'storeId',
-          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+          example: 'ddkjiahejlhfcafbddmgiahcphecmpfh',
         }),
       },
     },
@@ -61,7 +61,7 @@ class ChromeWebStoreRatingCount extends BaseChromeWebStoreRating {
         description,
         parameters: pathParams({
           name: 'storeId',
-          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+          example: 'ddkjiahejlhfcafbddmgiahcphecmpfh',
         }),
       },
     },
@@ -74,6 +74,17 @@ class ChromeWebStoreRatingCount extends BaseChromeWebStoreRating {
     }
   }
 
+  static transform(ratingCount) {
+    const match = ratingCount.match(/^(\d+(?:\.\d+)?)(k)?$/i)
+    if (!match) {
+      throw new InvalidResponse({
+        prettyMessage: 'unexpected rating count format',
+      })
+    }
+
+    return Number.parseFloat(ratingCount) * (match[2] ? 1e3 : 1)
+  }
+
   async handle({ storeId }) {
     const chromeWebStore = await this.fetch({
       storeId,
@@ -83,7 +94,9 @@ class ChromeWebStoreRatingCount extends BaseChromeWebStoreRating {
     if (ratingCount == null) {
       throw new NotFound({ prettyMessage: 'not found' })
     }
-    return this.constructor.render({ ratingCount })
+    return this.constructor.render({
+      ratingCount: this.constructor.transform(ratingCount),
+    })
   }
 }
 
@@ -100,7 +113,7 @@ class ChromeWebStoreRatingStars extends BaseChromeWebStoreRating {
         description,
         parameters: pathParams({
           name: 'storeId',
-          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+          example: 'ddkjiahejlhfcafbddmgiahcphecmpfh',
         }),
       },
     },

--- a/services/chrome-web-store/chrome-web-store-rating.spec.js
+++ b/services/chrome-web-store/chrome-web-store-rating.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai'
+import { test, given } from 'sazerac'
+import { InvalidResponse } from '../index.js'
+import { ChromeWebStoreRatingCount } from './chrome-web-store-rating.service.js'
+
+describe('ChromeWebStoreRatingCount', function () {
+  describe('transform', function () {
+    it('converts Chrome Web Store rating counts to numbers', function () {
+      test(ChromeWebStoreRatingCount.transform, () => {
+        given('999').expect(999)
+        given('3.5').expect(3.5)
+        given('3.5K').expect(3500)
+        given('3.5k').expect(3500)
+      })
+    })
+
+    it('throws when the format is unexpected', function () {
+      expect(() => ChromeWebStoreRatingCount.transform('2M')).to.throw(
+        InvalidResponse,
+      )
+      expect(() => ChromeWebStoreRatingCount.transform('ratings')).to.throw(
+        InvalidResponse,
+      )
+    })
+  })
+})

--- a/services/chrome-web-store/chrome-web-store-rating.tester.js
+++ b/services/chrome-web-store/chrome-web-store-rating.tester.js
@@ -1,6 +1,6 @@
 import Joi from 'joi'
 import { Agent, MockAgent, setGlobalDispatcher } from 'undici'
-import { isStarRating } from '../test-validators.js'
+import { isMetricWithPattern, isStarRating } from '../test-validators.js'
 import { ServiceTester } from '../tester.js'
 
 export const t = new ServiceTester({
@@ -10,7 +10,7 @@ export const t = new ServiceTester({
 })
 
 t.create('Rating')
-  .get('/rating/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/rating/gighmmpiobklfepjocnamgkkbiglidom.json')
   .expectBadge({
     label: 'rating',
     message: Joi.string().regex(/^\d\.?\d+?\/5$/),
@@ -21,10 +21,10 @@ t.create('Rating (not found)')
   .expectBadge({ label: 'rating', message: 'not found' })
 
 t.create('Rating Count')
-  .get('/rating-count/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/rating-count/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   .expectBadge({
     label: 'rating',
-    message: Joi.string().regex(/^\d+?\stotal$/),
+    message: isMetricWithPattern(/ total/),
   })
 
 t.create('Rating Count (not found)')
@@ -32,7 +32,7 @@ t.create('Rating Count (not found)')
   .expectBadge({ label: 'rating', message: 'not found' })
 
 t.create('Stars')
-  .get('/stars/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/stars/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   .expectBadge({ label: 'rating', message: isStarRating })
 
 t.create('Stars (not found)')
@@ -42,7 +42,7 @@ t.create('Stars (not found)')
 // Keep this "inaccessible" test, since this service does not use BaseService#_request.
 const mockAgent = new MockAgent()
 t.create('Rating (inaccessible)')
-  .get('/rating/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/rating/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   // webextension-store-meta uses undici internally, so we can't mock it with nock
   .before(function () {
     setGlobalDispatcher(mockAgent)

--- a/services/chrome-web-store/chrome-web-store-users.service.js
+++ b/services/chrome-web-store/chrome-web-store-users.service.js
@@ -15,7 +15,7 @@ class ChromeWebStoreUsers extends BaseChromeWebStoreService {
         description,
         parameters: pathParams({
           name: 'storeId',
-          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+          example: 'ddkjiahejlhfcafbddmgiahcphecmpfh',
         }),
       },
     },

--- a/services/chrome-web-store/chrome-web-store-users.tester.js
+++ b/services/chrome-web-store/chrome-web-store-users.tester.js
@@ -9,13 +9,13 @@ export const t = new ServiceTester({
 })
 
 t.create('Downloads (redirect)')
-  .get('/d/alhjnofcnnpeaphgeakdhkebafjcpeae.svg')
+  .get('/d/ddkjiahejlhfcafbddmgiahcphecmpfh.svg')
   .expectRedirect(
-    '/chrome-web-store/users/alhjnofcnnpeaphgeakdhkebafjcpeae.svg',
+    '/chrome-web-store/users/ddkjiahejlhfcafbddmgiahcphecmpfh.svg',
   )
 
 t.create('Users')
-  .get('/users/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/users/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   .expectBadge({ label: 'users', message: isMetric })
 
 t.create('Users (not found)')
@@ -25,7 +25,7 @@ t.create('Users (not found)')
 // Keep this "inaccessible" test, since this service does not use BaseService#_request.
 const mockAgent = new MockAgent()
 t.create('Users (inaccessible)')
-  .get('/users/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/users/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   // webextension-store-meta uses undici internally, so we can't mock it with nock
   .before(function () {
     setGlobalDispatcher(mockAgent)

--- a/services/chrome-web-store/chrome-web-store-version.service.js
+++ b/services/chrome-web-store/chrome-web-store-version.service.js
@@ -15,7 +15,7 @@ export default class ChromeWebStoreVersion extends BaseChromeWebStoreService {
         description,
         parameters: pathParams({
           name: 'storeId',
-          example: 'ogffaloegjglncjfehdfplabnoondfjo',
+          example: 'ddkjiahejlhfcafbddmgiahcphecmpfh',
         }),
       },
     },

--- a/services/chrome-web-store/chrome-web-store-version.tester.js
+++ b/services/chrome-web-store/chrome-web-store-version.tester.js
@@ -3,7 +3,7 @@ import { isVPlusDottedVersionAtLeastOne } from '../test-validators.js'
 import { createServiceTester } from '../tester.js'
 export const t = await createServiceTester()
 
-t.create('Version').get('/alhjnofcnnpeaphgeakdhkebafjcpeae.json').expectBadge({
+t.create('Version').get('/ddkjiahejlhfcafbddmgiahcphecmpfh.json').expectBadge({
   label: 'chrome web store',
   message: isVPlusDottedVersionAtLeastOne,
 })
@@ -15,7 +15,7 @@ t.create('Version (not found)')
 // Keep this "inaccessible" test, since this service does not use BaseService#_request.
 const mockAgent = new MockAgent()
 t.create('Version (inaccessible)')
-  .get('/alhjnofcnnpeaphgeakdhkebafjcpeae.json')
+  .get('/ddkjiahejlhfcafbddmgiahcphecmpfh.json')
   // webextension-store-meta uses undici internally, so we can't mock it with nock
   .before(function () {
     setGlobalDispatcher(mockAgent)


### PR DESCRIPTION
`ratingCount` returns a string which we were passing to our `metric` and `floorCountColor`, which expect numbers. This led to weird side-effects, for example the badge displaying `3.5K` where all Shields.io other count badges use the standard lower-case `3.5k` format. Colors were off as well. `transform` now turns it back into a number before these usages.

Additionally, I've refreshed all examples, as a bunch of non-manifest-v3 extensions got unpublished recently.